### PR TITLE
feat: refine data explorer styles

### DIFF
--- a/packages/client/webapp/src/components/Header.vue
+++ b/packages/client/webapp/src/components/Header.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import IconLogin16 from '@carbon/icons-vue/es/login/16';
+import Button from '@/components/Button.vue';
 import { useAuthStore } from '../stores/auth';
 
 const auth = useAuthStore();

--- a/packages/client/webapp/src/components/data-explorer/articles-listview.vue
+++ b/packages/client/webapp/src/components/data-explorer/articles-listview.vue
@@ -19,8 +19,8 @@
 						:class="{ selected: isSelected(d) }"
 						@click="updateExpandedRow(d)"
 					>
-						<td class="output-col">
-							<div class="output-layout">
+						<td class="title-and-abstract-col">
+							<div class="title-and-abstract-layout">
 								<!-- in case of requesting multiple selection -->
 								<div class="radio" @click.stop="updateSelection(d)">
 									<template v-if="enableMultipleSelection">
@@ -46,22 +46,22 @@
 								</div>
 							</div>
 						</td>
-						<td class="desc-col">
+						<td class="publisher-and-author-col">
 							<div class="text-bold">{{ d.publisher }}</div>
 							<div v-if="isExpanded(d)" class="knobs">
 								<multiline-description :text="formatArticleAuthors(d)" />
 							</div>
 						</td>
-						<td class="period-col">
+						<td class="journal-col">
 							<div class="text-bold">{{ d.journal }}</div>
 							<div>{{ d.type ?? '' }}</div>
 						</td>
-						<td class="region-col">
+						<td class="known-terms-col">
 							<div v-html="formatKnownTerms(d)"></div>
 						</td>
-						<td class="timeseries-col">
-							<div class="timeseries-container">
-								<!-- timeseries renderer -->
+						<td class="preview-col">
+							<div class="preview-container">
+								<!-- preview renderer -->
 							</div>
 						</td>
 					</tr>
@@ -206,7 +206,7 @@ export default defineComponent({
 	.table-fixed-head {
 		overflow-y: auto;
 		overflow-x: hidden;
-		height: 600px;
+		height: 100%;
 		width: 100%;
 	}
 	.table-fixed-head thead th {
@@ -235,7 +235,7 @@ export default defineComponent({
 	}
 	.tr-item.selected {
 		border: 2px double $selected;
-		.output-col {
+		.title-and-abstract-col {
 			border-left: 4px solid $selected;
 		}
 		td {
@@ -243,13 +243,12 @@ export default defineComponent({
 		}
 	}
 	.text-bold {
-		font-size: $font-size-large;
-		font-weight: 600;
+		font-weight: 500;
 		margin-bottom: 5px;
 	}
-	.output-col {
-		width: 33%;
-		.output-layout {
+	.title-and-abstract-col {
+		width: 40%;
+		.title-and-abstract-layout {
 			display: flex;
 			align-content: stretch;
 			align-items: stretch;
@@ -279,24 +278,24 @@ export default defineComponent({
 			}
 		}
 	}
-	.desc-col {
+	.publisher-and-author-col {
 		width: 33%;
 		overflow-wrap: anywhere;
 	}
-	.region-col {
-		width: 200px;
+	.known-terms-col {
+		width: 20%;
 	}
-	.period-col {
+	.journal-col {
 		width: 120px;
 	}
 	// time series hidden until actually put into use
-	.timeseries-col {
+	.preview-col {
 		padding-left: 5px;
 		padding-right: 10px;
 	}
-	.timeseries-container {
+	.preview-container {
 		background-color: #f1f1f1;
-		width: 110px;
+		width: 100px;
 		height: 50px;
 	}
 }

--- a/packages/client/webapp/src/components/data-explorer/common-listview.vue
+++ b/packages/client/webapp/src/components/data-explorer/common-listview.vue
@@ -4,16 +4,16 @@
 			<table>
 				<thead>
 					<tr>
-						<th><span class="left-cover" />Name</th>
-						<th>Desc</th>
-						<th>Source</th>
+						<th><span class="left-cover" />NAME</th>
+						<th>DESCRIPTION</th>
+						<th>SOURCE</th>
 						<th>PREVIEW<span class="right-cover" /></th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr v-for="d in items" :key="d.id" class="tr-item" @click="updateExpandedRow(d)">
-						<td class="output-col">
-							<div class="output-layout">
+						<td class="name-col">
+							<div class="name-layout">
 								<div class="radio">
 									<i
 										class="fa-regular fa-lg fa-fw"
@@ -29,12 +29,12 @@
 						<td class="desc-col">
 							<multiline-description :text="formatDescription(d)" />
 						</td>
-						<td class="period-col">
+						<td class="source-col">
 							<multiline-description :text="formatSource(d)" />
 						</td>
-						<td class="timeseries-col">
-							<div class="timeseries-container">
-								<!-- timeseries renderer -->
+						<td class="preview-col">
+							<div class="preview-container">
+								<!-- preview renderer -->
 							</div>
 						</td>
 					</tr>
@@ -144,7 +144,7 @@ export default defineComponent({
 				: `${item.desc.substring(0, maxSize)}...`;
 		},
 		formatSource(item: GenericResult) {
-			const maxSize = 25;
+			const maxSize = 40;
 			return this.isExpanded(item) || item.source.length < maxSize
 				? item.source
 				: `${item.source.substring(0, maxSize)}...`;
@@ -197,7 +197,7 @@ export default defineComponent({
 	.table-fixed-head {
 		overflow-y: auto;
 		overflow-x: hidden;
-		height: 600px;
+		height: 100%;
 		width: 100%;
 	}
 	.table-fixed-head thead th {
@@ -226,7 +226,7 @@ export default defineComponent({
 	}
 	.tr-item.selected {
 		border: 2px double $selected;
-		.output-col {
+		.name-col {
 			border-left: 4px solid $selected;
 		}
 		td {
@@ -234,13 +234,12 @@ export default defineComponent({
 		}
 	}
 	.text-bold {
-		font-size: $font-size-large;
-		font-weight: 600;
+		font-weight: 500;
 		margin-bottom: 5px;
 	}
-	.output-col {
-		width: 33%;
-		.output-layout {
+	.name-col {
+		width: 20%;
+		.name-layout {
 			display: flex;
 			align-content: stretch;
 			align-items: stretch;
@@ -274,20 +273,18 @@ export default defineComponent({
 		width: 33%;
 		overflow-wrap: anywhere;
 	}
-	.region-col {
-		width: 200px;
-	}
-	.period-col {
-		width: 120px;
+	.source-col {
+		width: 20%;
 	}
 	// time series hidden until actually put into use
-	.timeseries-col {
+	.preview-col {
 		padding-left: 5px;
 		padding-right: 10px;
+		width: 20%;
 	}
-	.timeseries-container {
+	.preview-container {
 		background-color: #f1f1f1;
-		width: 110px;
+		width: 100%;
 		height: 50px;
 	}
 }

--- a/packages/client/webapp/src/components/data-explorer/models-listview.vue
+++ b/packages/client/webapp/src/components/data-explorer/models-listview.vue
@@ -18,8 +18,8 @@
 						:class="{ selected: isSelected(d) }"
 						@click="updateExpandedRow(d)"
 					>
-						<td class="output-col">
-							<div class="output-layout">
+						<td class="name-and-desc-col">
+							<div class="name-and-desc-layout">
 								<!-- in case of requesting multiple selection -->
 								<div class="radio" @click.stop="updateSelection(d)">
 									<template v-if="enableMultipleSelection">
@@ -55,15 +55,15 @@
 								</div>
 							</div>
 						</td>
-						<td class="desc-col">
+						<td class="source-col">
 							<div class="text-bold">{{ d.source }}</div>
 						</td>
-						<td class="period-col">
+						<td class="category-col">
 							<div class="text-bold">{{ d.category }}</div>
 						</td>
-						<td class="timeseries-col">
-							<div class="timeseries-container">
-								<!-- timeseries renderer -->
+						<td class="preview-col">
+							<div class="preview-container">
+								<!-- preview renderer -->
 							</div>
 						</td>
 					</tr>
@@ -220,7 +220,7 @@ export default defineComponent({
 	.table-fixed-head {
 		overflow-y: auto;
 		overflow-x: hidden;
-		height: 600px;
+		height: 100%;
 		width: 100%;
 	}
 	.table-fixed-head thead th {
@@ -249,7 +249,7 @@ export default defineComponent({
 	}
 	.tr-item.selected {
 		border: 2px double $selected;
-		.output-col {
+		.name-and-desc-col {
 			border-left: 4px solid $selected;
 		}
 		td {
@@ -257,13 +257,12 @@ export default defineComponent({
 		}
 	}
 	.text-bold {
-		font-size: $font-size-large;
-		font-weight: 600;
+		font-weight: 500;
 		margin-bottom: 5px;
 	}
-	.output-col {
-		width: 33%;
-		.output-layout {
+	.name-and-desc-col {
+		width: 45%;
+		.name-and-desc-layout {
 			display: flex;
 			align-content: stretch;
 			align-items: stretch;
@@ -293,24 +292,21 @@ export default defineComponent({
 			}
 		}
 	}
-	.desc-col {
+	.source-col {
 		width: 33%;
 		overflow-wrap: anywhere;
 	}
-	.region-col {
-		width: 200px;
-	}
-	.period-col {
-		width: 120px;
+	.category-col {
+		width: 10%;
 	}
 	// time series hidden until actually put into use
-	.timeseries-col {
+	.preview-col {
 		padding-left: 5px;
 		padding-right: 10px;
 	}
-	.timeseries-container {
+	.preview-container {
 		background-color: #f1f1f1;
-		width: 110px;
+		width: 100%;
 		height: 50px;
 	}
 }

--- a/packages/client/webapp/src/components/data-explorer/search-bar.vue
+++ b/packages/client/webapp/src/components/data-explorer/search-bar.vue
@@ -23,7 +23,7 @@
 		<button
 			v-if="enableClearButton"
 			type="button"
-			class="btn clear-button"
+			class="btn clear-button button-padding"
 			:class="{ 'clear-button-disabled': isClearButtonDisabled }"
 			:disabled="isClearButtonDisabled"
 			@click="clearText"
@@ -33,7 +33,7 @@
 		<button
 			v-if="enableSearchButton"
 			type="button"
-			class="btn clear-button search-button"
+			class="btn button-padding search-button"
 			:class="{ 'search-button-disabled': isSearchButtonDisabled }"
 			:disabled="isSearchButtonDisabled"
 			@click="searchBtnHandler"
@@ -145,19 +145,23 @@ export default defineComponent({
 	justify-content: center;
 }
 
-.clear-button {
-	color: white;
+.button-padding {
 	padding: 4px;
 	padding-left: 8px;
 	padding-right: 8px;
 	margin: 4px;
+	cursor: pointer;
+}
+
+.clear-button {
+	color: white;
 }
 
 .search-button {
-	background-color: dodgerblue;
+	background-color: #2d8e2dff;
 }
 .search-button-disabled {
-	background-color: darken($color: dodgerblue, $amount: 25%);
+	background-color: darken($color: #92e192ff, $amount: 50%);
 	cursor: not-allowed;
 }
 .clear-button-disabled {
@@ -173,7 +177,7 @@ export default defineComponent({
 .flex-aligned-item {
 	display: flex;
 	align-items: center;
-	color: blue;
+	color: var(--un-color-accent-darker);
 
 	.flex-aligned-item-delete-btn {
 		color: red;

--- a/packages/client/webapp/src/components/data-explorer/search.vue
+++ b/packages/client/webapp/src/components/data-explorer/search.vue
@@ -183,7 +183,7 @@ export default defineComponent({
 		}
 
 		.results-count {
-			color: blue;
+			color: #1c5a1cff;
 			margin-right: 2rem;
 		}
 	}

--- a/packages/client/webapp/src/components/side-panel/side-panel-nav.vue
+++ b/packages/client/webapp/src/components/side-panel/side-panel-nav.vue
@@ -95,7 +95,7 @@ li {
 		content: '';
 		display: block;
 		position: absolute;
-		width: 50%;
+		width: 5%; // 50%
 		height: 100%;
 		top: 0;
 		z-index: -1;

--- a/packages/client/webapp/src/components/widgets/full-screen-modal-header.vue
+++ b/packages/client/webapp/src/components/widgets/full-screen-modal-header.vue
@@ -39,7 +39,7 @@ export default defineComponent({
 @import '../../styles/variables.scss';
 
 .full-screen-modal-header-container {
-	background-color: $accent-dark;
+	background-color: var(--un-color-accent-dark);
 	display: flex;
 	align-items: center;
 	min-height: 48px;

--- a/packages/client/webapp/src/styles/variables.scss
+++ b/packages/client/webapp/src/styles/variables.scss
@@ -86,3 +86,5 @@ $shadow-level-2:
 
 // Transitions
 $layout-transition: .3s ease;
+
+@import "facets-overrides";

--- a/packages/client/webapp/src/views/DataExplorer.vue
+++ b/packages/client/webapp/src/views/DataExplorer.vue
@@ -8,7 +8,7 @@
 			@selection="onSelection"
 		/>
 		<div class="flex h-100">
-			<div class="flex h-100" style="height: auto">
+			<div class="flex h-100 facets-panel-container">
 				<facets-panel
 					:facets="facets"
 					:filtered-facets="filteredFacets"
@@ -31,7 +31,6 @@
 					</template>
 				</search-bar>
 				<search
-					class="search"
 					:data-items="filteredDataItems"
 					:result-type="resultType"
 					:results-count="resultsCount"
@@ -330,16 +329,19 @@ export default defineComponent({
 @import '../styles/util.scss';
 
 .data-explorer-container {
-	position: relative;
+	position: absolute;
+	left: 0px;
+	top: 0px;
 	box-sizing: border-box;
-	overflow: hidden;
 	width: 100%;
+	height: calc(100vh - 50px);
+
+	.facets-panel-container {
+		background-color: $background-light-2;
+		height: calc(100vh - 50px);
+	}
 
 	.explorer-content {
-		.search {
-			height: calc(100% - 100px);
-		}
-
 		display: flex;
 		flex-direction: column;
 		flex: 1;


### PR DESCRIPTION
# Description
Refine data explorer styles, e.g. making the explorer view on top of everything and cover the whole page as well as use "greenish" colors matching a bit TERarium look 'n feel

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manual testing 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

