### PR TITLE
feat: home page refinements

### DIFF
--- a/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
+++ b/packages/client/hmi-client/src/components/articles/ArticlesCard.vue
@@ -62,10 +62,10 @@ function getRandomImage() {
 	height: 15rem;
 	min-width: 20rem;
 	border-radius: 0.5rem;
-	margin: 0.5rem;
-	transition: 0.2s;
 	text-align: left;
 	cursor: pointer;
+	/* Round the image corners by clipping them to fit the card */
+	overflow: hidden;
 }
 
 footer {

--- a/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
+++ b/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
@@ -3,7 +3,7 @@
 		<div class="add-selected-buttons">
 			<dropdown-button
 				:inner-button-label="'Add to a project'"
-				:is-dropdown-left-aligned="false"
+				:is-dropdown-left-aligned="true"
 				:items="projectsNames"
 				@item-selected="addAssetsToProject"
 			/>

--- a/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
+++ b/packages/client/hmi-client/src/components/articles/selected-article-pane.vue
@@ -98,6 +98,8 @@ onMounted(async () => {
 	display: flex;
 	flex-direction: column;
 	overflow-y: auto;
+	/* HACK: Ensure the pane is at least as long as the dropdown-button's list can be so the list isn't clipped at the bottom. */
+	padding-bottom: 300px;
 }
 
 .add-selected-buttons {

--- a/packages/client/hmi-client/src/components/projects/NewProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/NewProjectCard.vue
@@ -61,7 +61,6 @@ async function createNewProject() {
 	height: 15rem;
 	min-width: 20rem;
 	border-radius: 0.5rem;
-	margin: 0.5rem;
 	transition: 0.2s;
 	text-align: left;
 }

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -26,8 +26,6 @@ const props = withDefaults(defineProps<Props>(), {
 	height: 15rem;
 	min-width: 20rem;
 	border-radius: 0.5rem;
-	margin: 0.5rem;
-	transition: 0.2s;
 	text-align: left;
 	cursor: pointer;
 }

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -30,7 +30,7 @@ const placeholderRandomColorOpacity = Math.random();
 	border-radius: 0.5rem;
 	text-align: left;
 	cursor: pointer;
-	/* Round the image corners by clipping them to fit the card */
+	/* Round the image/placeholder color's corners by clipping them to fit the card */
 	overflow: hidden;
 }
 

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
-import IconNoImage32 from '@carbon/icons-vue/es/no-image/32';
-
 export interface Props {
 	name: string;
 }
 const props = withDefaults(defineProps<Props>(), {
 	name: 'Default Project Name'
 });
+
+const placeholderRandomColorOpacity = Math.random();
 </script>
 
 <template>
 	<div class="project-card">
-		<IconNoImage32 />
+		<div class="placeholder-color">
+			<div class="placeholder-color-random" :style="{ opacity: placeholderRandomColorOpacity }" />
+		</div>
 		<footer>{{ props?.name }}</footer>
 	</div>
 </template>
@@ -28,6 +30,8 @@ const props = withDefaults(defineProps<Props>(), {
 	border-radius: 0.5rem;
 	text-align: left;
 	cursor: pointer;
+	/* Round the image corners by clipping them to fit the card */
+	overflow: hidden;
 }
 
 footer {
@@ -35,9 +39,19 @@ footer {
 	padding: 0.5rem 1rem;
 }
 
-svg {
-	color: var(--un-color-body-text-disabled);
-	cursor: pointer;
-	margin: auto;
+.placeholder-color {
+	flex: 1;
+	min-height: 0;
+	background: var(--un-color-accent-lighter);
+	position: relative;
+}
+
+.placeholder-color-random {
+	background: var(--un-color-accent-light);
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 100%;
 }
 </style>

--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -97,7 +97,8 @@ const scroll = (direction: 'right' | 'left', event: PointerEvent) => {
 				<li class="card">
 					<NewProjectCard />
 				</li>
-				<li v-for="(project, index) in projects" class="card" :key="index">
+				<!-- .slice() to copy the array, .reverse() to put new projects at the left of the list instead of the right -->
+				<li v-for="(project, index) in projects.slice().reverse()" class="card" :key="index">
 					<router-link
 						style="text-decoration: none; color: inherit"
 						:to="'/projects/' + project.id"

--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -6,22 +6,19 @@ import IconTime32 from '@carbon/icons-vue/es/time/32';
 import IconChevronLeft32 from '@carbon/icons-vue/es/chevron--left/32';
 import IconChevronRight32 from '@carbon/icons-vue/es/chevron--right/32';
 import IconClose32 from '@carbon/icons-vue/es/close/16';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { Project } from '@/types/Project';
 import { XDDArticle, XDDSearchParams } from '@/types/XDD';
 import * as ProjectService from '@/services/project';
 import { searchXDDArticles } from '@/services/data';
 import selectedArticlePane from '@/components/articles/selected-article-pane.vue';
 
-const enum Categories {
-	Recents = 'Recents',
-	Trending = 'Trending',
-	Epidemiology = 'Epidemiology'
-}
-
-const categories = new Map<string, { icon: object }>([[Categories.Recents, { icon: IconTime32 }]]);
-
 const projects = ref<Project[]>([]);
+// Only display projects with at least one related article
+// Only display at most 5 projects
+const projectsToDisplay = computed(() =>
+	projects.value.filter((project) => project.relatedArticles.length > 0).slice(0, 5)
+);
 const relevantArticles = ref<XDDArticle[]>([]);
 const relevantSearchTerm = 'COVID-19';
 const relevantSearchParams: XDDSearchParams = { perPage: 30 };
@@ -54,6 +51,21 @@ const selectArticle = (item: XDDArticle) => {
 const close = () => {
 	selectedPaper.value = undefined;
 };
+
+const SCROLL_INCREMENT_IN_REM = 21;
+const scroll = (direction: 'right' | 'left', event: PointerEvent) => {
+	const chevronElement = event.target as HTMLElement;
+	const cardListElement = chevronElement.parentElement?.querySelector('ul');
+	if (cardListElement === null || cardListElement === undefined) return;
+	const marginLeftString =
+		cardListElement.style.marginLeft === '' ? '0' : cardListElement.style.marginLeft;
+	const currentMarginLeft = parseInt(marginLeftString, 10);
+	const changeInRem = direction === 'right' ? -SCROLL_INCREMENT_IN_REM : SCROLL_INCREMENT_IN_REM;
+	const newMarginLeft = currentMarginLeft + changeInRem;
+	// Don't let the list scroll far enough right that we see space before the
+	//	first card.
+	cardListElement.style.marginLeft = `${newMarginLeft > 0 ? 0 : newMarginLeft}rem`;
+};
 </script>
 
 <template>
@@ -74,63 +86,54 @@ const close = () => {
 		</div>
 
 		<h2>Projects</h2>
-		<template v-for="[key, value] in categories" :key="key">
-			<div>
-				<header>
-					<component :is="value.icon" />
-					<h3>{{ key }}</h3>
-				</header>
-				<div class="project-carousel">
-					<IconChevronLeft32 class="chevron-left" />
-					<ul>
-						<li v-if="key === Categories.Recents">
-							<NewProjectCard />
-						</li>
-						<li v-for="(project, index) in projects" :key="index">
-							<router-link
-								style="text-decoration: none; color: inherit"
-								:to="'/projects/' + project.id"
-								:projectId="project.id"
-							>
-								<ProjectCard :name="project.name" />
-							</router-link>
-						</li>
-					</ul>
-					<IconChevronRight32 class="chevron-right" />
-				</div>
-			</div>
-			<!-- Hot Topics carousel -->
-			<div>
-				<header>
-					<h3>Latest on {{ relevantSearchTerm }}</h3>
-				</header>
-				<div class="project-carousel">
-					<ul>
-						<li v-for="(paper, index) in relevantArticles" :key="index">
-							<div @click="selectArticle(paper)">
-								<ArticlesCard :article="paper" />
-							</div>
-						</li>
-					</ul>
-				</div>
-			</div>
-			<!-- For the top 5 projects show related articles -->
-			<!-- TODO: Only show this if there are related articles to begin with -->
-			<div v-for="(project, index) in projects.slice(0, 5)" :key="index">
-				<header>
-					<h3>Related to: {{ project.name }}</h3>
-				</header>
-				<div class="project-carousel">
-					<ul>
-						<li v-for="(paper, j) in project.relatedArticles" :key="j">
-							<div @click="selectArticle(paper)">
-								<ArticlesCard :article="paper" />
-							</div>
-						</li>
-					</ul>
-				</div>
-			</div>
-		</template>
+		<div class="carousel">
+			<header>
+				<component :is="IconTime32" />
+				<h3>Recent</h3>
+			</header>
+			<IconChevronLeft32 class="chevron chevron-left" @click="scroll('left', $event)" />
+			<IconChevronRight32 class="chevron chevron-right" @click="scroll('right', $event)" />
+			<ul>
+				<li class="card">
+					<NewProjectCard />
+				</li>
+				<li v-for="(project, index) in projects" class="card" :key="index">
+					<router-link
+						style="text-decoration: none; color: inherit"
+						:to="'/projects/' + project.id"
+						:projectId="project.id"
+					>
+						<ProjectCard :name="project.name" />
+					</router-link>
+				</li>
+			</ul>
+		</div>
+		<!-- Hot Topics carousel -->
+		<div class="carousel" v-if="relevantArticles.length > 0">
+			<header>
+				<h3>Latest on {{ relevantSearchTerm }}</h3>
+			</header>
+			<IconChevronLeft32 class="chevron chevron-left" @click="scroll('left', $event)" />
+			<IconChevronRight32 class="chevron chevron-right" @click="scroll('right', $event)" />
+			<ul>
+				<li v-for="(paper, index) in relevantArticles" :key="index" class="card">
+					<ArticlesCard :article="paper" @click="selectArticle(paper)" />
+				</li>
+			</ul>
+		</div>
+		<!-- Show related articles for the top 5 projects -->
+		<div v-for="(project, index) in projectsToDisplay" :key="index" class="carousel">
+			<header>
+				<h3>Related to: {{ project.name }}</h3>
+			</header>
+			<IconChevronLeft32 class="chevron chevron-left" @click="scroll('left', $event)" />
+			<IconChevronRight32 class="chevron chevron-right" @click="scroll('right', $event)" />
+			<ul>
+				<li v-for="(paper, j) in project.relatedArticles" :key="j" class="card">
+					<ArticlesCard :article="paper" @click="selectArticle(paper)" />
+				</li>
+			</ul>
+		</div>
 	</section>
 </template>
 
@@ -153,6 +156,7 @@ header {
 
 h2 {
 	font: var(--un-font-h2);
+	margin-left: 4rem;
 }
 
 h3 {
@@ -161,7 +165,6 @@ h3 {
 
 h2,
 header {
-	margin-left: 4rem;
 	margin-top: 1rem;
 }
 
@@ -170,69 +173,66 @@ header svg {
 	margin-right: 0.5rem;
 }
 
-.project-carousel {
-	align-items: center;
-	display: flex;
-	z-index: -1;
-	overflow-x: auto;
-	overflow-y: hidden;
+.carousel {
+	position: relative;
+	margin-left: 4rem;
 }
 
-.project-carousel svg {
-	/* 	chevron arrows - see about making the right ones appear as required (by watching scrollbar position)
+.carousel ul {
+	align-items: center;
+	display: flex;
+	margin: 0.5rem 0;
+}
+
+.chevron {
+	/* 	see about making the right ones appear as required (by watching scrollbar position)
 		eg. if I am on the very left of the carousel don't show the left arrow
 	*/
 	cursor: pointer;
-	margin: 0 0.5rem 1rem 1rem;
+	margin: 0 1rem;
 	position: absolute;
+	top: 50%;
 	visibility: visible;
-	z-index: 2;
-}
-
-/* Hide the arrows for now */
-.project-carousel svg[class|='chevron'] {
-	display: none;
-}
-
-.chevron-right {
-	right: 0;
-}
-
-.project-carousel svg:hover {
-	background-color: var(--un-color-body-surface-background);
+	z-index: 3;
+	background: var(--un-color-body-surface-secondary);
 	border-radius: 10rem;
+}
+
+.chevron:hover {
+	background-color: var(--un-color-body-surface-background);
 	color: var(--un-color-accent);
 }
 
-.project-carousel:hover svg {
-	visibility: visible;
+.chevron-left {
+	left: -4rem;
+}
+
+.chevron-right {
+	right: 0rem;
 }
 
 ul {
 	align-items: center;
 	display: inline-flex;
 	gap: 0.5rem;
-	margin: 0.5rem 4rem;
+	transition: margin-left 0.2s;
 }
 
 li {
-	height: 15rem;
 	list-style: none;
-	min-width: 20rem;
-	position: relative;
 }
 
-a:hover {
-	transform: scale(1.2);
-	z-index: 2;
+.card {
+	z-index: 1;
 	transition: 0.2s;
 }
 
-li > * {
-	position: absolute;
+.card:hover {
+	transform: scale(1.2);
+	z-index: 2;
 }
 
-.project-carousel:last-of-type {
+.carousel:last-of-type {
 	margin-bottom: 3rem;
 }
 

--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -62,7 +62,7 @@ const scroll = (direction: 'right' | 'left', event: PointerEvent) => {
 	const currentMarginLeft = parseInt(marginLeftString, 10);
 	const changeInRem = direction === 'right' ? -SCROLL_INCREMENT_IN_REM : SCROLL_INCREMENT_IN_REM;
 	const newMarginLeft = currentMarginLeft + changeInRem;
-	// Don't let the list scroll far enough right that we see space before the
+	// Don't let the list scroll far enough left that we see space before the
 	//	first card.
 	cardListElement.style.marginLeft = `${newMarginLeft > 0 ? 0 : newMarginLeft}rem`;
 };

--- a/packages/client/hmi-client/tests/e2e/base.spec.ts
+++ b/packages/client/hmi-client/tests/e2e/base.spec.ts
@@ -14,7 +14,7 @@ test.describe('main landing page test', () => {
 		await expect(page).toHaveTitle(/TERArium/);
 
 		// create a locator
-		const header = page.locator('text=Recents');
+		const header = page.locator('text=Recent');
 
 		// Expect an attribute "to be strictly equal" to the value.
 		await expect(header).toBeVisible();


### PR DESCRIPTION
https://user-images.githubusercontent.com/16928557/206247337-66662c68-029a-44bb-8bff-224137166c71.mov


# Description

- Don't show carousel rows for projects without papers.
- Apply card hover animation to all cards.
- Add arrow buttons to scroll through the list, remove scrollbar.
- Randomly select a green colour between `accent-light` and `accent-lighter` for each project card.
- Display new projects at the left of the list rather than the right
- Stop dropdown from being clipped after drilling down on a paper and selecting a project with a long name.

Note that there's some weird behaviour when you try to scroll a list farther to the right than it should be able to go, we'll probably need to wait till after the demo to address that.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

