### PR TITLE
feat: 165 display selected model

### DIFF
--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -15,7 +15,7 @@ export enum RoutePath {
 
 	DocView = '/docs/:id?',
 	Project = '/projects/:projectId',
-	ModelView = '/projects/:projectId/model',
+	ModelView = '/projects/:projectId/model/:modelId',
 	SimulationView = '/projects/:projectId/simulation',
 	Results = '/projects/:projectId/results',
 
@@ -41,7 +41,7 @@ export enum RouteName {
 const routes = [
 	{ name: RouteName.HomeRoute, path: RoutePath.Home, component: HomeView },
 	{ name: RouteName.SimulationRoute, path: RoutePath.SimulationView, component: Simulation },
-	{ name: RouteName.ModelRoute, path: RoutePath.ModelView, component: Model },
+	{ name: RouteName.ModelRoute, path: RoutePath.ModelView, component: Model, props: true },
 	{ path: RoutePath.Project, component: ProjectView, props: true },
 
 	// TODO

--- a/packages/client/hmi-client/src/types/Model.ts
+++ b/packages/client/hmi-client/src/types/Model.ts
@@ -1,11 +1,9 @@
+import { PetriNet } from '@/utils/petri-net-validator';
 import { Filters } from './Filter';
 
-export type ModelContent = {
-	S: { [key: string]: string };
-	T: { [key: string]: string };
-	I: { [key: string]: number };
-	O: { [key: string]: number };
-};
+// FIXME: other model content types will be supported depending on
+//	Model.framework
+export type ModelContent = PetriNet;
 
 export type Model = {
 	id: string;
@@ -16,7 +14,7 @@ export type Model = {
 	concept: string;
 	timestamp: string | Date;
 	parameters: { [key: string]: string };
-	content: ModelContent;
+	content: PetriNet;
 
 	type: string;
 };

--- a/packages/client/hmi-client/src/views/Model.vue
+++ b/packages/client/hmi-client/src/views/Model.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { IGraph } from '@graph-scaffolder/index';
-import { onMounted, ref, watch } from 'vue';
-import { PetriNet } from '@/utils/petri-net-validator';
+import { ref, watch } from 'vue';
 import {
 	runDagreLayout,
 	D3SelectionINode,
@@ -13,24 +12,11 @@ import { parsePetriNet2IGraph, NodeData, EdgeData, NodeType } from '@/services/m
 import API from '@/api/api';
 import { Model } from '@/types/Model';
 
-// This model can be deleted in future. Just used for init graph
-// TODO: replace this mock petri net with the model fetched from the backend
-const modelPetriNet: PetriNet = {
-	T: [{ tname: 'inf' }, { tname: 'recover' }, { tname: 'death' }],
-	S: [{ sname: 'S' }, { sname: 'I' }, { sname: 'R' }, { sname: 'D' }],
-	I: [
-		{ it: 1, is: 1 },
-		{ it: 1, is: 2 },
-		{ it: 2, is: 2 },
-		{ it: 3, is: 2 }
-	],
-	O: [
-		{ ot: 1, os: 2 },
-		{ ot: 1, os: 2 },
-		{ ot: 2, os: 3 },
-		{ ot: 3, os: 4 }
-	]
-};
+const props = defineProps<{
+	projectId: string; // FIXME: currently not used
+	modelId: string;
+}>();
+
 class ModelPlanRenderer extends BaseComputionGraph<NodeData, EdgeData> {
 	renderNodes(selection: D3SelectionINode<NodeData>) {
 		const state = selection.filter((d) => d.data.type === NodeType.State);
@@ -69,55 +55,43 @@ class ModelPlanRenderer extends BaseComputionGraph<NodeData, EdgeData> {
 	}
 }
 
-onMounted(async () => {
-	let renderer: ModelPlanRenderer | null = null;
-	const modelDrawnElement = document.getElementById('model-panel') as HTMLDivElement;
-	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(modelPetriNet); // get graph from petri net representation
-
-	renderer = new ModelPlanRenderer({
-		el: modelDrawnElement,
-		useAStarRouting: true,
-		runLayout: runDagreLayout
-	});
-
-	// Test on click
-	renderer.on(
-		'node-click',
-		(_eventName: string | symbol, _event, selection: D3SelectionINode<NodeData>) => {
-			console.log(selection.datum());
-		}
-	);
-
-	// write json to model-json and draw model to model-drawn:
-	await renderer?.setData(g);
-	await renderer?.render();
-});
-
 const getModel = async (modelId: string) => API.get(`/models/${modelId}`);
-
-// TODO: let the user choose the model to display
-const selectedModelId = ref('1');
 
 const model = ref<Model | null>(null);
 // Whenever selectedModelId changes, fetch model with that ID
 watch(
-	() => [selectedModelId.value],
+	() => [props.modelId],
 	async () => {
-		const result = await getModel(selectedModelId.value);
+		const result = await getModel(props.modelId);
 		model.value = result.data as Model;
 	},
 	{ immediate: true }
 );
+
+const graphElement = ref<HTMLDivElement | null>(null);
+// Render graph whenever a new model is fetched or whenever the HTML element
+//	that we render the graph to changes.
+watch([model, graphElement], async () => {
+	if (model.value === null || graphElement.value === null) return;
+	// Convert petri net into a graph
+	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(model.value.content);
+	// Create renderer
+	const renderer = new ModelPlanRenderer({
+		el: graphElement.value,
+		useAStarRouting: true,
+		runLayout: runDagreLayout
+	});
+	// Render graph
+	await renderer?.setData(g);
+	await renderer?.render();
+});
 </script>
 
 <template>
 	<section class="model">
 		<div>
 			<h3>{{ model?.name ?? '' }}</h3>
-			<div class="model-panels">
-				<div id="model-panel" class="model-panel"></div>
-				<div class="model-panel">{{ JSON.stringify(modelPetriNet) }}</div>
-			</div>
+			<div v-if="model !== null" ref="graphElement" class="graph-element"></div>
 		</div>
 		<aside>
 			<p class="description">{{ model?.description ?? '' }}</p>
@@ -138,16 +112,10 @@ watch(
 	display: flex;
 }
 
-.model-panels {
-	display: flex;
-	flex: 1;
-	min-width: 0;
-}
-
-.model-panel {
-	width: 500px;
-	height: 500px;
-	border: 1px solid var(--un-color-black-40);
+.graph-element {
+	width: 1000px;
+	height: 1000px;
+	background: var(--un-color-black-5);
 }
 
 aside {

--- a/packages/client/hmi-client/src/views/Model.vue
+++ b/packages/client/hmi-client/src/views/Model.vue
@@ -77,7 +77,7 @@ watch([model, graphElement], async () => {
 	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(model.value.content);
 	// Create renderer
 	const renderer = new ModelPlanRenderer({
-		el: graphElement.value,
+		el: graphElement.value as HTMLDivElement,
 		useAStarRouting: true,
 		runLayout: runDagreLayout
 	});


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/16928557/204041683-6f9dfafe-ea3f-4a56-bbee-dd6666c172db.png)

Model renderer now displays the model and metadata for the model whose ID is specified in the URL.

I also removed the debugging pane that displayed the model JSON and made the graph pane bigger.

Resolves #165

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing instructions

1. Make sure gateway, hmi-server, hmi-client and data-service are running
2. Navigate to http://localhost:8078/app/#/projects/1/model/2 . You should see the graph and metadata for the model whose name starts with "Okuonghae2020"
3. Changing the `2` in the URL will display other models, e.g. `3` is for "Giordano2020"

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

