### PR TITLE
bug: removing the dependency on label -id is used as id

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -351,7 +351,7 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			// @ts-ignore: D3 "this"
 			node = d3.select(this) as D3SelectionINode<V>;
 			const childrenNodes = node.selectAll('.node') as D3SelectionINode<V>;
-			nodeDraggingIds = [node.datum().label, ...childrenNodes.data().map((d) => d.label)];
+			nodeDraggingIds = [node.datum().id, ...childrenNodes.data().map((d) => d.id)];
 
 			sufficientlyMoved = false;
 			emitWrapper('node-drag-start', evt, node, renderer);

--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -13,14 +13,14 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>): IGraph<V, E> => {
 	graphScaffolder.traverseGraph(graphData, (node: INode<V>) => {
 		if (node.width && node.height) {
 			g.setNode(node.id, {
-				label: node.id,
+				label: node.label,
 				width: node.width,
 				height: node.height,
 				x: node.x,
 				y: node.y
 			});
 		} else {
-			g.setNode(node.id, { label: node.id, x: node.x, y: node.y });
+			g.setNode(node.id, { label: node.label, x: node.x, y: node.y });
 		}
 		if (!_.isEmpty(node.nodes)) {
 			// eslint-disable-next-line

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -26,9 +26,12 @@ const g: IGraph<NodeData, EdgeData> = {
  * First add each node found in S and T, then add each edge found in I and O
  */
 export const parsePetriNet2IGraph = (model: PetriNet) => {
+	// Reset current Graph.
+	g.nodes = [];
+	g.edges = [];
 	const nodeHeight = 20;
 	const nodeWidth = 20;
-	let nodeX = 0;
+	let nodeX = 10;
 	let nodeY = 10;
 	// add each nodes in S
 	for (let i = 0; i < model.S.length; i++) {
@@ -47,7 +50,7 @@ export const parsePetriNet2IGraph = (model: PetriNet) => {
 		});
 	}
 	nodeX = 100; // Move Transitions 100 to the right of S. This is a very poor way to display graphs but will have to do for now.
-	nodeY = 0;
+	nodeY = 10;
 	// Add each node found in T
 	for (let i = 0; i < model.T.length; i++) {
 		const aTransition = model.T[i];

--- a/packages/client/hmi-client/src/views/TA2Playground.vue
+++ b/packages/client/hmi-client/src/views/TA2Playground.vue
@@ -472,8 +472,8 @@ export default defineComponent({
 				}
 			}
 			g.edges.push({
-				source: sourceLabel,
-				target: targetLabel,
+				source: sourceID,
+				target: targetID,
 				points: [
 					{
 						x: sourceX, // + source.datum().width * 0.5,


### PR DESCRIPTION
# Description
Removing previous dependencies on node's label so it can be just used for visual text
Allowing the ID field to take all responsibilities an id should have

Previously would have to have a graph have label = id or not have interactive edges (when moving nodes for example)
![image](https://user-images.githubusercontent.com/17088680/203160618-b796ae3b-d048-44ab-8849-3deb7c12d13c.png)


Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Resolves #(issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually on model page 

Please describe the tests that you ran to verify your changes. Provide reproduction instructions and list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

