### PR TITLE
style: no image stretch in preview, accordion fills width, clickable doi in preview

### DIFF
--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -1,24 +1,25 @@
 <template>
 	<section class="doc-view-container" ref="sectionElem">
 		<div v-if="doc">
-			<div class="journal">{{ doc.journal }}</div>
-			<h4 class="title">
-				{{ doc.title }}
-			</h4>
-			<div class="authors">{{ formatArticleAuthors(doc) }}</div>
-			<br />
+			<header>
+				<div class="journal">{{ doc.journal }}</div>
+				<h4 class="title">
+					{{ doc.title }}
+				</h4>
+				<div class="authors">{{ formatArticleAuthors(doc) }}</div>
+				<br />
 
-			<div class="row">
-				<!-- TODO -->
-				<!-- Journal impact factor -->
-				<!-- # Citations -->
-				<div>
-					<div class="publisher">{{ doc.publisher }}</div>
-					<div class="doi">DOI: {{ doi }}</div>
+				<div class="row">
+					<!-- TODO -->
+					<!-- Journal impact factor -->
+					<!-- # Citations -->
+					<div>
+						<div class="publisher">{{ doc.publisher }}</div>
+						<div class="doi">DOI: {{ doi }}</div>
+					</div>
+					<Button v-if="docLink" label="Open PDF" @click="openPDF"> </Button>
 				</div>
-				<Button v-if="docLink" label="Open PDF" @click="openPDF"> </Button>
-			</div>
-
+			</header>
 			<Accordion :multiple="true" :active-index="[0, 1, 2, 3, 4, 5, 6, 7]" class="accordian">
 				<AccordionTab v-if="formattedAbstract.length > 0" header="Abstract">
 					{{ formattedAbstract }}
@@ -40,12 +41,14 @@
 				<AccordionTab v-if="figureArtifacts.length > 0" header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
+							<!-- <div> -->
 							<img
 								id="img"
 								:src="'data:image/jpeg;base64,' + ex.properties.image"
 								:alt="''"
 								:style="{ 'max-width': imageSize }"
 							/>
+							<!-- </div> -->
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -56,12 +59,14 @@
 				<AccordionTab v-if="tableArtifacts.length > 0" header="Tables">
 					<div v-for="ex in tableArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
+							<!-- <div> -->
 							<img
 								id="img"
 								:src="'data:image/jpeg;base64,' + ex.properties.image"
 								:alt="''"
 								:style="{ 'max-width': imageSize }"
 							/>
+							<!-- </div> -->
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -72,12 +77,14 @@
 				<AccordionTab v-if="equationArtifacts.length > 0" header="Equations">
 					<div v-for="ex in equationArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
+							<!-- <div> -->
 							<img
 								id="img"
 								:src="'data:image/jpeg;base64,' + ex.properties.image"
 								:alt="''"
 								:style="{ 'max-width': imageSize }"
 							/>
+							<!-- </div> -->
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -204,6 +211,7 @@ const relatedTerariumArtifacts = ref<ResultType[]>([]);
 const figureArtifacts = computed(
 	() => artifacts.value.filter((d) => d.askemClass === XDDExtractionType.Figure) || []
 );
+
 const tableArtifacts = computed(
 	() => artifacts.value.filter((d) => d.askemClass === XDDExtractionType.Table) || []
 );
@@ -247,6 +255,7 @@ const fetchDocumentArtifacts = async () => {
 		// note that some XDD documents do not have a valid doi
 		artifacts.value = [];
 	}
+	console.log(artifacts.value.filter((d) => d.askemClass === XDDExtractionType.Figure));
 };
 
 const fetchRelatedTerariumArtifacts = async () => {
@@ -298,9 +307,17 @@ onMounted(async () => {
 
 <style scoped>
 .doc-view-container {
-	padding: 2rem;
 	font-size: large;
 	overflow: auto;
+}
+
+header {
+	padding: 0rem 1rem;
+}
+
+div,
+span {
+	overflow-wrap: break-word;
 }
 
 .row {
@@ -335,7 +352,9 @@ onMounted(async () => {
 }
 
 .img-container > img {
-	margin: 5px;
+	height: min-content;
+	object-fit: contain;
+	margin-right: 10px;
 	border: 1px solid var(--gray-300);
 }
 </style>

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -46,14 +46,7 @@
 				<AccordionTab v-if="figureArtifacts.length > 0" header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<!-- <div> -->
-							<img
-								id="img"
-								:src="'data:image/jpeg;base64,' + ex.properties.image"
-								:alt="''"
-								:style="{ 'max-width': imageSize }"
-							/>
-							<!-- </div> -->
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -64,14 +57,7 @@
 				<AccordionTab v-if="tableArtifacts.length > 0" header="Tables">
 					<div v-for="ex in tableArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<!-- <div> -->
-							<img
-								id="img"
-								:src="'data:image/jpeg;base64,' + ex.properties.image"
-								:alt="''"
-								:style="{ 'max-width': imageSize }"
-							/>
-							<!-- </div> -->
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -82,14 +68,7 @@
 				<AccordionTab v-if="equationArtifacts.length > 0" header="Equations">
 					<div v-for="ex in equationArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
-							<!-- <div> -->
-							<img
-								id="img"
-								:src="'data:image/jpeg;base64,' + ex.properties.image"
-								:alt="''"
-								:style="{ 'max-width': imageSize }"
-							/>
-							<!-- </div> -->
+							<img id="img" :src="'data:image/jpeg;base64,' + ex.properties.image" :alt="''" />
 							<span>{{
 								ex.properties.caption ? ex.properties.caption : ex.properties.contentText
 							}}</span>
@@ -295,15 +274,8 @@ const formatCitation = (obj: { [key: string]: string }) => {
 	return `${obj.author}, ${obj.year}, "${obj.title}", ${obj.journal}, ${obj.doi}`;
 };
 
-// Image size will adapt depend on available space
-const imageSize = ref('160px');
-
 // fetch artifacts from COSMOS using the doc doi
 onMounted(async () => {
-	const rect = (sectionElem.value as HTMLElement).getBoundingClientRect();
-	if (rect.width > 800) {
-		imageSize.value = '400px';
-	}
 	fetchDocumentArtifacts();
 	fetchRelatedTerariumArtifacts();
 });
@@ -341,6 +313,7 @@ span {
 }
 
 .accordian {
+	font-size: 14px;
 	margin-top: 1rem;
 	margin-bottom: 1rem;
 }
@@ -352,13 +325,14 @@ span {
 /* Meant for left:right image:caption */
 .img-container {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
+	gap: 0.5rem;
 }
 
 .img-container > img {
-	height: min-content;
+	max-height: 10rem;
+	width: 100%;
 	object-fit: contain;
-	margin-right: 10px;
 	border: 1px solid var(--gray-300);
 }
 </style>

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -319,7 +319,7 @@ span {
 }
 
 .extracted-item {
-	padding-bottom: 20px;
+	padding-bottom: 0.5rem;
 }
 
 /* Meant for left:right image:caption */

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -311,10 +311,11 @@ a:hover {
 }
 
 .accordian {
-	font-size: 14px;
 	margin-top: 1rem;
-	margin-bottom: 1rem;
+	font-size: 14px;
 }
+
+/* .p-accordion .p-accordion-content {} */
 
 .extracted-item {
 	padding-bottom: 0.5rem;

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -3,33 +3,31 @@
 		<div v-if="doc">
 			<header>
 				<div class="journal">{{ doc.journal }}</div>
-				<h4 class="title">
-					{{ doc.title }}
-				</h4>
+				<h4 class="title">{{ doc.title }}</h4>
 				<div class="authors">{{ formatArticleAuthors(doc) }}</div>
-				<br />
-
-				<div class="row">
+				<div class="details">
+					<div v-if="docLink || doi">
+						DOI:
+						<a :href="`https://doi.org/${doi}`" target="_blank" rel="noreferrer noopener">
+							{{ doi }}
+						</a>
+					</div>
+					<div>{{ doc.publisher }}</div>
 					<!-- TODO -->
 					<!-- Journal impact factor -->
 					<!-- # Citations -->
-					<div>
-						<div class="publisher">{{ doc.publisher }}</div>
-						<div class="doi">
-							DOI:
-							<a :href="`https://doi.org/${doi}`" target="_blank" rel="noreferrer noopener">{{
-								doi
-							}}</a>
-						</div>
-					</div>
-					<Button v-if="docLink" label="Open PDF" @click="openPDF"> </Button>
+					<Button
+						v-if="docLink || doi"
+						class="p-button-sm p-button-outlined"
+						label="Open PDF"
+						@click="openPDF"
+					/>
 				</div>
 			</header>
 			<Accordion :multiple="true" :active-index="[0, 1, 2, 3, 4, 5, 6, 7]" class="accordian">
 				<AccordionTab v-if="formattedAbstract.length > 0" header="Abstract">
 					{{ formattedAbstract }}
 				</AccordionTab>
-
 				<AccordionTab
 					v-if="doc.knownEntities && doc.knownEntities.summaries.sections"
 					header="Section summaries"
@@ -42,7 +40,6 @@
 						<br />
 					</div>
 				</AccordionTab>
-
 				<AccordionTab v-if="figureArtifacts.length > 0" header="Figures">
 					<div v-for="ex in figureArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
@@ -53,7 +50,6 @@
 						</div>
 					</div>
 				</AccordionTab>
-
 				<AccordionTab v-if="tableArtifacts.length > 0" header="Tables">
 					<div v-for="ex in tableArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
@@ -64,7 +60,6 @@
 						</div>
 					</div>
 				</AccordionTab>
-
 				<AccordionTab v-if="equationArtifacts.length > 0" header="Equations">
 					<div v-for="ex in equationArtifacts" :key="ex.askemId" class="extracted-item">
 						<div class="img-container">
@@ -75,7 +70,6 @@
 						</div>
 					</div>
 				</AccordionTab>
-
 				<AccordionTab v-if="urlArtifacts.length > 0" header="URLs">
 					<div v-for="ex in urlArtifacts" :key="ex.url">
 						<b>{{ ex.resourceTitle }}</b>
@@ -84,7 +78,6 @@
 						</div>
 					</div>
 				</AccordionTab>
-
 				<AccordionTab v-if="otherArtifacts.length > 0" header="Others">
 					<div v-for="ex in otherArtifacts" :key="ex.askemId" class="extracted-item">
 						<b>{{ ex.properties.title }}</b>
@@ -93,17 +86,14 @@
 						{{ ex.properties.contentText }}
 					</div>
 				</AccordionTab>
-
 				<AccordionTab header="References">
 					<div v-for="(citation, key) of doc.citationList" :Key="key">
 						{{ key + 1 }}. {{ formatCitation(citation) }}
 					</div>
 				</AccordionTab>
-
 				<!--
 				<AccordionTab header="Cited by"> </AccordionTab>
 				-->
-
 				<AccordionTab
 					v-if="relatedTerariumArtifacts.length > 0"
 					header="Related TERARium artifacts"
@@ -120,7 +110,6 @@
 						<Column field="name" header="Papers"></Column>
 					</DataTable>
 				</AccordionTab>
-
 				<!--
 				<AccordionTab header="Provenance"> </AccordionTab>
 				-->
@@ -258,7 +247,8 @@ watch(doi, (currentValue, oldValue) => {
 });
 
 const openPDF = () => {
-	window.open(docLink.value as string);
+	if (docLink.value) window.open(docLink.value as string);
+	else if (doi.value) window.open(`https://doi.org/${doi.value}`);
 };
 
 /**
@@ -282,13 +272,12 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.doc-view-container {
-	font-size: large;
-	overflow: auto;
-}
-
 header {
 	padding: 0rem 1rem;
+	color: var(--text-color-subdued);
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
 }
 
 div,
@@ -296,20 +285,29 @@ span {
 	overflow-wrap: break-word;
 }
 
-.row {
-	display: flex;
-	justify-content: space-between;
+a {
+	color: var(--text-color-subdued);
 }
 
-.authors {
-	font-style: italic;
-	padding-top: 8px;
+a:hover {
+	color: var(--primary-color-dark);
 }
 
-.journal,
-.publisher,
-.doi {
-	padding-top: 8px;
+.p-button.p-button-outlined {
+	margin-top: 1rem;
+	background-color: transparent;
+	color: var(--text-color-primary);
+	font-weight: bold;
+	box-shadow: var(--text-color-disabled) inset 0 0 0 1px;
+}
+
+.title {
+	color: var(--text-color-primary);
+}
+
+.authors,
+.journal {
+	color: var(--primary-color-dark);
 }
 
 .accordian {
@@ -322,7 +320,6 @@ span {
 	padding-bottom: 0.5rem;
 }
 
-/* Meant for left:right image:caption */
 .img-container {
 	display: flex;
 	flex-direction: column;

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -15,7 +15,12 @@
 					<!-- # Citations -->
 					<div>
 						<div class="publisher">{{ doc.publisher }}</div>
-						<div class="doi">DOI: {{ doi }}</div>
+						<div class="doi">
+							DOI:
+							<a :href="`https://doi.org/${doi}`" target="_blank" rel="noreferrer noopener">{{
+								doi
+							}}</a>
+						</div>
 					</div>
 					<Button v-if="docLink" label="Open PDF" @click="openPDF"> </Button>
 				</div>

--- a/packages/client/hmi-client/src/components/articles/Document.vue
+++ b/packages/client/hmi-client/src/components/articles/Document.vue
@@ -255,7 +255,6 @@ const fetchDocumentArtifacts = async () => {
 		// note that some XDD documents do not have a valid doi
 		artifacts.value = [];
 	}
-	console.log(artifacts.value.filter((d) => d.askemClass === XDDExtractionType.Figure));
 };
 
 const fetchRelatedTerariumArtifacts = async () => {

--- a/packages/client/hmi-client/src/components/data-explorer/preview-panel.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/preview-panel.vue
@@ -8,7 +8,8 @@
 	>
 		<template v-slot:content>
 			<div class="slider-header content">
-				<i class="slider-header-item pi pi-times" @click="emit('update:previewItem', null)"></i>
+				<span>{{ resultType.toUpperCase() }}</span>
+				<i class="pi pi-times" @click="emit('update:previewItem', null)"></i>
 			</div>
 			<div class="selected-resources-pane">
 				<Document
@@ -114,28 +115,25 @@ const previewItemId = computed(() => {
 </script>
 
 <style scoped>
-i {
-	font-size: 1.5rem;
-	cursor: pointer;
-}
-
 .slider-header {
 	display: flex;
 	align-items: center;
+	margin: 1rem;
 }
 
 .slider-header.content {
-	flex-direction: row-reverse;
+	font-size: 14px;
+	color: var(--text-color-subdued);
+	font-weight: bold;
 	justify-content: space-between;
+}
+
+i {
+	cursor: pointer;
 }
 
 .slider-header.tab {
 	justify-content: center;
-}
-
-.slider-header-item {
-	font-weight: bold;
-	margin: 12px;
 }
 
 footer {

--- a/packages/client/hmi-client/src/components/data-explorer/search-item.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-item.vue
@@ -222,7 +222,7 @@ const formatFeatures = () => {
 							target="_blank"
 							rel="noreferrer noopener"
 						>
-							{{ `https://doi.org/${relatedAsset.properties.DOI}` }}
+							{{ relatedAsset.properties.DOI }}
 						</a>
 					</div>
 					<div class="link" v-else-if="relatedAsset.urlExtraction">


### PR DESCRIPTION
# Description

Styling improvements for data explorer preview
![image](https://user-images.githubusercontent.com/28237258/214701899-66406fc8-3a6e-4d97-bc40-237ce1a658f6.png)


Resolves #531 
