### PR TITLE
feat: update responsive matrix zoom to toggle between camera and selection modes

### DIFF
--- a/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
+++ b/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
@@ -273,7 +273,7 @@ export default {
 			update: 0,
 			move: 0,
 
-			cursorMode: CursorModes.Select,
+			cursorMode: CursorModes.SELECT,
 			resizeObserver: null as unknown as ResizeObserver
 		};
 	},
@@ -361,7 +361,7 @@ export default {
 			return microColSettings;
 		},
 		isCameraMode(): boolean {
-			return this.cursorMode === CursorModes.Camera;
+			return this.cursorMode === CursorModes.CAMERA;
 		}
 	},
 
@@ -1025,8 +1025,8 @@ export default {
 		handleKeyDown({ altKey }: KeyboardEvent) {
 			if (altKey && this.viewport) {
 				this.cursorMode =
-					this.cursorMode === CursorModes.Select ? CursorModes.Camera : CursorModes.Select;
-				this.viewport.pause = this.cursorMode === CursorModes.Select;
+					this.cursorMode === CursorModes.SELECT ? CursorModes.CAMERA : CursorModes.SELECT;
+				this.viewport.pause = this.cursorMode === CursorModes.SELECT;
 			}
 		},
 

--- a/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
+++ b/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
@@ -1,5 +1,5 @@
 <template>
-	<main class="matrix-container" ref="matrixContainer" :class="{ cameraCursor: isCameraMode }">
+	<main class="matrix-container" ref="matrixContainer" :class="{ 'camera-cursor': isCameraMode }">
 		<div class="matrix" ref="matrix" :style="matrixStyle">
 			<LabelCols
 				v-if="!disableLabelCol && rendererReady"
@@ -1115,7 +1115,7 @@ main {
 	cursor: default;
 }
 
-.cameraCursor {
+.camera-cursor {
 	cursor: move;
 }
 

--- a/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
+++ b/packages/client/hmi-client/src/components/responsive-matrix/matrix.vue
@@ -88,7 +88,8 @@ import {
 	CellStatus,
 	CellType,
 	Uniforms,
-	ParamMinMax
+	ParamMinMax,
+	CursorModes
 } from '@/types/ResponsiveMatrix';
 import { getGlMaxTextureSize, getTextureDim, uint32ArrayToRedIntTex } from './pixi-utils';
 
@@ -103,10 +104,6 @@ import matrixGridFS from './matrix-grid.fs.glsl';
 
 // EMPTY_POINT used as a fallback value
 const EMPTY_POINT = new Point();
-enum CursorModes {
-	Selection,
-	Camera
-}
 
 export default {
 	// ---------------------------------------------------------------------------- //
@@ -276,7 +273,7 @@ export default {
 			update: 0,
 			move: 0,
 
-			cursorMode: CursorModes.Selection,
+			cursorMode: CursorModes.Select,
 			resizeObserver: null as unknown as ResizeObserver
 		};
 	},
@@ -1028,8 +1025,8 @@ export default {
 		handleKeyDown({ altKey }: KeyboardEvent) {
 			if (altKey && this.viewport) {
 				this.cursorMode =
-					this.cursorMode === CursorModes.Selection ? CursorModes.Camera : CursorModes.Selection;
-				this.viewport.pause = this.cursorMode === CursorModes.Selection;
+					this.cursorMode === CursorModes.Select ? CursorModes.Camera : CursorModes.Select;
+				this.viewport.pause = this.cursorMode === CursorModes.Select;
 			}
 		},
 

--- a/packages/client/hmi-client/src/types/ResponsiveMatrix.ts
+++ b/packages/client/hmi-client/src/types/ResponsiveMatrix.ts
@@ -67,6 +67,6 @@ export type Uniforms = {
 };
 
 export enum CursorModes {
-	Select,
-	Camera
+	SELECT,
+	CAMERA
 }

--- a/packages/client/hmi-client/src/types/ResponsiveMatrix.ts
+++ b/packages/client/hmi-client/src/types/ResponsiveMatrix.ts
@@ -65,3 +65,8 @@ export type Uniforms = {
 	// cell element color data
 	uColor: Texture;
 };
+
+export enum CursorModes {
+	Select,
+	Camera
+}


### PR DESCRIPTION
# Description

Alt/Option key toggles between camera and selection modes with cursor changing styles to indicate mode. 

Should there be a label to additionally indicate active cursor mode?