### PR TITLE
feat(hmi-server): rowlimit added for csv preview

### DIFF
--- a/packages/client/hmi-client/src/services/dataset.ts
+++ b/packages/client/hmi-client/src/services/dataset.ts
@@ -51,7 +51,7 @@ async function getBulkDatasets(datasetIDs: string[]) {
 async function downloadRawFile(datasetId: string): Promise<string | null> {
 	// FIXME: review exposing the "wide_format" and "data_annotation_flag" later
 	const response = await API.get(
-		`/datasets/${datasetId}/download/rawfile?wide_format=true&data_annotation_flag=false`
+		`/datasets/${datasetId}/download/rawfile?wide_format=true&data_annotation_flag=false&row_limit=50`
 	);
 	return response?.data ?? null;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
@@ -125,7 +125,8 @@ public interface DatasetProxy {
 	Response getCsv(
 		@PathParam("id") String id,
 		@DefaultValue("true") @QueryParam("wide_format") final Boolean wideFormat,
-		@DefaultValue("false") @QueryParam("data_annotation_flag") Boolean dataAnnotationFlag
+		@DefaultValue("false") @QueryParam("data_annotation_flag") Boolean dataAnnotationFlag,
+		@DefaultValue("50") @QueryParam("row_limit") final Integer rowLimit
 	);
 
 	@POST

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
@@ -167,9 +167,10 @@ public class DatasetResource {
 	public Response getCsv(
 		@PathParam("id") final String id,
 		@DefaultValue("true") @QueryParam("wide_format") final Boolean wideFormat,
-		@DefaultValue("false") @QueryParam("data_annotation_flag") final Boolean dataAnnotationFlag
+		@DefaultValue("false") @QueryParam("data_annotation_flag") final Boolean dataAnnotationFlag,
+		@DefaultValue("50") @QueryParam("row_limit") final Integer rowLimit
 	) {
-		return proxy.getCsv(id, wideFormat, dataAnnotationFlag);
+		return proxy.getCsv(id, wideFormat, dataAnnotationFlag, rowLimit);
 	}
 
 	@POST


### PR DESCRIPTION
Adding the `row_limit` to the csv download api to limit the number of rows shown in the front end to not lock up the application.

Resolves #464
