### PR TITLE
feat: add simulation to TA2-playground

### DIFF
--- a/packages/client/webapp/src/views/TA2Playground.vue
+++ b/packages/client/webapp/src/views/TA2Playground.vue
@@ -514,8 +514,8 @@ export default defineComponent({
 
 		<div style="display: flex">
 			<div id="playground" class="playground-panel"></div>
-			<div id="output" class="playground-panel"></div>
 			<div id="solution" class="playground-panel"></div>
+			<div id="output" class="playground-panel"></div>
 		</div>
 	</section>
 </template>


### PR DESCRIPTION
# Description
This PR further develops the TA2-playground with ODE simulations. This provides some capability to prototype ideas around simulation itself, parameterization, and other related things. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Testing
Depends on https://github.com/DARPA-ASKEM/model-transform/pull/2, you will need to start the model-transform service.

Navigate to http://localhost:8078/app/#/ta2-playground
- click on LotkaVolterra to load the petri-net
- click on simulate to run, you can click this many times to run with different initial conditions
- 
![image](https://user-images.githubusercontent.com/1220927/196200881-c60dd24d-b205-4b8a-b2a1-27fffc3e68df.png)

