### PR TITLE
feat(hmi-server): highlights on extractions

### DIFF
--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -330,6 +330,7 @@ const getAssets = async (params: GetAssetsParams) => {
 const getXDDArtifacts = async (term: string, extractionTypes?: XDDExtractionType[]) => {
 	let url = '/document/extractions?';
 	url += `term=${term}`;
+	url += '&include_highlights=true';
 
 	if (extractionTypes) {
 		url += '&ASKEM_CLASS=';

--- a/packages/client/hmi-client/src/types/Document.ts
+++ b/packages/client/hmi-client/src/types/Document.ts
@@ -24,6 +24,7 @@ export type XDDArtifact = {
 	askemId: string;
 	xddCreated: Date;
 	xddRegistrant: number;
+	highlight: string[];
 };
 
 export type XDDUrlExtraction = {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/Extraction.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/Extraction.java
@@ -8,6 +8,7 @@ import lombok.experimental.Accessors;
 import javax.json.bind.annotation.JsonbProperty;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 
 
 /**
@@ -29,6 +30,8 @@ public class Extraction implements Serializable {
 
 	private Number xddRegistrant;
 
+	private List<String> highlight;
+
 
 	@JsonbProperty("ASKEM_CLASS")
 	public void setAskemClass(String askemClass) {
@@ -48,6 +51,11 @@ public class Extraction implements Serializable {
 	@JsonbProperty("_xdd_registrant")
 	public void setXddRegistrant(Number xddRegistrant) {
 		this.xddRegistrant = xddRegistrant;
+	}
+
+	@JsonbProperty("_highlight")
+	public void setHighlight(List<String> highlight) {
+		this.highlight = highlight;
 	}
 
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
@@ -4,6 +4,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDExtractionsResponseOK;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDResponse;
 
+import javax.management.Query;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -21,7 +22,8 @@ public interface ExtractionProxy {
 		@QueryParam("doi") final String doi,
 		@QueryParam("query_all") final String queryAll,
 		@QueryParam("page") final Integer page,
-		@QueryParam("ASKEM_CLASS") String askemClass
+		@QueryParam("ASKEM_CLASS") String askemClass,
+		@QueryParam("include_highlights") String include_highlights
 	);
 
 	@GET

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/ExtractionResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/ExtractionResource.java
@@ -29,16 +29,16 @@ public class ExtractionResource {
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Tag(name = "Search XDD for extractions related to the document identified in the payload")
-	public XDDResponse<XDDExtractionsResponseOK> searchExtractions(@QueryParam("term") final String term, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass) {
+	public XDDResponse<XDDExtractionsResponseOK> searchExtractions(@QueryParam("term") final String term, @QueryParam("page") final Integer page, @QueryParam("ASKEM_CLASS") String askemClass, @QueryParam("include_highlights") String include_highlights) {
 
 		Matcher matcher = DOI_VALIDATION_PATTERN.matcher(term);
 
 		Boolean isDoi = matcher.find();
 
 		if (isDoi) {
-			return proxy.getExtractions(term, null, page, askemClass);
+			return proxy.getExtractions(term, null, page, askemClass, include_highlights);
 		} else {
-			return proxy.getExtractions(null, term, page, askemClass);
+			return proxy.getExtractions(null, term, page, askemClass, include_highlights);
 		}
 	}
 


### PR DESCRIPTION
XDD has added highlights to extractions and changed it so attached documents to extractions also contain highlights when their extractions do.  We use the later feature here in this PR and technically didn't need to add the highlights field to extractions because thats ununsed.... but ive put it in should we ever want to take advantage of that

# Description

* Include a summary of the changes and the related issue. 
* Include relevant motivation and context.

Resolves #555 
