### PR TITLE
feat: after adding project go to said project

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown-panel/selected-resources-options-pane.vue
+++ b/packages/client/hmi-client/src/components/drilldown-panel/selected-resources-options-pane.vue
@@ -49,6 +49,9 @@ import * as ProjectService from '@/services/project';
 import { addPublication } from '@/services/external';
 import { Dataset } from '@/types/Dataset';
 import IconClose16 from '@carbon/icons-vue/es/close/16';
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
 
 const props = defineProps({
 	selectedSearchItems: {
@@ -172,6 +175,7 @@ const addAssetsToProject = async (projectName?: string) => {
 	addResourcesToProject(projectId);
 
 	emit('close');
+	router.push(`/projects/${projectId}`);
 };
 
 const removeItem = (item: ResultType) => {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
@@ -92,7 +92,7 @@ public class HomeResource {
     //Using proxy get all of the projects. 
     //Parse the nonesense into Project type
     private List<Project> getAllProjects(){
-        Integer pageSize = 50;
+        Integer pageSize = 50; //TODO: Determine a better way of grabbing "all" of a users projects. This will cap out at 50
         Integer page = 0;
         List<Project> allProjects = projectProxy.getProjects(pageSize, page);
         

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
@@ -92,7 +92,7 @@ public class HomeResource {
     //Using proxy get all of the projects. 
     //Parse the nonesense into Project type
     private List<Project> getAllProjects(){
-        Integer pageSize = 5;
+        Integer pageSize = 50;
         Integer page = 0;
         List<Project> allProjects = projectProxy.getProjects(pageSize, page);
         


### PR DESCRIPTION
# Description
Also tagging on grabbing 50 projects instead of 5 for the home page. This will let us see up to 50 of our own projects. Not sure how to determine this number at the moment so hoping 50 is good

https://user-images.githubusercontent.com/17088680/213547692-12802ca1-eec4-4d44-b091-abfbe52944da.mov




Resolves #(issue)
#494 
