### PR TITLE
fix: sidebar state and styles

### DIFF
--- a/packages/client/hmi-client/src/components/Sidebar.vue
+++ b/packages/client/hmi-client/src/components/Sidebar.vue
@@ -3,7 +3,7 @@
  * Sidebar component for navigating view.
  * */
 import { ref, computed } from 'vue';
-import { RouteParamsRaw, useRouter } from 'vue-router';
+import { RouteParamsRaw, useRoute, useRouter } from 'vue-router';
 
 // Icons
 import IconCaretLeft16 from '@carbon/icons-vue/es/caret--left/16';
@@ -36,8 +36,9 @@ function openSidePanel() {
 	isSidePanelClose.value = false;
 }
 
-// The Project page is the default
-const selectedView = ref<RouteName>(RouteName.ProjectRoute);
+const route = useRoute();
+// Assumes that the only routes we'll navigate to are represented in RouteName
+const selectedView = computed(() => (route.name as RouteName) ?? RouteName.ProjectRoute);
 const showSidePanel = computed(() => selectedView.value !== RouteName.ProjectRoute);
 
 function showSidebar(view: RouteName): boolean {
@@ -85,7 +86,6 @@ const openView = (view: RouteName) => {
 
 		// Change the view
 		router.push({ name: view, params });
-		selectedView.value = view;
 	} else if (showSidebar(view) && !isSidePanelClose.value) {
 		openSidePanel();
 	}
@@ -249,8 +249,7 @@ aside {
 }
 
 aside.side-panel-close {
-	padding: 0;
-	width: 0;
+	display: none;
 }
 
 aside header {


### PR DESCRIPTION
https://user-images.githubusercontent.com/16928557/206210072-4bc25784-ca30-4633-8509-2dde0876cff1.mov

# Description

Let route decide which sidebar button is active. This fixes the bug where navigating to different spaces without clicking the sidebar buttons wouldn't cause the sidebar to update.

Fix visual bug where panel title was still visible when panel is closed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Navigate to a model, click "add to workflow". Side bar should update to workflows space.
Click the sketches, after the 9th, you should be taken to the matrix page and the sidebar should update.

Hide the sidebar and the panel title should not be visible

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

