### PR TITLE
fix: remove the print margin from code editor

### DIFF
--- a/packages/client/hmi-client/src/views/CodeView.vue
+++ b/packages/client/hmi-client/src/views/CodeView.vue
@@ -77,6 +77,7 @@ function onSelectedTextChange() {
 async function initialize(editorInstance) {
 	editor.value = editorInstance;
 	editorInstance.session.selection.on('changeSelection', onSelectedTextChange);
+	editorInstance.setShowPrintMargin(false);
 }
 </script>
 <style>


### PR DESCRIPTION
Before:
<img width="1470" alt="Screenshot 2023-01-31 at 8 42 38 PM" src="https://user-images.githubusercontent.com/4606322/215925493-64afbaff-d89b-4a95-8a51-8a7855ca7a2b.png">


After:
<img width="1470" alt="Screenshot 2023-01-31 at 8 50 17 PM" src="https://user-images.githubusercontent.com/4606322/215925526-f020b1c5-34ed-4085-a02e-91308f6f443b.png">
