### PR TITLE
feat: throwing up a quickie unauthorized page

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -1,22 +1,26 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import Navbar from '@/components/Navbar.vue';
 import Sidebar from '@/components/Sidebar.vue';
 import { Project } from '@/types/Project';
 import * as ProjectService from '@/services/project';
 import useResourcesStore from '@/stores/resources';
+import API from '@/api/api';
 import { RoutePath, useCurrentRoute } from './router/index';
 
 /**
  * Router
  */
 const route = useRoute();
+const router = useRouter();
 const currentRoute = useCurrentRoute();
 const isSidebarVisible = computed(
 	() =>
 		currentRoute.value.path !== RoutePath.Home && currentRoute.value.path !== RoutePath.DataExplorer
 );
+const isErrorState = computed(() => currentRoute.value.name === 'unauthorized');
+
 const searchBarText = ref('');
 const relatedSearchTerms = ref<string[]>([]);
 const resources = useResourcesStore();
@@ -35,6 +39,17 @@ function updateSearchBar(newQuery) {
 function updateRelatedSearchTerms(newTerms) {
 	relatedSearchTerms.value = newTerms.slice(0, 5);
 }
+
+API.interceptors.response.use(
+	(response) => response,
+	(error) => {
+		const status = error.response.status;
+		console.error(error);
+		if (status === 401 || status === 403) {
+			router.push({ name: 'unauthorized' });
+		}
+	}
+);
 
 watch(
 	() => route.params.projectId,
@@ -55,13 +70,19 @@ watch(
 
 <template>
 	<Navbar
+		v-if="!isErrorState"
 		class="header"
 		:project="project"
 		:searchBarText="searchBarText"
 		:relatedSearchTerms="relatedSearchTerms"
 	/>
 	<main>
-		<Sidebar v-if="isSidebarVisible" class="sidebar" data-test-id="sidebar" :project="project" />
+		<Sidebar
+			v-if="isSidebarVisible && !isErrorState"
+			class="sidebar"
+			data-test-id="sidebar"
+			:project="project"
+		/>
 		<router-view
 			class="page"
 			:project="project"

--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -12,6 +12,7 @@ import SimulationResultView from '@/views/SimulationResult.vue';
 import TA2Playground from '@/views/TA2Playground.vue';
 import TheiaView from '@/views/theia.vue';
 import DataExplorerView from '@/views/DataExplorer.vue';
+import UnauthorizedView from '@/views/Unauthorized.vue';
 import { RouteName } from './routes';
 
 export enum RoutePath {
@@ -23,6 +24,7 @@ export enum RoutePath {
 	Simulation = '/projects/:projectId/simulations/:assetId?',
 	SimulationResult = '/projects/:projectId/simulation-results/:assetId?',
 	DataExplorer = '/explorer',
+	Unauthorized = '/unauthorized',
 
 	// Playground and experiments, these components are testing-only
 	Theia = '/theia',
@@ -32,6 +34,7 @@ export enum RoutePath {
 }
 
 const routes = [
+	{ name: 'unauthorized', path: RoutePath.Unauthorized, component: UnauthorizedView },
 	{ name: RouteName.DocumentRoute, path: RoutePath.Document, component: DocumentView, props: true },
 	{ name: RouteName.HomeRoute, path: RoutePath.Home, component: HomeView },
 	{ name: RouteName.ModelRoute, path: RoutePath.Model, component: ModelView, props: true },
@@ -49,6 +52,8 @@ const routes = [
 		component: DataExplorerView,
 		props: (route) => ({ query: route.query.q })
 	},
+	{ name: RouteName.SimulationRoute, path: RoutePath.Simulation, component: SimulationView },
+
 	// Playground and experiments, these components are testing-only
 	{ path: RoutePath.Theia, component: TheiaView },
 	{ path: RoutePath.Ta2Playground, component: TA2Playground },

--- a/packages/client/hmi-client/src/views/Unauthorized.vue
+++ b/packages/client/hmi-client/src/views/Unauthorized.vue
@@ -1,0 +1,22 @@
+<template>
+	<section class="unauthorized">
+		<h2>Unauthorized</h2>
+		<p>
+			You have been authenticated but not authorized to use this application, please contact
+			Uncharted to be granted access. Once you have been authroized please
+			<a href="#" @click="auth.logout">Sign-in</a> again.
+		</p>
+	</section>
+</template>
+
+<script setup lang="ts">
+import useAuthStore from '@/stores/auth';
+
+const auth = useAuthStore();
+</script>
+
+<style>
+.unauthorized {
+	padding: 2rem;
+}
+</style>


### PR DESCRIPTION
### Summary
Throwing up a quickie unauthorized page, most likely this is a temporary or will be massively revamped later on.
Right now the purpose is to guide people who have been authenticated via Github but not yet authorized in Terarium

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/1220927/213806838-df875a72-56b0-42c9-a78a-914679d4793b.png">


### Testing
This is a bit difficult to test locally, what you can do is go into the hmi-server,  in HomeResource.java change
```
        return Response
            .status(Response.Status.OK)
            .entity(allProjects)
            .type(MediaType.APPLICATION_JSON)
            .build();
```

To

```
        return Response
            .status(Response.Status.FORBIDDEN)
            .entity(allProjects)
            .type(MediaType.APPLICATION_JSON)
            .build();
```

