### PR TITLE
feat: show username in project page; allow user to edit project page

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -66,6 +66,12 @@ watch(
 	},
 	{ immediate: true }
 );
+
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+resources.$subscribe((mutation, state) => {
+	project.value = state.activeProject;
+});
 </script>
 
 <template>

--- a/packages/client/hmi-client/src/components/Navbar.vue
+++ b/packages/client/hmi-client/src/components/Navbar.vue
@@ -91,17 +91,25 @@ function goToPage(event) {
 	}
 }
 
-watch(activeProjectId, (newProjectId) => {
-	const projectNavKey = `/projects/${newProjectId}`;
+function updateProjectNavItem(id, name) {
+	const projectNavKey = `/projects/${id}`;
 	const projectNavItem = {
 		[projectNavKey]: {
-			name: activeProjectName.value,
+			name,
 			icon: 'pi pi-images',
 			routeName: RouteName.ProjectRoute
 		}
 	};
 	navItems.value = { ...initialNavItems, ...projectNavItem };
 	selectedPage.value = navItems.value[currentRoute.value.path];
+}
+
+watch(activeProjectId, (newProjectId) => {
+	updateProjectNavItem(newProjectId, activeProjectName.value);
+});
+
+watch(activeProjectName, (newProjectName) => {
+	updateProjectNavItem(activeProjectId.value, newProjectName);
 });
 
 watch(currentRoute, (newRoute) => {

--- a/packages/client/hmi-client/src/components/projects/NewProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/NewProjectCard.vue
@@ -6,15 +6,18 @@ import Textarea from 'primevue/textarea';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import * as ProjectService from '@/services/project';
+import useAuthStore from '@/stores/auth';
 
 const router = useRouter();
+const auth = useAuthStore();
 
 const isModalVisible = ref(false);
 const name = ref('');
 const description = ref('');
 
 async function createNewProject() {
-	const project = await ProjectService.create(name.value, description.value);
+	const author = auth.name ?? '';
+	const project = await ProjectService.create(name.value, description.value, author);
 	if (project) {
 		router.push(`/projects/${project.id}`);
 		isModalVisible.value = false;

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -15,12 +15,28 @@ import { getRelatedDocuments } from './data';
  */
 async function create(
 	name: Project['name'],
-	description: Project['description'] = ''
+	description: Project['description'] = '',
+	username: Project['username'] = ''
 ): Promise<Project | null> {
 	try {
-		const response = await API.post(`/projects`, { name, description });
+		const response = await API.post(`/projects`, { name, description, username });
 		const { status, data } = response;
 		if (status !== 201) return null;
+		return data ?? null;
+	} catch (error) {
+		console.error(error);
+		return null;
+	}
+}
+
+async function update(project: Project): Promise<Project | null> {
+	try {
+		const { id, name, description, active, username } = project;
+		const response = await API.put(`/projects/${id}`, { id, name, description, active, username });
+		const { status, data } = response;
+		if (status !== 200) {
+			return null;
+		}
 		return data ?? null;
 	} catch (error) {
 		console.error(error);
@@ -123,4 +139,4 @@ async function getRelatedArticles(aProject: Project): Promise<XDDArticle[]> {
 	}
 }
 
-export { create, get, getAll, addAsset, deleteAsset, getAssets, getRelatedArticles };
+export { create, update, get, getAll, addAsset, deleteAsset, getAssets, getRelatedArticles };

--- a/packages/client/hmi-client/src/types/Project.ts
+++ b/packages/client/hmi-client/src/types/Project.ts
@@ -38,4 +38,5 @@ export type Project = {
 	concept: string | null;
 	assets: SimpleProjectAssets;
 	relatedArticles: XDDArticle[];
+	username: string;
 };

--- a/packages/client/hmi-client/src/views/Project.vue
+++ b/packages/client/hmi-client/src/views/Project.vue
@@ -38,7 +38,6 @@ async function updateProjectName() {
 	updatedProject.name = newProjectName.value;
 	const id = await updateProject(updatedProject);
 	if (id) {
-		console.log('set active project');
 		resources.setActiveProject(updatedProject);
 	}
 }

--- a/packages/client/hmi-client/src/views/Project.vue
+++ b/packages/client/hmi-client/src/views/Project.vue
@@ -5,10 +5,13 @@ import ResourcesList from '@/components/resources/resources-list.vue';
 import InputText from 'primevue/inputtext';
 import { update as updateProject } from '@/services/project';
 import useResourcesStore from '@/stores/resources';
+import Button from 'primevue/button';
 
 const props = defineProps<{
 	project: Project;
 }>();
+
+const mockRelatedProjects = ['Project A', 'Project B'];
 
 const resources = useResourcesStore();
 const isEditingProjectName = ref(false);
@@ -65,12 +68,23 @@ async function updateProjectName() {
 			<section class="summary">
 				<!-- This div is so that child elements will automatically collapse margins -->
 				<div>
+					<!-- Author -->
+					<section class="contributors">
+						{{ project?.username }}
+						<Button label="+ Add contributor" />
+					</section>
 					<section class="description">
-						<!-- Author -->
-						<section class="author">{{ project?.username }}</section>
 						<p>
 							{{ project?.description }}
 						</p>
+					</section>
+					<section class="related">
+						Related projects
+						<ul>
+							<li v-for="item in mockRelatedProjects" :key="item">
+								<Button :label="item" class="item" />
+							</li>
+						</ul>
 					</section>
 				</div>
 			</section>
@@ -81,7 +95,9 @@ async function updateProjectName() {
 	</div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@import '@/assets/css/theme/variables';
+
 .flex-container {
 	display: flex;
 	flex-direction: column;
@@ -114,18 +130,29 @@ section {
 	flex: 0.25;
 }
 
-.author {
+.contributors {
 	line-height: 1.75rem;
+	margin: 0 0 1rem 0;
+	font-weight: $fontWeightSemiBold;
+	align-items: flex-start;
 }
 
 .detail {
 	flex: 0.75;
 }
 
-.summary section,
-.detail section {
+.summary,
+.detail {
 	margin: 1rem 0;
 	display: block;
+}
+
+.summary section {
+	margin-bottom: 1rem;
+}
+
+.related {
+	font-weight: $fontWeightSemiBold;
 }
 
 h3 {
@@ -155,5 +182,27 @@ h3 {
 
 .p-inputtext:enabled:focus {
 	box-shadow: none;
+}
+
+.p-button,
+.p-button:enabled:hover,
+.p-button:enabled:focus {
+	background-color: transparent;
+	color: var(--text-color-secondary);
+	padding: 0;
+}
+
+ul {
+	list-style: none;
+	display: inline-flex;
+}
+
+.item,
+.item:enabled:hover,
+.item:enabled:focus {
+	background-color: var(--surface-secondary);
+	color: var(--text-color-secondary);
+	padding: 0 0.5rem 0 0.5rem;
+	margin: 0.5rem;
 }
 </style>

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -39,6 +39,8 @@ public class Project implements Serializable {
 
 	private List<ResourceType> assets;
 
+	private String username;
+
 	@JsonbProperty("relatedArticles")
 	@Setter private List<Document> relatedDocuments;
 

--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -21,7 +21,7 @@ mp.openapi.extensions.smallrye.info.description=REST endpoints for the TERArium 
 ########################################################################################################################
 # Microservice configurations
 ########################################################################################################################
-%dev.data-service/mp-rest/url=http://localhost:8001
+%dev.data-service/mp-rest/url=http://localhost:3020
 %prod.data-service/mp-rest/url=http://${data-service}:3020
 %dev.model-service/mp-rest/url=http://localhost:3010
 %prod.model-service/mp-rest/url=http://${model-service}:3010

--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -21,7 +21,7 @@ mp.openapi.extensions.smallrye.info.description=REST endpoints for the TERArium 
 ########################################################################################################################
 # Microservice configurations
 ########################################################################################################################
-%dev.data-service/mp-rest/url=http://localhost:3020
+%dev.data-service/mp-rest/url=http://localhost:8001
 %prod.data-service/mp-rest/url=http://${data-service}:3020
 %dev.model-service/mp-rest/url=http://localhost:3010
 %prod.model-service/mp-rest/url=http://${model-service}:3010


### PR DESCRIPTION
- Persist username in project when it is created
- Show username in project view
- Allow user to edit project name in project page by clicking on menu and selecting edit
- Formatted date nicely
- Date does not get updated (should be handled by backend?)
- No feedback when inside/outside of editing mode (user can unfocus the text input and be unaware that they are still editing)


https://user-images.githubusercontent.com/16358728/214919649-d7a7368c-25f7-47b6-8fcf-f23266a4173c.mov


https://user-images.githubusercontent.com/16358728/214681844-44cbd54d-7b60-4150-bed7-bcf55c400a23.mov

@YohannParis @jamiewaese-uncharted 