### PR TITLE
ci: switch to use triggers rather than wait on workflow completion

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,10 +6,10 @@
 name: Playwright Tests
 on:
   workflow_call:
-  workflow_run:
-    workflows: ['Lint & Test']
-    types:
-      - completed
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
 jobs:
   e2e-tests:
     timeout-minutes: 30
@@ -22,13 +22,6 @@ jobs:
         shardIndex: [1]
         shardTotal: [1]
     steps:
-      # 1.0 - only run if the dependant workflows were successful
-      - name: Workflow Run Wait
-        if: contains(github.event.ref, '/tags/') == false
-        uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
-        with:
-          timeout: 180000
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -80,13 +73,6 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-      # 1.0 - only run if the dependant workflows were successful
-      - name: Workflow Run Wait
-        if: contains(github.event.ref, '/tags/') == false
-        uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
-        with:
-          timeout: 180000
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Workflow Run Wait
         if: contains(github.event.ref, '/tags/') == false
         uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
+        with:
+          timeout: 180000
 
       - uses: actions/checkout@v3
         with:
@@ -82,6 +84,8 @@ jobs:
       - name: Workflow Run Wait
         if: contains(github.event.ref, '/tags/') == false
         uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
+        with:
+          timeout: 180000
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,6 +57,8 @@ jobs:
       - name: Workflow Run Wait
         if: contains(github.event.ref, '/tags/') == false
         uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
+        with:
+          timeout: 600000
 
       # 1.1 - checkout the files
       - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,12 +5,8 @@
 name: Build and Publish
 
 on:
-  workflow_run:
-    workflows: ['Playwright Tests', 'Lint & Test']
-    branches: ['main']
-    types:
-      - completed
   push:
+    branches: ['main']
     tags: ['*']
 
 env:
@@ -20,46 +16,22 @@ env:
   BAKE_GROUP: prod
 
 jobs:
+  # Run Lint and Unit Tests
   test:
-    if: contains(github.event.ref, '/tags/')
     uses: ./.github/workflows/lint_test.yml
 
+  # Run E2E Tests
   e2e-tests:
-    if: contains(github.event.ref, '/tags/')
     uses: ./.github/workflows/playwright.yml
 
   # Generate a matrix based on all the targets defined in the
   # bake file.
   targets:
     name: Generate targets list from provided bake file
-    if: github.ref_name == 'main' || contains(github.event.ref, '/tags/')
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.targets.outputs.matrix }}
     steps:
-      - name: debug
-        run: |
-          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
-            TAG=latest
-          else
-            SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
-            if [[ -n $SEMVER ]]; then
-              TAG=${SEMVER}
-            else
-              TAG=${{ github.ref_name }}
-            fi
-          fi
-
-          echo "${{ github.event }}"
-          echo "$TAG"
-
-      # 1.0 - only run if the dependant workflows were successful
-      - name: Workflow Run Wait
-        if: contains(github.event.ref, '/tags/') == false
-        uses: ahmadnassri/action-workflow-run-wait@2aa3d9e1a12ecaaa9908e368eaf2123bb084323e
-        with:
-          timeout: 600000
-
       # 1.1 - checkout the files
       - name: Checkout
         uses: actions/checkout@v3
@@ -85,10 +57,11 @@ jobs:
     permissions:
       packages: write
       contents: read
-    # this job depends on the 'targets' job
+    # this job depends on the 'targets' job and tests
     needs:
       - targets
       - test
+      - e2e-tests
 
     # 2.0 - Build a matrix strategy from the retrieved target list
     strategy:


### PR DESCRIPTION
# Description

The workflow_run call is less than desired. Switching to manually trigger tests on publish instead and not have a long dependency chain.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Increased timeout to 10 min on main build phase

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

