### PR TITLE
fix: force one color scheme

### DIFF
--- a/packages/client/hmi-client/src/assets/css/style.css
+++ b/packages/client/hmi-client/src/assets/css/style.css
@@ -43,7 +43,7 @@
 :root {
 	background-color: var(--un-color-body-surface-background);
 	color: var(--un-color-body-text-primary);
-	color-scheme: light dark;
+	color-scheme: light;
 	font: var(--un-font-body);
 }
 
@@ -54,13 +54,6 @@ body {
 	flex-direction: column;
 	font: inherit;
 	isolation: isolate;
-}
-
-@media (prefers-color-scheme: dark) {
-	:root {
-		/*  background-color: var(--un-color-black-70);
-		color: var(--un-color-black-5); */
-	}
 }
 
 h1 {


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/16928557/205107913-cc1ac5c4-fab3-4f58-9c58-52a2fe8dbf7a.png)


After

![image](https://user-images.githubusercontent.com/16928557/205107999-ff7474cc-e2d5-4f72-8169-a66866cd05a1.png)



# Description

Some controls would render illegibly depending on your OS color scheme settings.
This change forces all instances to use the same color scheme for now.

We can add support for dark mode if and when it becomes a priority, and when we can actually ensure pages look correct in both versions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

