### PR TITLE
feat: clean up home page carousel

### DIFF
--- a/packages/client/hmi-client/src/components/Sidebar.vue
+++ b/packages/client/hmi-client/src/components/Sidebar.vue
@@ -96,7 +96,8 @@ const BUTTON_ORDER = [
 	RouteName.SimulationRoute,
 	RouteName.ModelRoute,
 	RouteName.DatasetRoute,
-	RouteName.SimulationResultRoute
+	RouteName.SimulationResultRoute,
+	RouteName.DocumentRoute
 ];
 
 const DISABLED_BUTTONS = [RouteName.ProvenanceRoute, RouteName.ProfileRoute];

--- a/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
+++ b/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
@@ -41,13 +41,13 @@ function getRandomImage() {
 </script>
 <template>
 	<div class="article-card">
-		<div class="card-image" v-if="images.length > 0">
-			<img id="img" :src="'data:image/jpeg;base64,' + shownImage" :alt="''" />
-		</div>
-		<div class="card-image" v-else>
-			<img id="img" :src="'data:image/jpeg;base64,' + getRandomImage()" :alt="''" />
-			<!-- <IconNoImage32 /> -->
-		</div>
+		<img
+			v-if="images.length > 0"
+			class="card-image"
+			:src="'data:image/jpeg;base64,' + shownImage"
+			alt="''"
+		/>
+		<img v-else class="card-image" :src="'data:image/jpeg;base64,' + getRandomImage()" alt="''" />
 		<footer>{{ articleName }}</footer>
 	</div>
 </template>
@@ -58,7 +58,7 @@ function getRandomImage() {
 	background-color: var(--un-color-body-surface-primary);
 	display: flex;
 	flex-direction: column;
-	justify-content: flex-end;
+	align-items: center;
 	height: 15rem;
 	min-width: 20rem;
 	border-radius: 0.5rem;
@@ -73,14 +73,9 @@ footer {
 	padding: 0.5rem 1rem;
 }
 
-svg {
-	color: var(--un-color-body-text-disabled);
-	cursor: pointer;
-	margin: auto;
-}
 .card-image {
-	height: inherit;
-	min-width: inherit;
-	display: inherit;
+	flex: 1;
+	min-height: 0;
+	width: fit-content;
 }
 </style>

--- a/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
+++ b/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
@@ -71,6 +71,7 @@ function getRandomImage() {
 footer {
 	border-top: 1px solid var(--un-color-body-stroke);
 	padding: 0.5rem 1rem;
+	align-self: stretch;
 }
 
 .card-image {

--- a/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
+++ b/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
@@ -1,25 +1,18 @@
 <template>
-	<div class="breakdown-pane-container">
+	<div class="selected-article-pane">
 		<div class="add-selected-buttons">
 			<dropdown-button
-				v-if="selectedSearchItems.length > 0"
 				:inner-button-label="'Add to a project'"
 				:is-dropdown-left-aligned="false"
 				:items="projectsNames"
 				@item-selected="addAssetsToProject"
 			/>
 		</div>
-		<div class="selected-items-container">
-			<div v-for="(item, indx) in selectedSearchItems" class="selected-item" :key="`item-${indx}`">
-				<div class="content">
-					<div>Publisher: {{ item.publisher }}</div>
-					<div>Author: {{ item.author.map((a) => a.name).join(', ') }}</div>
-					<div>Abstract: {{ formatAbstract(item) }}</div>
-					<div>Journal: {{ item.journal }}</div>
-					<div>Doc ID:: {{ item.gddid }}</div>
-				</div>
-			</div>
-		</div>
+		<div>Publisher: {{ selectedArticle.publisher }}</div>
+		<div>Author: {{ selectedArticle.author.map((a) => a.name).join(', ') }}</div>
+		<div>Abstract: {{ formatAbstract(selectedArticle) }}</div>
+		<div>Journal: {{ selectedArticle.journal }}</div>
+		<div>Doc ID:: {{ selectedArticle.gddid }}</div>
 	</div>
 </template>
 
@@ -33,8 +26,8 @@ import * as ProjectService from '@/services/project';
 import { addPublication } from '@/services/external';
 
 const props = defineProps({
-	selectedSearchItems: {
-		type: Array as PropType<XDDArticle[]>,
+	selectedArticle: {
+		type: Object as PropType<XDDArticle>,
 		required: true
 	}
 });
@@ -49,29 +42,27 @@ const projectsNames = computed(() => projectsList.value.map((p) => p.name));
 
 const addResourcesToProject = async (projectId: string) => {
 	// send selected items to the store
-	props.selectedSearchItems.forEach(async (selectedItem) => {
-		const body: PublicationAsset = {
-			id: projectId,
-			xdd_uri: selectedItem.gddid,
-			title: selectedItem.title
-		};
+	const body: PublicationAsset = {
+		id: projectId,
+		xdd_uri: props.selectedArticle.gddid,
+		title: props.selectedArticle.title
+	};
 
-		// FIXME: handle cases where assets is already added to the project
+	// FIXME: handle cases where assets is already added to the project
 
-		// first, insert into the proper table/collection
-		const res = await addPublication(body);
-		if (res) {
-			const publicationId = res.id;
+	// first, insert into the proper table/collection
+	const res = await addPublication(body);
+	if (res) {
+		const publicationId = res.id;
 
-			// then, link and store in the project assets
-			const assetsType = PUBLICATIONS;
-			await ProjectService.addAsset(projectId, assetsType, publicationId);
+		// then, link and store in the project assets
+		const assetsType = PUBLICATIONS;
+		await ProjectService.addAsset(projectId, assetsType, publicationId);
 
-			// update local copy of project assets
-			validProject.value?.assets.publications.push(publicationId);
-			resources.activeProjectAssets?.publications.push(body);
-		}
-	});
+		// update local copy of project assets
+		validProject.value?.assets.publications.push(publicationId);
+		resources.activeProjectAssets?.publications.push(body);
+	}
 };
 
 // TODO: May need more formatting than just replcing <p></p> in future
@@ -79,10 +70,8 @@ const formatAbstract = (item: XDDArticle) =>
 	item.abstract.replace('<p>', '\n').replace('</p>', '\n') || '[no abstract]';
 
 const addAssetsToProject = async (projectName?: string) => {
-	if (props.selectedSearchItems.length === 0) return;
-
 	let projectId = '';
-	if (projectName !== undefined && typeof projectName === 'string') {
+	if (projectName !== undefined) {
 		const project = projectsList.value.find((p) => p.name === projectName);
 		projectId = project?.id as string;
 	} else {
@@ -104,60 +93,19 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.invalid-project {
-	background-color: gray;
-	cursor: not-allowed;
-}
-
-.selected-title {
-	margin-bottom: 5px;
-	font-size: larger;
-	text-align: center;
-	font-weight: bold;
-	color: var(--un-color-accent);
+.selected-article-pane {
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
 }
 
 .add-selected-buttons {
 	display: flex;
+	margin-bottom: 2rem;
 }
 
 .add-selected-buttons button {
-	margin-bottom: 5px;
-	padding-top: 4px;
-	padding-bottom: 4px;
-}
-
-.breakdown-pane-container {
-	margin-bottom: 40px;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-}
-
-.selected-items-container {
-	display: flex;
-	flex-direction: column;
-	overflow-y: auto;
-	margin-top: 10px;
-}
-
-.selected-items-container .selected-item {
-	padding: 5px;
-	background: var(--un-color-white);
-	margin-top: 1px;
-}
-
-.selected-items-container .item-header {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.selected-items-container .item-header .item-title {
-	font-weight: 500;
-}
-
-.selected-items-container .item-header .icon {
-	margin-right: 5px;
+	margin-bottom: 2px;
 }
 </style>

--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -65,7 +65,11 @@ const close = () => {
 					<h4>{{ selectedPaper.title }}</h4>
 					<IconClose32 class="close-button" @click="close()" />
 				</div>
-				<selected-article-pane :selected-search-items="[selectedPaper]" @close="close()" />
+				<selected-article-pane
+					class="selected-article-pane"
+					:selected-article="selectedPaper"
+					@close="close()"
+				/>
 			</div>
 		</div>
 
@@ -258,8 +262,8 @@ li > * {
 .modal-header {
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: 2rem;
 }
+
 .close-button {
 	width: 2rem;
 	height: 2rem;
@@ -269,5 +273,9 @@ li > * {
 
 .close-button:hover {
 	opacity: 100%;
+}
+
+.selected-article-pane {
+	margin: 2rem 0;
 }
 </style>

--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -5,6 +5,7 @@ import ArticlesCard from '@/components/articles/ArticlesCard.vue';
 import IconTime32 from '@carbon/icons-vue/es/time/32';
 import IconChevronLeft32 from '@carbon/icons-vue/es/chevron--left/32';
 import IconChevronRight32 from '@carbon/icons-vue/es/chevron--right/32';
+import IconClose32 from '@carbon/icons-vue/es/close/16';
 import { onMounted, ref } from 'vue';
 import { Project } from '@/types/Project';
 import { XDDArticle, XDDSearchParams } from '@/types/XDD';
@@ -57,26 +58,18 @@ const close = () => {
 
 <template>
 	<section>
-		<h2>Projects</h2>
 		<!-- modal window for showing selected paper -->
-		<div v-if="selectedPaper !== undefined" class="modal-mask-paper">
-			<div class="modal-wrapper-paper" @click.stop="selectedPaper ? {} : close()">
-				<div class="modal-container-paper">
-					<div class="modal-header">
-						<button type="button" class="close-button" @click="close()">Close</button>
-						{{ selectedPaper.title }}
-					</div>
-					<div class="modal-body-paper">
-						<selected-article-pane
-							class="selected-resources-pane"
-							:selected-search-items="[selectedPaper]"
-							@close="close()"
-						/>
-					</div>
+		<div v-if="selectedPaper !== undefined" class="selected-paper-modal-mask" @click="close()">
+			<div class="selected-paper-modal" @click.stop>
+				<div class="modal-header">
+					<h4>{{ selectedPaper.title }}</h4>
+					<IconClose32 class="close-button" @click="close()" />
 				</div>
+				<selected-article-pane :selected-search-items="[selectedPaper]" @close="close()" />
 			</div>
 		</div>
 
+		<h2>Projects</h2>
 		<template v-for="[key, value] in categories" :key="key">
 			<div>
 				<header>
@@ -239,7 +232,7 @@ li > * {
 	margin-bottom: 3rem;
 }
 
-.modal-mask-paper {
+.selected-paper-modal-mask {
 	position: fixed;
 	z-index: 9998;
 	top: 0;
@@ -247,39 +240,34 @@ li > * {
 	width: 100%;
 	height: 100%;
 	background-color: rgba(0, 0, 0, 0.5);
-	display: table;
-	transition: opacity 0.3s ease;
-	overflow-y: auto;
+	display: flex;
+	align-items: center;
 }
-.modal-wrapper-paper {
-	display: table-cell;
-	vertical-align: middle;
-	height: 100%;
-}
-.modal-container-paper {
+.selected-paper-modal {
 	position: relative;
 	width: 500px;
 	margin: 0px auto;
-	background-color: #fff;
+	background-color: var(--un-color-body-surface-primary);
 	border-radius: 2px;
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
-	transition: all 0.3s ease;
 	overflow-y: auto;
-	height: 75%;
+	max-height: 75%;
+	padding: 1rem;
 }
 
-.modal-header-paper {
-	padding: 15px;
-}
 .modal-header {
-	max-width: 90%; /* Leave room for close button */
-}
-
-.modal-body-paper {
-	padding: 15px;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 2rem;
 }
 .close-button {
-	position: absolute;
-	right: 0;
+	width: 2rem;
+	height: 2rem;
+	cursor: pointer;
+	opacity: 50%;
+}
+
+.close-button:hover {
+	opacity: 100%;
 }
 </style>


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/16928557/206031206-193458da-0979-4dee-ab0d-202d1ca9e141.png)
Clean up carousel styles (images used to overflow card)

![image](https://user-images.githubusercontent.com/16928557/206031261-8ee437de-8297-4009-9c30-1fd8a9f28bef.png)
Clean up modal that opens when you click a card (and you can now click the dim background to close the modal)

Simplify selected-article-pane prop type.
Remove a bunch of unused styles.
Add Papers tab back to side bar (accidentally removed it recently)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing instructions

Go to the home page.
Ensure cards load and their images don't overflow.
Click a card and ensure the modal looks alright.
Ensure the Papers tab is visible in the sidebar once more.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

