### PR TITLE
chore: limit esbuild upgrades by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
 			"automerge": true,
 			"automergeType": "pr",
 			"platformAutomerge": true
+		},
+		{
+			"description": "Limit ESBuild upgrades to < 0.17 due to breaking changes introduced in v0.17",
+			"matchPackageNames": ["esbuild"],
+			"allowedVersions": "<0.17.0"
 		}
 	]
 }


### PR DESCRIPTION
# Description

Limit the upgrade range for ESBuild by renovate due to breaking changes in v0.17.x

Resolves #649 
