### PR TITLE
feat: add endpoints for persisting and getting user events

### DIFF
--- a/packages/services/hmi-server/build.gradle
+++ b/packages/services/hmi-server/build.gradle
@@ -18,6 +18,13 @@ dependencies {
 	implementation "io.quarkus:quarkus-smallrye-openapi"
 	implementation "io.quarkus:quarkus-arc"
 
+	// Persistence
+	implementation "io.quarkus:quarkus-hibernate-orm"
+	implementation "io.quarkus:quarkus-jdbc-postgresql"
+	implementation "io.quarkus:quarkus-hibernate-orm-panache"
+	annotationProcessor "io.quarkus:quarkus-panache-common"
+
+
 	// REST client
 	implementation "io.quarkus:quarkus-rest-client"
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
@@ -1,0 +1,63 @@
+package software.uncharted.terarium.hmiserver.entities;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Sort;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.models.EventType;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Data
+@Accessors(chain = true)
+@NoArgsConstructor
+public class Event extends PanacheEntityBase implements Serializable {
+	@Id
+	private String id = UUID.randomUUID().toString();
+
+	@Column(nullable = false)
+	private Long timestampMillis = Instant.now().toEpochMilli();
+
+	@Column(nullable = false)
+	private Long projectId;
+
+	@Column(nullable = false)
+	private String username;
+
+	@Column(nullable = false)
+	private EventType type;
+
+	@Column(length = 2047)
+	private String value;
+
+	/**
+	 * Gets events by type and an option search string for values
+	 * @param type				the {@link EventType}
+	 * @param projectId		the project id
+	 * @param username		the username of the current user
+	 * @param like				optional search string for values of matching events
+	 * @param limit				the maximum number of events to return
+	 * @return						a list of {@link Event} matching the input
+	 */
+	public static List<Event> findAllByTypeAndProjectAndUsernameAndLikeLimit(final EventType type, final Long projectId, final String username, String like, int limit) {
+		PanacheQuery<Event> query;
+		if (like != null && !like.isEmpty()) {
+			query = find("type = ?1 and projectid = ?2 and username = ?3 and value like ?4", Sort.descending("timestampmillis"), type, projectId, username, "%" + like + "%");
+		} else {
+			query = find("type = ?1 and projectid = ?2 and username = ?3", Sort.descending("timestampmillis"), type, projectId, username);
+		}
+
+		return query
+			.range(0, limit)
+			.list();
+	}
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
@@ -36,7 +36,6 @@ public class Event extends PanacheEntityBase implements Serializable {
 	@Column(nullable = false)
 	private Long timestampMillis = Instant.now().toEpochMilli();
 
-	@Column(nullable = false)
 	private Long projectId;
 
 	@Column(nullable = false)
@@ -51,7 +50,7 @@ public class Event extends PanacheEntityBase implements Serializable {
 	/**
 	 * Gets events by type and an option search string for values
 	 * @param type				the {@link EventType}
-	 * @param projectId		the project id
+	 * @param projectId		the optional project id
 	 * @param username		the username of the current user
 	 * @param like				optional search string for values of matching events
 	 * @param limit				the maximum number of events to return
@@ -60,9 +59,17 @@ public class Event extends PanacheEntityBase implements Serializable {
 	public static List<Event> findAllByTypeAndProjectAndUsernameAndLikeLimit(final EventType type, final Long projectId, final String username, String like, int limit) {
 		PanacheQuery<Event> query;
 		if (like != null && !like.isEmpty()) {
-			query = find("type = ?1 and projectid = ?2 and username = ?3 and value like ?4", Sort.descending("timestampmillis"), type, projectId, username, "%" + like + "%");
+			if (projectId != null) {
+				query = find("type = ?1 and projectid = ?2 and username = ?3 and value like ?4", Sort.descending("timestampmillis"), type, projectId, username, "%" + like + "%");
+			} else {
+				query = find("type = ?1 and username = ?2 and value like ?3", Sort.descending("timestampmillis"), type, username, "%" + like + "%");
+			}
 		} else {
-			query = find("type = ?1 and projectid = ?2 and username = ?3", Sort.descending("timestampmillis"), type, projectId, username);
+			if (projectId != null) {
+				query = find("type = ?1 and projectid = ?2 and username = ?3", Sort.descending("timestampmillis"), type, projectId, username);
+			} else {
+				query = find("type = ?1 and username = ?2", Sort.descending("timestampmillis"), type, username);
+			}
 		}
 
 		return query

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
@@ -11,6 +11,8 @@ import software.uncharted.terarium.hmiserver.models.EventType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
@@ -20,6 +22,13 @@ import java.util.UUID;
 @Data
 @Accessors(chain = true)
 @NoArgsConstructor
+@Table(indexes = {
+	@Index(columnList = "timestampmillis"),
+	@Index(columnList = "projectid"),
+	@Index(columnList = "username"),
+	@Index(columnList = "type"),
+	@Index(columnList = "value")
+})
 public class Event extends PanacheEntityBase implements Serializable {
 	@Id
 	private String id = UUID.randomUUID().toString();

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
@@ -1,0 +1,5 @@
+package software.uncharted.terarium.hmiserver.models;
+
+public enum EventType {
+	SEARCH
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
@@ -1,5 +1,18 @@
 package software.uncharted.terarium.hmiserver.models;
 
+import lombok.Getter;
+
 public enum EventType {
-	SEARCH
+	SEARCH(true);
+
+	EventType(boolean persistent) {
+		this.persistent = persistent;
+	}
+
+	EventType() {
+		this.persistent = false;
+	}
+
+	@Getter
+	final boolean persistent;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -54,7 +54,7 @@ public class EventResource {
 	 */
 	@POST
 	@Transactional
-	public Response putEvent(final Event event) {
+	public Response postEvent(final Event event) {
 		log.info("Event | " + securityIdentity.getPrincipal().getName() + " | " + event);
 
 		// Do not save the event to the database if the type is not specified as persistent

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -1,0 +1,62 @@
+package software.uncharted.terarium.hmiserver.resources;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import software.uncharted.terarium.hmiserver.entities.Event;
+import software.uncharted.terarium.hmiserver.models.EventType;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("/api/events")
+@Authenticated
+@Tag(name = "Events REST Endpoints")
+public class EventResource {
+	@Inject
+	private SecurityIdentity securityIdentity;
+
+	/**
+	 * Gets a list of events sorted by timestamp descending
+	 * @param type				the {@link EventType} of the events to fetch
+	 * @param projectId		the projectId to fetch events for
+	 * @param limit				the number of events to fetch
+	 * @return						a list of {@link Event} for the given user/project/type sorted by most to least recent
+	 */
+	@GET
+	public Response getEvents(@QueryParam("type") final EventType type,
+														@QueryParam("projectId") final Long projectId,
+														@QueryParam("search") final String likeValue,
+														@QueryParam("limit") @DefaultValue("10") final int limit) {
+		if (type == null || projectId == null) {
+			return Response
+				.status(Response.Status.BAD_REQUEST)
+				.build();
+		}
+
+		return Response
+			.ok(Event.findAllByTypeAndProjectAndUsernameAndLikeLimit(type, projectId, securityIdentity.getPrincipal().getName(), likeValue, limit))
+			.build();
+	}
+
+	/**
+	 * Create an event
+	 * @param event	the {@link Event} instance
+	 * @return			the persisted event instance
+	 */
+	@PUT
+	@Transactional
+	public Response putEvent(final Event event) {
+		event.setUsername(securityIdentity.getPrincipal().getName());
+		Event.persist(event);
+		return Response
+			.ok(event)
+			.build();
+	}
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -9,7 +9,7 @@ import software.uncharted.terarium.hmiserver.models.EventType;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -29,7 +29,7 @@ public class EventResource {
 	 * @param limit				the number of events to fetch
 	 * @return						a list of {@link Event} for the given user/project/type sorted by most to least recent
 	 */
-	@GET
+	@POST
 	public Response getEvents(@QueryParam("type") final EventType type,
 														@QueryParam("projectId") final Long projectId,
 														@QueryParam("search") final String likeValue,

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.Response;
 @Slf4j
 public class EventResource {
 	@Inject
-	private SecurityIdentity securityIdentity;
+	SecurityIdentity securityIdentity;
 
 	/**
 	 * Gets a list of events sorted by timestamp descending

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.resources;
 
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import software.uncharted.terarium.hmiserver.entities.Event;
 import software.uncharted.terarium.hmiserver.models.EventType;
@@ -9,8 +10,8 @@ import software.uncharted.terarium.hmiserver.models.EventType;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
@@ -18,6 +19,7 @@ import javax.ws.rs.core.Response;
 @Path("/api/events")
 @Authenticated
 @Tag(name = "Events REST Endpoints")
+@Slf4j
 public class EventResource {
 	@Inject
 	private SecurityIdentity securityIdentity;
@@ -29,7 +31,7 @@ public class EventResource {
 	 * @param limit				the number of events to fetch
 	 * @return						a list of {@link Event} for the given user/project/type sorted by most to least recent
 	 */
-	@POST
+	@GET
 	public Response getEvents(@QueryParam("type") final EventType type,
 														@QueryParam("projectId") final Long projectId,
 														@QueryParam("search") final String likeValue,
@@ -50,9 +52,18 @@ public class EventResource {
 	 * @param event	the {@link Event} instance
 	 * @return			the persisted event instance
 	 */
-	@PUT
+	@POST
 	@Transactional
 	public Response putEvent(final Event event) {
+		log.info("Event | " + securityIdentity.getPrincipal().getName() + " | " + event);
+
+		// Do not save the event to the database if the type is not specified as persistent
+		if (!event.getType().isPersistent()) {
+			return Response
+				.ok(null)
+				.build();
+		}
+
 		event.setUsername(securityIdentity.getPrincipal().getName());
 		Event.persist(event);
 		return Response

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -36,7 +36,7 @@ public class EventResource {
 														@QueryParam("projectId") final Long projectId,
 														@QueryParam("search") final String likeValue,
 														@QueryParam("limit") @DefaultValue("10") final int limit) {
-		if (type == null || projectId == null) {
+		if (type == null) {
 			return Response
 				.status(Response.Status.BAD_REQUEST)
 				.build();

--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -12,9 +12,12 @@ quarkus.keycloak.policy-enforcer.enable=true
 # JDBC
 ########################################################################################################################
 quarkus.datasource.db-kind = postgresql
-quarkus.datasource.username = terarium
-quarkus.datasource.password = terarium123
-quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5021/terarium
+%dev.quarkus.datasource.username = terarium
+%prod.quarkus.datasource.username = ${terarium-db-user}
+%dev.quarkus.datasource.password = terarium123
+%prod.quarkus.datasource.password = ${terarium-db-password}
+%prod.quarkus.datasource.jdbc.url = jdbc:postgresql://${terarium-db-host}:${terarium-db-port}/terarium
+%dev.quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5021/terarium
 # add new columns but do not drop
 quarkus.hibernate-orm.database.generation=update
 ########################################################################################################################

--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -9,6 +9,15 @@ quarkus.oidc.client-id=app
 quarkus.oidc.tls.verification=none
 quarkus.keycloak.policy-enforcer.enable=true
 ########################################################################################################################
+# JDBC
+########################################################################################################################
+quarkus.datasource.db-kind = postgresql
+quarkus.datasource.username = terarium
+quarkus.datasource.password = terarium123
+quarkus.datasource.jdbc.url = jdbc:postgresql://localhost:5021/terarium
+# add new columns but do not drop
+quarkus.hibernate-orm.database.generation=update
+########################################################################################################################
 # Deployment Configurations
 ########################################################################################################################
 quarkus.http.port=3000


### PR DESCRIPTION
This PR adds Hibernate connection properties for persisting values to a database.  We add a simple `EventResource` endpoint that allows for creating of events and listing/search for previous events.  

The `EventType` can be specified as `persistent` meaning that records are stored in the database for the given user.  This is useful for recording things like searches, logins, logouts, etc.  Non-persistent events are logged for metrics and/or dashboarding after the fact (eg/ facet filter, add X to project, etc)

To create an event:
```bash
curl --location --request POST 'http://localhost:3000/api/events' \
--header 'Authorization: Bearer ...
--data-raw '{
    "type": "SEARCH",
    "projectId": 1,
    "value": "covid-19"
}'
```
Results in the following event persisted to the database:
```json
{
    "id": "11d773fb-62a8-44d3-98c9-64efcbd3767f",
    "timestampMillis": 1674058852832,
    "projectId": 1,
    "username": "adam",
    "type": "SEARCH",
    "value": "covid-19"
}
```
A unique id is generated, along with the timestamp of event creation, the projectId, username, type, and value of the event are persisted.

We additionally provide and endpoint for fetching events:
```bash
curl --location --request GET 'http://localhost:3000/api/events?projectId=1&type=SEARCH' \
--header 'Authorization: Bearer ... '
```
Results in:
```json
[
    {
        "id": "a604313e-8a97-4607-987a-aa53c3db8368",
        "timestampMillis": 1674059193970,
        "projectId": 1,
        "username": "adam",
        "type": "SEARCH",
        "value": "covid-19"
    }
]
```

The `projectId` and `type` are required parameters. We inherently filter to only events created by the requesting user. We can optionally provide a `search` term that will filter the results based on the search string being contained in the `value` field of the event.  

eg:
```
```bash
curl --location --request GET 'http://localhost:3000/api/events?projectId=1&type=SEARCH&value=cov' \
--header 'Authorization: Bearer ... '
```
