### PR TITLE
chore: use model service in staging account by default

### DIFF
--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -37,10 +37,9 @@ mp.openapi.extensions.smallrye.info.description=REST endpoints for the TERArium 
 ########################################################################################################################
 skema/mp-rest/url=https://skema-py.staging.terarium.ai
 skema-rust/mp-rest/url=https://skema-rs.staging.terarium.ai
+model-service/mp-rest/url=https://model-service.staging.terarium.ai
 %dev.data-service/mp-rest/url=http://${data-service-host:localhost}:${data-service-port:3020}
 %prod.data-service/mp-rest/url=http://${data-service}:3020
-%dev.model-service/mp-rest/url=http://${model-service-host:localhost}:${model-service-port:3010}
-%prod.model-service/mp-rest/url=http://${model-service}:3010
 xdd-document-service/mp-rest/url=https://xdd.wisc.edu
 xdd-extraction-service/mp-rest/url=https://xdddev.chtc.io
 ########################################################################################################################


### PR DESCRIPTION
Use the model service running in the staging account default.  This PR must coincide with https://github.com/DARPA-ASKEM/orchestration/pull/113