### PR TITLE
feat: extract route names to routes.ts

### DIFF
--- a/packages/client/hmi-client/src/components/Sidebar.vue
+++ b/packages/client/hmi-client/src/components/Sidebar.vue
@@ -26,7 +26,7 @@ import ProfileSidebarPanel from '@/components/sidebar-panel/profile-sidebar-pane
 import SimulationResultSidebarPanel from '@/components/sidebar-panel/simulation-result-sidebar-panel.vue';
 import SimulationPlanSidebarPanel from '@/components/sidebar-panel/simulation-plan-sidebar-panel.vue';
 
-import { RouteName } from '@/router/index';
+import { RouteName } from '@/router/routes';
 import { MODELS, PLANS, SIMULATION_RUNS, Project, DATASETS } from '@/types/Project';
 
 const router = useRouter();

--- a/packages/client/hmi-client/src/components/sidebar-panel/dataset-sidebar-panel.vue
+++ b/packages/client/hmi-client/src/components/sidebar-panel/dataset-sidebar-panel.vue
@@ -29,7 +29,7 @@ import { onMounted, ref } from 'vue';
 import IconClose32 from '@carbon/icons-vue/es/close/32';
 import { deleteAsset } from '@/services/project';
 import { DATASETS } from '@/types/Project';
-import { RouteName } from '@/router';
+import { RouteName } from '@/router/routes';
 import { Dataset } from '@/types/Dataset';
 
 const router = useRouter();

--- a/packages/client/hmi-client/src/components/sidebar-panel/model-sidebar-panel.vue
+++ b/packages/client/hmi-client/src/components/sidebar-panel/model-sidebar-panel.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from 'vue';
 import IconClose32 from '@carbon/icons-vue/es/close/32';
 import { deleteAsset } from '@/services/project';
 import { MODELS } from '@/types/Project';
-import { RouteName } from '@/router';
+import { RouteName } from '@/router/routes';
 import { Model } from '@/types/Model';
 
 const router = useRouter();

--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -11,6 +11,7 @@ import SimulationView from '@/views/Simulation.vue';
 import SimulationResultView from '@/views/SimulationResult.vue';
 import TA2Playground from '@/views/TA2Playground.vue';
 import TheiaView from '@/views/theia.vue';
+import { RouteName } from './routes';
 
 export enum RoutePath {
 	Home = '/',
@@ -26,19 +27,6 @@ export enum RoutePath {
 	Ta2Playground = '/ta2-playground',
 	ResponsivePlaygroundPath = '/responsive-playground',
 	SimulationPlanPlaygroundPath = '/simulation-plan-playground'
-}
-
-// Named routes
-export enum RouteName {
-	DatasetRoute = 'dataset',
-	DocumentRoute = 'document',
-	HomeRoute = 'home',
-	ModelRoute = 'model',
-	ProfileRoute = 'profile',
-	ProjectRoute = 'project',
-	ProvenanceRoute = 'provenance',
-	SimulationRoute = 'simulation',
-	SimulationResultRoute = 'simulationResult'
 }
 
 const routes = [

--- a/packages/client/hmi-client/src/router/routes.ts
+++ b/packages/client/hmi-client/src/router/routes.ts
@@ -1,0 +1,11 @@
+export enum RouteName {
+	DatasetRoute = 'dataset',
+	DocumentRoute = 'document',
+	HomeRoute = 'home',
+	ModelRoute = 'model',
+	ProfileRoute = 'profile',
+	ProjectRoute = 'project',
+	ProvenanceRoute = 'provenance',
+	SimulationRoute = 'simulation',
+	SimulationResultRoute = 'simulationResult'
+}

--- a/packages/client/hmi-client/src/views/Model.vue
+++ b/packages/client/hmi-client/src/views/Model.vue
@@ -12,6 +12,7 @@ import { parsePetriNet2IGraph, NodeData, EdgeData, NodeType, getModel } from '@/
 import { Model } from '@/types/Model';
 import Button from '@/components/Button.vue';
 import { useRouter } from 'vue-router';
+import { RouteName } from '@/router/routes';
 
 const props = defineProps<{
 	modelId: string;
@@ -91,8 +92,7 @@ watch([model, graphElement], async () => {
 // FIXME: update after Dec 8 demo
 const router = useRouter();
 const goToSimulationPlanPage = () => {
-	// FIXME: can't use RouteName.SimulationRoute because of dependency cycle.
-	router.push({ name: 'simulation' });
+	router.push({ name: RouteName.SimulationRoute });
 };
 </script>
 

--- a/packages/client/hmi-client/src/views/Simulation.vue
+++ b/packages/client/hmi-client/src/views/Simulation.vue
@@ -11,6 +11,7 @@ import {
 import { parseSimulationPlan2IGraph } from '@/services/simulation';
 import API from '@/api/api';
 import { curveBasis } from 'd3';
+import { RouteName } from '@/router/routes';
 
 // FIXME: remove after Dec 8 demo
 const IS_DEC_8_DEMO = true;
@@ -133,8 +134,7 @@ const nextSlide = () => {
 };
 const router = useRouter();
 const goToSimulationResultsPage = () => {
-	// FIXME: can't use RouteName.SimulationResultRoute because it would result in a dependency cycle
-	router.push({ name: 'simulationResult' });
+	router.push({ name: RouteName.SimulationResultRoute });
 };
 </script>
 


### PR DESCRIPTION
# Description

Previously we couldn't import the `RouteName` enum into any of the views because it lived in `router/index.ts`. That file imports all of the views, so importing it into a view would create a dependency cycle.

Now the enum is extracted to its own file that can be safely imported in `router/index.ts` and each view that needs it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Technical debt

# How Has This Been Tested?

- Can still jump to different views using the sidebar
- Can still jump to the Workflow page by clicking the button in the Model right side panel
- Can still jump to the simulation result page by clicking through the 9 sketches in the Workflow page.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

