### PR TITLE
fix(document-service): temp fix for document link

### DIFF
--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Document.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Document.java
@@ -36,7 +36,11 @@ public class Document implements Serializable {
 
 	private String year;
 
-	private List<Map<String, String>> link;
+	/**
+	 * This *should* be List<Map<String, String>> however for some reason that is currently broken
+	 * TODO: must make this work again
+	 */
+	private Object link;
 
 	private List<Map<String, String>> author;
 


### PR DESCRIPTION
In some cases the link property is not set right.  This is a temp fix to get that working correctly.

# Description

* Previously I thought that there needed to be front end work done with this - thanks Tom for the help on that! - it turns out I was a few hours out of date and Shawn had addressed the front end issues when he was refactoring into smaller vue components!
@dgauldie I will not merge this even once approved until I have your thumbs up to!

Resolves #544