### PR TITLE
feat: zoomRange option

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -15,6 +15,7 @@ interface Options {
 	runLayout: AsyncLayoutFunction<any, any> | LayoutFunction<any, any>;
 
 	useZoom?: boolean;
+	zoomRange?: [number, number];
 	useStableLayout?: boolean;
 
 	// Attempt to use the same set of zoom parameters across layout changes
@@ -294,7 +295,16 @@ export abstract class Renderer<V, E> extends EventEmitter {
 		const minZoom = 0.05;
 		const maxZoom = Math.max(2, Math.floor((this.graph.width as number) / this.chartSize.width));
 		let zoomLevel = Math.min(1, 1 / ((this.graph.height as number) / this.chartSize.height));
-		this.zoom = d3.zoom().scaleExtent([minZoom, maxZoom]).on('zoom', zoomed).on('end', zoomEnd);
+
+		if (this.options.zoomRange) {
+			this.zoom = d3
+				.zoom()
+				.scaleExtent(this.options.zoomRange)
+				.on('zoom', zoomed)
+				.on('end', zoomEnd);
+		} else {
+			this.zoom = d3.zoom().scaleExtent([minZoom, maxZoom]).on('zoom', zoomed).on('end', zoomEnd);
+		}
 		svg.call(this.zoom as any).on('dblclick.zoom', null);
 
 		let zoomX =


### PR DESCRIPTION
### Summary
Provide a `zoomRange` option. The zoomRange provides a `[minZoom, maxZoom]` input array.

Example:
```
const renderer = new SampleRenderer({
	el: div,
	useAStarRouting: true,
	zoomRange: [0.1, 10],
	runLayout: runLayout
});
```

A configuration of
- [0.5, 4] means you can pull-back by a factor of 2 and zoom-in by a factor of 4
- [0.1, 1] means you can pull-back by a factor of 10, and zoom-in is disabled

### Test
Can muck around with the example in "examples/src/index.ts"
```
npm run develop
```