### PR TITLE
chore: add workflows for server unit tests

### DIFF
--- a/.github/workflows/test-server-unit.yaml
+++ b/.github/workflows/test-server-unit.yaml
@@ -1,0 +1,27 @@
+---
+# This workflow runs server Unit Tests
+
+name: Server Unit Tests
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+
+jobs:
+  unit-tests:
+    name: Quarkus Unit Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      # Debugging purposes to verify branch being worked on
+      - run: git branch
+
+      - name: Setup Java v17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: gradle
+
+      - name: Run Unit Tests
+        run: ./gradlew test --info

--- a/.github/workflows/test-server.yaml
+++ b/.github/workflows/test-server.yaml
@@ -17,5 +17,5 @@ on:
 
 jobs:
   unit-tests:
-    name: Client Unit Tests
-    uses: ./.github/workflows/test-client-unit.yaml
+    name: Server Unit Tests
+    uses: ./.github/workflows/test-server-unit.yaml

--- a/.github/workflows/test-server.yaml
+++ b/.github/workflows/test-server.yaml
@@ -13,7 +13,6 @@ on:
     branches: ['main']
     paths:
       - 'packages/services/hmi-server/**'
-      - '.github/workflows/**'
 
 jobs:
   unit-tests:

--- a/.github/workflows/test-server.yaml
+++ b/.github/workflows/test-server.yaml
@@ -1,0 +1,21 @@
+---
+# This workflow runs all server tests
+
+name: Server Tests
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+  push:
+    branches: ['main']
+    paths:
+      - 'packages/services/hmi-server/**'
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'packages/services/hmi-server/**'
+      - '.github/workflows/**'
+
+jobs:
+  unit-tests:
+    name: Client Unit Tests
+    uses: ./.github/workflows/test-client-unit.yaml

--- a/packages/services/hmi-server/README.md
+++ b/packages/services/hmi-server/README.md
@@ -14,6 +14,20 @@ You can run your application in dev mode that enables live coding using:
 
 > **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
 
+## Testing
+
+To test the application, run:
+
+```bash
+./gradlew test --info
+```
+
+To test the application in interactive/TDD mode, run:
+
+```bash
+./gradlew --console=plain quarkusTest
+```
+
 ## Packaging and running the application
 
 The application can be packaged using:

--- a/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/services/StructuredLogTests.java
+++ b/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/services/StructuredLogTests.java
@@ -13,7 +13,7 @@ public class StructuredLogTests {
 
 	@Test
 	public void testItThrowsWhenOddNumberOfArguments() {
-		Assertions.assertThrows(NullPointerException.class, () -> structuredLog.log(StructuredLog.Type.EVENT, "adam", "single_element"));
+		Assertions.assertThrows(RuntimeException.class, () -> structuredLog.log(StructuredLog.Type.EVENT, "adam", "single_element"));
 	}
 
 	@Test

--- a/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/services/StructuredLogTests.java
+++ b/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/services/StructuredLogTests.java
@@ -13,7 +13,7 @@ public class StructuredLogTests {
 
 	@Test
 	public void testItThrowsWhenOddNumberOfArguments() {
-		Assertions.assertThrows(RuntimeException.class, () -> structuredLog.log(StructuredLog.Type.EVENT, "adam", "single_element"));
+		Assertions.assertThrows(NullPointerException.class, () -> structuredLog.log(StructuredLog.Type.EVENT, "adam", "single_element"));
 	}
 
 	@Test


### PR DESCRIPTION
This runs the quarkus tests on PRs and in main

When a file changes in the `packages/services/hmi-server` directory, this will trigger the workflow to run the quarkus tests:
<img width="1024" alt="Screenshot 2023-03-03 at 11 01 52 AM" src="https://user-images.githubusercontent.com/4606322/222768320-6d126784-50e5-489b-8d77-f19de829fd9d.png">

