### PR TITLE
fix: issue with error in vite config for docker compose

### DIFF
--- a/packages/client/hmi-client/vite.config.local.ts
+++ b/packages/client/hmi-client/vite.config.local.ts
@@ -26,7 +26,7 @@ config.server.proxy = {
 };
 // Fix HMR port to match port set in docker compose. https://vitejs.dev/config/server-options.html#server-hmr
 config.server.hmr = {
-	port: 8078
+	clientPort: 8078
 };
 
 export default config;


### PR DESCRIPTION
# Description

* Fixes an issue when running the docker compose setup where the Vue websocket is listening on the wrong port because I got the option name wrong.

