### PR TITLE
chore: add Dockerfile to exlude permission file for automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,4 @@ docs/*  @dgauldie @pascaleproulx @YohannParis
 # Solution: make files used by renovate owned by everyone
 **/package.json
 **/yarn.lock
+**/Dockerfile*


### PR DESCRIPTION
# Description

Adding Dockerfile changes to be automergable by Renovate

Resolves #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

None

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

