### PR TITLE
feat: add contextmenu event

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -283,6 +283,18 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			});
 		});
 
+		svg.on('contextmenu', function (evt) {
+			evt.preventDefault();
+			const pointer = d3.pointer(evt);
+			const pointerCoords = d3.zoomTransform(svg.node() as SVGGElement).invert(pointer);
+			emit('background-contextmenu', evt, d3.select(this), renderer, {
+				x: pointerCoords[0],
+				y: pointerCoords[1],
+				clientX: pointer[0],
+				clientY: pointer[1]
+			});
+		});
+
 		const width = this.chartSize.width;
 		const height = this.chartSize.height;
 		const x = d3


### PR DESCRIPTION
### Summary
Add contextmenu event emitter

Usage, 
```
	renderer.on('background-contextmenu', (_evtName: string, _evt: any, _selection: any, _renderer: any, v: any) => {
		console.log(v);
	});
```

where v is

```
{
    "x": 140.26393561924868,
    "y": 27.61464767074014,
    "clientX": 52,
    "clientY": 54
}
```


### Testing
Not applicable, just adding a lib function
