### PR TITLE
chore: use staging deployment for skema

### DIFF
--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -33,10 +33,8 @@ mp.openapi.extensions.smallrye.info.description=REST endpoints for the TERArium 
 ########################################################################################################################
 # Microservice configurations
 ########################################################################################################################
-%dev.skema/mp-rest/url=http://34.239.166.132:8002
-%prod.skema/mp-rest/url=http://34.239.166.132:8002
-%dev.skema-rust/mp-rest/url=http://34.239.166.132:8085
-%prod.skema-rust/mp-rest/url=http://34.239.166.132:8085
+skema/mp-rest/url=https://skema-py.staging.terarium.ai
+skema-rust/mp-rest/url=https://skema-rs.staging.terarium.ai
 %dev.data-service/mp-rest/url=http://localhost:3020
 %prod.data-service/mp-rest/url=http://${data-service}:3020
 %dev.model-service/mp-rest/url=http://localhost:3010


### PR DESCRIPTION
Update skema urls to point at deployment into staging kubernetes cluster.

Note that in aws deployed configurations, we use internal DNS for resolving these urls.  Thus, the production app will point at the production (pinned) skema pods