### PR TITLE
fix: reverting docker images to keycloak:dev-1.0.0 for keycloak servi…

### DIFF
--- a/kubernetes/local/gateway-keycloak-deployment.yaml
+++ b/kubernetes/local/gateway-keycloak-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gateway-keycloak
 spec:
   containers:
-    - image: docker.uncharted.software/auth/keycloak:dev-1.1.0
+    - image: docker.uncharted.software/auth/keycloak:dev-1.0.0
       name: gateway-keycloak
       args:
         - start-dev
@@ -36,7 +36,7 @@ spec:
       volumeMounts:
         - name: theme-volume
           mountPath: /shared
-    - image: docker.uncharted.software/auth/keycloak:dev-1.1.0
+    - image: docker.uncharted.software/auth/keycloak:dev-1.0.0
       name: init-gateway-keycloak
       args:
         - import

--- a/kubernetes/local/gateway.sh
+++ b/kubernetes/local/gateway.sh
@@ -12,7 +12,7 @@ if [[ ${1} == "up" ]]; then
 
     if [ ${APPLE_SILICON:-0} -eq 0 ]; then
 			docker pull docker.uncharted.software/auth/httpd-openidc:dev-1.0.1
-			docker pull docker.uncharted.software/auth/keycloak:dev-1.1.0
+			docker pull docker.uncharted.software/auth/keycloak:dev-1.0.0
     else
         echo "not pulling latest images as Apple Silicon httpd-openidc has not been pushed to the repo"
     fi


### PR DESCRIPTION
# Description
Reverting docker image for keycloak to previous version (1.0.0) as version 1.1.0 has been failing. 

Resolves #(issue) - Not aware of a number that this was tracked under

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Restarting app, connecting to port 8078, being redirected to 8079 (keycloak) and successfully signing in

Please describe the tests that you ran to verify your changes. Provide reproduction instructions and list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

