### PR TITLE
chore: add workaround for renovate and codeowners to play well together

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,11 @@
 
 # Documentation owners
 docs/*  @dgauldie @pascaleproulx @YohannParis
+
+# CODEOWNERS prevent renovate automerge since it will automatically ask for review
+# See documentation for more details: https://docs.renovatebot.com/key-concepts/automerge/#codeowners
+# NOTE: leave at the bottom for precedence matching
+# May need to be updated as required
+# Solution: make files used by renovate owned by everyone
+**/*/package.json
+**/*/yarn.lock

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
 		":label(RenovateBot)",
 		":semanticCommits"
 	],
-	"schedule": ["before 6am on Tuesday"],
 	"npm": {
 		"stabilityDays": 3
 	},


### PR DESCRIPTION
# Description

Make files that RenovateBot touches owned by everyone. This 'should' resolve the catch 22 of needing approval for Renovate updates during automerge. This does not break the fact that approval is still required for major upgrades.

NOTE: temporarily removing scheduling for the bot (so that it is triggered daily) for testing purpose of this fix will reschedule once resolved.

Resolves N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No manual test. Requires live testing of the bot runner.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

