### PR TITLE
fix: undo temporary hackathon changes, fix grid duplicates

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -294,8 +294,9 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			.domain([-1, height + 1])
 			.range([-1, height + 1]);
 
-		const gX = svg.append('g').attr('class', 'axis axis--x');
-		const gY = svg.append('g').attr('class', 'axis axis--y');
+		svg.selectAll('.grid').remove();
+		const gX = svg.append('g').attr('class', 'axis axis--x').classed('grid', true);
+		const gY = svg.append('g').attr('class', 'axis axis--y').classed('grid', true);
 		const xAxis = d3
 			.axisBottom(x)
 			.ticks(((width + 2) / (height + 2)) * 10)

--- a/packages/client/hmi-client/src/page/ModelEditor.vue
+++ b/packages/client/hmi-client/src/page/ModelEditor.vue
@@ -63,7 +63,7 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 import graphScaffolder, { IGraph } from '@graph-scaffolder/index';
-import { runDagreLayout2, D3SelectionINode, D3SelectionIEdge } from '@/services/graph';
+import { runDagreLayout, D3SelectionINode, D3SelectionIEdge } from '@/services/graph';
 import { onMounted, ref, computed, watch } from 'vue';
 import { PetriNet } from '@/utils/petri-net-validator';
 import { parsePetriNet2IGraph, NodeData, EdgeData, NodeType } from '@/services/model';
@@ -804,7 +804,7 @@ onMounted(async () => {
 	renderer = new SampleRenderer({
 		el: playground,
 		useAStarRouting: false, // People get distracted with squiggly connectors - Jan 2023
-		runLayout: runDagreLayout2,
+		runLayout: runDagreLayout,
 		useStableZoomPan: true
 	});
 

--- a/packages/client/hmi-client/src/page/ModelRunner.vue
+++ b/packages/client/hmi-client/src/page/ModelRunner.vue
@@ -136,7 +136,7 @@ onMounted(async () => {
 	renderer = new (SampleRenderer as any)({
 		el: playground,
 		useAStarRouting: true,
-		runLayout: runDagreLayout2,
+		runLayout: runDagreLayout,
 		useStableZoomPan: true
 	});
 

--- a/packages/client/hmi-client/src/page/ModelRunner.vue
+++ b/packages/client/hmi-client/src/page/ModelRunner.vue
@@ -11,7 +11,7 @@
 import * as d3 from 'd3';
 import graphScaffolder from '@graph-scaffolder/index';
 import { moveTo } from '@graph-scaffolder/fn/move-to';
-import { runDagreLayout2, D3SelectionINode, D3SelectionIEdge } from '@/services/graph';
+import { runDagreLayout, D3SelectionINode, D3SelectionIEdge } from '@/services/graph';
 import { onMounted, ref } from 'vue';
 import { parsePetriNet2IGraph } from '@/services/model';
 

--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -50,10 +50,7 @@ export abstract class BaseComputionGraph<V, E> extends graphScaffolder.BasicRend
 	}
 }
 
-export const runDagreLayout = <V, E>(
-	graphData: IGraph<V, E>,
-	lr: boolean = false
-): IGraph<V, E> => {
+export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true): IGraph<V, E> => {
 	const g = new dagre.graphlib.Graph({ compound: true });
 	g.setGraph({});
 	g.setDefaultEdgeLabel(() => ({}));
@@ -135,6 +132,3 @@ export const runDagreLayout = <V, E>(
 
 	return graphData;
 };
-
-export const runDagreLayout2 = <V, E>(graphData: IGraph<V, E>): IGraph<V, E> =>
-	runDagreLayout(graphData, true);


### PR DESCRIPTION
### Summary
Small changes and fixes based on chatter with Jamie
- Remove a temporary LR (left-right) vs TD (top-down) layout from hackathon, by default the layout will do LR.
- Fix a grid element duplication issue if useGrid option is enabled


<img width="508" alt="image" src="https://user-images.githubusercontent.com/1220927/219201248-ed0b5669-0037-4c81-8704-002c0171bfed.png">


### Test
Go to any model view, the graph structure should be flowing left-ight instead of top-down