### PR TITLE
ci: set specific buildkit version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -149,6 +149,9 @@ jobs:
       # 2.7 - Setup Docker BuildX for multi platform building
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       # 2.8 - Build and push Docker Images
       - name: Build Images using BuildX Bake


### PR DESCRIPTION
Pinning version of buildkit being used to build and push images.

Reason:
Recent changes upgraded the buildx version which includes a newer version of buildkit, which in turn uses a new version of `containerd` which causes this root issue. It is not a GH issue per se but due to their recent upgrades it was introduced with the actions that were being used in the CI.

[Reference](https://github.com/docker/build-push-action/issues/761)

Resolution:
Pinning the buildkit version we are using for the build and publish step, this resolves the current issue.  Investigation of further places where we can pin the version is ongoing. Shared publish scripts have also been updated.

Tests:
Pushed a dummy tag to build the images with this fix and all images were successful. 