### PR TITLE
chore(hmi-server): moving more auto complete logic to back end

### DIFF
--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -397,7 +397,7 @@ const getAutocomplete = async (searchTerm: string) => {
 	const url = `/document/extractions/askem_autocomplete/${searchTerm}`;
 	const response = await API.get(url);
 	if (response.status === 204) return [];
-	return response.data?.map((d) => d.text) ?? [];
+	return response.data ?? [];
 };
 
 const searchXDDDocuments = async (term: string, xddSearchParam?: XDDSearchParams) => {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/autocomplete/AutoComplete.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/autocomplete/AutoComplete.java
@@ -5,6 +5,9 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 
 @Data
@@ -13,6 +16,8 @@ import java.io.Serializable;
 public class AutoComplete implements Serializable {
 
 	private Suggest suggest;
+
+	private static final String AUTOCOMPLETE_FIELD = "text";
 
 	/**
 	 * Looks at the underlying objects returned by XDD and determines if there are any auto complete suggestions.
@@ -26,6 +31,20 @@ public class AutoComplete implements Serializable {
 			|| suggest.getEntitySuggestFuzzy().isEmpty()
 			|| suggest.getEntitySuggestFuzzy().get(0).getOptions() == null
 			|| suggest.getEntitySuggestFuzzy().get(0).getOptions().isEmpty());
+	}
+
+	/**
+	 * Returns a list of autocomplete suggestions, or an empty list if there is none
+	 *
+	 * @return
+	 */
+	public List<String> getAutoCompletes() {
+		List<String> autoCompletes = new ArrayList<>();
+		for (Map<String, Object> options : getSuggest().getEntitySuggestFuzzy().get(0).getOptions()) {
+			autoCompletes.add(options.get(AUTOCOMPLETE_FIELD).toString());
+		}
+
+		return autoCompletes;
 	}
 
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/autocomplete/EntitySuggestFuzzy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/autocomplete/EntitySuggestFuzzy.java
@@ -6,6 +6,7 @@ import lombok.experimental.Accessors;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Accessors(chain = true)
@@ -13,5 +14,5 @@ import java.util.List;
 public class EntitySuggestFuzzy implements Serializable {
 
 	// We don't care what this is here, we just need to know how many it is, hence Object
-	private List<Object> options;
+	private List<Map<String, Object>> options;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/ExtractionResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/ExtractionResource.java
@@ -96,7 +96,7 @@ public class ExtractionResource {
 
 			return Response
 				.status(Response.Status.OK)
-				.entity(autoComplete.getSuggest().getEntitySuggestFuzzy().get(0).getOptions())
+				.entity(autoComplete.getAutoCompletes())
 				.type(MediaType.APPLICATION_JSON)
 				.build();
 


### PR DESCRIPTION
This has been something that ive been meaning to do for a few weeks but haven't gotten the time.  Fully moving the massaging of this data to the back end so the front end just gets a list of strings.

# Description

* Include a summary of the changes and the related issue. 
* Include relevant motivation and context.

Resolves #825
