### PR TITLE
fix: error determining provenance

### DIFF
--- a/packages/client/hmi-client/src/components/documents/selected-document-pane.vue
+++ b/packages/client/hmi-client/src/components/documents/selected-document-pane.vue
@@ -23,7 +23,8 @@
 
 <script setup lang="ts">
 import { computed, onMounted, PropType, ref } from 'vue';
-import { DocumentAsset, DocumentType } from '@/types/Document';
+import { DocumentType } from '@/types/Document';
+import { DocumentAsset } from '@/types/Types';
 import useResourcesStore from '@/stores/resources';
 import { IProject, ProjectAssetTypes } from '@/types/Project';
 import * as ProjectService from '@/services/project';
@@ -123,6 +124,7 @@ onMounted(async () => {
 .textblock {
 	padding: 0px 0px 5px 15px;
 }
+
 /* TODO: All of this dropdown styling has been used before. If all dropdowns are green with white text and rounded we should export this into a styling component likely */
 
 .dropdown-button {
@@ -147,6 +149,7 @@ subheader {
 :deep .p-dropdown .p-dropdown-trigger {
 	color: white;
 }
+
 .p-button.p-button-secondary {
 	border: 1px solid var(--surface-border);
 	box-shadow: none;

--- a/packages/client/hmi-client/src/page/data-explorer/components/selected-resources-header-pane.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/selected-resources-header-pane.vue
@@ -25,7 +25,8 @@
 import { computed, onMounted, PropType, ref } from 'vue';
 import { isDataset, isModel, isDocument } from '@/utils/data-util';
 import { ResultType } from '@/types/common';
-import { DocumentAsset, DocumentType } from '@/types/Document';
+import { DocumentType } from '@/types/Document';
+import { DocumentAsset } from '@/types/Types';
 import useResourcesStore from '@/stores/resources';
 import { IProject, ProjectAssetTypes } from '@/types/Project';
 import dropdown from 'primevue/dropdown';

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -51,7 +51,7 @@ import { useRoute, useRouter } from 'vue-router';
 import Tree from 'primevue/tree';
 import Button from 'primevue/button';
 import Chip from 'primevue/chip';
-import { DocumentAsset } from '@/types/Document';
+import { DocumentAsset } from '@/types/Types';
 import { Model } from '@/types/Model';
 import { Dataset } from '@/types/Dataset';
 

--- a/packages/client/hmi-client/src/services/external.ts
+++ b/packages/client/hmi-client/src/services/external.ts
@@ -3,7 +3,7 @@
  */
 
 import API from '@/api/api';
-import { DocumentAsset } from '@/types/Document';
+import { DocumentAsset } from '@/types/Types';
 
 /**
  * Get external document asset linked by a given project asset/doc id

--- a/packages/client/hmi-client/src/types/Dataset.ts
+++ b/packages/client/hmi-client/src/types/Dataset.ts
@@ -65,7 +65,7 @@ export type Dataset = {
 
 export type DatasetSearchParams = {
 	filters?: Filters;
-	related_search_id?: string | number;
+	related_search_id?: string;
 	related_search_enabled?: boolean; // if true, then perform a search by example by finding related datasets
 };
 

--- a/packages/client/hmi-client/src/types/Model.ts
+++ b/packages/client/hmi-client/src/types/Model.ts
@@ -21,7 +21,7 @@ export type Model = ITypedModel<any>;
 
 export type ModelSearchParams = {
 	filters?: Filters;
-	related_search_id?: string | number;
+	related_search_id?: string;
 	related_search_enabled?: boolean; // if true, then perform a search by example by finding related models
 };
 

--- a/packages/client/hmi-client/src/types/Project.ts
+++ b/packages/client/hmi-client/src/types/Project.ts
@@ -1,4 +1,5 @@
-import { DocumentType, DocumentAsset } from '@/types/Document';
+import { DocumentType } from '@/types/Document';
+import { DocumentAsset } from '@/types/Types';
 import { Model } from './Model';
 
 export enum ProjectAssetTypes {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -10,6 +10,12 @@ export interface Event {
     value?: string;
 }
 
+export interface DocumentAsset {
+    id?: number;
+    title: string;
+    xdd_uri: string;
+}
+
 export enum EventType {
     Search = "SEARCH",
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/entities/Event.java
@@ -4,6 +4,7 @@ import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.panache.common.Sort;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
@@ -32,6 +33,7 @@ import java.util.UUID;
 	@Index(columnList = "type"),
 	@Index(columnList = "value")
 })
+@EqualsAndHashCode(callSuper = true)
 public class Event extends PanacheEntityBase implements Serializable {
 	@Id
 	@TSOptional
@@ -57,12 +59,13 @@ public class Event extends PanacheEntityBase implements Serializable {
 
 	/**
 	 * Gets events by type and an option search string for values
-	 * @param type				the {@link EventType}
-	 * @param projectId		the optional project id
-	 * @param username		the username of the current user
-	 * @param like				optional search string for values of matching events
-	 * @param limit				the maximum number of events to return
-	 * @return						a list of {@link Event} matching the input
+	 *
+	 * @param type      the {@link EventType}
+	 * @param projectId the optional project id
+	 * @param username  the username of the current user
+	 * @param like      optional search string for values of matching events
+	 * @param limit     the maximum number of events to return
+	 * @return a list of {@link Event} matching the input
 	 */
 	public static List<Event> findAllByTypeAndProjectAndUsernameAndLikeLimit(final EventType type, final Long projectId, final String username, String like, int limit) {
 		PanacheQuery<Event> query;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/exceptions/HmiResponseExceptionMapper.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/exceptions/HmiResponseExceptionMapper.java
@@ -1,5 +1,7 @@
 package software.uncharted.terarium.hmiserver.exceptions;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
 import javax.ws.rs.core.Response;
@@ -10,10 +12,21 @@ public class HmiResponseExceptionMapper implements ResponseExceptionMapper<Runti
 	public RuntimeException toThrowable(Response response) {
 		//TODO we can/should intelligently handle these error codes and create nice thrown exceptions for them.
 		if (response.getStatus() >= 400 && response.getStatus() < 500) {
-			throw new RuntimeException("The remote service responded with HTTP " + response.getStatus());
+			throw new ResponseRuntimeException("The remote service responded with HTTP " + response.getStatus(), response.getStatus());
 		} else if (response.getStatus() >= 500) {
-			throw new RuntimeException("The remote service responded with HTTP " + response.getStatus());
+			throw new ResponseRuntimeException("The remote service responded with HTTP " + response.getStatus(), response.getStatus());
 		}
 		return null;
+	}
+
+	@Data
+	@EqualsAndHashCode(callSuper = true)
+	public class ResponseRuntimeException extends RuntimeException {
+		private int status;
+
+		public ResponseRuntimeException(String message, int status) {
+			super(message);
+			this.status = status;
+		}
 	}
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Assets.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Assets.java
@@ -19,6 +19,6 @@ public class Assets implements Serializable {
 	List<Intermediate> intermediates;
 	List<Model> models;
 	List<SimulationPlan> plans;
-	List<Publication> publications;
+	List<DocumentAsset> publications;
 	List<SimulationRun> simulationRuns;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/DocumentAsset.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/DocumentAsset.java
@@ -3,13 +3,17 @@ package software.uncharted.terarium.hmiserver.models.dataservice;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 
 import java.io.Serializable;
 
 @Data
 @Accessors(chain = true)
-public class Publication implements Serializable {
+@TSModel
+public class DocumentAsset implements Serializable {
 
+	@TSOptional
 	private Long id;
 
 	@JsonProperty("xdd_uri")

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ResourceType.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ResourceType.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 @Accessors(chain = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-	@JsonSubTypes.Type(value = Publication.class, name = "publication"),
+	@JsonSubTypes.Type(value = DocumentAsset.class, name = "publication"),
 	@JsonSubTypes.Type(value = Model.class, name = "model"),
 })
 public class ResourceType implements Serializable {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ExternalProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ExternalProxy.java
@@ -1,7 +1,9 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import software.uncharted.terarium.hmiserver.models.dataservice.Publication;
+import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
+import software.uncharted.terarium.hmiserver.models.dataservice.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.Software;
 
 import javax.ws.rs.*;
@@ -11,6 +13,7 @@ import javax.ws.rs.core.Response;
 @RegisterRestClient(configKey = "data-service")
 @Path("/external")
 @Produces(MediaType.APPLICATION_JSON)
+@RegisterProvider(HmiResponseExceptionMapper.class)
 public interface ExternalProxy {
 
 	@GET
@@ -48,6 +51,6 @@ public interface ExternalProxy {
 	@Path("/publications")
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response createPublication(
-		Publication publication
+		DocumentAsset publication
 	);
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ExternalResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ExternalResource.java
@@ -1,9 +1,12 @@
 package software.uncharted.terarium.hmiserver.resources.dataservice;
 
 import io.quarkus.security.Authenticated;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import software.uncharted.terarium.hmiserver.models.dataservice.Publication;
+import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
+import software.uncharted.terarium.hmiserver.models.dataservice.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.Software;
 import software.uncharted.terarium.hmiserver.proxies.dataservice.ExternalProxy;
 
@@ -49,10 +52,24 @@ public class ExternalResource {
 
 	@GET
 	@Path("/publications/{id}")
+	@APIResponses({
+		@APIResponse(responseCode = "500", description = "An error occurred retrieving publicatione information"),
+		@APIResponse(responseCode = "204", description = "No publication with this ID found, but request was valid")})
 	public Response getPublication(
 		@PathParam("id") final String id
 	) {
-		return proxy.getPublication(id);
+		try {
+			return proxy.getPublication(id);
+		} catch (HmiResponseExceptionMapper.ResponseRuntimeException e) {
+			if (e.getStatus() == 404) {
+				return Response.noContent().build();
+			} else {
+				return Response
+					.status(Response.Status.INTERNAL_SERVER_ERROR)
+					.type(MediaType.APPLICATION_JSON)
+					.build();
+			}
+		}
 	}
 
 	@DELETE
@@ -67,7 +84,7 @@ public class ExternalResource {
 	@Path("/publications")
 	@Consumes(MediaType.APPLICATION_JSON)
 	public Response createPublication(
-		final Publication publication
+		final DocumentAsset publication
 	) {
 		return proxy.createPublication(publication);
 	}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import software.uncharted.terarium.hmiserver.models.documentservice.RelatedDocument;
 import software.uncharted.terarium.hmiserver.models.dataservice.Assets;
-import software.uncharted.terarium.hmiserver.models.dataservice.Publication;
+import software.uncharted.terarium.hmiserver.models.dataservice.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResourceType;
 import software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy;
 import software.uncharted.terarium.hmiserver.models.dataservice.Project;
@@ -82,7 +82,7 @@ public class HomeResource {
 				continue;
 			}
 
-			List<Publication> currentProjectPublications = assets.getPublications();
+			List<DocumentAsset> currentProjectPublications = assets.getPublications();
 
 			if (currentProjectPublications.size() > 0) {
 


### PR DESCRIPTION
# Description

• Updating back end to use same terminology as front end.
• Using new typescript generation to keep this file in sync with front end.
• Now when retrieving publications if a 404 is hit we change this to a 204 for our front end.
• Updating exception being used by back end to pass on response code.
• Front end now asks TDS for correct document asset before proceeding.
• Using generated DocumentAsset

Resolves #843
