### PR TITLE
feat: add request and response logging filters to hmi server

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/RequestLoggingRequestFilter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/RequestLoggingRequestFilter.java
@@ -1,0 +1,22 @@
+package software.uncharted.terarium.hmiserver;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.time.Instant;
+
+@Provider
+@Slf4j
+public class RequestLoggingRequestFilter implements ContainerRequestFilter {
+	public static final String REQUEST_START_TIMESTAMP_MS = "request-start-timestamp-ms";
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+		log.info("REQUEST STARTED | " + requestContext.getRequest().getMethod() + " | " + requestContext.getUriInfo().getRequestUri() + " | " + user);
+		requestContext.setProperty(REQUEST_START_TIMESTAMP_MS, Instant.now().toEpochMilli());
+	}
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/RequestLoggingResponseFilter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/RequestLoggingResponseFilter.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.hmiserver;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.time.Instant;
+
+@Provider
+@Slf4j
+public class RequestLoggingResponseFilter implements ContainerResponseFilter {
+	@Override
+	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+		final long durationMs = Instant.now().toEpochMilli() - (long)requestContext.getProperty(RequestLoggingRequestFilter.REQUEST_START_TIMESTAMP_MS);
+		log.info("REQUEST COMPLETED | " + requestContext.getRequest().getMethod() + " | " + requestContext.getUriInfo().getRequestUri() + " | " + user + " | " + durationMs + "ms");
+	}
+}


### PR DESCRIPTION
This PR logs a message when requests are started and completed.  They include:
- request path
- request type
- requesting user
- duration (in the case of responses)

Eg:
```
2023-01-20 10:42:01,328 INFO  [org.key.ada.aut.PolicyEnforcer] (Quarkus Main Thread) Paths provided in configuration.
2023-01-20 10:42:02,156 INFO  [io.quarkus] (Quarkus Main Thread) hmi-server 1.0.0-SNAPSHOT on JVM (powered by Quarkus 2.14.2.Final) started in 4.128s. Listening on: http://localhost:3000
...
2023-01-20 10:42:10,056 INFO  [sof.unc.ter.hmi.RequestLoggingRequestFilter] (executor-thread-0) REQUEST STARTED | GET | http://localhost:3000/api/events?type=SEARCH | adam
2023-01-20 10:42:10,230 INFO  [sof.unc.ter.hmi.RequestLoggingResponseFilter] (executor-thread-0) REQUEST COMPLETED | GET | http://localhost:3000/api/events?type=SEARCH | adam | 171ms