### PR TITLE
feat: use embedded xdd doc in extractions & improve their display in explorer

### DIFF
--- a/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
@@ -1,111 +1,118 @@
 <template>
-	<div>
-		<div v-if="viewType === XDDViewType.EXTRACTIONS" class="extractions-container">
-			<!-- FIXME: the content of this div is copied and adapted from Document.vue -->
-			<div v-for="ex in extractions" :key="ex.askemId">
-				<template
-					v-if="
-						ex.properties.image &&
-						(ex.askemClass === XDDExtractionType.Figure ||
-							ex.askemClass === XDDExtractionType.Table ||
-							ex.askemClass === XDDExtractionType.Equation)
-					"
+	<div class="table-fixed-head">
+		<table>
+			<tbody>
+				<tr
+					v-for="d in articles"
+					:key="d.gddid"
+					class="tr-item"
+					:class="{ selected: isSelected(d) }"
+					@click="updateExpandedRow(d)"
 				>
-					<!-- render figure -->
-					{{ ex.properties.caption ? ex.properties.caption : ex.properties.contentText }}
-					<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
-				</template>
-				<template v-else>
-					<!-- render textual content -->
-					<b>{{ ex.properties.title }}</b>
-					{{ ex.properties.caption }}
-					{{ ex.properties.abstractText }}
-					{{ ex.properties.contentText }}
-				</template>
-			</div>
-		</div>
-		<div v-if="viewType === XDDViewType.PUBLICATIONS" class="table-fixed-head">
-			<table>
-				<tbody>
-					<tr
-						v-for="d in articles"
-						:key="d.gddid"
-						class="tr-item"
-						:class="{ selected: isSelected(d) }"
-						@click="updateExpandedRow(d)"
-					>
-						<td class="title-and-abstract-col">
-							<div class="title-and-abstract-layout">
-								<!-- in case of requesting multiple selection -->
-								<div class="radio" @click.stop="updateSelection(d)">
-									<span v-show="isSelected(d)">
-										<IconCheckboxChecked20 />
-									</span>
-									<span v-show="!isSelected(d)">
-										<IconCheckbox20 />
-									</span>
-								</div>
-								<div class="content">
-									<div class="text-bold">{{ formatTitle(d) }}</div>
-									<multiline-description :text="formatDescription(d)" />
-									<div>{{ d.publisher }}, {{ d.journal }}</div>
-									<div v-if="isExpanded(d)" class="knobs">
-										<b>Author(s):</b>
-										<div>
-											{{ formatArticleAuthors(d) }}
-										</div>
-										<div
-											v-if="d.knownEntities && d.knownEntities.url_extractions.length > 0"
-											class="url-extractions"
-										>
-											<b>URL Extractions(s):</b>
-											<div v-for="ex in d.knownEntities.url_extractions" :key="ex.url">
-												<a :href="ex.url" target="_blank" rel="noreferrer noopener">{{
-													ex.resource_title
-												}}</a>
-											</div>
-										</div>
-									</div>
-									<div v-if="d.highlight" class="knobs">
-										<span v-for="h in d.highlight" :key="h">
-											<span v-html="h"></span>
-										</span>
-									</div>
-									<div v-html="formatKnownTerms(d)"></div>
-									<div class="related-docs" @click.stop="fetchRelatedDocument(d)">
-										Related Documents
-									</div>
-									<div v-if="isExpanded(d) && d.relatedDocuments" class="related-docs-container">
-										<div v-for="a in d.relatedDocuments" :key="a.gddid">
-											{{ a.title }}
-											<span class="item-select" @click.stop="updateSelection(a)"
-												>{{ isSelected(a) ? 'Unselect' : 'Select' }}
-											</span>
-										</div>
+					<td>
+						<div class="content-container">
+							<!-- in case of requesting multiple selection -->
+							<div class="radio" @click.stop="updateSelection(d)">
+								<span v-show="isSelected(d)">
+									<IconCheckboxChecked20 />
+								</span>
+								<span v-show="!isSelected(d)">
+									<IconCheckbox20 />
+								</span>
+							</div>
+							<div class="content">
+								<div class="text-bold">{{ formatTitle(d) }}</div>
+								<multiline-description :text="formatDescription(d)" />
+								<div>{{ d.publisher }}, {{ d.journal }}</div>
+								<div v-if="isExpanded(d)" class="knobs">
+									<b>Author(s):</b>
+									<div>
+										{{ formatArticleAuthors(d) }}
 									</div>
 									<div
-										v-if="isExpanded(d) && d.relatedDocuments && d.relatedDocuments.length === 0"
+										v-if="d.knownEntities && d.knownEntities.url_extractions.length > 0"
+										class="url-extractions"
 									>
-										No related documents found!
+										<b>URL Extractions(s):</b>
+										<div v-for="ex in d.knownEntities.url_extractions" :key="ex.url">
+											<a :href="ex.url" target="_blank" rel="noreferrer noopener">{{
+												ex.resource_title
+											}}</a>
+										</div>
+									</div>
+								</div>
+								<div v-if="d.highlight" class="knobs">
+									<span v-for="h in d.highlight" :key="h">
+										<span v-html="h"></span>
+									</span>
+								</div>
+								<div v-html="formatKnownTerms(d)"></div>
+								<div class="related-docs" @click.stop="fetchRelatedDocument(d)">
+									Related Documents
+								</div>
+								<div v-if="isExpanded(d) && d.relatedDocuments" class="related-docs-container">
+									<div v-for="a in d.relatedDocuments" :key="a.gddid">
+										{{ a.title }}
+										<span class="item-select" @click.stop="updateSelection(a)"
+											>{{ isSelected(a) ? 'Unselect' : 'Select' }}
+										</span>
+									</div>
+								</div>
+								<div v-if="isExpanded(d) && d.relatedDocuments && d.relatedDocuments.length === 0">
+									No related documents found!
+								</div>
+							</div>
+							<div v-if="d.relatedExtractions" class="content content-extractions">
+								<div class="related-docs" @click.stop="updateExpandedRow(d)">
+									Extractions ({{ d.relatedExtractions?.length }})
+								</div>
+								<div v-if="d.relatedExtractions && isExpanded(d)" class="extractions-container">
+									<!-- FIXME: the content of this div is copied and adapted from Document.vue -->
+									<div v-for="ex in d.relatedExtractions" :key="ex.askemId">
+										<template
+											v-if="
+												ex.properties.image &&
+												(ex.askemClass === XDDExtractionType.Figure ||
+													ex.askemClass === XDDExtractionType.Table ||
+													ex.askemClass === XDDExtractionType.Equation)
+											"
+										>
+											<!-- render figure -->
+											{{
+												ex.properties.caption ? ex.properties.caption : ex.properties.contentText
+											}}
+											<img
+												id="img"
+												:src="'data:image/jpeg;base64,' + ex.properties.image"
+												:alt="''"
+											/>
+										</template>
+										<template v-else>
+											<!-- render textual content -->
+											<b>{{ ex.properties.title }}</b>
+											{{ ex.properties.caption }}
+											{{ ex.properties.abstractText }}
+											{{ ex.properties.contentText }}
+										</template>
 									</div>
 								</div>
 							</div>
-						</td>
-					</tr>
-					<tr v-if="articles.length === 0" class="tr-item">
-						<td colspan="100%" style="text-align: center">No data available</td>
-					</tr>
-				</tbody>
-			</table>
-		</div>
+						</div>
+					</td>
+				</tr>
+				<tr v-if="articles.length === 0" class="tr-item">
+					<td colspan="100%" style="text-align: center">No data available</td>
+				</tr>
+			</tbody>
+		</table>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { PropType, ref, toRefs, watch } from 'vue';
 import MultilineDescription from '@/components/widgets/multiline-description.vue';
-import { XDDArticle, XDDArtifact, XDDExtractionType } from '@/types/XDD';
-import { ResultType, XDDViewType } from '@/types/common';
+import { XDDArticle, XDDExtractionType } from '@/types/XDD';
+import { ResultType } from '@/types/common';
 import { isXDDArticle } from '@/utils/data-util';
 import IconCheckbox20 from '@carbon/icons-vue/es/checkbox/20';
 import IconCheckboxChecked20 from '@carbon/icons-vue/es/checkbox--checked/20';
@@ -118,10 +125,6 @@ const props = defineProps({
 		type: Array as PropType<XDDArticle[]>,
 		default: () => []
 	},
-	extractions: {
-		type: Array as PropType<XDDArtifact[]>,
-		default: () => []
-	},
 	rawConceptFacets: {
 		type: Object as PropType<ConceptFacets | null>,
 		default: () => null
@@ -129,10 +132,6 @@ const props = defineProps({
 	selectedSearchItems: {
 		type: Array as PropType<ResultType[]>,
 		required: true
-	},
-	viewType: {
-		type: String,
-		default: XDDViewType.PUBLICATIONS
 	}
 });
 
@@ -142,7 +141,7 @@ const expandedRowId = ref('');
 
 const resources = useResourcesStore();
 
-const { articles, selectedSearchItems, extractions } = toRefs(props);
+const { articles, selectedSearchItems } = toRefs(props);
 
 watch(
 	articles,
@@ -257,58 +256,60 @@ tbody tr:first-child {
 	margin-bottom: 5px;
 }
 
-.title-and-abstract-col {
-	width: 40%;
-}
-
-.title-and-abstract-layout {
+.content-container {
 	display: flex;
 	align-content: stretch;
 	align-items: stretch;
 }
 
-.title-and-abstract-layout .radio {
+.content-container .radio {
 	flex: 0 0 auto;
 	align-self: flex-start;
 	margin: 3px 5px 0 0;
 }
 
-.title-and-abstract-layout .content {
+.content-container .content {
 	flex: 1 1 auto;
 	overflow-wrap: anywhere;
 }
 
-.title-and-abstract-layout .content .knobs {
+.content-container .content-extractions {
+	width: 100%;
+	overflow-y: auto;
+	max-height: 500px;
+}
+
+.content-container .content .knobs {
 	margin-top: 10px;
 }
 
-.title-and-abstract-layout .content .knobs .url-extractions {
+.content-container .content .knobs .url-extractions {
 	display: flex;
 	flex-direction: column;
 }
 
-.title-and-abstract-layout .content .related-docs {
+.content-container .content .related-docs {
 	margin-top: 1rem;
 	color: blue;
 }
 
-.title-and-abstract-layout .content .related-docs:hover {
+.content-container .content .related-docs:hover {
 	text-decoration: underline;
 }
 
-.title-and-abstract-layout .content .related-docs-container {
+.content-container .content .related-docs-container {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 	margin-left: 1rem;
 }
 
-.title-and-abstract-layout .content .related-docs-container .item-select {
+.content-container .content .related-docs-container .item-select {
 	color: green;
 	font-weight: bold;
 }
 
-.title-and-abstract-layout .content .related-docs-container .item-select:hover {
+.content-container .content .related-docs-container .item-select:hover {
 	text-decoration: underline;
 }
 

--- a/packages/client/hmi-client/src/types/XDD.ts
+++ b/packages/client/hmi-client/src/types/XDD.ts
@@ -64,6 +64,7 @@ export type XDDArticle = {
 	knownEntities?: XDDArticleKnownEntity; // TEMP: mapped from known_entities
 	// additional-client-side fields
 	relatedDocuments?: XDDArticle[];
+	relatedExtractions?: XDDArtifact[];
 };
 
 export type PublicationAsset = {
@@ -88,6 +89,7 @@ export type XDDArtifactProperties = {
 	sectionID: string;
 	sectionTitle: string;
 	caption: string;
+	documentBibjson: XDDArticle; // the embedded document metadata wherein this artifact is extracted
 };
 
 // XDD extraction object, which should match Extraction.java at the backend

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -9,11 +9,6 @@ export enum ViewType {
 	GRAPH = 'graph'
 }
 
-export enum XDDViewType {
-	PUBLICATIONS = 'publications',
-	EXTRACTIONS = 'extractions'
-}
-
 export enum ResourceType {
 	XDD = 'xdd',
 	MODEL = 'model',

--- a/packages/client/hmi-client/src/views/DataExplorer.vue
+++ b/packages/client/hmi-client/src/views/DataExplorer.vue
@@ -76,30 +76,8 @@
 						:result-type="resultType"
 						:selected-search-items="selectedSearchItems"
 						:search-term="searchTerm"
-						:xdd-view-type="xddViewType"
 						@toggle-data-item-selected="toggleDataItemSelected"
-					>
-						<template #header>
-							<div class="button-group bottom-padding">
-								<button
-									type="button"
-									class="small-button"
-									:class="{ active: xddViewType === XDDViewType.PUBLICATIONS }"
-									@click="xddViewType = XDDViewType.PUBLICATIONS"
-								>
-									Publications
-								</button>
-								<button
-									type="button"
-									class="small-button"
-									:class="{ active: xddViewType === XDDViewType.EXTRACTIONS }"
-									@click="xddViewType = XDDViewType.EXTRACTIONS"
-								>
-									Figures/Tables
-								</button>
-							</div>
-						</template>
-					</search-results-list>
+					/>
 					<div class="results-count-label">Showing {{ resultsCount }} item(s).</div>
 				</div>
 			</template>
@@ -142,8 +120,7 @@ import {
 	Facets,
 	ResourceType,
 	ResultType,
-	ViewType,
-	XDDViewType
+	ViewType
 } from '@/types/common';
 import { getFacets } from '@/utils/facets';
 import {
@@ -182,7 +159,6 @@ const filteredFacets = ref<Facets>({});
 //
 const resultType = ref<string>(ResourceType.XDD);
 const viewType = ref<string>(ViewType.LIST);
-const xddViewType = ref<string>(XDDViewType.PUBLICATIONS);
 
 // optimize search performance: only fetch as needed
 const dirtyResults = ref<{ [resultType: string]: boolean }>({});
@@ -211,10 +187,10 @@ const resultsCount = computed(() => {
 				if (resultType.value !== ResourceType.XDD) {
 					total += resList.results.length;
 				} else {
-					total +=
-						xddViewType.value === XDDViewType.PUBLICATIONS
-							? resList.results.length
-							: resList.xddExtractions?.length ?? 0;
+					total += resList.results.length;
+					// xddViewType.value === XDDViewType.PUBLICATIONS
+					// 	? resList.results.length
+					// 	: resList.xddExtractions?.length ?? 0;
 				}
 			}
 		}
@@ -518,10 +494,6 @@ onUnmounted(() => {
 	cursor: pointer;
 	border-left-width: 0;
 	height: 40px;
-}
-
-.button-group button.small-button {
-	height: 32px;
 }
 
 .button-group button:first-child {

--- a/packages/client/hmi-client/src/views/DataExplorer.vue
+++ b/packages/client/hmi-client/src/views/DataExplorer.vue
@@ -78,7 +78,6 @@
 						:search-term="searchTerm"
 						@toggle-data-item-selected="toggleDataItemSelected"
 					/>
-					<div class="results-count-label">Showing {{ resultsCount }} item(s).</div>
 				</div>
 			</template>
 			<template v-if="viewType === ViewType.MATRIX">
@@ -167,36 +166,6 @@ const xddDataset = computed(() =>
 	resultType.value === ResourceType.XDD ? resources.xddDataset : 'TERArium'
 );
 const clientFilters = computed(() => query.clientFilters);
-
-const resultsCount = computed(() => {
-	let total = 0;
-	if (resultType.value === ResourceType.ALL) {
-		// count the results from all subsystems
-		dataItems.value.forEach((res) => {
-			const count = res?.hits ?? res?.results.length;
-			total += count;
-		});
-	} else {
-		// only return the results count for the selected subsystems
-		const resList = dataItems.value.find((res) => res.searchSubsystem === resultType.value);
-		if (resList) {
-			if (resList.hits) {
-				total += resList.hits;
-			} else {
-				// eslint-disable-next-line no-lonely-if
-				if (resultType.value !== ResourceType.XDD) {
-					total += resList.results.length;
-				} else {
-					total += resList.results.length;
-					// xddViewType.value === XDDViewType.PUBLICATIONS
-					// 	? resList.results.length
-					// 	: resList.xddExtractions?.length ?? 0;
-				}
-			}
-		}
-	}
-	return total;
-});
 
 const xddDatasetSelectionChanged = (newDataset: string) => {
 	if (xddDataset.value !== newDataset) {
@@ -537,11 +506,6 @@ onUnmounted(() => {
 	flex-direction: column;
 	flex: 1;
 	align-items: center;
-}
-
-.data-explorer-container .results-content .results-count-label {
-	font-weight: bold;
-	margin: 4px;
 }
 
 .xdd-known-terms {

--- a/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Extraction.java
+++ b/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Extraction.java
@@ -68,4 +68,6 @@ class ExtractionProperties implements Serializable {
 	private String sectionTitle;
 
 	private String caption;
+
+	private Document documentBibjson;
 }

--- a/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/ExtractionProxy.java
+++ b/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/ExtractionProxy.java
@@ -15,6 +15,7 @@ public interface ExtractionProxy {
     @GET
     @Path("object")
     Response getExtractions(
-            @QueryParam("doi") String doi
+			@QueryParam("doi") String doi,
+			@QueryParam("query_all") String query_all
     );
 }

--- a/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/ExtractionResource.java
+++ b/packages/services/document-server/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/ExtractionResource.java
@@ -24,7 +24,7 @@ public class ExtractionResource {
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Search XDD for extractions related to the document identified in the payload")
-	public Response searchExtractions(@QueryParam("doi") final String doi) {
-		return proxy.getExtractions(doi);
+	public Response searchExtractions(@QueryParam("doi") final String doi, @QueryParam("query_all") final String query_all) {
+		return proxy.getExtractions(doi, query_all);
 	}
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/xdd/Extraction.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/xdd/Extraction.java
@@ -68,4 +68,6 @@ class ExtractionProperties implements Serializable {
 	private String sectionTitle;
 
 	private String caption;
+
+	private Document documentBibjson;
 }


### PR DESCRIPTION
# Description
xDD has recently embedded documents metadata with each xDD extractions. This is particularly the case when searching Figures and Tables. So now we have the chance to quickly identify the source document where extractions have been pulled. The proposed change leverage the aforementioned to display the resulting Figure/Table search results as additional documents in the xDD search results.

NOTE styling is not the focus of this PR. But rather utilizing the new xDD feature wherein document metadata is now embedded as part of xDD extractions search result

<img width="1095" alt="Screen Shot 2023-01-09 at 4 44 15 PM" src="https://user-images.githubusercontent.com/69688226/211414381-1de6fb91-0549-4aaa-abd2-ad2ed8c903e0.png">

Resolves #437 
