### PR TITLE
fix(document-service): temp fix for citation list typing

### DIFF
--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Document.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/models/xdd/Document.java
@@ -54,7 +54,14 @@ public class Document implements Serializable {
 		this.gddId = id;
 	}
 
-	private List<Map<String, String>> citationList;
+	/**
+	 * This is primairly a List<Map<String,String>>, however, there is one specific field named _in_xdd
+	 * which is coming to us as a Boolean.  Once this is changed we should change this back to have
+	 * values of String.
+	 *
+	 * @param v
+	 */
+	private List<Map<String, Object>> citationList;
 
 	public String getID() {
 		return this.gddId;
@@ -76,7 +83,7 @@ public class Document implements Serializable {
 	}
 
 	@JsonbProperty("citation_list")
-	public void setCitationList(List<Map<String, String>> v) {
+	public void setCitationList(List<Map<String, Object>> v) {
 		this.citationList = v;
 	}
 


### PR DESCRIPTION
This map should contain only Strings as value types, however, in some cases we're getting a Boolean returned to us not as a String.  Changing this to `Object` as a temp fix until xDD fixed this on their end.

# Description

* This should be a temp fix

Resolves #553
