### PR TITLE
ci: update target extraction from bakefile

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,12 +46,13 @@ jobs:
       - name: Create matrix
         id: targets
         run: |
-          if [[ '${{ github.ref_type }}' == 'branch' && '${{ github.ref_name }}' == 'main' ]]; then
+          if [[ "${{ github.ref_type }}" == "branch" && "${{ github.ref_name }}" == "main" ]]; then
             BAKE_GROUP=staging
           else
             BAKE_GROUP=prod
           fi
-          echo "matrix=$(docker buildx bake $BAKE_GROUP -f ${{ env.BAKE_FILE }} --print | jq -cr '.group.default.targets')" >> $GITHUB_OUTPUT
+          TARGETS=$(docker buildx bake $BAKE_GROUP -f ${{ env.BAKE_FILE }} --print | jq -cr ".group.$BAKE_GROUP.targets")
+          echo "matrix=$TARGETS" >> $GITHUB_OUTPUT
 
       # 1.3 (optional) - output the generated target list for verification
       - name: Show matrix


### PR DESCRIPTION
# Description

CI was failing to build and publish docker images. Yesterday there was a GH outage which caused some issues which also seems to have been a time where they updated their docker/buidx version. As a result the output of the bake file we were using changed and our script to extract the appropriate targets was incorrect. This update should resolve the issue to match the new output.

NOTE: not sure how we would be notified of buildx output format changes but this is a possible issue for future as well if it changes again.
