### PR TITLE
fix: correct failing server build script

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build",
     "dev": "yarn run serve",
     "serve": "ts-node-esm src/app.ts"
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
Needed to add the --build flag to use "[build mode](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript)".

Build mode will follow references to other typescript packages (in this case, `shared`) so that they are built as well.

This PR also adds an output directory for `shared` so that when the TypeScript is compiled the output isn't mixed in with the source or included in version control

## Testing

From the root of the project, run:
```
yarn workspace server run build
```

Which should complete without issue. You should notice a `dist` directory created within `shared`.