### PR TITLE
chore: add gradle properties to exclusion permission for automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,4 @@ docs/*  @dgauldie @pascaleproulx @YohannParis
 **/package.json
 **/yarn.lock
 **/Dockerfile*
+**/gradle.properties


### PR DESCRIPTION
# Description

Expand the gradle.properties files to be owned by everyone for Renovate automerge to work.

Resolves #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

