### PR TITLE
feat: add client log shipping from hmi client to hmi server

### DIFF
--- a/packages/client/hmi-client/package.json
+++ b/packages/client/hmi-client/package.json
@@ -34,6 +34,7 @@
 		"primevue": "3.21.0",
 		"sass": "1.56.1",
 		"vue": "3.2.45",
+		"vue-logger-plugin": "2.2.3",
 		"vue-router": "4.1.6"
 	},
 	"devDependencies": {

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import PrimeVue from 'primevue/config';
-import { createLogger } from 'vue-logger-plugin';
+import { logger } from '@/utils/logger';
 import useAuthStore from './stores/auth';
 import router from './router';
 import App from './App.vue';
@@ -11,7 +11,7 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 app.use(PrimeVue, { ripple: true });
-app.use(createLogger({}));
+app.use(logger);
 
 const auth = useAuthStore();
 await auth.fetchSSO();

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import PrimeVue from 'primevue/config';
+import { createLogger } from 'vue-logger-plugin';
 import useAuthStore from './stores/auth';
 import router from './router';
 import App from './App.vue';
@@ -10,6 +11,7 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 app.use(PrimeVue, { ripple: true });
+app.use(createLogger({}));
 
 const auth = useAuthStore();
 await auth.fetchSSO();

--- a/packages/client/hmi-client/src/utils/logger.ts
+++ b/packages/client/hmi-client/src/utils/logger.ts
@@ -1,0 +1,75 @@
+// HMI-Client logging service
+import API from '@/api/api';
+import { createLogger, LogEvent, LoggerHook, LogLevel } from 'vue-logger-plugin';
+// TODO: add logic for different modes
+// const env = process.env.NODE_ENV;
+
+// LogDetails Interface
+interface LogDetails {
+	level: LogLevel;
+	message: string;
+}
+
+// Usage:
+// import logger from '@/utils/logger';
+class LogBuffer {
+	logs: LogDetails[];
+
+	constructor() {
+		this.logs = [];
+	}
+
+	clearLogs = () => {
+		this.logs = [];
+	};
+
+	add = (log: LogDetails) => {
+		this.logs.push(log);
+	};
+
+	isEmpty = (): boolean => {
+		if (this.logs.length > 0) {
+			return false;
+		}
+		return true;
+	};
+
+	getLogBuffer = (): LogDetails[] => this.logs;
+
+	startService = () => {
+		setInterval(() => {
+			this.sendLogsToServer();
+		}, 5000);
+	};
+
+	sendLogsToServer = async () => {
+		if (!this.isEmpty()) {
+			await API.post(`/logs/`, {
+				logs: this.getLogBuffer()
+			})
+				.then(() => {
+					this.clearLogs();
+				})
+				.catch((error) => {
+					console.error(error);
+				});
+		}
+	};
+}
+
+export const logBuffer = new LogBuffer();
+
+// after hook
+const bufferLog: LoggerHook = {
+	async run(event: LogEvent) {
+		const thisLog = { level: event.level, message: event.argumentArray[0] };
+		logBuffer.add(thisLog);
+	}
+};
+
+// create logger with options
+export const logger = createLogger({
+	enabled: true,
+	level: 'debug',
+	afterHooks: [bufferLog]
+});

--- a/packages/client/hmi-client/src/utils/logger.ts
+++ b/packages/client/hmi-client/src/utils/logger.ts
@@ -44,15 +44,15 @@ class LogBuffer {
 
 	sendLogsToServer = async () => {
 		if (!this.isEmpty()) {
-			await API.post(`/logs/`, {
-				logs: this.getLogBuffer()
-			})
-				.then(() => {
-					this.clearLogs();
-				})
-				.catch((error) => {
-					console.error(error);
+			try {
+				const resp = await API.post(`/logs/`, {
+					logs: this.getLogBuffer()
 				});
+				const { status } = resp;
+				if (status !== 200) console.warn('POST to /logs did not return a 200');
+			} catch (error) {
+				console.error(error);
+			}
 		}
 	};
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/loggingservice/LoggingService.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/loggingservice/LoggingService.java
@@ -1,0 +1,48 @@
+package software.uncharted.terarium.hmiserver.models.loggingservice;
+
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+import io.vertx.core.json.JsonObject;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import java.io.Serializable;
+
+@ApplicationScoped
+@Slf4j
+@Data
+@Accessors(chain = true)
+public class LoggingService implements Serializable {
+    private List<JsonObject> logs;
+
+    public void echoLogs(String name){
+        this.logs.forEach(l -> logMessage(l, name));
+    }
+
+    private void logMessage(JsonObject payload, String name) {
+        String level = payload.getString("level");
+        String message = "HMI-Log | " + name + " | " + payload.getString("message");
+
+        switch (level) {
+            case "trace":
+                log.trace(message);
+                break;
+            case "debug":
+                log.debug(message);
+                break;
+            case "info":
+                log.info(message);
+                break;
+            case "warn":
+                log.warn(message);
+                break;
+            case "error":
+                log.error(message);
+                break;
+            default:
+                log.info("Invalid logging level, defaulting to info level: " + message);
+                break;
+        }
+    }
+
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
@@ -1,0 +1,36 @@
+package software.uncharted.terarium.hmiserver.resources.loggingservice;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import software.uncharted.terarium.hmiserver.models.loggingservice.LoggingService;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/api/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Authenticated
+@Tag(name = "Model REST Endpoints")
+public class LoggingResource {
+
+	@Inject
+	SecurityIdentity securityIdentity;
+
+	@Inject
+	LoggingService loggingService;
+
+	@POST
+	@Path("/logs")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.APPLICATION_JSON)
+	public Response letsDoThis(LoggingService logData) {
+		logData.echoLogs(securityIdentity.getPrincipal().getName());
+		return Response.ok().build();
+	}
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
@@ -27,9 +27,7 @@ public class LoggingResource {
 
 	@POST
 	@Path("/logs")
-	@Produces(MediaType.APPLICATION_JSON)
-	@Consumes(MediaType.APPLICATION_JSON)
-	public Response letsDoThis(LoggingService logData) {
+	public Response echoLogs(LoggingService logData) {
 		logData.echoLogs(securityIdentity.getPrincipal().getName());
 		return Response.ok().build();
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6388,6 +6388,7 @@ cors@latest:
     vite: 3.2.5
     vitest: 0.24.5
     vue: 3.2.45
+    vue-logger-plugin: 2.2.3
     vue-router: 4.1.6
     vue-tsc: 1.0.22
   languageName: unknown
@@ -11374,6 +11375,13 @@ send@latest:
   peerDependencies:
     eslint: ">=6.0.0"
   checksum: e2e6b05989294c4439d91283a78a0cb444cfba30f2715a5be1950d7815cadb5c8f449d9362a92bdd163cb8944abaac73bb076ce3c27b27586eaa4560002e6dfd
+  languageName: node
+  linkType: hard
+
+"vue-logger-plugin@npm:2.2.3":
+  version: 2.2.3
+  resolution: "vue-logger-plugin@npm:2.2.3"
+  checksum: 6f5416c821c35aa84c2a6f5813b4b6d386b037029872dd46d5e436cd0179066c02d739532335f81f035128028f0151af8c24d947886666244f9a82e4f6dc8f8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

First part of the setting up a logging framework to capture user logs in a structured manner.  This will allow to measure user interactions and issues that occurred during usage.

Currently uses `vue-logger-plugin` and it's `afterHook` to buffer log messages and then post the messages periodically every 5 seconds.

Resolves #(issue)
Resolves the first part of setting up the instrumentation to

ship client calls to the server
the server saves structured logs

https://github.com/DARPA-ASKEM/TERArium/issues/462#event-8213619647