### PR TITLE
chore: correcting property name

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -34,7 +34,7 @@ public class Project implements Serializable {
 
 	private String username;
 
-	@JsonbProperty("relatedArticles")
+	@JsonbProperty("relatedDocuments")
 	@Setter
 	private List<Document> relatedDocuments;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -36,6 +36,7 @@ public class Project implements Serializable {
 	private String username;
 
 	@JsonAlias("relatedDocuments")
+	@JsonbProperty("relatedArticles")
 	@Setter
 	private List<Document> relatedDocuments;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import javax.json.bind.annotation.JsonbProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 import lombok.Setter;
 
@@ -34,7 +35,7 @@ public class Project implements Serializable {
 
 	private String username;
 
-	@JsonbProperty("relatedDocuments")
+	@JsonAlias("relatedDocuments")
 	@Setter
 	private List<Document> relatedDocuments;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -35,8 +35,8 @@ public class Project implements Serializable {
 
 	private String username;
 
-	@JsonAlias("relatedDocuments")
-	@JsonbProperty("relatedArticles")
+	@JsonAlias("relatedArticles")
+	@JsonbProperty("relatedDocuments")
 	@Setter
 	private List<Document> relatedDocuments;
 


### PR DESCRIPTION
# Description
Correcting jsonbproperty name for expected output for frontend to work with
Allows home page to correctly pull relatedDocuments for example
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/17088680/217925430-36331736-12d0-46e0-af31-7ffe4127090b.png">

