### PR TITLE
style: adjust nav dropdown/suggested terms and add cart number

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -37,7 +37,7 @@ function updateSearchBar(newQuery) {
 }
 
 function updateRelatedSearchTerms(newTerms) {
-	relatedSearchTerms.value = newTerms.slice(0, 5);
+	relatedSearchTerms.value = newTerms;
 }
 
 API.interceptors.response.use(

--- a/packages/client/hmi-client/src/components/Navbar.vue
+++ b/packages/client/hmi-client/src/components/Navbar.vue
@@ -136,9 +136,9 @@ watch(currentRoute, (newRoute) => {
 		<SearchBar
 			class="searchbar"
 			:text="searchBarText"
+			:suggested-terms="relatedSearchTerms"
 			@search-text-changed="searchTextChanged"
 			@toggle-search-by-example="searchByExampleModalToggled"
-			:relatedSearchTerms="relatedSearchTerms"
 		/>
 		<section class="header-right">
 			<Button

--- a/packages/client/hmi-client/src/components/Navbar.vue
+++ b/packages/client/hmi-client/src/components/Navbar.vue
@@ -113,7 +113,7 @@ watch(currentRoute, (newRoute) => {
 	<header>
 		<section class="header-left">
 			<img src="@assets/images/TERArium-logo.png" height="48" width="168" alt="logo" />
-			<section class="nav">
+			<nav>
 				<Dropdown
 					class="dropdown"
 					v-model="selectedPage"
@@ -131,7 +131,7 @@ watch(currentRoute, (newRoute) => {
 						<span>{{ slotProps.option.name }}</span>
 					</template>
 				</Dropdown>
-			</section>
+			</nav>
 		</section>
 		<SearchBar
 			class="searchbar"
@@ -177,7 +177,7 @@ header {
 
 section {
 	display: flex;
-	gap: 1rem;
+	gap: 0.5rem;
 }
 
 .user-button {
@@ -190,10 +190,10 @@ section {
 	background-color: var(--surface-secondary);
 }
 
-.nav {
-	justify-content: center;
-	margin-left: auto;
+nav {
+	justify-content: space-between;
 	flex: 0.5;
+	margin-right: auto;
 }
 
 .header-left {
@@ -211,6 +211,7 @@ section {
 
 .p-dropdown {
 	height: 3rem;
+	width: 9rem;
 	flex: 1;
 	border: 0;
 }

--- a/packages/client/hmi-client/src/components/Slider.vue
+++ b/packages/client/hmi-client/src/components/Slider.vue
@@ -66,6 +66,7 @@ const sidePanelTabStyle = computed(
 .slider.left.open .slider-content {
 	border-right: 1px solid var(--surface-border);
 }
+
 .slider.right.closed .slider-tab,
 .slider.right.open .slider-content {
 	border-left: 1px solid var(--surface-border);
@@ -80,11 +81,13 @@ const sidePanelTabStyle = computed(
 	position: relative;
 	height: 100%;
 }
+
 .slider.open .slider-tab,
 .slider.closed .slider-content {
 	visibility: hidden;
 	opacity: 0;
 }
+
 .slider-content {
 	position: relative;
 	width: 100%;

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -21,19 +21,16 @@
 			<i class="pi pi-history" />
 			<i class="pi pi-image" title="Search by Example" @click="toggleSearchByExample" />
 		</div>
-		<div class="suggested-items" v-if="isSuggestedItemsVisible">
-			Suggested items
-			<ul>
-				<li v-for="item in suggestedItems" :key="item">
-					<Button :label="item" class="item" @click="addSearchTerm(item)" />
-				</li>
-			</ul>
-			<Button
-				icon="pi pi-times"
-				class="p-button-rounded clear-search-terms"
-				@click="isSuggestedItemsVisible = false"
-			/>
-		</div>
+		<span class="suggested-terms" v-if="isSuggestedItemsVisible"
+			>Suggested terms:<Chip
+				v-for="item in suggestedItems"
+				:key="item"
+				removable
+				remove-icon="pi pi-times"
+			>
+				<span @click="addSearchTerm(item)">{{ item }}</span>
+			</Chip>
+		</span>
 	</div>
 </template>
 
@@ -41,7 +38,7 @@
 import { onMounted, ref, computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import InputText from 'primevue/inputtext';
-import Button from 'primevue/button';
+import Chip from 'primevue/chip';
 
 const props = defineProps<{
 	text?: string;
@@ -104,11 +101,35 @@ watch(suggestedItems, (newItems) => {
 	width: 100%;
 }
 
-.suggested-items {
-	margin: 1rem 0 0.5rem 0;
-	height: 2rem;
-	display: flex;
+.suggested-terms {
+	margin: 0.75rem 0 0.25rem 0;
+	display: inline-flex;
+	gap: 0.5rem;
+	margin-left: 0.5rem;
+	margin-right: auto;
 	align-items: center;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
+.suggested-terms,
+.p-chip {
+	font-size: small;
+	font-weight: bold;
+	color: var(--text-color-subdued);
+}
+
+.p-chip {
+	padding: 0 0.75rem;
+}
+
+.p-chip span {
+	margin: 0.25rem 0;
+	cursor: pointer;
+}
+
+.p-chip::v-deep .p-chip-remove-icon {
+	font-size: inherit;
 }
 
 .p-input-icon-left {
@@ -158,16 +179,6 @@ watch(suggestedItems, (newItems) => {
 
 .clear-search.hidden {
 	visibility: hidden;
-}
-
-.p-button.p-button-icon-only.p-button-rounded {
-	height: 2rem;
-	width: 2rem;
-}
-
-ul {
-	list-style: none;
-	display: inline-flex;
 }
 
 .item {

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -21,7 +21,7 @@
 			<i class="pi pi-history" />
 			<i class="pi pi-image" title="Search by Example" @click="toggleSearchByExample" />
 		</div>
-		<span class="suggested-terms" v-if="suggestedTerms && suggestedTerms.length > 0"
+		<span class="suggested-terms" v-if="suggestedTerms && suggestedTerms.entries.length > 0"
 			>Suggested terms:<Chip
 				v-for="item in suggestedTerms"
 				:key="item"

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -21,7 +21,7 @@
 			<i class="pi pi-history" />
 			<i class="pi pi-image" title="Search by Example" @click="toggleSearchByExample" />
 		</div>
-		<span class="suggested-terms" v-if="suggestedTerms && suggestedTerms.entries.length > 0"
+		<span class="suggested-terms" v-if="suggestedTerms && !isEmpty(suggestedTerms)"
 			>Suggested terms:<Chip
 				v-for="item in suggestedTerms"
 				:key="item"
@@ -39,6 +39,7 @@ import { onMounted, ref, computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import InputText from 'primevue/inputtext';
 import Chip from 'primevue/chip';
+import { isEmpty } from 'lodash';
 
 const props = defineProps<{
 	text?: string;
@@ -74,7 +75,6 @@ const toggleSearchByExample = () => {
 onMounted(() => {
 	const { q } = route.query;
 	searchText.value = q?.toString() ?? searchText.value;
-	console.log(props.suggestedTerms);
 });
 
 watch(defaultText, (newText) => {

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -21,9 +21,9 @@
 			<i class="pi pi-history" />
 			<i class="pi pi-image" title="Search by Example" @click="toggleSearchByExample" />
 		</div>
-		<span class="suggested-terms" v-if="isSuggestedItemsVisible"
+		<span class="suggested-terms" v-if="suggestedTerms && suggestedTerms.length > 0"
 			>Suggested terms:<Chip
-				v-for="item in suggestedItems"
+				v-for="item in suggestedTerms"
 				:key="item"
 				removable
 				remove-icon="pi pi-times"
@@ -42,7 +42,7 @@ import Chip from 'primevue/chip';
 
 const props = defineProps<{
 	text?: string;
-	relatedSearchTerms?: string[];
+	suggestedTerms?: string[];
 }>();
 
 const emit = defineEmits(['search-text-changed', 'toggle-search-by-example']);
@@ -52,9 +52,7 @@ const route = useRoute();
 const searchText = ref('');
 const defaultText = computed(() => props.text);
 const isClearSearchButtonHidden = computed(() => !searchText.value);
-const isSuggestedItemsVisible = ref(false);
 const inputElement = ref<HTMLInputElement | null>(null);
-const suggestedItems = computed(() => props.relatedSearchTerms);
 
 const clearText = () => {
 	searchText.value = '';
@@ -76,15 +74,11 @@ const toggleSearchByExample = () => {
 onMounted(() => {
 	const { q } = route.query;
 	searchText.value = q?.toString() ?? searchText.value;
-	isSuggestedItemsVisible.value = suggestedItems.value ? suggestedItems.value.length > 0 : false;
+	console.log(props.suggestedTerms);
 });
 
 watch(defaultText, (newText) => {
 	searchText.value = newText || searchText.value;
-});
-
-watch(suggestedItems, (newItems) => {
-	isSuggestedItemsVisible.value = newItems ? newItems.length > 0 : false;
 });
 </script>
 
@@ -121,6 +115,7 @@ watch(suggestedItems, (newItems) => {
 
 .p-chip {
 	padding: 0 0.75rem;
+	background-color: var(--surface-200);
 }
 
 .p-chip span {

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -87,6 +87,8 @@ watch(defaultText, (newText) => {
 	display: flex;
 	align-items: center;
 	flex-direction: column;
+	max-width: 50%;
+	overflow: hidden;
 }
 
 .search {
@@ -99,7 +101,7 @@ watch(defaultText, (newText) => {
 	margin: 0.75rem 0 0.25rem 0;
 	display: inline-flex;
 	gap: 0.5rem;
-	margin-left: 0.5rem;
+	margin-left: 0.25rem;
 	margin-right: auto;
 	align-items: center;
 	overflow: hidden;
@@ -124,7 +126,7 @@ watch(defaultText, (newText) => {
 }
 
 .p-chip::v-deep .p-chip-remove-icon {
-	font-size: inherit;
+	font-size: 0.75rem;
 }
 
 .p-input-icon-left {

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -21,7 +21,7 @@
 			<i class="pi pi-history" />
 			<i class="pi pi-image" title="Search by Example" @click="toggleSearchByExample" />
 		</div>
-		<span class="suggested-terms" v-if="suggestedTerms && !isEmpty(suggestedTerms)"
+		<span class="suggested-terms" v-if="suggestedTerms && suggestedTerms[0]"
 			>Suggested terms:<Chip
 				v-for="item in suggestedTerms"
 				:key="item"
@@ -39,7 +39,6 @@ import { onMounted, ref, computed, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import InputText from 'primevue/inputtext';
 import Chip from 'primevue/chip';
-import { isEmpty } from 'lodash';
 
 const props = defineProps<{
 	text?: string;

--- a/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/search-bar.vue
@@ -39,7 +39,6 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import InputText from 'primevue/inputtext';
 import Chip from 'primevue/chip';
-import Button from 'primevue/button';
 import * as EventService from '@/services/event';
 import { EventType } from '@/types/EventType';
 import useResourcesStore from '@/stores/resources';

--- a/packages/client/hmi-client/src/components/data-explorer/slider-panel.vue
+++ b/packages/client/hmi-client/src/components/data-explorer/slider-panel.vue
@@ -22,6 +22,11 @@
 					@click="emit('update:isOpen', true)"
 				/>
 				<h4 class="slider-header-item">{{ header }}</h4>
+				<Badge
+					v-if="selectedSearchItemsAmount"
+					:value="selectedSearchItemsAmount"
+					size="large"
+				></Badge>
 			</div>
 			<slot name="tab"></slot>
 		</template>
@@ -29,6 +34,7 @@
 </template>
 
 <script setup lang="ts">
+import Badge from 'primevue/badge';
 import Slider from '../Slider.vue';
 
 defineProps({
@@ -49,11 +55,14 @@ defineProps({
 		type: String,
 		default: '56px'
 	},
-
 	// slider-panel props
 	header: {
 		type: String,
 		default: ''
+	},
+	selectedSearchItemsAmount: {
+		type: Number,
+		default: 0
 	}
 });
 
@@ -81,11 +90,13 @@ i {
 	display: flex;
 	align-items: center;
 }
+
 .slider-header.content {
 	flex-direction: row-reverse;
 	justify-content: space-between;
 	padding: 16px;
 }
+
 .slider-header.tab {
 	justify-content: center;
 }
@@ -98,18 +109,26 @@ i.slider-header-item {
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	padding: 16px;
-	gap: 16px;
+	padding: 1rem;
+	gap: 2rem;
 }
+
 .slider-tab-header h4 {
 	text-align: left;
 	transform-origin: top right;
 	line-height: 1em;
+	margin-bottom: 1rem;
+}
+
+.p-badge {
+	background-color: var(--surface-200);
+	color: var(--text-color-primary);
 }
 
 .slider-tab-header.left h4 {
 	transform: translateX(-2em) rotate(270deg);
 }
+
 .slider-tab-header.right h4 {
 	transform: translateX(-1.5em) rotate(270deg);
 }

--- a/packages/client/hmi-client/src/views/DataExplorer.vue
+++ b/packages/client/hmi-client/src/views/DataExplorer.vue
@@ -93,6 +93,7 @@
 				direction="right"
 				header="Cart"
 				v-model:is-open="isSliderResourcesOpen"
+				:selected-search-items-amount="selectedSearchItems.length"
 			>
 				<template v-slot:content>
 					<selected-resources-options-pane


### PR DESCRIPTION
# Description

- Amount of items in cart is shown

- nav dropdown is adjusted

- Suggested terms list works and is restyled. 
 
There is a more backend related issue that should be solved in a future PR. When switching to a model or dataset you won't see suggested terms (as you should) but when you switch back to papers you won't see them anymore because the suggested terms are called along with the papers. Since the papers are already here the suggested terms are assumed to be here too but they are not. New suggested terms will only appear if something is freshly searched.

Resolves #(issue)
