### PR TITLE
chore: add missing label for feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]: "
-labels: bug, feature
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG]: '
-labels: 'bug'
+title: "[BUG]: "
+labels: bug, feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[FEAT]: '
-labels: 'enhancement'
+title: "[FEAT]: "
+labels: feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/task-request.md
+++ b/.github/ISSUE_TEMPLATE/task-request.md
@@ -1,8 +1,8 @@
 ---
 name: Task request
 about: Template for development tasks
-title: '[TASK]: '
-labels: 'task'
+title: "[TASK]: "
+labels: task
 assignees: ''
 
 ---


### PR DESCRIPTION
The feature template was using an old `label` type that no longer exists. Updating it to use `feature` now.