### PR TITLE
chore: correct naming for expected output

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Publication.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Publication.java
@@ -12,12 +12,8 @@ public class Publication implements Serializable {
 
 	private String id;
 
-	private String xddUri;
-	@JsonbProperty("xdd_uri")
-	public void setXddUri(String xddUri){
-			this.xddUri = xddUri;
-	}
-	public String getXddUri(){ return this.xddUri; }
+    @JsonbProperty("xdd_uri")
+    private String xddUri;
 
 	@JsonbProperty("title")
 	private String title;


### PR DESCRIPTION
# Description
Changing publication's naming to allow us to hit the /external/publications POST with the expected JSON formatting

https://user-images.githubusercontent.com/17088680/214401897-a077e3dc-f92d-4fd8-86fb-ebb35f79991d.mov



Resolves #(issue)
#528 