### PR TITLE
chore: xDD known_entities fixes

### DIFF
--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -24,9 +24,18 @@
 					{{ formattedAbstract }}
 				</AccordionTab>
 
-				<!--
-				<AccordionTab header="Snippets"> </AccordionTab>
-				-->
+				<AccordionTab
+					v-if="doc.knownEntities && doc.knownEntities.summaries.sections"
+					header="Snippets"
+				>
+					<div v-for="(v, k) of doc.knownEntities.summaries.sections" :key="k">
+						<div>
+							<strong>{{ k }}</strong>
+						</div>
+						<div>{{ v }}</div>
+						<br />
+					</div>
+				</AccordionTab>
 
 				<AccordionTab v-if="figureArtifacts.length > 0" header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -26,7 +26,7 @@
 
 				<AccordionTab
 					v-if="doc.knownEntities && doc.knownEntities.summaries.sections"
-					header="Snippets"
+					header="Section summaries"
 				>
 					<div v-for="(v, k) of doc.knownEntities.summaries.sections" :key="k">
 						<div>

--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -489,7 +489,7 @@ const searchXDDArticles = async (term: string, xddSearchParam?: XDDSearchParams)
 const getDocumentById = async (docid: string) => {
 	const searchParams: XDDSearchParams = {
 		docid,
-		known_entities: 'urlExtractions'
+		known_entities: 'url_extractions,summaries'
 	};
 	const xddRes = await searchXDDArticles('', searchParams);
 	if (xddRes) {

--- a/packages/client/hmi-client/src/types/XDD.ts
+++ b/packages/client/hmi-client/src/types/XDD.ts
@@ -33,6 +33,9 @@ export type XDDUrlExtraction = {
 
 export type XDDArticleKnownEntity = {
 	urlExtractions: XDDUrlExtraction[];
+	summaries: {
+		sections: { [key: string]: string };
+	};
 };
 
 export type XDDArticle = {

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/KnownEntities.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/KnownEntities.java
@@ -6,12 +6,15 @@ import lombok.experimental.Accessors;
 import javax.json.bind.annotation.JsonbProperty;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Accessors(chain = true)
 public class KnownEntities implements Serializable {
 
 	public List<XDDUrlExtraction> urlExtractions;
+
+	public Map<String, Map<String, String>> summaries;
 
 	@JsonbProperty("url_extractions")
 	public void setURLExtractions(List<XDDUrlExtraction> urlExtractions) {

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/XDDUrlExtraction.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/XDDUrlExtraction.java
@@ -5,6 +5,7 @@ import lombok.experimental.Accessors;
 
 import javax.json.bind.annotation.JsonbProperty;
 import java.io.Serializable;
+import java.util.List;
 
 @Data
 @Accessors(chain = true)
@@ -14,7 +15,7 @@ public class XDDUrlExtraction implements Serializable {
 
 	private String resourceTitle;
 
-	private String extractedFrom;
+	private List<String> extractedFrom;
 
 	@JsonbProperty("resource_title")
 	public void setResourceTitle(String resourceTitle) {
@@ -22,7 +23,7 @@ public class XDDUrlExtraction implements Serializable {
 	}
 
 	@JsonbProperty("extracted_from")
-	public void setExtractedFrom(String extractedFrom) {
+	public void setExtractedFrom(List<String> extractedFrom) {
 		this.extractedFrom = extractedFrom;
 	}
 

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/DocumentProxy.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/DocumentProxy.java
@@ -30,7 +30,8 @@ public interface DocumentProxy {
 		@QueryParam("pubname") String pubname,
 		@QueryParam("publisher") String publisher,
 		@QueryParam("additional_fields") String additional_fields,
-		@QueryParam("match") String match
+		@QueryParam("match") String match,
+		@QueryParam("known_entities") String known_entities
 	);
 
 	@GET

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DocumentResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DocumentResource.java
@@ -70,7 +70,6 @@ public class DocumentResource {
 				publisher = null;
 				additional_fields = null;
 				match = null;
-				known_entities = null;
 			}
 
 			XDDResponse<XDDArticlesResponseOK> doc = proxy.getDocuments(

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DocumentResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DocumentResource.java
@@ -46,9 +46,9 @@ public class DocumentResource {
 		@QueryParam("pubname") String pubname,
 		@QueryParam("publisher") String publisher,
 		@QueryParam("additional_fields") String additional_fields,
-		@QueryParam("match") String match
+		@QueryParam("match") String match,
+		@QueryParam("known_entities") String known_entities
 	) {
-
 
 		// only go ahead with the query if at least one param is present
 		if (docid != null || doi != null || term != null) {
@@ -70,11 +70,12 @@ public class DocumentResource {
 				publisher = null;
 				additional_fields = null;
 				match = null;
+				known_entities = null;
 			}
 
 			XDDResponse<XDDArticlesResponseOK> doc = proxy.getDocuments(
 				docid, doi, title, term, dataset, include_score, include_highlights, inclusive, full_results, max, per_page, dict, facets,
-				min_published, max_published, pubname, publisher, additional_fields, match);
+				min_published, max_published, pubname, publisher, additional_fields, match, known_entities);
 			return doc;
 
 		}


### PR DESCRIPTION
### Summary
Provisional work to hook up snippets sections with summaries sections from xDD

<img width="474" alt="image" src="https://user-images.githubusercontent.com/1220927/214212741-bf8399c3-d669-4561-bdb9-6a47d85518c9.png">


### Test
Select documents within project artifacts or in data explorer, some of them will have summary extractions.