### PR TITLE
fix(hmi-client): searching for doi in extractions uses wrong api params

### DIFF
--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -258,18 +258,10 @@ const getAssets = async (
 //
 // fetch list of extractions data from the HMI server
 //
-const getXDDArtifacts = async (
-	doc_doi: string,
-	term?: string,
-	extractionTypes?: XDDExtractionType[]
-) => {
+const getXDDArtifacts = async (term: string, extractionTypes?: XDDExtractionType[]) => {
 	let url = '/xdd/extractions?';
-	if (doc_doi !== '') {
-		url += `doi=${doc_doi}`;
-	}
-	if (term !== undefined) {
-		url += `query_all=${term}`;
-	}
+	url += `term=${term}`;
+
 	if (extractionTypes) {
 		url += '&ASKEM_CLASS=';
 		for (let i = 0; i < extractionTypes.length; i++) {
@@ -435,8 +427,8 @@ const searchXDDArticles = async (term: string, xddSearchParam?: XDDSearchParams)
 			// Temporary call to get a sufficient amount of extractions
 			// (Every call is limited to providing 30 extractions)
 			extractionsSearchResults = [
-				...(await getXDDArtifacts('', term, [XDDExtractionType.Figure, XDDExtractionType.Table])),
-				...(await getXDDArtifacts('', term, [XDDExtractionType.Document]))
+				...(await getXDDArtifacts(term, [XDDExtractionType.Figure, XDDExtractionType.Table])),
+				...(await getXDDArtifacts(term, [XDDExtractionType.Document]))
 			];
 		}
 

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/ExtractionResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/ExtractionResource.java
@@ -8,12 +8,18 @@ import software.uncharted.terarium.documentserver.proxies.xdd.ExtractionProxy;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "XDD Extraction REST Endpoint")
-@Path("/object")
+@Path("/api/xdd/extractions")
 public class ExtractionResource {
+
+
+	// source: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+	private static final Pattern DOI_VALIDATION_PATTERN = Pattern.compile("^10.\\d{4,9}\\/[-._;()\\/:A-Z0-9]+$", Pattern.CASE_INSENSITIVE);
 
 	@RestClient
 	ExtractionProxy proxy;
@@ -22,7 +28,16 @@ public class ExtractionResource {
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Search XDD for extractions related to the document identified in the payload")
-	public XDDResponse<XDDExtractionsResponseOK> searchExtractions(@QueryParam("doi") final String doi, @QueryParam("query_all") final String queryAll, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass) {
-		return proxy.getExtractions(doi, queryAll, page, askemClass);
+	public XDDResponse<XDDExtractionsResponseOK> searchExtractions(@QueryParam("term") final String term, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass) {
+
+		Matcher matcher = DOI_VALIDATION_PATTERN.matcher(term);
+
+		Boolean isDoi = matcher.find();
+
+		if (isDoi) {
+			return proxy.getExtractions(term, null, page, askemClass);
+		} else {
+			return proxy.getExtractions(null, term, page, askemClass);
+		}
 	}
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/xdd/ExtractionProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/xdd/ExtractionProxy.java
@@ -11,12 +11,11 @@ import javax.ws.rs.core.Response;
 
 @RegisterRestClient(configKey = "extraction-service")
 @Produces(MediaType.APPLICATION_JSON)
+@Path("/api/xdd/extractions")
 public interface ExtractionProxy {
 	@GET
-	@Path("object")
 	Response getExtractions(
-		@QueryParam("doi") String doi,
-		@QueryParam("query_all") String queryAll,
+		@QueryParam("term") String term,
 		@QueryParam("page") Integer page,
 		@QueryParam("ASKEM_CLASS") String askemClass
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/xdd/ExtractionResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/xdd/ExtractionResource.java
@@ -24,7 +24,7 @@ public class ExtractionResource {
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Search XDD for extractions either using keyword search or for a given document identifier")
-	public Response searchExtractions(@QueryParam("doi") final String doi, @QueryParam("query_all") final String queryAll, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass) {
-		return proxy.getExtractions(doi, queryAll, page, askemClass);
+	public Response searchExtractions(@QueryParam("term") final String term, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass) {
+		return proxy.getExtractions(term, page, askemClass);
 	}
 }


### PR DESCRIPTION

Simplifying the detection of doi's by the front end for extractions, and moving the whole thing to the back end. Changing API to remove seperate fields for search terms vs. DOI since it doesnt make a difference on our end.

# Description

* Extraction resource now does the doi vs query all detection on the back end.
* Changed document api to only handle a single search term.

Resolves #595
