### PR TITLE
fix: do not run tests on docker compose build

### DIFF
--- a/packages/services/hmi-server/docker/Dockerfile.dev
+++ b/packages/services/hmi-server/docker/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN source "/root/.sdkman/bin/sdkman-init.sh" && sdk install gradle
 COPY . /hmi-server/
 WORKDIR /hmi-server
 
-RUN source "/root/.sdkman/bin/sdkman-init.sh" && gradle build
+RUN source "/root/.sdkman/bin/sdkman-init.sh" && gradle build -x test
 
 EXPOSE 3000
 


### PR DESCRIPTION
# Description

Can't run tests that use docker inside docker while building a docker image, so skipping the tests on build.