### PR TITLE
fix: correcting return data for document facet

### DIFF
--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -310,10 +310,12 @@ const getAssets = async (params: GetAssetsParams) => {
 
 		// Set values
 		const newFacets: Facets = getArticleFacets(returnResults);
-		results.allDataFilteredWithFacets = results.allData;
-		results.allDataFilteredWithFacets.results = returnResults;
-		results.allData.facets = newFacets;
-		results.allData.xddExtractions = xddResults.xddExtractions;
+		results.allDataFilteredWithFacets = {
+			results: returnResults,
+			searchSubsystem: resourceType,
+			facets: newFacets,
+			rawConceptFacets: conceptFacets
+		};
 	} else {
 		results.allDataFilteredWithFacets = results.allData;
 	}


### PR DESCRIPTION
# Description

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/17088680/217607856-9aef8dca-ca29-4cfd-b587-3b806c9b183c.png">

* Include a summary of the changes and the related issue. 
    Changed how we are returning data after filtering by a document facet.
* Include relevant motivation and context.
     Previously the facets bar would mistakenly remove facets that had no relevance to selected facets

Resolves #(issue)
#679 
