### PR TITLE
chore: run e2e tests at 10am eastern

### DIFF
--- a/.github/workflows/test-client-e2e.yaml
+++ b/.github/workflows/test-client-e2e.yaml
@@ -6,9 +6,9 @@
 name: Client E2E Tests
 # yamllint disable-line rule:truthy
 on:
-  # schedule tests to run everyday at 5am
+  # schedule tests to run every day at 3pm UTC (10am eastern)
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 15 * * *'
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
# Description
This runs the E2E tests at 10am eastern as opposed to midnight eastern.  It's more likely people will pay attention to any errors if they're run during work hours.

Resolves #427 
