### PR TITLE
chore: fix REST subobject pattern

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelProxy.java
@@ -61,13 +61,13 @@ public interface ModelProxy {
 	);
 
 	@GET
-	@Path("/descriptions/{id}")
+	@Path("/{id}/descriptions")
 	Response getDescription(
 		@PathParam("id") String id
 	);
 
 	@GET
-	@Path("/parameters/{id}")
+	@Path("/{id}/parameters")
 	Response getParameters(
 		@PathParam("id") String id
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/SimulationProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/SimulationProxy.java
@@ -50,13 +50,13 @@ public interface SimulationProxy {
 	);
 
 	@GET
-	@Path("/runs/descriptions/{id}")
+	@Path("/runs/{id}/descriptions")
 	Response getSimulationRunDescription(
 		@PathParam("id") String id
 	);
 
 	@GET
-	@Path("/runs/parameters/{id}")
+	@Path("/runs/{id}/parameters")
 	Response getSimulationRunParameters(
 		@PathParam("id") String id
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ModelResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ModelResource.java
@@ -80,15 +80,15 @@ public class ModelResource {
 	@Path("/descriptions")
 	public Response getDescriptions(
 
-		@DefaultValue("100") @QueryParam("page_size")final Integer pageSize,
-		@DefaultValue("0") @QueryParam("page")final Integer page
+		@DefaultValue("100") @QueryParam("page_size") final Integer pageSize,
+		@DefaultValue("0") @QueryParam("page") final Integer page
 
 	) {
 		return proxy.getDescriptions(pageSize, page);
 	}
 
 	@GET
-	@Path("/descriptions/{id}")
+	@Path("/{id}/descriptions")
 	public Response getDescription(
 		@PathParam("id") final String id
 	) {
@@ -96,7 +96,7 @@ public class ModelResource {
 	}
 
 	@GET
-	@Path("/parameters/{id}")
+	@Path("/{id}/parameters")
 	public Response getParameters(
 		@PathParam("id") final String id
 	) {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/SimulationResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/SimulationResource.java
@@ -69,7 +69,7 @@ public class SimulationResource {
 	}
 
 	@GET
-	@Path("/runs/descriptions/{id}")
+	@Path("/runs/{id}/descriptions")
 	public Response getSimulationRunDescription(
 		@PathParam("id") final String id
 	) {
@@ -77,7 +77,7 @@ public class SimulationResource {
 	}
 
 	@GET
-	@Path("/runs/parameters/{id}")
+	@Path("/runs/{id}/parameters")
 	public Response getSimulationRunParameters(
 		@PathParam("id") final String id
 	) {


### PR DESCRIPTION
Aligning API end points for models and simulations to that found in data service.

# Description

- /models/descriptions/{id} -> /models/{id}/descriptions
- /models/parameters/{id} -> /models/{id}/parameters
- /simulations/runs/descriptions/{id} -> /simulations/runs/{id}/descriptions
- /simulations/runs/parameters/{id} -> /simulations/runs/{id}/parameters

Resolves #434
