### PR TITLE
chore: show preview of explorer search result items on click

### DIFF
--- a/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
@@ -7,7 +7,7 @@
 					:key="d.gddid"
 					class="tr-item"
 					:class="{ selected: isSelected(d) }"
-					@click="updateExpandedRow(d)"
+					@click="togglePreview(d)"
 				>
 					<td>
 						<div class="content-container">
@@ -24,7 +24,7 @@
 								<div class="text-bold">{{ formatTitle(d) }}</div>
 								<multiline-description :text="formatDescription(d)" />
 								<div>{{ d.publisher }}, {{ d.journal }}</div>
-								<div v-if="isExpanded(d)" class="knobs">
+								<div v-if="isExpanded()" class="knobs">
 									<b>Author(s):</b>
 									<div>
 										{{ formatArticleAuthors(d) }}
@@ -50,7 +50,7 @@
 								<div class="related-docs" @click.stop="fetchRelatedDocument(d)">
 									Related Documents
 								</div>
-								<div v-if="isExpanded(d) && d.relatedDocuments" class="related-docs-container">
+								<div v-if="isExpanded() && d.relatedDocuments" class="related-docs-container">
 									<div v-for="a in d.relatedDocuments" :key="a.gddid">
 										{{ a.title }}
 										<span class="item-select" @click.stop="updateSelection(a)"
@@ -58,15 +58,15 @@
 										</span>
 									</div>
 								</div>
-								<div v-if="isExpanded(d) && d.relatedDocuments && d.relatedDocuments.length === 0">
+								<div v-if="isExpanded() && d.relatedDocuments && d.relatedDocuments.length === 0">
 									No related documents found!
 								</div>
 							</div>
 							<div v-if="d.relatedExtractions" class="content content-extractions">
-								<div class="related-docs" @click.stop="updateExpandedRow(d)">
+								<div class="related-docs" @click.stop="togglePreview(d)">
 									Extractions ({{ d.relatedExtractions?.length }})
 								</div>
-								<div v-if="d.relatedExtractions && isExpanded(d)" class="extractions-container">
+								<div v-if="d.relatedExtractions && isExpanded()" class="extractions-container">
 									<!-- FIXME: the content of this div is copied and adapted from Document.vue -->
 									<div v-for="ex in d.relatedExtractions" :key="ex.askemId">
 										<template
@@ -109,7 +109,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, ref, toRefs, watch } from 'vue';
+import { PropType, toRefs, watch } from 'vue';
 import MultilineDescription from '@/components/widgets/multiline-description.vue';
 import { XDDArticle, XDDExtractionType } from '@/types/XDD';
 import { ResultType } from '@/types/common';
@@ -135,9 +135,9 @@ const props = defineProps({
 	}
 });
 
+// clicked: make the item shown in the preview
+// selected: add the item to the cart
 const emit = defineEmits(['toggle-article-selected']);
-
-const expandedRowId = ref('');
 
 const resources = useResourcesStore();
 
@@ -154,11 +154,7 @@ watch(
 	{ immediate: true }
 );
 
-const isExpanded = (article: XDDArticle) => expandedRowId.value === article.title;
-
-const updateExpandedRow = (article: XDDArticle) => {
-	expandedRowId.value = expandedRowId.value === article.title ? '' : article.title;
-};
+const isExpanded = () => false;
 
 const formatTitle = (d: XDDArticle) => (d.title ? d.title : d.title);
 
@@ -174,23 +170,27 @@ const isSelected = (article: XDDArticle) =>
 	});
 
 const updateSelection = (article: XDDArticle) => {
-	emit('toggle-article-selected', article);
+	emit('toggle-article-selected', { item: article, type: 'selected' });
+};
+
+const togglePreview = (article: XDDArticle) => {
+	emit('toggle-article-selected', { item: article, type: 'clicked' });
 };
 
 const fetchRelatedDocument = async (article: XDDArticle) => {
-	if (!isExpanded(article)) {
-		updateExpandedRow(article);
-	}
+	togglePreview(article);
 	if (!article.relatedDocuments) {
-		article.relatedDocuments = await getRelatedDocuments(article.gddid, resources.xddDataset);
+		// eslint-disable-next-line no-underscore-dangle
+		article.relatedDocuments = await getRelatedDocuments(
+			article.gddid || article._gddid,
+			resources.xddDataset
+		);
 	}
 };
 
 const formatDescription = (d: XDDArticle) => {
 	if (!d.abstractText || typeof d.abstractText !== 'string') return '';
-	return isExpanded(d) || d.abstractText.length < 140
-		? d.abstractText
-		: `${d.abstractText.substring(0, 140)}...`;
+	return d.abstractText.length < 140 ? d.abstractText : `${d.abstractText.substring(0, 140)}...`;
 };
 
 const formatKnownTerms = (d: XDDArticle) => {

--- a/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/articles-listview.vue
@@ -180,8 +180,8 @@ const togglePreview = (article: XDDArticle) => {
 const fetchRelatedDocument = async (article: XDDArticle) => {
 	togglePreview(article);
 	if (!article.relatedDocuments) {
-		// eslint-disable-next-line no-underscore-dangle
 		article.relatedDocuments = await getRelatedDocuments(
+			// eslint-disable-next-line no-underscore-dangle
 			article.gddid || article._gddid,
 			resources.xddDataset
 		);

--- a/packages/client/hmi-client/src/components/data-explorer/datasets-listview.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/datasets-listview.vue
@@ -16,7 +16,7 @@
 						:key="d.id"
 						class="tr-item"
 						:class="{ selected: isSelected(d) }"
-						@click="updateExpandedRow(d)"
+						@click="togglePreview(d)"
 					>
 						<td class="name-and-desc-col">
 							<div class="name-and-desc-layout">
@@ -31,7 +31,7 @@
 								</div>
 								<div class="content">
 									<div class="text-bold">{{ formatOutputName(d) }}</div>
-									<template v-if="isExpanded(d)">
+									<template v-if="isExpanded()">
 										<br />
 										<div><b>Concepts</b></div>
 										<ul>
@@ -69,7 +69,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, ref, toRefs, watch } from 'vue';
+import { PropType, toRefs, watch } from 'vue';
 import { ResultType } from '@/types/common';
 import IconCheckbox20 from '@carbon/icons-vue/es/checkbox/20';
 import IconCheckboxChecked20 from '@carbon/icons-vue/es/checkbox--checked/20';
@@ -98,8 +98,6 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle-dataset-selected']);
 
-const expandedRowId = ref<string | number>('');
-
 const { datasets, selectedSearchItems } = toRefs(props);
 
 watch(
@@ -124,11 +122,7 @@ const getConceptTags = (dataset: Dataset) => {
 	return tags;
 };
 
-const isExpanded = (dataset: Dataset) => expandedRowId.value === dataset.id;
-
-const updateExpandedRow = (dataset: Dataset) => {
-	expandedRowId.value = expandedRowId.value === dataset.id ? '' : dataset.id;
-};
+const isExpanded = () => false;
 
 const formatOutputName = (d: Dataset) => d.name;
 
@@ -142,14 +136,16 @@ const isSelected = (dataset: Dataset) =>
 	});
 
 const updateSelection = (dataset: Dataset) => {
-	emit('toggle-dataset-selected', dataset);
+	emit('toggle-dataset-selected', { item: dataset, type: 'selected' });
+};
+
+const togglePreview = (dataset: Dataset) => {
+	emit('toggle-dataset-selected', { item: dataset, type: 'clicked' });
 };
 
 const formatDescription = (d: Dataset) => {
 	if (!d.description) return '';
-	return isExpanded(d) || d.description.length < 140
-		? d.description
-		: `${d.description.substring(0, 140)}...`;
+	return d.description.length < 140 ? d.description : `${d.description.substring(0, 140)}...`;
 };
 
 const formatFeatures = (d: Dataset) => {
@@ -157,7 +153,7 @@ const formatFeatures = (d: Dataset) => {
 	if (!features || features.length === 0) return [];
 	const featuresNames = features.map((f) => (f.display_name !== '' ? f.display_name : f.name));
 	const max = 5;
-	return isExpanded(d) || featuresNames.length < max ? featuresNames : featuresNames.slice(0, max);
+	return featuresNames.length < max ? featuresNames : featuresNames.slice(0, max);
 };
 </script>
 

--- a/packages/client/hmi-client/src/components/data-explorer/models-listview.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/models-listview.vue
@@ -16,7 +16,7 @@
 						:key="d.id"
 						class="tr-item"
 						:class="{ selected: isSelected(d) }"
-						@click="updateExpandedRow(d)"
+						@click="togglePreview(d)"
 					>
 						<td class="name-and-desc-col">
 							<div class="name-and-desc-layout">
@@ -31,7 +31,7 @@
 								</div>
 								<div class="content">
 									<div class="text-bold">{{ formatOutputName(d) }}</div>
-									<template v-if="isExpanded(d)">
+									<template v-if="isExpanded()">
 										<br />
 										<div><b>Concepts</b></div>
 										<ul>
@@ -67,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, ref, toRefs, watch } from 'vue';
+import { PropType, toRefs, watch } from 'vue';
 import { Model } from '@/types/Model';
 import { ResultType } from '@/types/common';
 import { isModel } from '@/utils/data-util';
@@ -96,8 +96,6 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle-model-selected']);
 
-const expandedRowId = ref<string | number>('');
-
 const { models, selectedSearchItems } = toRefs(props);
 
 watch(
@@ -122,11 +120,7 @@ const getConceptTags = (model: Model) => {
 	return tags;
 };
 
-const isExpanded = (model: Model) => expandedRowId.value === model.id;
-
-const updateExpandedRow = (model: Model) => {
-	expandedRowId.value = expandedRowId.value === model.id ? '' : model.id;
-};
+const isExpanded = () => false;
 
 const formatOutputName = (d: Model) => d.name;
 
@@ -140,14 +134,16 @@ const isSelected = (model: Model) =>
 	});
 
 const updateSelection = (model: Model) => {
-	emit('toggle-model-selected', model);
+	emit('toggle-model-selected', { item: model, type: 'selected' });
+};
+
+const togglePreview = (model: Model) => {
+	emit('toggle-model-selected', { item: model, type: 'clicked' });
 };
 
 const formatDescription = (d: Model) => {
 	if (!d.description) return '';
-	return isExpanded(d) || d.description.length < 140
-		? d.description
-		: `${d.description.substring(0, 140)}...`;
+	return d.description.length < 140 ? d.description : `${d.description.substring(0, 140)}...`;
 };
 </script>
 

--- a/packages/client/hmi-client/src/components/data-explorer/search-results-list.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-results-list.vue
@@ -61,8 +61,8 @@ const props = defineProps({
 
 const emit = defineEmits(['toggle-data-item-selected']);
 
-const toggleDataItemSelected = (item: ResultType) => {
-	emit('toggle-data-item-selected', item);
+const toggleDataItemSelected = (dataItem: { item: ResultType; type?: string }) => {
+	emit('toggle-data-item-selected', dataItem);
 };
 
 const filteredModels = computed(() => {

--- a/packages/client/hmi-client/src/components/data-explorer/search-results-matrix.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-results-matrix.vue
@@ -89,7 +89,7 @@ const isClusterIncludesVariable = (c: ResultsCluster, v: string) => {
 const updateSelection = (cluster: ResultsCluster) => {
 	cluster.selected = !cluster.selected;
 	cluster.items.forEach((item) => {
-		emit('toggle-data-item-selected', item);
+		emit('toggle-data-item-selected', { item });
 	});
 };
 

--- a/packages/client/hmi-client/src/components/resources/resources-list.vue
+++ b/packages/client/hmi-client/src/components/resources/resources-list.vue
@@ -7,7 +7,7 @@ import useResourcesStore from '@/stores/resources';
 import { RouteParamsRaw, useRouter } from 'vue-router';
 
 const props = defineProps<{
-	project: Project;
+	project: Project | null;
 	resourceRoute?: RouteName;
 	// maybe add list size later
 }>();
@@ -35,13 +35,14 @@ const assetAmount = props.resourceRoute ? 10 : 2;
 filteredRouteMetadata.forEach((metadata) => {
 	const route = metadata.route;
 	const { displayName, icon, projectAsset } = metadata;
-	if (projectAsset && activeProjectAssets !== null) {
+	if (projectAsset && activeProjectAssets !== null && props?.project !== null) {
+		const projId = props?.project.id;
 		const assets = activeProjectAssets[projectAsset].slice(0, assetAmount);
 		assets.forEach((asset) => {
 			resources.push({
 				route,
 				params: {
-					projectId: props?.project.id,
+					projectId: projId,
 					assetId: route === RouteName.DocumentRoute ? asset.xdd_uri : asset.id
 				},
 				name: displayName,

--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -279,7 +279,7 @@ const getXDDArtifacts = async (doc_doi: string, term?: string) => {
 //  semantic similarity (i.e., document embedding) from XDD via the HMI server
 //
 const getRelatedDocuments = async (docid: string, dataset: string | null) => {
-	if (docid === '' || dataset === null) {
+	if (docid === '' || dataset) {
 		return [] as XDDArticle[];
 	}
 

--- a/packages/client/hmi-client/src/views/DataExplorer.vue
+++ b/packages/client/hmi-client/src/views/DataExplorer.vue
@@ -91,7 +91,21 @@
 					/>
 				</div>
 			</template>
+			<!-- document preview -->
+			<document
+				v-if="previewItem"
+				class="selected-resources-pane"
+				:asset-id="previewItemId"
+				:project="resources.activeProject"
+			>
+				<template #footer>
+					Add to cart
+					<br />
+					Add to Project
+				</template>
+			</document>
 			<selected-resources-options-pane
+				v-else
 				class="selected-resources-pane"
 				:selected-search-items="selectedSearchItems"
 				@remove-item="toggleDataItemSelected"
@@ -111,6 +125,7 @@ import SearchBar from '@/components/data-explorer/search-bar.vue';
 import DropdownButton from '@/components/widgets/dropdown-button.vue';
 import FacetsPanel from '@/components/data-explorer/facets-panel.vue';
 import SelectedResourcesOptionsPane from '@/components/drilldown-panel/selected-resources-options-pane.vue';
+import Document from '@/views/Document.vue';
 
 import { fetchData, getXDDSets } from '@/services/data';
 import {
@@ -133,16 +148,15 @@ import useQueryStore from '@/stores/query';
 import filtersUtil from '@/utils/filters-util';
 import useResourcesStore from '@/stores/resources';
 import { getResourceTypeIcon, isDataset, isModel, isXDDArticle, validate } from '@/utils/data-util';
-import { cloneDeep, intersectionBy, isEmpty, max, min, unionBy } from 'lodash';
+import { cloneDeep, intersectionBy, isEmpty, isEqual, max, min, unionBy } from 'lodash';
 import { Dataset } from '@/types/Dataset';
-
-// FIXME: page count is not taken into consideration
 
 const emit = defineEmits(['hide', 'show-overlay', 'hide-overlay']);
 
 const dataItems = ref<SearchResults[]>([]);
 const dataItemsUnfiltered = ref<SearchResults[]>([]);
 const selectedSearchItems = ref<ResultType[]>([]);
+const previewItem = ref<ResultType | null>(null);
 const searchTerm = ref('');
 const query = useQueryStore();
 const resources = useResourcesStore();
@@ -317,8 +331,23 @@ const onClose = () => {
 	emit('hide');
 };
 
-const toggleDataItemSelected = (item: ResultType) => {
+const toggleDataItemSelected = (dataItem: { item: ResultType; type?: string }) => {
 	let foundIndx = -1;
+	const item = dataItem.item;
+
+	if (dataItem.type && dataItem.type === 'clicked') {
+		// toggle preview
+		if (isEqual(dataItem.item, previewItem.value)) {
+			// clear preview item and close the preview panel
+			// FIXME: should we clear the preview if item is de-selected even if other items are still selected
+			previewItem.value = null;
+		} else {
+			// open the preview panel
+			previewItem.value = item;
+		}
+		return; // do not add to cart if the purpose is to toggel preview
+	}
+
 	selectedSearchItems.value.forEach((searchItem, indx) => {
 		if (isModel(item) && isModel(searchItem)) {
 			const itemAsModel = item as Model;
@@ -342,6 +371,16 @@ const toggleDataItemSelected = (item: ResultType) => {
 		selectedSearchItems.value = [...selectedSearchItems.value, item];
 	}
 };
+
+const previewItemId = computed(() => {
+	if (previewItem.value === null) return '';
+	if (isXDDArticle(previewItem.value)) {
+		const itemAsArticle = previewItem.value as XDDArticle;
+		// eslint-disable-next-line no-underscore-dangle
+		return itemAsArticle.gddid || itemAsArticle._gddid;
+	}
+	return '';
+});
 
 // this is called whenever the user apply some facet filter(s)
 watch(clientFilters, async (n, o) => {
@@ -497,7 +536,7 @@ onUnmounted(() => {
 
 .facets-panel {
 	margin-top: 10px;
-	width: 250px;
+	width: 20%;
 	overflow-y: auto;
 }
 
@@ -533,6 +572,6 @@ onUnmounted(() => {
 }
 
 .selected-resources-pane {
-	width: 250px;
+	width: 35%;
 }
 </style>

--- a/packages/client/hmi-client/src/views/Document.vue
+++ b/packages/client/hmi-client/src/views/Document.vue
@@ -77,6 +77,7 @@
 			:resourceRoute="RouteName.DocumentRoute"
 			@show-data-explorer="emit('show-data-explorer')"
 		/>
+		<slot name="footer"> </slot>
 	</section>
 </template>
 
@@ -92,7 +93,7 @@ import ResourcesList from '@/components/resources/resources-list.vue';
 
 const props = defineProps<{
 	assetId: string;
-	project: Project;
+	project: Project | null;
 }>();
 
 const emit = defineEmits(['show-data-explorer']);


### PR DESCRIPTION
# Description
Small refactor within the data explorer, leveraging the "Document" view to show preview of search result items on click.


Resolves #(issue)
