### PR TITLE
chore: only run e2e tests on weekdays

### DIFF
--- a/.github/workflows/test-client-e2e.yaml
+++ b/.github/workflows/test-client-e2e.yaml
@@ -6,9 +6,9 @@
 name: Client E2E Tests
 # yamllint disable-line rule:truthy
 on:
-  # schedule tests to run every day at 3pm UTC (10am eastern)
+  # schedule tests to run every day at 3pm UTC (10am eastern) monday-friday
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 15 * * 1-5'
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
Nobody wants notifications on the weekends