### PR TITLE
feat(hmi-server): adding chaching to xDD sets and dictionaries

### DIFF
--- a/packages/services/hmi-server/build.gradle
+++ b/packages/services/hmi-server/build.gradle
@@ -24,6 +24,9 @@ dependencies {
 	implementation "io.quarkus:quarkus-hibernate-orm-panache"
 	annotationProcessor "io.quarkus:quarkus-panache-common"
 
+	// Caching
+	implementation "io.quarkus:quarkus-cache"
+	implementation "io.quarkus:quarkus-scheduler"
 
 	// REST client
 	implementation "io.quarkus:quarkus-rest-client"

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/caching/CacheClearService.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/caching/CacheClearService.java
@@ -1,0 +1,59 @@
+package software.uncharted.terarium.hmiserver.caching;
+
+
+import io.quarkus.cache.CacheManager;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.ScheduledExecution;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class CacheClearService {
+
+	public enum CacheCollection {
+		XDD
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public enum CacheName {
+		XDD_SETS(Constants.XDD_SETS_NAME, CacheCollection.XDD),
+		XDD_DICTIONARIES(Constants.XDD_DICTIONARIES_NAME, CacheCollection.XDD);
+
+
+		private final String name;
+
+		private final CacheCollection collection;
+
+		public static List<CacheName> findAllByCollection(CacheCollection collection) {
+			return Stream.of(values())
+				.filter(cacheName -> cacheName.collection.equals(collection))
+				.collect(Collectors.toList());
+		}
+
+		public static class Constants {
+			public static final String XDD_SETS_NAME = "xdd-sets";
+			public static final String XDD_DICTIONARIES_NAME = "xdd-dictionaries";
+		}
+	}
+
+	@Inject
+	CacheManager cacheManager;
+
+	@Scheduled(cron = "0 0 * * * ?")
+		// every hour on the hour
+	void clearXDDCaches(ScheduledExecution execution) {
+		System.out.println("clear");
+		CacheName.findAllByCollection(CacheCollection.XDD).forEach(cacheName -> {
+			cacheManager.getCache(cacheName.getName()).ifPresent(cache ->
+				cache.invalidateAll().await().indefinitely()
+			);
+		});
+	}
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/caching/CacheClearService.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/caching/CacheClearService.java
@@ -49,7 +49,6 @@ public class CacheClearService {
 	@Scheduled(cron = "0 0 * * * ?")
 		// every hour on the hour
 	void clearXDDCaches(ScheduledExecution execution) {
-		System.out.println("clear");
 		CacheName.findAllByCollection(CacheCollection.XDD).forEach(cacheName -> {
 			cacheManager.getCache(cacheName.getName()).ifPresent(cache ->
 				cache.invalidateAll().await().indefinitely()

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
@@ -1,6 +1,8 @@
 package software.uncharted.terarium.hmiserver.proxies.documentservice;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.*;
 
 import javax.ws.rs.*;
@@ -8,6 +10,7 @@ import javax.ws.rs.core.MediaType;
 
 @RegisterRestClient(configKey = "xdd-document-service")
 @Produces(MediaType.APPLICATION_JSON)
+@RegisterProvider(HmiResponseExceptionMapper.class)
 public interface DocumentProxy {
 	@GET
 	@Path("/api/articles")

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/DictionariesResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/DictionariesResource.java
@@ -1,7 +1,9 @@
 package software.uncharted.terarium.hmiserver.resources.documentservice;
 
+import io.quarkus.cache.CacheResult;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import software.uncharted.terarium.hmiserver.caching.CacheClearService;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDDictionariesResponseOK;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDResponse;
 import software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy;
@@ -22,6 +24,7 @@ public class DictionariesResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available dictionaries")
 	@Path("/dictionaries")
+	@CacheResult(cacheName = CacheClearService.CacheName.Constants.XDD_DICTIONARIES_NAME)
 	public XDDResponse<XDDDictionariesResponseOK> getAvailableDictionaries(@QueryParam("all") @DefaultValue("") String all) {
 		return proxy.getAvailableDictionaries(all);
 	}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/SetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/SetResource.java
@@ -1,7 +1,9 @@
 package software.uncharted.terarium.hmiserver.resources.documentservice;
 
+import io.quarkus.cache.CacheResult;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import software.uncharted.terarium.hmiserver.caching.CacheClearService;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDSetsResponse;
 import software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy;
 
@@ -23,6 +25,7 @@ public class SetResource {
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Get available XDD sets or collections")
+	@CacheResult(cacheName = CacheClearService.CacheName.Constants.XDD_SETS_NAME)
 	public XDDSetsResponse getAvailableSets() {
 		return proxy.getAvailableSets();
 	}


### PR DESCRIPTION
Adding caching to xDD sets and dictionaries. Adding some super basic exception/error handling. It will be part of the exceptions task later to fill these out more. Cash will invalidate once an hour.

This is a remount of https://github.com/DARPA-ASKEM/TERArium/pull/677 and includes the PR feedback from @chris-dickson

# Description

* Include a summary of the changes and the related issue. 
* Include relevant motivation and context.

Resolves #374 
