### PR TITLE
feat: add request logging for document-service

### DIFF
--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/RequestLoggingRequestFilter.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/RequestLoggingRequestFilter.java
@@ -1,0 +1,22 @@
+package software.uncharted.terarium.documentserver;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.time.Instant;
+
+@Provider
+@Slf4j
+public class RequestLoggingRequestFilter implements ContainerRequestFilter {
+	public static final String REQUEST_START_TIMESTAMP_MS = "request-start-timestamp-ms";
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+		log.info("REQUEST STARTED | " + requestContext.getRequest().getMethod() + " | " + requestContext.getUriInfo().getRequestUri() + " | " + user);
+		requestContext.setProperty(REQUEST_START_TIMESTAMP_MS, Instant.now().toEpochMilli());
+	}
+}

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/RequestLoggingResponseFilter.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/RequestLoggingResponseFilter.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.documentserver;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.time.Instant;
+
+@Provider
+@Slf4j
+public class RequestLoggingResponseFilter implements ContainerResponseFilter {
+	@Override
+	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+		final long durationMs = Instant.now().toEpochMilli() - (long)requestContext.getProperty(RequestLoggingRequestFilter.REQUEST_START_TIMESTAMP_MS);
+		log.info("REQUEST COMPLETED | " + requestContext.getRequest().getMethod() + " | " + requestContext.getUriInfo().getRequestUri() + " | " + user + " | " + durationMs + "ms");
+	}
+}


### PR DESCRIPTION
This adds the standard request/response logging to the document-service so we can see the proxied requests being sent to it