### PR TITLE
feat: vuetify integration

### DIFF
--- a/packages/client/hmi-client/README.md
+++ b/packages/client/hmi-client/README.md
@@ -1,6 +1,7 @@
 # Vue 3 + TypeScript + Vite
 
 - TERArium uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+- Design System is [Vuetify](https://next.vuetifyjs.com/en/).
 - We are using IBM Carbon Icons:
   - Check how to use them [within Vue](https://github.com/carbon-design-system/carbon/tree/v10/packages/icons-vue).
   - The reference [icons library](https://carbondesignsystem.com/guidelines/icons/library).

--- a/packages/client/hmi-client/package.json
+++ b/packages/client/hmi-client/package.json
@@ -32,7 +32,8 @@
 		"pixi.js": "7.0.4",
 		"sass": "1.56.1",
 		"vue": "3.2.41",
-		"vue-router": "4.1.6"
+		"vue-router": "4.1.6",
+		"vuetify": "3.0.5"
 	},
 	"devDependencies": {
 		"@pinia/testing": "0.0.14",

--- a/packages/client/hmi-client/src/assets/css/properties.css
+++ b/packages/client/hmi-client/src/assets/css/properties.css
@@ -1,0 +1,92 @@
+@import '@node_modules/@uncharted.software/design-tokens/build/css/uncharted-tokens.css';
+
+:root {
+    /* Overwriting Uncharted design-tokens for TERArium */
+    --un-color-accent-darker: #133013ff;
+    --un-color-accent-dark: #1C5A1Cff;
+    --un-color-accent: #2D8E2Dff;
+    --un-color-accent-rgb: 45,142,45;
+    --un-color-accent-light: #92E192ff;
+    --un-color-accent-lighter: #E4FAE4ff;
+    --un-color-accent-mono: #39B539;
+    --un-color-body-surface-secondary: #f4f4f4;
+
+    --label-color: #707070;
+    --text-color-light: #C2C2C4;
+    --text-color-medium: #9C9D9E;
+    --text-color-dark: #16161C;
+
+    --label-color: #707070;
+    --text-color-light: #C2C2C4;
+    --text-color-medium: #9C9D9E;
+    --text-color-dark: #16161C;
+    --font-size-small: 1.2rem;
+    --font-size-medium: 1.4rem;
+    --font-size-large: 1.6rem;
+    --navbar-outer-height: 51px;
+    --separator: #e5e5e5;
+    --background-light-1: #FFFFFF;
+    --background-light-2: #F2F2F2;
+    --background-light-3: #E6E6E6;
+    --background-light-1-faded: #FAFAFA;
+
+    /* Layout */
+    --header-height: 3.5rem;
+}
+
+/**
+ * Overwriting Vuetify values with:
+ *      - Uncharted Design Tokens
+ *      - TERArium
+ */
+ html .v-theme--light {
+    --v-theme-background: 255,255,255;
+    --v-theme-background-overlay-multiplier: 1;
+    --v-theme-surface: 255,255,255;
+    --v-theme-surface-overlay-multiplier: 1;
+    --v-theme-surface-variant: 66,66,66;
+    --v-theme-surface-variant-overlay-multiplier: 2;
+    --v-theme-on-surface-variant: 238,238,238;
+    --v-theme-primary: var(--un-color-accent-rgb);
+    --v-theme-primary-overlay-multiplier: 2;
+    --v-theme-primary-darken-1: 55,0,179;
+    --v-theme-primary-darken-1-overlay-multiplier: 2;
+    --v-theme-secondary: 3,218,198;
+    --v-theme-secondary-overlay-multiplier: 1;
+    --v-theme-secondary-darken-1: 1,135,134;
+    --v-theme-secondary-darken-1-overlay-multiplier: 1;
+    --v-theme-error: 176,0,32;
+    --v-theme-error-overlay-multiplier: 2;
+    --v-theme-info: 33,150,243;
+    --v-theme-info-overlay-multiplier: 1;
+    --v-theme-success: 76,175,80;
+    --v-theme-success-overlay-multiplier: 1;
+    --v-theme-warning: 251,140,0;
+    --v-theme-warning-overlay-multiplier: 1;
+    --v-theme-on-background: 0,0,0;
+    --v-theme-on-surface: 0,0,0;
+    --v-theme-on-primary: 255,255,255;
+    --v-theme-on-primary-darken-1: 255,255,255;
+    --v-theme-on-secondary: 0,0,0;
+    --v-theme-on-secondary-darken-1: 255,255,255;
+    --v-theme-on-error: 255,255,255;
+    --v-theme-on-info: 255,255,255;
+    --v-theme-on-success: 255,255,255;
+    --v-theme-on-warning: 255,255,255;
+    --v-border-color: 0, 0, 0;
+    --v-border-opacity: 0.12;
+    --v-high-emphasis-opacity: 0.87;
+    --v-medium-emphasis-opacity: 0.6;
+    --v-disabled-opacity: 0.38;
+    --v-idle-opacity: 0.04;
+    --v-hover-opacity: 0.04;
+    --v-focus-opacity: 0.12;
+    --v-selected-opacity: 0.08;
+    --v-activated-opacity: 0.12;
+    --v-pressed-opacity: 0.12;
+    --v-dragged-opacity: 0.08;
+    --v-theme-kbd: 33, 37, 41;
+    --v-theme-on-kbd: 255, 255, 255;
+    --v-theme-code: 245, 245, 245;
+    --v-theme-on-code: 0, 0, 0;
+}

--- a/packages/client/hmi-client/src/assets/css/style.css
+++ b/packages/client/hmi-client/src/assets/css/style.css
@@ -1,6 +1,6 @@
 @import '@node_modules/@ibm/plex/css/ibm-plex.css';
-@import '@node_modules/@uncharted.software/design-tokens/build/css/uncharted-tokens.css';
 @import '@assets/css/reset.css';
+@import '@assets/css/properties.css';
 
 :root {
 	font-synthesis: none;
@@ -8,40 +8,6 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-text-size-adjust: 100%;
-
-	/* Overwriting Uncharted design-tokens for TERArium */
-	--un-color-accent-darker: #133013ff;
-	--un-color-accent-dark: #1C5A1Cff;
-	--un-color-accent: #2D8E2Dff;
-	--un-color-accent-light: #92E192ff;
-	--un-color-accent-lighter: #E4FAE4ff;
-	--un-color-accent-mono: #39B539;
-	--un-color-body-surface-secondary: #f4f4f4;
-	
-	--label-color: #707070;
-	--text-color-light: #C2C2C4;
-	--text-color-medium: #9C9D9E;
-	--text-color-dark: #16161C;
-
-	--label-color: #707070;
-	--text-color-light: #C2C2C4;
-	--text-color-medium: #9C9D9E;
-	--text-color-dark: #16161C;
-	--font-size-small: 1.2rem;
-	--font-size-medium: 1.4rem;
-	--font-size-large: 1.6rem;
-	--navbar-outer-height: 51px;
-	--separator: #e5e5e5;
-	--background-light-1: #FFFFFF;
-	--background-light-2: #F2F2F2;
-	--background-light-3: #E6E6E6;
-	--background-light-1-faded: #FAFAFA;
-
-	/* Layout */
-	--header-height: 3.5rem;
-}
-
-:root {
 	background-color: var(--un-color-body-surface-background);
 	color: var(--un-color-body-text-primary);
 	color-scheme: light;

--- a/packages/client/hmi-client/src/components/Header.vue
+++ b/packages/client/hmi-client/src/components/Header.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
-import Button from '@/components/Button.vue';
 import IconSearchLocate16 from '@carbon/icons-vue/es/search--locate/16';
 import { useCurrentRouter } from '@/router/index';
 import { Project } from '@/types/Project';
@@ -35,9 +34,9 @@ defineProps<{
 			<span>{{ projectName }}</span>
 		</p>
 		<aside>
-			<Button class="data-explorer" @click="goToDataExplorer">
+			<v-btn variant="flat" color="primary" class="data-explorer" @click="goToDataExplorer">
 				<IconSearchLocate16 />
-			</Button>
+			</v-btn>
 		</aside>
 	</header>
 </template>
@@ -80,7 +79,7 @@ aside {
 	gap: 1rem;
 }
 
-button.data-explorer {
-	background-color: var(--un-color-accent);
+.data-explorer svg {
+	fill: var(--un-color-white);
 }
 </style>

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -1,14 +1,20 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
+import 'vuetify/styles';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
 import useAuthStore from './stores/auth';
 import router from './router';
 import App from './App.vue';
-
 import './assets/css/style.css';
 
 const app = createApp(App);
 app.use(createPinia());
 app.use(router);
+
+const vuetify = createVuetify({ components, directives });
+app.use(vuetify);
 
 const auth = useAuthStore();
 await auth.fetchSSO();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6462,6 +6462,7 @@ cors@latest:
     vue: 3.2.41
     vue-router: 4.1.6
     vue-tsc: 1.0.12
+    vuetify: 3.0.5
   languageName: unknown
   linkType: soft
 
@@ -11461,6 +11462,25 @@ send@latest:
     "@vue/server-renderer": 3.2.41
     "@vue/shared": 3.2.41
   checksum: 5328bf14c672c29fcde6747cac05ea7ffa46522ea8198120cdd61ba2847a1692e316019b942deb93326235e60b5d19b6db443c2fd8a827bba4b90c6595a709cd
+  languageName: node
+  linkType: hard
+
+"vuetify@npm:3.0.5":
+  version: 3.0.5
+  resolution: "vuetify@npm:3.0.5"
+  peerDependencies:
+    vite-plugin-vuetify: ^1.0.0-alpha.12
+    vue: ^3.2.0
+    vue-i18n: ^9.0.0
+    webpack-plugin-vuetify: ^2.0.0-alpha.11
+  peerDependenciesMeta:
+    vite-plugin-vuetify:
+      optional: true
+    vue-i18n:
+      optional: true
+    webpack-plugin-vuetify:
+      optional: true
+  checksum: 3cc596e5bbd1d7604e283938b7a37844e9af7a909c7b8acf84c1291b563220f8386458b15701f2bcfb6d0982310e61b8dc20b7ed818c6b41341525ec7037c1af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

* Implemented [Vuetify](https://next.vuetifyjs.com/en/) as design system
* Added a property css files to overwrite the Vuetify CSS properties with TERArium ones
* Change the _Data Explorer_ button in the header with Vuetify as first test.