### PR TITLE
fix: d3.each selecton context with "this"

### DIFF
--- a/packages/client/graph-scaffolder/src/core/delta-renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/delta-renderer.ts
@@ -30,11 +30,7 @@ export default abstract class DeltaRenderer<V, E> extends Renderer<V, E> {
 				d.state = 'updated';
 			});
 
-			// D3 binding does not like arrow-functions
-			// eslint-disable-next-line
-			[newNodes, nodesGroup].forEach(function (g) {
-				// D3 binding does not like arrow-functions
-				// eslint-disable-next-lin
+			[newNodes, nodesGroup].forEach((g) => {
 				g.each(function (d) {
 					// @ts-ignore: D3 needs "this" to bind to selection context
 					const selection2 = d3.select(this as any);

--- a/packages/client/graph-scaffolder/src/core/delta-renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/delta-renderer.ts
@@ -30,8 +30,13 @@ export default abstract class DeltaRenderer<V, E> extends Renderer<V, E> {
 				d.state = 'updated';
 			});
 
-			[newNodes, nodesGroup].forEach((g) => {
-				g.each((d) => {
+			// D3 binding does not like arrow-functions
+			// eslint-disable-next-line
+			[newNodes, nodesGroup].forEach(function (g) {
+				// D3 binding does not like arrow-functions
+				// eslint-disable-next-lin
+				g.each(function (d) {
+					// @ts-ignore: D3 needs "this" to bind to selection context
 					const selection2 = d3.select(this as any);
 
 					// Allocate for the node itself


### PR DESCRIPTION
# Description
When using D3's d3.each syntax with d3.selection, `this` needs to refer to the bounded selection context. The current code uses arrow-functions which provides the wrong context so things can break. This PR fixes this by restoring them back into non-arrow functions and add TS/ES ignore declarations to get around the build warnings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
This is rather awkward  to test, since the problems are introduced in a piece of code (DeltaRenderer) that is not currently in use. 

To test, replace `packages/client/graph-scaffolder/examples/src/index.ts` with the following code snippet which uses the DeltaRenderer

Then under graph-scaffolder
- Run `npm run develop`
- Goto `localhost:8090` 
  - With the changes in this PR you will be able to see a sample graph
  - Without the changes in this PR you will get JS errors

```
import * as _ from 'lodash';
import * as d3 from 'd3';
import DeltaRenderer from '../../src/core/delta-renderer';
import { group } from '../../src/fn/group';
import { IEdge, IGraph, INode } from '../../src/types';

import { runLayout } from './dagre';

interface NodeData {
	type: string;
}

interface EdgeData {
	val: number;
}

type D3SelectionINode<T> = d3.Selection<d3.BaseType, INode<T>, null, any>;
type D3SelectionIEdge<T> = d3.Selection<d3.BaseType, IEdge<T>, null, any>;

export const pathFn = d3
	.line<{ x: number; y: number }>()
	.x((d) => d.x)
	.y((d) => d.y);

class SampleRenderer extends DeltaRenderer<NodeData, EdgeData> {
	constructor(options: any) {
		super(options);
	}

	renderNodesAdded(selection: D3SelectionINode<NodeData>) {
		const species = selection.filter((d) => d.data.type === 'species');
		const transitions = selection.filter((d) => d.data.type === 'transition');

		transitions
			.append('rect')
			.attr('width', (d) => d.width)
			.attr('height', (d) => d.height)
			.style('fill', '#88C')
			.style('stroke', '#888');

		species
			.append('circle')
			.attr('cx', (d) => d.width * 0.5)
			.attr('cy', (d) => d.height * 0.5)
			.attr('r', (d) => d.width * 0.5)
			.attr('fill', '#f80');

		selection
			.append('text')
			.attr('y', -5)
			.text((d) => d.label);
	}
	renderNodesUpdated(_selection: D3SelectionINode<NodeData>) {}
	renderNodesRemoved(_selection: D3SelectionINode<NodeData>) {}


	renderEdgesAdded(selection: D3SelectionIEdge<EdgeData>) {
		selection
			.append('path')
			.attr('d', (d) => pathFn(d.points))
			.style('fill', 'none')
			.style('stroke', '#000');
	}

	renderEdgesUpdated(selection: D3SelectionIEdge<EdgeData>) {}
	renderEdgesRemoved(selection: D3SelectionIEdge<EdgeData>) {}
}

// Render
const div = document.createElement('div');
div.style.height = '800px';
div.style.width = '800px';
document.body.append(div);

const renderer = new SampleRenderer({
	el: div,
	useAStarRouting: true,
	runLayout: runLayout
});
renderer.on('node-click', () => {
	console.log('node click');
});
renderer.on('node-dbl-click', () => {
	console.log('node double click');
});
renderer.on(
	'node-mouse-enter',
	(_eventName: string, _evt: any, selection: D3SelectionINode<NodeData>) => {
		// selection.select('rect').style('fill', '#f80');
	}
);
renderer.on(
	'node-mouse-leave',
	(_eventName: string, _evt: any, selection: D3SelectionINode<NodeData>) => {
		// selection.select('rect').style('fill', '#eee');
	}
);

renderer.on('hello', (evtName: string, t: string) => {
	console.log(evtName, t);
});

let g: IGraph<NodeData, EdgeData> = {
	width: 500,
	height: 500,
	nodes: [
		{
			id: 'susceptible',
			label: 'susceptible',
			x: 0,
			y: 0,
			height: 50,
			width: 50,
			data: { type: 'species' },
			nodes: []
		},
		{
			id: 'infected',
			label: 'infected',
			x: 0,
			y: 0,
			height: 50,
			width: 50,
			data: { type: 'species' },
			nodes: []
		},
		{
			id: 'recovered',
			label: 'recovered',
			x: 0,
			y: 0,
			height: 50,
			width: 50,
			data: { type: 'species' },
			nodes: []
		},
		{
			id: 'infection',
			label: 'infection',
			x: 0,
			y: 0,
			height: 40,
			width: 40,
			data: { type: 'transition' },
			nodes: []
		},
		{
			id: 'recovery',
			label: 'recovery',
			x: 0,
			y: 0,
			height: 40,
			width: 40,
			data: { type: 'transition' },
			nodes: []
		}
	],
	edges: [
		{ id: '1', source: 'susceptible', target: 'infection', points: [], data: null },
		{ id: '2', source: 'infection', target: 'infected', points: [], data: { val: 2 } },
		{ id: '3', source: 'infected', target: 'recovery', points: [], data: null },
		{ id: '4', source: 'recovery', target: 'recovered', points: [], data: null },
		{ id: '5', source: 'infected', target: 'infection', points: [], data: null }
	]
};

g = runLayout(_.cloneDeep(g));

const run = async () => {
	await renderer.setData(g);
	await renderer.render();

	group(renderer, 'xyz', ['123', '456']);
	renderer.render();
};

run();

```