### PR TITLE
fix: title to correctly match test case

### DIFF
--- a/packages/client/hmi-client/index.html
+++ b/packages/client/hmi-client/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8" />
 	<link rel="icon" type="image/png" href="src/assets/images/terarium-icon.png" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>terarium</title>
+	<title>TERArium</title>
 	<script type="module" src="src/main.ts"></script>
 </head>
 


### PR DESCRIPTION
# Description
If you want the title to all be lowercase let me know and I will change it

<img width="391" alt="image" src="https://user-images.githubusercontent.com/17088680/217314017-6fdb6503-717f-4b57-9fb1-d28e243f0d27.png">


Resolves #(issue)
#657 