### PR TITLE
fix: home page design tweak

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/_variables.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/_variables.scss
@@ -408,7 +408,7 @@ $accordionContentPadding: 0.5rem !default;
 
 //tabview
 $tabviewNavBorder: solid rgba(0, 0, 0, .12) !default;
-$tabviewNavBorderWidth: 0 0 1px 0 !default;
+$tabviewNavBorderWidth: 0 0 0 0 !default;
 $tabviewNavBg: #ffffff !default;
 
 $tabviewHeaderSpacing: 0 !default;

--- a/packages/client/hmi-client/src/assets/css/theme/_variables.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/_variables.scss
@@ -41,6 +41,7 @@ $fontWeightSemiBold: 600;
 $textColor: rgb(16, 24, 40);
 $textSecondaryColor: $emphasis-medium !default;
 $borderRadius: 4px !default;
+$bigBorderRadius: 8px !default;
 $transitionDuration: .2s !default;
 $formElementTransition: background-color $transitionDuration, border-color $transitionDuration, color $transitionDuration, box-shadow $transitionDuration, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1) !default;
 $actionIconTransition: background-color $transitionDuration, color $transitionDuration, box-shadow $transitionDuration !default;
@@ -450,7 +451,8 @@ $cardSubTitleFontWeight: 400 !default;
 $cardSubTitleColor: $textSecondaryColor !default;
 $cardContentPadding: 0 0 !default;
 $cardFooterPadding: 1rem 0 0 0 !default;
-$cardShadow: 0 2px 1px -1px rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 1px 3px 0 rgba(0, 0, 0, .12) !default;
+$cardShadow: 0 2px 4px 0 rgba(0,0,0,0.10) !default;
+$cardShadowHover: 0 4px 8px 0 rgba(0,0,0,0.10) !default;
 
 //editor
 $editorToolbarBg: $panelHeaderBg !default;

--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/panel/_card.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/panel/_card.scss
@@ -2,7 +2,10 @@
     background: $panelContentBg;
     color: $panelContentTextColor;
     box-shadow: $cardShadow;
-    border-radius: $borderRadius;
+    border-radius: $bigBorderRadius;
+    transition: box-shadow 0.1s ease, border 0.1s ease;
+    border: solid 1px $panelContentBg;
+
 
     .p-card-body {
         padding: $cardBodyPadding;
@@ -27,4 +30,10 @@
     .p-card-footer {
         padding: $cardFooterPadding;
     }
+}
+
+
+.p-card:hover {
+    box-shadow: $cardShadowHover;
+    border: solid 1px var(--surface-highlight);
 }

--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/panel/_card.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/panel/_card.scss
@@ -4,7 +4,8 @@
     box-shadow: $cardShadow;
     border-radius: $bigBorderRadius;
     transition: box-shadow 0.1s ease, border 0.1s ease;
-    border: solid 1px $panelContentBg;
+    border: solid 1px var(--gray-50);
+    cursor: pointer;
 
 
     .p-card-body {
@@ -35,5 +36,5 @@
 
 .p-card:hover {
     box-shadow: $cardShadowHover;
-    border: solid 1px var(--surface-highlight);
+    border: solid 1px var(--surface-border);
 }

--- a/packages/client/hmi-client/src/components/documents/DocumentCard.vue
+++ b/packages/client/hmi-client/src/components/documents/DocumentCard.vue
@@ -23,7 +23,7 @@
 			</section>
 			<section class="authors">
 				<ul>
-					<li v-for="(author, index) in document?.author" :key="index">{{ author.name }}</li>
+					<li v-for="(author, index) in document?.author" :key="index">{{ author.name }},</li>
 				</ul>
 			</section>
 		</template>
@@ -107,8 +107,9 @@ onMounted(async () => {
 }
 
 .journal {
-	margin-bottom: 0.5rem;
+	margin-bottom: 0.25rem;
 	height: 2.4rem;
+	font-size: var(--font-caption);
 }
 
 .journal-name {
@@ -130,7 +131,8 @@ onMounted(async () => {
 
 .authors {
 	overflow: hidden;
-	height: 3.75rem;
+	height: 3.25rem;
+	font-size: var(--font-caption);
 }
 
 .p-card {
@@ -147,7 +149,7 @@ ul.skeleton {
 li {
 	list-style: none;
 	display: inline;
-	margin-right: 0.5rem;
+	margin-right: 0.25rem;
 	color: var(--text-color-secondary);
 }
 </style>

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -69,6 +69,12 @@ defineProps<{ project?: IProject }>();
 .project-stats {
 	display: flex;
 	justify-content: space-between;
+	font-size: var(--font-caption);
+	vertical-align: bottom;
+}
+
+.pi {
+	vertical-align: bottom;
 }
 
 .project-stats.skeleton {
@@ -140,6 +146,7 @@ defineProps<{ project?: IProject }>();
 	justify-content: space-between;
 	color: var(--text-color-secondary);
 	padding-top: 0.5rem;
+	font-size: var(--font-caption);
 }
 
 .project-footer.skeleton {
@@ -147,7 +154,7 @@ defineProps<{ project?: IProject }>();
 }
 
 .p-button.p-button-icon-only.p-button-rounded {
-	height: 3rem;
-	width: 3rem;
+	height: 2rem;
+	width: 2rem;
 }
 </style>

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -287,8 +287,9 @@ section {
 }
 
 .papers {
-	background-color: var(--surface-secondary);
+	background: linear-gradient(180deg, var(--chevron-hover), #d5e8e5);
 	padding: 1rem;
+	border-top: 1px solid var(--gray-100);
 }
 
 .papers p {
@@ -307,7 +308,7 @@ h3 {
 }
 
 .p-tabview:deep(.p-tabview-panels) {
-	padding: 1rem 0 1rem 0;
+	padding: 0 0 0 0;
 }
 
 header svg {

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -501,8 +501,9 @@ a {
 	flex-direction: column;
 	justify-content: center;
 	gap: 1rem;
-	border-radius: 4px;
+	border-radius: 8px;
 	transition: background-color 0.2s ease, box-shadow 0.2s ease;
+	cursor: pointer;
 }
 
 .new-project-card > p {
@@ -515,9 +516,8 @@ a {
 }
 
 .new-project-card:hover {
-	background-color: var(--surface-hover);
-	box-shadow: 0 2px 1px -1px rgb(0 0 0 / 20%), 0 1px 1px 0 rgb(0 0 0 / 14%),
-		0 1px 3px 0 rgb(0 0 0 / 12%);
+	background-color: var(--surface);
+	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 }
 
 .new-project-button {

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -293,6 +293,7 @@ section {
 }
 
 .papers p {
+	color: var(--text-color-primary);
 	margin: 1rem 0 1rem 0rem;
 }
 


### PR DESCRIPTION
# Description

- removed bottom border of tabview
- added subtle border top of papers section
- added green linear gradient background to papers section
- removed extra padding around the first tabview (the projects section)
- softened the box-shadow behind Cards
- changed font size of project card footer to caption
- changed font size of stats at top of project cards and adjusted vertical alignment
- changed font size of journal and author names in paper cards
- reduced size of 3-dot menu on cards to 2rem
- added white border to cards
- added hover state for cards with transition effect to increase the box-shadow and change the border color

Resolve #836 