### PR TITLE
chore: article reno work 2 - tabs, adaptive ui, and other tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -1,5 +1,5 @@
 <template>
-	<section class="doc-view-container">
+	<section class="doc-view-container" ref="sectionElem">
 		<div v-if="doc">
 			<div class="journal">{{ doc.journal }}</div>
 			<div v-if="docLink" class="title">
@@ -32,7 +32,12 @@
 				<AccordionTab header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<img
+								id="img"
+								:src="'data:image/jpeg;base64,' + ex.properties.image"
+								:alt="''"
+								:style="{ 'max-width': imageSize }"
+							/>
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -43,7 +48,12 @@
 				<AccordionTab header="Tables">
 					<div v-for="ex in tableArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<img
+								id="img"
+								:src="'data:image/jpeg;base64,' + ex.properties.image"
+								:alt="''"
+								:style="{ 'max-width': imageSize }"
+							/>
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -54,7 +64,12 @@
 				<AccordionTab header="Equations">
 					<div v-for="ex in equationArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<img
+								id="img"
+								:src="'data:image/jpeg;base64,' + ex.properties.image"
+								:alt="''"
+								:style="{ 'max-width': imageSize }"
+							/>
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -100,6 +115,8 @@ import Button from 'primevue/button';
 import { getDocumentById, getXDDArtifacts } from '@/services/data';
 import { XDDArticle, XDDArtifact, XDDExtractionType } from '@/types/XDD';
 import { getDocumentDoi } from '@/utils/data-util';
+
+const sectionElem = ref(null);
 
 const props = defineProps<{
 	assetId: string;
@@ -182,8 +199,15 @@ watch(doi, (currentValue, oldValue) => {
 	}
 });
 
+// Image size will adapt depend on available space
+const imageSize = ref('160px');
+
 // fetch artifacts from COSMOS using the doc doi
 onMounted(async () => {
+	const rect = (sectionElem.value as HTMLElement).getBoundingClientRect();
+	if (rect.width > 800) {
+		imageSize.value = '400px';
+	}
 	fetchArtifacts();
 });
 </script>
@@ -235,7 +259,6 @@ onMounted(async () => {
 }
 
 .img-container > img {
-	max-width: 180px;
 	margin: 5px;
 	border: 1px solid var(--background-light-3);
 }

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -29,22 +29,34 @@
 
 				<AccordionTab header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
-						<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
-						{{ ex.properties.caption ? ex.properties.caption : ex.properties.contentText }}
+						<div class="img-container">
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<span>{{
+								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
+							}}</span>
+						</div>
 					</div>
 				</AccordionTab>
 
 				<AccordionTab header="Tables">
 					<div v-for="ex in tableArtifacts" :key="ex.askemId" class="extracted-item">
-						<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
-						{{ ex.properties.caption ? ex.properties.caption : ex.properties.contentText }}
+						<div class="img-container">
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<span>{{
+								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
+							}}</span>
+						</div>
 					</div>
 				</AccordionTab>
 
 				<AccordionTab header="Equations">
 					<div v-for="ex in equationArtifacts" :key="ex.askemId" class="extracted-item">
-						<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
-						{{ ex.properties.caption ? ex.properties.caption : ex.properties.contentText }}
+						<div class="img-container">
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
+							<span>{{
+								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
+							}}</span>
+						</div>
 					</div>
 				</AccordionTab>
 
@@ -71,12 +83,6 @@
 				<AccordionTab header="Provenance"> </AccordionTab>
 			</Accordion>
 		</div>
-		<resources-list
-			v-else
-			:project="props?.project"
-			:resourceRoute="RouteName.DocumentRoute"
-			@show-data-explorer="emit('show-data-explorer')"
-		/>
 	</section>
 </template>
 
@@ -88,16 +94,10 @@ import Button from 'primevue/button';
 import { getDocumentById, getXDDArtifacts } from '@/services/data';
 import { XDDArticle, XDDArtifact, XDDExtractionType } from '@/types/XDD';
 import { getDocumentDoi } from '@/utils/data-util';
-import { RouteName } from '@/router/routes';
-import { Project } from '@/types/Project';
-import ResourcesList from '@/components/resources/resources-list.vue';
 
 const props = defineProps<{
 	assetId: string;
-	project: Project | null;
 }>();
-
-const emit = defineEmits(['show-data-explorer']);
 
 const doc = ref<XDDArticle | null>(null);
 
@@ -220,5 +220,17 @@ onMounted(async () => {
 
 .extracted-item {
 	padding-bottom: 20px;
+}
+
+/* Meant for left:right image:caption */
+.img-container {
+	display: flex;
+	flex-direction: row;
+}
+
+.img-container > img {
+	max-width: 180px;
+	margin: 5px;
+	border: 1px solid var(--background-light-3);
 }
 </style>

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -20,12 +20,14 @@
 				<Button label="Open PDF"></Button>
 			</div>
 
-			<Accordion :multiple="true" class="accordian">
+			<Accordion :multiple="true" :active-index="[0, 1, 2, 3, 4, 5, 6, 7]" class="accordian">
 				<AccordionTab header="Abstract">
 					{{ formatAbstract(doc) }}
 				</AccordionTab>
 
+				<!--
 				<AccordionTab header="Snippets"> </AccordionTab>
+				-->
 
 				<AccordionTab header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
@@ -78,7 +80,11 @@
 					</div>
 				</AccordionTab>
 
+				<!--
 				<AccordionTab header="Other versions"> </AccordionTab>
+				-->
+				<AccordionTab header="References"> </AccordionTab>
+				<AccordionTab header="Cited by"> </AccordionTab>
 				<AccordionTab header="Related TERARium artifacts"> </AccordionTab>
 				<AccordionTab header="Provenance"> </AccordionTab>
 			</Accordion>

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -116,7 +116,7 @@ import { getDocumentById, getXDDArtifacts } from '@/services/data';
 import { XDDArticle, XDDArtifact, XDDExtractionType } from '@/types/XDD';
 import { getDocumentDoi } from '@/utils/data-util';
 
-const sectionElem = ref(null);
+const sectionElem = ref<HTMLElement | null>(null);
 
 const props = defineProps<{
 	assetId: string;

--- a/packages/client/hmi-client/src/components/resources/resources-list.vue
+++ b/packages/client/hmi-client/src/components/resources/resources-list.vue
@@ -12,8 +12,6 @@ const props = defineProps<{
 	// maybe add list size later
 }>();
 
-const emit = defineEmits(['show-data-explorer']);
-
 const router = useRouter();
 const activeProjectAssets = useResourcesStore().activeProjectAssets;
 
@@ -56,6 +54,10 @@ filteredRouteMetadata.forEach((metadata) => {
 function openResource(name: RouteName, params: RouteParamsRaw) {
 	router.push({ name, params });
 }
+
+const openDataExplorer = () => {
+	router.push({ name: RouteName.DataExplorerRoute });
+};
 </script>
 
 <template>
@@ -69,9 +71,9 @@ function openResource(name: RouteName, params: RouteParamsRaw) {
 			<resource-card :resource="resource" />
 		</li>
 	</ul>
-	<p v-else>
+	<p>
 		Find Models, Datasets, or Papers with the
-		<a @click="emit('show-data-explorer')"> Data Explorer </a>
+		<a @click="openDataExplorer()"> Data Explorer </a>
 	</p>
 </template>
 

--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 import { createRouter, createWebHashHistory } from 'vue-router';
-import DocumentView from '@/views/Document.vue';
+import DocumentView from '@/views/DocumentView.vue';
 import HomeView from '@/views/Home.vue';
 import DatasetView from '@/views/Dataset.vue';
 import ProjectView from '@/views/Project.vue';

--- a/packages/client/hmi-client/src/views/DataExplorer.vue
+++ b/packages/client/hmi-client/src/views/DataExplorer.vue
@@ -107,7 +107,7 @@ import SearchBar from '@/components/data-explorer/search-bar.vue';
 import DropdownButton from '@/components/widgets/dropdown-button.vue';
 import FacetsPanel from '@/components/data-explorer/facets-panel.vue';
 import SelectedResourcesOptionsPane from '@/components/drilldown-panel/selected-resources-options-pane.vue';
-import Document from '@/views/Document.vue';
+import Document from '@/components/articles/Document.vue';
 
 import { fetchData, getXDDSets } from '@/services/data';
 import {

--- a/packages/client/hmi-client/src/views/Dataset.vue
+++ b/packages/client/hmi-client/src/views/Dataset.vue
@@ -12,8 +12,6 @@ const props = defineProps<{
 	project: Project;
 }>();
 
-const emit = defineEmits(['show-data-explorer']);
-
 const dataset = ref<Dataset | null>(null);
 const rawContent = ref<string | null>(null);
 
@@ -110,12 +108,7 @@ const formatFeatures = (d: Dataset) => {
 				</table>
 			</div>
 		</template>
-		<resources-list
-			v-else
-			:project="props?.project"
-			:resourceRoute="RouteName.DatasetRoute"
-			@show-data-explorer="emit('show-data-explorer')"
-		/>
+		<resources-list v-else :project="props?.project" :resourceRoute="RouteName.DatasetRoute" />
 	</section>
 </template>
 

--- a/packages/client/hmi-client/src/views/DocumentView.vue
+++ b/packages/client/hmi-client/src/views/DocumentView.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import Document from '@/components/articles/Document.vue';
+import TabContainer from '@/components/tabs/TabContainer.vue';
+import { ref, watch, computed } from 'vue';
+import { Tab } from '@/types/common';
+import useResourcesStore from '@/stores/resources';
+import { Project } from '@/types/Project';
+import { RouteName } from '@/router/routes';
+import { useTabStore } from '@/stores/tabs';
+import { isEmpty } from 'lodash';
+import ResourcesList from '@/components/resources/resources-list.vue';
+
+const props = defineProps<{
+	assetId?: string;
+	project: Project;
+}>();
+
+const emit = defineEmits(['show-data-explorer']);
+
+const resourcesStore = useResourcesStore();
+const tabStore = useTabStore();
+
+const newDocumentId = computed(() => props.assetId);
+const openTabs = ref<Tab[]>([]);
+const activeTabIndex = ref(0);
+const documentsInCurrentProject = resourcesStore.activeProjectAssets?.publications; // fixme
+const activeProject = resourcesStore.activeProject;
+const tabContext = `document${activeProject?.id}`;
+
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+tabStore.$subscribe((mutation, state) => {
+	const savedTabs = state.tabMap.get(tabContext);
+	if (savedTabs) {
+		openTabs.value = savedTabs;
+	}
+	activeTabIndex.value = tabStore.getActiveTabIndex(tabContext);
+});
+
+function removeClosedTab(tabIndexToRemove: number) {
+	tabStore.removeTab(tabContext, tabIndexToRemove);
+}
+
+function getDocumentName(id: string): string | null {
+	const currentDocument = documentsInCurrentProject?.find((doc) => doc.xdd_uri.toString() === id);
+	if (currentDocument) {
+		return currentDocument.title;
+	}
+	return null;
+}
+
+function setActiveTab(index: number) {
+	activeTabIndex.value = index;
+	tabStore.setActiveTabIndex(tabContext, index);
+}
+
+watch(newDocumentId, (id) => {
+	if (id) {
+		const newTab = {
+			name: getDocumentName(id),
+			props: {
+				assetId: id
+			}
+		} as Tab;
+		// Would have loved to use a Set here instead of an array, but equality does not work as expected for objects
+		const foundTabIndex = openTabs.value.findIndex((tab) => {
+			const tabProps = tab.props as { assetId: string };
+			return tabProps.assetId === props.assetId;
+		});
+		if (foundTabIndex === -1) {
+			openTabs.value.push(newTab);
+			tabStore.setTabs(tabContext, openTabs.value);
+			tabStore.setActiveTabIndex(tabContext, openTabs.value.length - 1);
+		} else {
+			tabStore.setActiveTabIndex(tabContext, foundTabIndex);
+		}
+	}
+});
+
+const previousOpenTabs = tabStore.getTabs(tabContext);
+if (previousOpenTabs) {
+	openTabs.value = openTabs.value.concat(previousOpenTabs);
+	setActiveTab(tabStore.getActiveTabIndex(tabContext));
+}
+</script>
+
+<template>
+	<TabContainer
+		v-if="!isEmpty(Array.from(openTabs))"
+		class="tab-container"
+		:tabs="Array.from(openTabs)"
+		:component-to-render="Document"
+		:active-tab="props.assetId"
+		@tab-closed="(tab) => removeClosedTab(tab)"
+		@tab-selected="(index) => setActiveTab(index)"
+		:active-tab-index="activeTabIndex"
+	>
+	</TabContainer>
+	<section v-else class="recent-documents-page">
+		<resources-list
+			:project="props.project"
+			:resource-route="RouteName.ModelRoute"
+			@show-data-explorer="emit('show-data-explorer')"
+		/>
+	</section>
+</template>
+
+<style scoped>
+.recent-documents-page {
+	margin: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding: 1rem;
+	background: var(--un-color-body-surface-primary);
+}
+
+.tab-container {
+	height: 100%;
+}
+</style>

--- a/packages/client/hmi-client/src/views/DocumentView.vue
+++ b/packages/client/hmi-client/src/views/DocumentView.vue
@@ -15,8 +15,6 @@ const props = defineProps<{
 	project: Project;
 }>();
 
-const emit = defineEmits(['show-data-explorer']);
-
 const resourcesStore = useResourcesStore();
 const tabStore = useTabStore();
 
@@ -97,11 +95,7 @@ if (previousOpenTabs) {
 	>
 	</TabContainer>
 	<section v-else class="recent-documents-page">
-		<resources-list
-			:project="props.project"
-			:resource-route="RouteName.ModelRoute"
-			@show-data-explorer="emit('show-data-explorer')"
-		/>
+		<resources-list :project="props.project" :resource-route="RouteName.ModelRoute" />
 	</section>
 </template>
 

--- a/packages/client/hmi-client/src/views/ModelView.vue
+++ b/packages/client/hmi-client/src/views/ModelView.vue
@@ -15,8 +15,6 @@ const props = defineProps<{
 	project: Project;
 }>();
 
-const emit = defineEmits(['show-data-explorer']);
-
 const resourcesStore = useResourcesStore();
 const tabStore = useTabStore();
 
@@ -97,11 +95,7 @@ if (previousOpenTabs) {
 	>
 	</TabContainer>
 	<section v-else class="recent-models-page">
-		<resources-list
-			:project="props.project"
-			:resource-route="RouteName.ModelRoute"
-			@show-data-explorer="emit('show-data-explorer')"
-		/>
+		<resources-list :project="props.project" :resource-route="RouteName.ModelRoute" />
 	</section>
 </template>
 

--- a/packages/client/hmi-client/src/views/Project.vue
+++ b/packages/client/hmi-client/src/views/Project.vue
@@ -5,8 +5,6 @@ import ResourcesList from '@/components/resources/resources-list.vue';
 defineProps<{
 	project: Project;
 }>();
-
-const emit = defineEmits(['show-data-explorer']);
 </script>
 
 <template>
@@ -29,7 +27,7 @@ const emit = defineEmits(['show-data-explorer']);
 				</div>
 			</section>
 			<section class="detail">
-				<resources-list :project="project" @show-data-explorer="emit('show-data-explorer')" />
+				<resources-list :project="project" />
 			</section>
 		</section>
 	</div>


### PR DESCRIPTION
### Summary
This is a 2nd round of refactoring and restyling Document viewer
- Add a tab system similar to that of models, Document is moved to its own component and a "DocumentViewer" view is added.
- Clean up accordion as per design spec
- Make image sizing adaptive depending on available width, for data-explorer images will be smaller, for the full document view images will be larger

I placed the new component within "articles" folder for now,  we will probably want to reorg and have better nomenclatures soon.


In full viewer with tabs:
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/1220927/212387554-4beb274a-b612-4341-8e1d-007801796c0b.png">

In data explorer:
<img width="1672" alt="image" src="https://user-images.githubusercontent.com/1220927/212387966-f51ffc55-1a06-4260-bcbb-cdfab0a08625.png">



### Testing
- Go into project => papers and select a few documents, should be tabbed and able to switch between tabs
- Go into explorer and search for "covid", select and see documents in the right side pane
