### PR TITLE
fix: target identity on scroll click event

### DIFF
--- a/packages/client/hmi-client/src/views/Home.vue
+++ b/packages/client/hmi-client/src/views/Home.vue
@@ -64,7 +64,11 @@ const close = () => {
 const SCROLL_INCREMENT_IN_REM = 21;
 const scroll = (direction: 'right' | 'left', event: PointerEvent) => {
 	const chevronElement = event.target as HTMLElement;
-	const cardListElement = chevronElement.parentElement?.querySelector('ul');
+	const cardListElement =
+		chevronElement.nodeName === 'svg'
+			? chevronElement.parentElement?.querySelector('ul')
+			: chevronElement.parentElement?.parentElement?.querySelector('ul');
+
 	if (cardListElement === null || cardListElement === undefined) return;
 	const marginLeftString =
 		cardListElement.style.marginLeft === '' ? '0' : cardListElement.style.marginLeft;


### PR DESCRIPTION
### Summary
This address a somewhat rare issue when the click event lands on svg:path instead of svg, which cause the parent element query to misfire


### Test
In the home view, scroll should work regardless of where the click is betting registered on the icon-button.


Close #341 