### PR TITLE
chore: add a simple test suite for XDD proxies

### DIFF
--- a/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/proxies/DocumentProxyTests.java
+++ b/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/proxies/DocumentProxyTests.java
@@ -1,0 +1,79 @@
+package software.uncharted.terarium.hmiserver.proxies;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.DocumentsResponseOK;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDDictionariesResponseOK;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDResponse;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDSetsResponse;
+
+@QuarkusTest
+public class DocumentProxyTests {
+
+	@RestClient
+	DocumentProxy documentProxy;
+
+	@Test
+	public void testItCanFetchSets() {
+		final XDDSetsResponse response = documentProxy.getAvailableSets();
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNotNull(response.getDescription());
+		Assertions.assertNotNull(response.getAvailable_sets());
+		Assertions.assertTrue(response.getAvailable_sets().size() > 0);
+	}
+
+	@Test
+	public void testItCanGetAllAvailableDictionaries() {
+		final XDDResponse<XDDDictionariesResponseOK> response = documentProxy.getAvailableDictionaries("");
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNull(response.getError());
+		Assertions.assertNotNull(response.getSuccess());
+		Assertions.assertNotNull(response.getSuccess().getData());
+		Assertions.assertTrue(response.getSuccess().getData().size() > 0);
+	}
+
+	@Test
+	public void testItCanGetADocumentById() {
+		final String TARGET_ID = "607182f63f2ac7e701921c92";
+		final XDDResponse<DocumentsResponseOK> response = documentProxy.getDocuments(
+			TARGET_ID, null, null, null, null, null, null, null, null, null, null, null, null,
+			null, null, null, null, null, null, "url_extractions,summaries");
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNull(response.getError());
+		Assertions.assertNotNull(response.getSuccess());
+		Assertions.assertNotNull(response.getSuccess().getData());
+		Assertions.assertEquals(1, response.getSuccess().getData().size());
+		Assertions.assertEquals(TARGET_ID, response.getSuccess().getData().get(0).getID());
+	}
+
+	@Test
+	public void testItCanSearchForADocByTerm() {
+		final XDDResponse<DocumentsResponseOK> response = documentProxy.getDocuments(
+			null, null, null, "COVID-19", "xdd-covid-19", "true", "true", null, null, "100", "2", null, "true",
+			null, null, null, null, "title,abstract", "true", "url_extractions");
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNull(response.getError());
+		Assertions.assertNotNull(response.getSuccess());
+		Assertions.assertNotNull(response.getSuccess().getData());
+		Assertions.assertTrue(response.getSuccess().getData().size() > 0);
+
+		Assertions.assertNotNull(response.getSuccess().getData().get(0).getHighlight());
+		Assertions.assertTrue(response.getSuccess().getData().get(0).getHighlight().size() > 0);
+
+		Assertions.assertNotNull(response.getSuccess().getData().get(0).getAbstractText());
+		Assertions.assertTrue(response.getSuccess().getData().get(0).getAbstractText().length() > 0);
+
+		Assertions.assertNotNull(response.getSuccess().getData().get(0).getTitle());
+		Assertions.assertTrue(response.getSuccess().getData().get(0).getTitle().length() > 0);
+
+		Assertions.assertNotNull(response.getSuccess().getFacets());
+		Assertions.assertTrue(response.getSuccess().getFacets().size() > 0);
+	}
+}

--- a/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/proxies/ExtractionProxyTests.java
+++ b/packages/services/hmi-server/src/test/java/software/uncharted/terarium/hmiserver/proxies/ExtractionProxyTests.java
@@ -1,0 +1,37 @@
+package software.uncharted.terarium.hmiserver.proxies;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.uncharted.terarium.hmiserver.models.documentservice.autocomplete.AutoComplete;
+import software.uncharted.terarium.hmiserver.proxies.documentservice.ExtractionProxy;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDExtractionsResponseOK;
+import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDResponse;
+
+@QuarkusTest
+public class ExtractionProxyTests {
+
+	@RestClient
+	ExtractionProxy proxy;
+
+	@Test
+	public void testItCanGetExtractions() {
+		XDDResponse<XDDExtractionsResponseOK> response = proxy.getExtractions(null, "covid", null, null, "true");
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNull(response.getError());
+		Assertions.assertNotNull(response.getSuccess().getData());
+		Assertions.assertTrue(response.getSuccess().getData().size() > 0);
+	}
+
+	@Test
+	public void testItCanGetAutocomplete() {
+		final AutoComplete response = proxy.getAutocomplete("cov");
+
+		Assertions.assertNotNull(response);
+		Assertions.assertNotNull(response.getSuggest());
+		Assertions.assertNotNull(response.getSuggest().getEntitySuggestFuzzy());
+		Assertions.assertTrue(response.getSuggest().getEntitySuggestFuzzy().size() > 0);
+	}
+}


### PR DESCRIPTION
This adds a simple integration test suite between Terarium and XDD.  This is intended to allow us to know if XDD has updated something that will break us.

Pros: We will get alerted when XDD changes their models
Cons: Our builds will fail if this happens or XDD goes down

We'll have to see if this becomes a nuisance.  Otherwise we can look into adding a global "allow 500 errors" for these tests if it happens often.