### PR TITLE
ci: ci build optimizations

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,104 +58,104 @@ jobs:
         run: |
           echo ${{ steps.targets.outputs.matrix }}
 
-  build-push:
-    name: build-bake-push
-    runs-on: ubuntu-22.04
-    if: github.ref_name == 'main' || contains(github.event.ref, '/tags/')
-    permissions:
-      packages: write
-      contents: read
-    # this job depends on the following jobs before beginning
-    needs:
-      - targets
-      - lint
-      - lint-client
-      - test-client
+  # build-push:
+  #   name: build-bake-push
+  #   runs-on: ubuntu-22.04
+  #   if: github.ref_name == 'main' || contains(github.event.ref, '/tags/')
+  #   permissions:
+  #     packages: write
+  #     contents: read
+  #   # this job depends on the following jobs before beginning
+  #   needs:
+  #     - targets
+  #     - lint
+  #     - lint-client
+  #     - test-client
 
-    # 2.0 - Build a matrix strategy from the retrieved target list
-    strategy:
-      fail-fast: true
-      matrix:
-        target: ${{ fromJson(needs.targets.outputs.matrix) }}
+  #   # 2.0 - Build a matrix strategy from the retrieved target list
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target: ${{ fromJson(needs.targets.outputs.matrix) }}
 
-    steps:
-      # 2.1 - Checkout the repository
-      - name: Checkout the repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+  #   steps:
+  #     # 2.1 - Checkout the repository
+  #     - name: Checkout the repository
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.event.workflow_run.head_branch }}
 
-      # 2.2 - Install the appropriate tool based on target
-      - name: Setup Node v18.8.0
-        if: matrix.target == 'hmi-client'
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.8.0
-          cache: 'yarn'
+  #     # 2.2 - Install the appropriate tool based on target
+  #     - name: Setup Node v18.8.0
+  #       if: matrix.target == 'hmi-client'
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 18.8.0
+  #         cache: 'yarn'
 
-      - name: Validate GradleW JAR
-        if: matrix.target != 'hmi-client'
-        uses: gradle/wrapper-validation-action@9aa31f26bc8e536d1faf4b332bb8365350743a18
+  #     - name: Validate GradleW JAR
+  #       if: matrix.target != 'hmi-client'
+  #       uses: gradle/wrapper-validation-action@9aa31f26bc8e536d1faf4b332bb8365350743a18
 
-      - name: Setup Java v17
-        if: matrix.target != 'hmi-client'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: gradle
+  #     - name: Setup Java v17
+  #       if: matrix.target != 'hmi-client'
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         distribution: 'temurin'
+  #         java-version: 17
+  #         cache: gradle
 
-      # 2.3 - Build all packages and move them to required location for Docker
-      - name: Build
-        run: |
-          make image-${{ matrix.target }}
+  #     # 2.3 - Build all packages and move them to required location for Docker
+  #     - name: Build
+  #       run: |
+  #         make image-${{ matrix.target }}
 
-      # 2.4 - Set environment variables to be used within the bake file
-      # NOTE: this overrides the defaults and should be specific to this deployment
-      - name: set env variables for bakefile
-        run: |
-          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
-            TAG=latest
-          else
-            SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
-            if [[ -n $SEMVER ]]; then
-              TAG=${SEMVER}
-            else
-              TAG=${{ github.ref_name }}
-            fi
-          fi
+  #     # 2.4 - Set environment variables to be used within the bake file
+  #     # NOTE: this overrides the defaults and should be specific to this deployment
+  #     - name: set env variables for bakefile
+  #       run: |
+  #         if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
+  #           TAG=latest
+  #         else
+  #           SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
+  #           if [[ -n $SEMVER ]]; then
+  #             TAG=${SEMVER}
+  #           else
+  #             TAG=${{ github.ref_name }}
+  #           fi
+  #         fi
 
-          echo "$TAG"
+  #         echo "$TAG"
 
-          echo "VERSION=${TAG,,}" >> ${GITHUB_ENV}
-          echo "DOCKER_REGISTRY=${{ env.REGISTRY }}" >> ${GITHUB_ENV}
-          # Lowercase the owner for docker image naming conventions
-          echo "DOCKER_ORG=${OWNER,,}" >> ${GITHUB_ENV}
-          java --version
+  #         echo "VERSION=${TAG,,}" >> ${GITHUB_ENV}
+  #         echo "DOCKER_REGISTRY=${{ env.REGISTRY }}" >> ${GITHUB_ENV}
+  #         # Lowercase the owner for docker image naming conventions
+  #         echo "DOCKER_ORG=${OWNER,,}" >> ${GITHUB_ENV}
+  #         java --version
 
-      # 2.5 - Login against the docker registry
-      - name: Login to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     # 2.5 - Login against the docker registry
+  #     - name: Login to registry ${{ env.REGISTRY }}
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 2.6 - Setup QEMU for platform emulation
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+  #     # 2.6 - Setup QEMU for platform emulation
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v2
 
-      # 2.7 - Setup Docker BuildX for multi platform building
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+  #     # 2.7 - Setup Docker BuildX for multi platform building
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
 
-      # 2.8 - Build and push Docker Images
-      - name: Build Images using BuildX Bake
-        uses: docker/bake-action@v2
-        with:
-          files: ./${{ env.BAKE_FILE }}
-          targets: ${{ matrix.target }}
-          push: true
-          set: |
-            *.cache-from=type=gha,scope=build-${{ matrix.target }}
-            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
+  #     # 2.8 - Build and push Docker Images
+  #     - name: Build Images using BuildX Bake
+  #       uses: docker/bake-action@v2
+  #       with:
+  #         files: ./${{ env.BAKE_FILE }}
+  #         targets: ${{ matrix.target }}
+  #         push: true
+  #         set: |
+  #           *.cache-from=type=gha,scope=build-${{ matrix.target }}
+  #           *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,104 +58,104 @@ jobs:
         run: |
           echo ${{ steps.targets.outputs.matrix }}
 
-  # build-push:
-  #   name: build-bake-push
-  #   runs-on: ubuntu-22.04
-  #   if: github.ref_name == 'main' || contains(github.event.ref, '/tags/')
-  #   permissions:
-  #     packages: write
-  #     contents: read
-  #   # this job depends on the following jobs before beginning
-  #   needs:
-  #     - targets
-  #     - lint
-  #     - lint-client
-  #     - test-client
+  build-push:
+    name: build-bake-push
+    runs-on: ubuntu-22.04
+    if: github.ref_name == 'main' || contains(github.event.ref, '/tags/')
+    permissions:
+      packages: write
+      contents: read
+    # this job depends on the following jobs before beginning
+    needs:
+      - targets
+      - lint
+      - lint-client
+      - test-client
 
-  #   # 2.0 - Build a matrix strategy from the retrieved target list
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target: ${{ fromJson(needs.targets.outputs.matrix) }}
+    # 2.0 - Build a matrix strategy from the retrieved target list
+    strategy:
+      fail-fast: true
+      matrix:
+        target: ${{ fromJson(needs.targets.outputs.matrix) }}
 
-  #   steps:
-  #     # 2.1 - Checkout the repository
-  #     - name: Checkout the repository
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      # 2.1 - Checkout the repository
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
-  #     # 2.2 - Install the appropriate tool based on target
-  #     - name: Setup Node v18.8.0
-  #       if: matrix.target == 'hmi-client'
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 18.8.0
-  #         cache: 'yarn'
+      # 2.2 - Install the appropriate tool based on target
+      - name: Setup Node v18.8.0
+        if: matrix.target == 'hmi-client'
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.8.0
+          cache: 'yarn'
 
-  #     - name: Validate GradleW JAR
-  #       if: matrix.target != 'hmi-client'
-  #       uses: gradle/wrapper-validation-action@9aa31f26bc8e536d1faf4b332bb8365350743a18
+      - name: Validate GradleW JAR
+        if: matrix.target != 'hmi-client'
+        uses: gradle/wrapper-validation-action@9aa31f26bc8e536d1faf4b332bb8365350743a18
 
-  #     - name: Setup Java v17
-  #       if: matrix.target != 'hmi-client'
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         distribution: 'temurin'
-  #         java-version: 17
-  #         cache: gradle
+      - name: Setup Java v17
+        if: matrix.target != 'hmi-client'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: gradle
 
-  #     # 2.3 - Build all packages and move them to required location for Docker
-  #     - name: Build
-  #       run: |
-  #         make image-${{ matrix.target }}
+      # 2.3 - Build all packages and move them to required location for Docker
+      - name: Build
+        run: |
+          make image-${{ matrix.target }}
 
-  #     # 2.4 - Set environment variables to be used within the bake file
-  #     # NOTE: this overrides the defaults and should be specific to this deployment
-  #     - name: set env variables for bakefile
-  #       run: |
-  #         if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
-  #           TAG=latest
-  #         else
-  #           SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
-  #           if [[ -n $SEMVER ]]; then
-  #             TAG=${SEMVER}
-  #           else
-  #             TAG=${{ github.ref_name }}
-  #           fi
-  #         fi
+      # 2.4 - Set environment variables to be used within the bake file
+      # NOTE: this overrides the defaults and should be specific to this deployment
+      - name: set env variables for bakefile
+        run: |
+          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
+            TAG=latest
+          else
+            SEMVER=$( echo ${{ github.ref_name }} | sed -nre 's/^v[^0-9]*(([0-9]+\.)*[0-9]+(-[a-z]+)?).*/\1/p')
+            if [[ -n $SEMVER ]]; then
+              TAG=${SEMVER}
+            else
+              TAG=${{ github.ref_name }}
+            fi
+          fi
 
-  #         echo "$TAG"
+          echo "$TAG"
 
-  #         echo "VERSION=${TAG,,}" >> ${GITHUB_ENV}
-  #         echo "DOCKER_REGISTRY=${{ env.REGISTRY }}" >> ${GITHUB_ENV}
-  #         # Lowercase the owner for docker image naming conventions
-  #         echo "DOCKER_ORG=${OWNER,,}" >> ${GITHUB_ENV}
-  #         java --version
+          echo "VERSION=${TAG,,}" >> ${GITHUB_ENV}
+          echo "DOCKER_REGISTRY=${{ env.REGISTRY }}" >> ${GITHUB_ENV}
+          # Lowercase the owner for docker image naming conventions
+          echo "DOCKER_ORG=${OWNER,,}" >> ${GITHUB_ENV}
+          java --version
 
-  #     # 2.5 - Login against the docker registry
-  #     - name: Login to registry ${{ env.REGISTRY }}
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.repository_owner }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      # 2.5 - Login against the docker registry
+      - name: Login to registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     # 2.6 - Setup QEMU for platform emulation
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v2
+      # 2.6 - Setup QEMU for platform emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-  #     # 2.7 - Setup Docker BuildX for multi platform building
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
+      # 2.7 - Setup Docker BuildX for multi platform building
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-  #     # 2.8 - Build and push Docker Images
-  #     - name: Build Images using BuildX Bake
-  #       uses: docker/bake-action@v2
-  #       with:
-  #         files: ./${{ env.BAKE_FILE }}
-  #         targets: ${{ matrix.target }}
-  #         push: true
-  #         set: |
-  #           *.cache-from=type=gha,scope=build-${{ matrix.target }}
-  #           *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
+      # 2.8 - Build and push Docker Images
+      - name: Build Images using BuildX Bake
+        uses: docker/bake-action@v2
+        with:
+          files: ./${{ env.BAKE_FILE }}
+          targets: ${{ matrix.target }}
+          push: true
+          set: |
+            *.cache-from=type=gha,scope=build-${{ matrix.target }}
+            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,6 @@ env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
   BAKE_FILE: docker-bake.hcl
-  BAKE_GROUP: prod
 
 jobs:
   # Run Global Lint
@@ -43,10 +42,16 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       # 1.2 - Generate a matrix output of all the targets for the specified group
+      # if its not triggered by tag use `staging` bake group instead
       - name: Create matrix
         id: targets
         run: |
-          echo "matrix=$(docker buildx bake ${{ env.BAKE_GROUP }} -f ${{ env.BAKE_FILE }} --print | jq -cr '.group.default.targets')" >> $GITHUB_OUTPUT
+          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
+            BAKE_GROUP=staging
+          else
+            BAKE_GROUP=prod
+          fi
+          echo "matrix=$(docker buildx bake $BAKE_GROUP -f ${{ env.BAKE_FILE }} --print | jq -cr '.group.default.targets')" >> $GITHUB_OUTPUT
 
       # 1.3 (optional) - output the generated target list for verification
       - name: Show matrix

--- a/.github/workflows/test-client-e2e.yaml
+++ b/.github/workflows/test-client-e2e.yaml
@@ -4,9 +4,10 @@
 # See: https://playwright.dev/
 
 name: Client E2E Tests
-# yamllint disable-line rule:truthy
 on:
-  workflow_call:
+  # schedule tests to run everyday at 5am
+  schedule:
+    - cron: '0 5 * * *'
 
 jobs:
   e2e-tests:

--- a/.github/workflows/test-client-e2e.yaml
+++ b/.github/workflows/test-client-e2e.yaml
@@ -4,6 +4,7 @@
 # See: https://playwright.dev/
 
 name: Client E2E Tests
+# yamllint disable-line rule:truthy
 on:
   # schedule tests to run everyday at 5am
   schedule:

--- a/.github/workflows/test-client.yaml
+++ b/.github/workflows/test-client.yaml
@@ -18,7 +18,3 @@ jobs:
   unit-tests:
     name: Client Unit Tests
     uses: ./.github/workflows/test-client-unit.yaml
-
-  e2e-tests:
-    name: E2E Tests
-    uses: ./.github/workflows/test-client-e2e.yaml

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -29,6 +29,11 @@ group "prod" {
   targets = ["hmi-client", "hmi-server", "hmi-server-native"]
 }
 
+# Simplified build without the `native` version for quicker turnaround staging deployments
+group "staging" {
+  targets = ["hmi-client", "hmi-server"]
+}
+
 group "default" {
   targets = ["hmi-client-base", "hmi-server-base"]
 }


### PR DESCRIPTION
# Description

This is a double PR that changes the following CI builds:

1. Adding a new group to the bake file for staging. When merging PRs to `main` it will ONLY build the client and regular server. Native server build will only be build when doing a tagged publish.
2. E2E tests will no longer be run on each PR, instead they will be run daily at 5am. Devs should check the action status/slack notification for errors