### PR TITLE
feat: list model assets and allow removing existing one or add from explorer

### DIFF
--- a/packages/client/hmi-client/src/components/Sidebar.vue
+++ b/packages/client/hmi-client/src/components/Sidebar.vue
@@ -45,7 +45,7 @@ function openView(view: string, openViewSidePanel: boolean = true): void {
 	}
 
 	// FIXME: sort out the difference between routing to a page and opening the side-panel
-	if ([RouteName.ModelRoute, RouteName.SimulationRoute].includes(view as RouteName)) {
+	if ([RouteName.SimulationRoute].includes(view as RouteName)) {
 		router.push({ name: view });
 	}
 }

--- a/packages/client/hmi-client/src/components/drilldown-panel/selected-resources-options-pane.vue
+++ b/packages/client/hmi-client/src/components/drilldown-panel/selected-resources-options-pane.vue
@@ -50,7 +50,7 @@ import { ResourceType, ResultType } from '@/types/common';
 import { Model } from '@/types/Model';
 import { XDDArticle } from '@/types/XDD';
 import useResourcesStore from '@/stores/resources';
-import { Project, PUBLICATIONS } from '@/types/Project';
+import { MODELS, Project, PUBLICATIONS } from '@/types/Project';
 import DropdownButton from '@/components/widgets/dropdown-button.vue';
 import * as ProjectService from '@/services/project';
 import { addPublication } from '@/services/external';
@@ -145,7 +145,16 @@ const addResourcesToProject = async (projectId: string) => {
 				validProject.value?.assets.publications.push(publicationId);
 			}
 		}
-		// FIXME: add similar code for inserting other types of resources
+		if (isModel(selectedItem)) {
+			// FIXME: handle cases where assets is already added to the project
+			const modelId = selectedItem.id;
+			// then, link and store in the project assets
+			const assetsType = MODELS;
+			await ProjectService.addAsset(projectId, assetsType, modelId);
+
+			// update local copy of project assets
+			validProject.value?.assets.models.push(modelId);
+		}
 	});
 };
 

--- a/packages/client/hmi-client/src/components/sidebar-panel/model-sidebar-panel.vue
+++ b/packages/client/hmi-client/src/components/sidebar-panel/model-sidebar-panel.vue
@@ -1,8 +1,27 @@
 <template>
-	<Button action @click="goToTheia">
-		<IconScript16 />
-		New model from code
-	</Button>
+	<div class="model-list-container">
+		<Button action @click="goToTheia">
+			<IconScript16 />
+			New model from code
+		</Button>
+		<div
+			v-for="mId in models"
+			:key="mId"
+			class="model-link"
+			:class="{ active: mId === modelId }"
+			@click="openModelPage(mId)"
+		>
+			<span class="model-view-icon">
+				<IconMachineLearningModel32 />
+			</span>
+			<span class="model-title">
+				{{ mId }}
+			</span>
+			<span class="model-delete-btn" @click.stop="removeModel(mId)">
+				<IconClose32 />
+			</span>
+		</div>
+	</div>
 </template>
 
 <script setup lang="ts">
@@ -14,7 +33,114 @@
 import { useRouter } from 'vue-router';
 import Button from '@/components/Button.vue';
 import IconScript16 from '@carbon/icons-vue/es/script/16';
+import IconMachineLearningModel32 from '@carbon/icons-vue/es/machine-learning-model/32';
+import useResourcesStore from '@/stores/resources';
+import { onMounted, ref } from 'vue';
+import IconClose32 from '@carbon/icons-vue/es/close/32';
+import { deleteAsset } from '@/services/project';
+import { MODELS } from '@/types/Project';
+import { getModel } from '@/services/model';
+import { RouteName } from '@/router';
 
 const router = useRouter();
+const resourcesStore = useResourcesStore();
+
 const goToTheia = () => router.push('/theia');
+
+const modelId = ref('');
+const models = ref<string[]>([]);
+
+const openModelPage = async (mId: string) => {
+	const publicationDetails = await getModel(mId);
+	// pass this model id as param
+	if (publicationDetails) {
+		modelId.value = mId; // track selection
+		router.push({
+			name: RouteName.ModelRoute,
+			params: { projectId: resourcesStore.activeProject?.id, modelId: mId }
+		});
+	}
+};
+
+const removeModel = async (mId: string) => {
+	// remove the model from the project assets
+	if (resourcesStore.activeProject) {
+		const assetsType = MODELS;
+		deleteAsset(resourcesStore.activeProject.id, assetsType, mId);
+		// remove also from the local cache
+		resourcesStore.activeProject.assets[MODELS] = resourcesStore.activeProject.assets[
+			MODELS
+		].filter((a) => a !== mId);
+		models.value = resourcesStore.activeProject.assets[MODELS];
+	}
+
+	// if the user deleted the currently selected model, then clear its content from the view
+	if (mId === modelId.value) {
+		// clear the model ID as a URL param
+		router.push({
+			name: RouteName.ModelRoute,
+			params: { projectId: resourcesStore.activeProject?.id, modelId: '' }
+		});
+	}
+};
+
+onMounted(() => {
+	// get the list of models associated with this project and display them
+	const modelsInCurrentProject = resourcesStore.activeProject?.assets.models;
+	if (modelsInCurrentProject) {
+		models.value = modelsInCurrentProject;
+	}
+});
 </script>
+
+<style scoped>
+.model-list-container {
+	overflow-y: auto;
+	margin-top: 1rem;
+	height: 100%;
+	overflow-y: auto;
+}
+
+.model-link {
+	padding: 0.5rem;
+	cursor: pointer;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.model-link:hover:not(.active) {
+	background-color: var(--un-color-body-surface-secondary);
+}
+
+.active {
+	font-size: var(--un-font-body);
+	background-color: var(--un-color-body-surface-background);
+}
+
+.model-view-icon {
+	padding-right: 0.5rem;
+}
+
+.model-delete-btn {
+	color: var(--un-color-body-text-disabled);
+}
+
+.model-delete-btn:hover {
+	/* color: var(--un-color-body-text-primary); */
+	color: red;
+}
+
+span {
+	display: inline-flex;
+	align-items: center;
+}
+
+.model-title {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	display: inline;
+}
+</style>

--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -15,7 +15,7 @@ export enum RoutePath {
 
 	DocView = '/docs/:id?',
 	Project = '/projects/:projectId',
-	ModelView = '/projects/:projectId/model/:modelId',
+	ModelView = '/projects/:projectId/model/:modelId?',
 	SimulationView = '/projects/:projectId/simulation',
 	Results = '/projects/:projectId/results',
 

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -1,3 +1,4 @@
+import API from '@/api/api';
 import { PetriNet } from '@/utils/petri-net-validator';
 import { IGraph } from '@graph-scaffolder/types';
 
@@ -92,3 +93,5 @@ export const parsePetriNet2IGraph = (model: PetriNet) => {
 
 	return { ...g };
 };
+
+export const getModel = async (modelId: string) => API.get(`/models/${modelId}`);

--- a/packages/client/hmi-client/src/views/Model.vue
+++ b/packages/client/hmi-client/src/views/Model.vue
@@ -8,8 +8,7 @@ import {
 	BaseComputionGraph,
 	pathFn
 } from '@/services/graph';
-import { parsePetriNet2IGraph, NodeData, EdgeData, NodeType } from '@/services/model';
-import API from '@/api/api';
+import { parsePetriNet2IGraph, NodeData, EdgeData, NodeType, getModel } from '@/services/model';
 import { Model } from '@/types/Model';
 
 const props = defineProps<{
@@ -55,15 +54,17 @@ class ModelPlanRenderer extends BaseComputionGraph<NodeData, EdgeData> {
 	}
 }
 
-const getModel = async (modelId: string) => API.get(`/models/${modelId}`);
-
 const model = ref<Model | null>(null);
 // Whenever selectedModelId changes, fetch model with that ID
 watch(
 	() => [props.modelId],
 	async () => {
-		const result = await getModel(props.modelId);
-		model.value = result.data as Model;
+		if (props.modelId !== '') {
+			const result = await getModel(props.modelId);
+			model.value = result.data as Model;
+		} else {
+			model.value = null;
+		}
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
# Description

Add support for loading models from project assets. The user can click on any model name (currently shown as ID) from the side panel to view it. The user can also remove any listed model which will deletes the model from the project assets. Models can be found in the data explorer and can be added to any project from there as well!


Resolves #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide reproduction instructions and list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

