### PR TITLE
chore: fix failing e2e test

### DIFF
--- a/packages/client/hmi-client/tests/e2e/base.spec.ts
+++ b/packages/client/hmi-client/tests/e2e/base.spec.ts
@@ -11,7 +11,7 @@ test.describe('main landing page test', () => {
 
 	test('should load the main page correctly', async ({ page }) => {
 		// Expect a title "to contain" a substring.
-		await expect(page).toHaveTitle(/TERArium/);
+		await expect(page).toHaveTitle(/Terarium/);
 
 		// create a locator
 		const header = page.locator('text=Recent');


### PR DESCRIPTION
The name change caused a (rather silly) test to fail