### PR TITLE
fix: bad document id given at load of application

### DIFF
--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -102,12 +102,11 @@ async function deleteAsset(projectId: string, assetsType: string, assetId) {
 async function getRelatedArticles(aProject: Project): Promise<XDDArticle[]> {
 	const resp = await getAssets(aProject.id);
 	try {
+		// Dec 6th 2022:
 		// TODO: Speak with XDD Team about broken doc: 5f6d0e20a58f1dfd52184931
 		// Grab the 2nd of publication for related results because grabbing the first provides a broken doc id: 5f6d0e20a58f1dfd52184931
-		const listOfRelatedArticles = await getRelatedDocuments(
-			String(resp?.[ProjectAssetTypes.PUBLICATIONS][1].xdd_uri),
-			'xdd-covid-19'
-		);
+		const docId = resp ? resp?.[ProjectAssetTypes.PUBLICATIONS][1].xdd_uri : '';
+		const listOfRelatedArticles = await getRelatedDocuments(docId, 'xdd-covid-19');
 		return listOfRelatedArticles;
 	} catch (error) {
 		// If resp = null (project has no assets or cannot be found)

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -105,8 +105,10 @@ async function getRelatedArticles(aProject: Project): Promise<XDDArticle[]> {
 		// Dec 6th 2022:
 		// TODO: Speak with XDD Team about broken doc: 5f6d0e20a58f1dfd52184931
 		// Grab the 2nd of publication for related results because grabbing the first provides a broken doc id: 5f6d0e20a58f1dfd52184931
-		const docId = resp ? resp?.[ProjectAssetTypes.PUBLICATIONS][1].xdd_uri : '';
-		const listOfRelatedArticles = await getRelatedDocuments(docId, 'xdd-covid-19');
+		const listOfRelatedArticles = await getRelatedDocuments(
+			resp?.[ProjectAssetTypes.PUBLICATIONS][1].xdd_uri ?? '',
+			'xdd-covid-19'
+		);
 		return listOfRelatedArticles;
 	} catch (error) {
 		// If resp = null (project has no assets or cannot be found)


### PR DESCRIPTION
# Description

* Adding safety code here to handle `undefined` being passed in as a String value.
* There are a few related issues here like "why can this asset not be found" and "why have we hardcoded to look at the second document in the list and not the first" but those can be addressed later..... this safety code would be needed either way and solves the build issues at hand.

Resolves #455 
