### PR TITLE
chore: rename TERArium to Terarium

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,16 +1,16 @@
-# TERArium Contributing Guide
+# Terarium Contributing Guide
 
-Hi! We're really excited that you're interested in contributing to TERArium! Before submitting your contribution, please
+Hi! We're really excited that you're interested in contributing to Terarium! Before submitting your contribution, please
 read through the following guide.
 
 ## Repository Setup
 
-The TERArium repo is a mixed repo using yarn workspaces and Java backend components. The package managers used to
+The Terarium repo is a mixed repo using yarn workspaces and Java backend components. The package managers used to
 install and link dependencies are [yarn](https://yarnpkg.com/getting-started) and [gradle](https://gradle.org/).
 
 To develop and test the core application:
 
-1. Stand up the TERArium services by running the `deploy-terarium.sh up` script from within the
+1. Stand up the Terarium services by running the `deploy-terarium.sh up` script from within the
    [Orchestration](https://github.com/DARPA-ASKEM/orchestration) repository
 2. To stop a pod from running in kubernetes so that you can run locally to debug, run the following commands from the
    orchestration repo's `kubernetes/local` directory. Replace `[NAME]` with the name of the service you would like to
@@ -101,7 +101,7 @@ tag.
 Each package contains a `tests` directory which may contain one or both of `e2e` and `ct` subdirectories. The tests are
 run using [Vitest](https://vitest.dev/) + [Playwright](https://playwright.dev/).
 
-Before running the tests, make sure that TERArium has installed dependencies and has been built.
+Before running the tests, make sure that Terarium has installed dependencies and has been built.
 
 - `yarn test:e2e` by default runs every integration across all 3 browsers (Chromium, FireFox, WebKit)
 - `yarn test:ct` runs component specific tests

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Build and Publish](https://github.com/DARPA-ASKEM/TERArium/actions/workflows/publish.yaml/badge.svg?event=push)](https://github.com/DARPA-ASKEM/TERArium/actions/workflows/publish.yaml)
+[![Build and Publish](https://github.com/DARPA-ASKEM/Terarium/actions/workflows/publish.yaml/badge.svg?event=push)](https://github.com/DARPA-ASKEM/TERArium/actions/workflows/publish.yaml)
 
-# TERArium
+# Terarium
 
-TERArium is the client application for the ASKEM program providing capabilities to create, modify, simulate, and publish
+Terarium is the client application for the ASKEM program providing capabilities to create, modify, simulate, and publish
 machine extracted models.
 
 ## Install and dependencies
 
-The TERArium client is built with Typescript and Vue3. The TERArium server is built with Java and Quarkus. To run and
-develop TERArium, you will need these as a prerequisite:
+The Terarium client is built with Typescript and Vue3. The Terarium server is built with Java and Quarkus. To run and
+develop Terarium, you will need these as a prerequisite:
 
 - [Yarn 2](https://yarnpkg.com/getting-started/install)
 - [NodeJS 18](https://nodejs.org/en/download/current/)
@@ -128,7 +128,7 @@ You can then execute your native executable with: `./build/terarium-1.0.0-SNAPSH
 # Docker build
 docker build . -t <image_name>
 
-# Run, make TERArium available on http://localhost:3000
+# Run, make Terarium available on http://localhost:3000
 docker run -p 3000:3000 -ti <image_name>
 ```
 

--- a/docs/Postman.md
+++ b/docs/Postman.md
@@ -7,11 +7,11 @@ keycloak. Follow these steps to get yourself up and running.
    with them, so consider doing this too.
 2. Under **My Workspace** click Import, then drag and drop the
    file [terarium.postman_globals](../terarium.postman_globals.json) file into the UI.
-3. Clicking on **Environments** you should now see an entry called TERArium Local.
+3. Clicking on **Environments** you should now see an entry called Terarium Local.
 
 ![](Postman_toolbar.png)
 
-4. Ensure that your environment is set to **<span style="color:#FF0000">TERArium Local</span>** and then click on
+4. Ensure that your environment is set to **<span style="color:#FF0000">Terarium Local</span>** and then click on
    the **<span style="color:#00FF00">+</span>** to create a new request.
 5. Under the URL, enter `localhost:3000/YOURAPIPATH`. For example, `localhost:3000/api/projects`.
 6. Click on **Authorization** and then enter the following values (if a value is missing here assume it is
@@ -31,8 +31,8 @@ keycloak. Follow these steps to get yourself up and running.
 * Scope: `{{Scope}}`
 * Client Authentication: `Send as Basic Auth header`
 
-7. Once entered, click the **Get New Access Token** button. This will open TERArium in your browser of choice.
-8. Log into TERArium.  **You will likely notice your browser block a popup at this time. Click through this warning
+7. Once entered, click the **Get New Access Token** button. This will open Terarium in your browser of choice.
+8. Log into Terarium.  **You will likely notice your browser block a popup at this time. Click through this warning
    banner to allow popups from this page.**
 9. This will bring you back to Postman where you can confirm the token acquired.
 10. You should now be able to hit the **Send** button to send your request.

--- a/packages/client/hmi-client/README.md
+++ b/packages/client/hmi-client/README.md
@@ -5,7 +5,7 @@
 # Setup
 ## Vue 3 + TypeScript + Vite
 
-- TERArium uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+- Terarium uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 - [Uncharted Design Tokens](https://github.com/unchartedsoftware/design-tokens)
 - CSS utility library is [PrimeFlex](https://www.primefaces.org/primeflex/)
 - Components System is [PrimeVue](https://primefaces.org/primevue).

--- a/packages/client/hmi-client/src/assets/css/style.scss
+++ b/packages/client/hmi-client/src/assets/css/style.scss
@@ -2,7 +2,7 @@
 @import '@assets/css/reset.css';
 @import '@assets/css/asset.scss';
 
-/** 
+/**
  * PrimeVue
  * https://primefaces.org/primevue/setup
  */
@@ -10,8 +10,8 @@
 @import '@node_modules/primevue/resources/primevue.min.css';
 @import '@node_modules/primeicons/primeicons.css';
 
-/* 
- * TERArium PrimeVue Theme 
+/*
+ * Terarium PrimeVue Theme
  * https://www.primefaces.org/designer/primevue
  */
 @import '@assets/css/theme/theme.scss';

--- a/packages/client/hmi-client/src/components/Navbar.vue
+++ b/packages/client/hmi-client/src/components/Navbar.vue
@@ -6,9 +6,9 @@
 					v-if="currentProjectId"
 					src="@assets/svg/terarium-icon.svg"
 					height="36"
-					alt="TERArium icon"
+					alt="Terarium icon"
 				/>
-				<img v-else src="@assets/svg/terarium-logo.svg" height="36" alt="TERArium logo" />
+				<img v-else src="@assets/svg/terarium-logo.svg" height="36" alt="Terarium logo" />
 			</router-link>
 			<h1 v-if="currentProjectId" @click="showNavigationMenu">
 				{{ currentProjectName }}
@@ -271,7 +271,7 @@ i {
 }
 </style>
 <style>
-/* 
+/*
  * On it's own style, because the pop-up happend outside of this component.
  * To left align the content with the h1.
  */

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -160,7 +160,7 @@ const dirtyResults = ref<{ [resourceType: string]: boolean }>({});
 
 const clientFilters = computed(() => queryStore.clientFilters);
 const xddDataset = computed(() =>
-	resourceType.value === ResourceType.XDD ? resources.xddDataset : 'TERArium'
+	resourceType.value === ResourceType.XDD ? resources.xddDataset : 'Terarium'
 );
 
 const sliderWidth = computed(() =>
@@ -240,7 +240,7 @@ const executeSearch = async () => {
 		[ResourceType.XDD]: {
 			dict: dictNames.value,
 			dataset:
-				xddDataset.value === ResourceType.ALL || xddDataset.value === 'TERArium'
+				xddDataset.value === ResourceType.ALL || xddDataset.value === 'Terarium'
 					? null
 					: xddDataset.value,
 			max: pageSize.value,

--- a/packages/client/hmi-client/src/services/provenance.ts
+++ b/packages/client/hmi-client/src/services/provenance.ts
@@ -126,7 +126,7 @@ async function getRelatedArtifacts(
 	}
 
 	// NOTE: performing a provenance search returns
-	//        a list of TERArium artifacts, which means different types of artifacts
+	//        a list of Terarium artifacts, which means different types of artifacts
 	//        are returned and the explorer view would have to decide to display them
 	return response;
 }

--- a/packages/services/hmi-server/src/main/resources/application.properties
+++ b/packages/services/hmi-server/src/main/resources/application.properties
@@ -33,9 +33,9 @@ quarkus.log.console.json=false
 ########################################################################################################################
 # OpenAPI configurations
 ########################################################################################################################
-mp.openapi.extensions.smallrye.info.title=TERArium API
+mp.openapi.extensions.smallrye.info.title=Terarium API
 mp.openapi.extensions.smallrye.info.version=1.0.0
-mp.openapi.extensions.smallrye.info.description=REST endpoints for the TERArium application
+mp.openapi.extensions.smallrye.info.description=REST endpoints for the Terarium application
 ########################################################################################################################
 # Microservice configurations
 ########################################################################################################################

--- a/terarium.postman_globals.json
+++ b/terarium.postman_globals.json
@@ -37,8 +37,8 @@
 			"enabled": true
 		}
 	],
-	"name": "TERArium Local",
-	"_postman_variable_scope": "TERArium Local",
+	"name": "Terarium Local",
+	"_postman_variable_scope": "Terarium Local",
 	"_postman_exported_at": "2022-11-15T18:16:39.989Z",
 	"_postman_exported_using": "Postman/10.1.2"
 }


### PR DESCRIPTION
# Description

* Go through the whole repo to remove the old convention to write `Terarium`