### PR TITLE
feat(document-service): adding chaching to xDD sets and dictionaries

### DIFF
--- a/packages/client/hmi-client/src/types/XDD.ts
+++ b/packages/client/hmi-client/src/types/XDD.ts
@@ -57,7 +57,7 @@ export type XDDArticle = {
 	highlight: string[];
 	knownEntities?: XDDArticleKnownEntity;
 
-	// We don not know exactly what is in citatinList - DC Jan 2023
+	// We do not know exactly what is in citationList - DC Jan 2023
 	citationList: { [key: string]: string }[];
 
 	// additional-client-side fields

--- a/packages/services/document-service/build.gradle
+++ b/packages/services/document-service/build.gradle
@@ -17,6 +17,9 @@ dependencies {
 	implementation "io.quarkus:quarkus-smallrye-openapi"
 	implementation "io.quarkus:quarkus-arc"
 
+	// Caching
+	implementation "io.quarkus:quarkus-cache"
+
 	// REST client
 	implementation "io.quarkus:quarkus-rest-client"
 

--- a/packages/services/document-service/build.gradle
+++ b/packages/services/document-service/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
 	// Caching
 	implementation "io.quarkus:quarkus-cache"
+	implementation "io.quarkus:quarkus-scheduler"
 
 	// REST client
 	implementation "io.quarkus:quarkus-rest-client"

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/caching/CacheClearService.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/caching/CacheClearService.java
@@ -1,0 +1,58 @@
+package software.uncharted.terarium.documentserver.caching;
+
+import io.quarkus.cache.CacheManager;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.ScheduledExecution;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class CacheClearService {
+
+	public enum CacheCollection {
+		XDD
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum CacheName {
+		XDD_SETS(Constants.XDD_SETS_NAME, CacheCollection.XDD),
+		XDD_DICTIONARIES(Constants.XDD_DICTIONARIES_NAME, CacheCollection.XDD);
+
+
+		private final String name;
+
+		private final CacheCollection collection;
+
+		public static List<CacheName> findAllByCollection(CacheCollection collection) {
+			return Stream.of(values())
+				.filter(cacheName -> cacheName.collection.equals(collection))
+				.collect(Collectors.toList());
+		}
+
+		public static class Constants {
+			public static final String XDD_SETS_NAME = "xdd-sets";
+			public static final String XDD_DICTIONARIES_NAME = "xdd-dictionaries";
+		}
+	}
+
+	@Inject
+	CacheManager cacheManager;
+
+	@Scheduled(cron = "0 0 * * * ?")
+		// every hour on the hour
+	void clearXDDCaches(ScheduledExecution execution) {
+		System.out.println("clear");
+		CacheName.findAllByCollection(CacheCollection.XDD).forEach(cacheName -> {
+			cacheManager.getCache(cacheName.getName()).ifPresent(cache ->
+				cache.invalidateAll().await().indefinitely()
+			);
+		});
+	}
+}

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/exceptions/DocumentResponseExceptionMapper.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/exceptions/DocumentResponseExceptionMapper.java
@@ -1,0 +1,19 @@
+package software.uncharted.terarium.documentserver.exceptions;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+import javax.ws.rs.core.Response;
+
+public class DocumentResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
+
+	@Override
+	public RuntimeException toThrowable(Response response) {
+		//TODO we can/should intelligently handle these error codes and create nice thrown exceptions for them.
+		if (response.getStatus() >= 400 && response.getStatus() < 500) {
+			throw new RuntimeException("The remote service responded with HTTP " + response.getStatus());
+		} else if (response.getStatus() >= 500) {
+			throw new RuntimeException("The remote service responded with HTTP " + response.getStatus());
+		}
+		return null;
+	}
+}

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/DocumentProxy.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/proxies/xdd/DocumentProxy.java
@@ -1,6 +1,8 @@
 package software.uncharted.terarium.documentserver.proxies.xdd;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.documentserver.exceptions.DocumentResponseExceptionMapper;
 import software.uncharted.terarium.documentserver.responses.xdd.*;
 
 import javax.ws.rs.*;
@@ -8,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 
 @RegisterRestClient(configKey = "xdd-document-service")
 @Produces(MediaType.APPLICATION_JSON)
+@RegisterProvider(DocumentResponseExceptionMapper.class)
 public interface DocumentProxy {
 	@GET
 	@Path("/api/articles")

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DictionariesResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DictionariesResource.java
@@ -5,6 +5,7 @@ import io.quarkus.cache.CacheResult;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import software.uncharted.terarium.documentserver.caching.CacheClearService;
 import software.uncharted.terarium.documentserver.responses.xdd.XDDDictionariesResponseOK;
 import software.uncharted.terarium.documentserver.responses.xdd.XDDResponse;
 import software.uncharted.terarium.documentserver.proxies.xdd.DocumentProxy;
@@ -28,18 +29,10 @@ public class DictionariesResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available XDD dictionaries")
 	@Path("/dictionaries")
-	@CacheResult(cacheName = CACHE_NAME)
+	@CacheResult(cacheName = CacheClearService.CacheName.Constants.XDD_DICTIONARIES_NAME)
 	public XDDResponse<XDDDictionariesResponseOK> getAvailableDictionaries(@QueryParam("all") @DefaultValue("") String all) {
-		try {
-			XDDResponse<XDDDictionariesResponseOK> response = proxy.getAvailableDictionaries(all);
-		} catch (RuntimeException e) {
-			log.error("Unable to get dictionaries. Invalidating cache.", e);
-			invalidateXDDCache(all);
-		}
-		return null;
-	}
+		return proxy.getAvailableDictionaries(all);
 
-	@CacheInvalidate(cacheName = CACHE_NAME)
-	public void invalidateXDDCache(@QueryParam("all") @DefaultValue("") String all) {
 	}
+	
 }

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DictionariesResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/DictionariesResource.java
@@ -1,5 +1,8 @@
 package software.uncharted.terarium.documentserver.resources.xdd;
 
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheResult;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import software.uncharted.terarium.documentserver.responses.xdd.XDDDictionariesResponseOK;
@@ -13,7 +16,10 @@ import javax.ws.rs.core.MediaType;
 
 @Tag(name = "XDD Dictionaries REST Endpoint")
 @Path("/api")
+@Slf4j
 public class DictionariesResource {
+	// Also defined in application.properties
+	private static final String CACHE_NAME = "xDD-Dictionaries";
 
 	@RestClient
 	DocumentProxy proxy;
@@ -22,7 +28,18 @@ public class DictionariesResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available XDD dictionaries")
 	@Path("/dictionaries")
+	@CacheResult(cacheName = CACHE_NAME)
 	public XDDResponse<XDDDictionariesResponseOK> getAvailableDictionaries(@QueryParam("all") @DefaultValue("") String all) {
-		return proxy.getAvailableDictionaries(all);
+		try {
+			XDDResponse<XDDDictionariesResponseOK> response = proxy.getAvailableDictionaries(all);
+		} catch (RuntimeException e) {
+			log.error("Unable to get dictionaries. Invalidating cache.", e);
+			invalidateXDDCache(all);
+		}
+		return null;
+	}
+
+	@CacheInvalidate(cacheName = CACHE_NAME)
+	public void invalidateXDDCache(@QueryParam("all") @DefaultValue("") String all) {
 	}
 }

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/SetResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/SetResource.java
@@ -1,21 +1,24 @@
 package software.uncharted.terarium.documentserver.resources.xdd;
 
+import io.quarkus.cache.CacheInvalidate;
+import io.quarkus.cache.CacheResult;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import software.uncharted.terarium.documentserver.responses.xdd.XDDSetsResponse;
 import software.uncharted.terarium.documentserver.proxies.xdd.DocumentProxy;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
 @Path("/sets")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "XDD Sets REST Endpoint")
+@Slf4j
 public class SetResource {
+
+	private static final String CACHE_NAME = "xDD-Sets";
 
 	@RestClient
 	DocumentProxy proxy;
@@ -23,7 +26,19 @@ public class SetResource {
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available XDD sets or collections")
+	@CacheResult(cacheName = CACHE_NAME)
 	public XDDSetsResponse getAvailableSets() {
-		return proxy.getAvailableSets();
+
+		try {
+			return proxy.getAvailableSets();
+		} catch (RuntimeException e) {
+			log.error("Unable to get sets. Invalidating cache.", e);
+			invalidateXDDCache();
+		}
+		return null;
+	}
+
+	@CacheInvalidate(cacheName = CACHE_NAME)
+	public void invalidateXDDCache() {
 	}
 }

--- a/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/SetResource.java
+++ b/packages/services/document-service/src/main/java/software/uncharted/terarium/documentserver/resources/xdd/SetResource.java
@@ -1,10 +1,11 @@
 package software.uncharted.terarium.documentserver.resources.xdd;
 
-import io.quarkus.cache.CacheInvalidate;
+
 import io.quarkus.cache.CacheResult;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import software.uncharted.terarium.documentserver.caching.CacheClearService;
 import software.uncharted.terarium.documentserver.responses.xdd.XDDSetsResponse;
 import software.uncharted.terarium.documentserver.proxies.xdd.DocumentProxy;
 
@@ -18,7 +19,6 @@ import javax.ws.rs.core.MediaType;
 @Slf4j
 public class SetResource {
 
-	private static final String CACHE_NAME = "xDD-Sets";
 
 	@RestClient
 	DocumentProxy proxy;
@@ -26,19 +26,11 @@ public class SetResource {
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available XDD sets or collections")
-	@CacheResult(cacheName = CACHE_NAME)
+	@CacheResult(cacheName = CacheClearService.CacheName.Constants.XDD_SETS_NAME)
 	public XDDSetsResponse getAvailableSets() {
 
-		try {
-			return proxy.getAvailableSets();
-		} catch (RuntimeException e) {
-			log.error("Unable to get sets. Invalidating cache.", e);
-			invalidateXDDCache();
-		}
-		return null;
+		return proxy.getAvailableSets();
+
 	}
 
-	@CacheInvalidate(cacheName = CACHE_NAME)
-	public void invalidateXDDCache() {
-	}
 }

--- a/packages/services/document-service/src/main/resources/application.properties
+++ b/packages/services/document-service/src/main/resources/application.properties
@@ -18,3 +18,8 @@ quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.3.0-jav
 ########################################################################################################################
 xdd-document-service/mp-rest/url=https://xdd.wisc.edu
 xdd-extraction-service/mp-rest/url=https://xdddev.chtc.io
+########################################################################################################################
+# Caching (these names correspond to names defined in their java classes - don't change)
+########################################################################################################################
+quarkus.cache.caffeine."xDD-Dictionaries".expire-after-write=86400
+quarkus.cache.caffeine."xDD-Sets".expire-after-write=86400

--- a/packages/services/document-service/src/main/resources/application.properties
+++ b/packages/services/document-service/src/main/resources/application.properties
@@ -18,8 +18,4 @@ quarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:22.3.0-jav
 ########################################################################################################################
 xdd-document-service/mp-rest/url=https://xdd.wisc.edu
 xdd-extraction-service/mp-rest/url=https://xdddev.chtc.io
-########################################################################################################################
-# Caching (these names correspond to names defined in their java classes - don't change)
-########################################################################################################################
-quarkus.cache.caffeine."xDD-Dictionaries".expire-after-write=86400
-quarkus.cache.caffeine."xDD-Sets".expire-after-write=86400
+


### PR DESCRIPTION
Adding caching to xDD sets and dictionaries.  Adding some super basic exception/error handling to invalidate the cache (as that doesn't happen automatically).  It will be part of the exceptions task later to fill these out more.  Cash will invalidate once a day.

# Description

* Include a summary of the changes and the related issue. 
* Include relevant motivation and context.

Resolves #374 
