### PR TITLE
chore: various petrinet renderer tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -27,7 +27,7 @@
 			</AccordionTab>
 			<AccordionTab header="Model diagram">
 				<div v-if="model" ref="graphElement" class="graph-element" />
-				<ContextMenu ref="menu" :model="items" />
+				<ContextMenu ref="menu" :model="contextMenuItems" />
 			</AccordionTab>
 			<template v-if="!isEditable">
 				<AccordionTab header="State variables">
@@ -89,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import _, { isEmpty } from 'lodash';
+import { remove, isEmpty } from 'lodash';
 import { IGraph } from '@graph-scaffolder/index';
 import { watch, ref, computed, onMounted, onUnmounted } from 'vue';
 import { runDagreLayout } from '@/services/graph';
@@ -179,18 +179,18 @@ let renderer: PetrinetRenderer | null = null;
 let eventX = 0;
 let eventY = 0;
 
-const keyHandler = (event: KeyboardEvent) => {
+const editorKeyHandler = (event: KeyboardEvent) => {
 	if (event.key === 'Backspace' && renderer) {
 		if (renderer && renderer.nodeSelection) {
 			const nodeData = renderer.nodeSelection.datum();
-			_.remove(renderer.graph.edges, (e) => e.source === nodeData.id || e.target === nodeData.id);
-			_.remove(renderer.graph.nodes, (n) => n.id === nodeData.id);
+			remove(renderer.graph.edges, (e) => e.source === nodeData.id || e.target === nodeData.id);
+			remove(renderer.graph.nodes, (n) => n.id === nodeData.id);
 			renderer.render();
 		}
 
 		if (renderer && renderer.edgeSelection) {
 			const edgeData = renderer.edgeSelection.datum();
-			_.remove(
+			remove(
 				renderer.graph.edges,
 				(e) => e.source === edgeData.source || e.target === edgeData.target
 			);
@@ -199,7 +199,8 @@ const keyHandler = (event: KeyboardEvent) => {
 	}
 };
 
-const items = ref([
+// Model editor context menu
+const contextMenuItems = ref([
 	{
 		label: 'Add State',
 		icon: 'pi pi-fw pi-circle',
@@ -255,7 +256,6 @@ watch([model, graphElement], async () => {
 	await renderer?.render();
 });
 
-// FIXME: update after Dec 8 demo
 const router = useRouter();
 const goToSimulationPlanPage = () => {
 	router.push({
@@ -268,11 +268,11 @@ const goToSimulationPlanPage = () => {
 
 onMounted(async () => {
 	fetchRelatedTerariumArtifacts();
-	document.addEventListener('keyup', keyHandler);
+	document.addEventListener('keyup', editorKeyHandler);
 });
 
 onUnmounted(() => {
-	document.removeEventListener('keyup', keyHandler);
+	document.removeEventListener('keyup', editorKeyHandler);
 });
 
 const toggleEditMode = () => {

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -27,7 +27,7 @@
 			</AccordionTab>
 			<AccordionTab header="Model diagram">
 				<div v-if="model" ref="graphElement" class="graph-element" />
-				<ContextMenu ref="menu" :model="items" @item-click="testItem" />
+				<ContextMenu ref="menu" :model="items" />
 			</AccordionTab>
 			<template v-if="!isEditable">
 				<AccordionTab header="State variables">
@@ -243,7 +243,7 @@ watch([model, graphElement], async () => {
 		renderer?.addEdge(d.source, d.target);
 	});
 
-	renderer.on('background-contextmenu', (evtName, evt, _selection, _renderer, pos: any) => {
+	renderer.on('background-contextmenu', (_evtName, evt, _selection, _renderer, pos: any) => {
 		if (renderer?.editMode) return;
 		eventX = pos.x;
 		eventY = pos.y;

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -204,7 +204,6 @@ const items = ref([
 		label: 'Add State',
 		icon: 'pi pi-fw pi-circle',
 		command: () => {
-			console.log('add state');
 			if (renderer) {
 				renderer.addNode('S', 'test', { x: eventX, y: eventY });
 			}
@@ -214,7 +213,6 @@ const items = ref([
 		label: 'Add Transition',
 		icon: 'pi pi-fw pi-stop',
 		command: () => {
-			console.log('add transition');
 			if (renderer) {
 				renderer.addNode('T', 'test', { x: eventX, y: eventY });
 			}
@@ -246,6 +244,7 @@ watch([model, graphElement], async () => {
 	});
 
 	renderer.on('background-contextmenu', (evtName, evt, _selection, _renderer, pos: any) => {
+		if (renderer?.editMode) return;
 		eventX = pos.x;
 		eventY = pos.y;
 		menu.value.toggle(evt);

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -170,16 +170,23 @@ watch(
 );
 
 const graphElement = ref<HTMLDivElement | null>(null);
+
+let renderer: PetrinetRenderer | null = null;
+
 // Render graph whenever a new model is fetched or whenever the HTML element
 //	that we render the graph to changes.
 watch([model, graphElement], async () => {
 	if (model.value === null || graphElement.value === null) return;
 	// Convert petri net into a graph
-	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(model.value.content);
+	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(model.value.content, {
+		S: { width: 60, height: 60 },
+		T: { width: 40, height: 40 }
+	});
+
 	// Create renderer
-	const renderer = new PetrinetRenderer({
+	renderer = new PetrinetRenderer({
 		el: graphElement.value as HTMLDivElement,
-		useAStarRouting: true,
+		useAStarRouting: false,
 		runLayout: runDagreLayout,
 		dragSelector: 'no-drag'
 	});
@@ -204,9 +211,10 @@ onMounted(async () => {
 	fetchRelatedTerariumArtifacts();
 });
 
-function toggleEditMode() {
+const toggleEditMode = () => {
 	isEditing.value = !isEditing.value;
-}
+	renderer.setEditMode(isEditing.value);
+};
 
 const title = computed(() => highlightSearchTerms(model.value?.name ?? ''));
 const description = computed(() => highlightSearchTerms(model.value?.description ?? ''));

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -245,7 +245,7 @@ watch([model, graphElement], async () => {
 	});
 
 	renderer.on('background-contextmenu', (_evtName, evt, _selection, _renderer, pos: any) => {
-		if (renderer?.editMode) return;
+		if (!renderer?.editMode) return;
 		eventX = pos.x;
 		eventY = pos.y;
 		menu.value.toggle(evt);

--- a/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
@@ -11,6 +11,9 @@ const pathFn = d3
 	.x((d) => d.x)
 	.y((d) => d.y);
 
+const EDGE_COLOR = '#333333';
+const EDGE_OPACITY = 0.5;
+
 export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, EdgeData> {
 	nodeSelection: D3SelectionINode<NodeData> | null = null;
 
@@ -34,13 +37,14 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 			.attr('refX', 2)
 			.attr('refY', 0)
 			.attr('orient', 'auto')
-			.attr('markerWidth', 15)
-			.attr('markerHeight', 15)
+			.attr('markerWidth', 20)
+			.attr('markerHeight', 20)
 			.attr('markerUnits', 'userSpaceOnUse')
 			.attr('xoverflow', 'visible')
 			.append('svg:path')
 			.attr('d', ARROW)
-			.style('fill', '#000')
+			.style('fill', EDGE_COLOR)
+			.style('fill-opacity', EDGE_OPACITY)
 			.style('stroke', 'none');
 	}
 
@@ -158,7 +162,8 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 			.append('path')
 			.attr('d', (d) => pathFn(d.points))
 			.style('fill', 'none')
-			.style('stroke', '#000')
+			.style('stroke', EDGE_COLOR)
+			.style('stroke-opacity', EDGE_OPACITY)
 			.style('stroke-width', 2)
 			.attr('marker-end', 'url(#arrowhead)');
 
@@ -180,6 +185,7 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 				.attr('y', point.y)
 				.attr('stroke', null)
 				.attr('fill', '#000')
+				.style('font-size', 18)
 				.text((d) => d.data?.numEdges as number);
 		});
 	}
@@ -266,6 +272,8 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 		});
 
 		this.on('node-click', (_eventName, _event, selection: D3SelectionINode<NodeData>) => {
+			if (!this.editMode) return;
+
 			// hide any handles which are already open
 			if (this.nodeSelection) {
 				this.nodeSelection.selectAll('.no-drag').style('opacity', 0).style('visibility', 'hidden');
@@ -287,6 +295,8 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 		});
 
 		this.on('edge-click', (_eventName, _event, selection: D3SelectionIEdge<EdgeData>) => {
+			if (!this.editMode) return;
+
 			if (this.edgeSelection) {
 				this.deselectEdge(this.edgeSelection);
 			}
@@ -327,6 +337,25 @@ export class PetrinetRenderer extends graphScaffolder.BasicRenderer<NodeData, Ed
 			default:
 				return { x: node.x, y: node.y };
 		}
+	}
+
+	addNode(type: string, name: string, pos: { x: number; y: number }) {
+		// FIXME: hardwired sizing
+		const size = type === 'S' ? 60 : 30;
+		this.graph.nodes.push({
+			id: `s-${this.graph.nodes.length + 1}`,
+			label: name,
+			x: pos.x,
+			y: pos.y,
+			width: size,
+			height: size,
+			nodes: [],
+			data: {
+				type
+			}
+		});
+
+		this.render();
 	}
 
 	addEdge(source: any, target: any) {

--- a/packages/client/hmi-client/src/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/petrinet/petrinet-service.ts
@@ -193,16 +193,30 @@ export const parseIGraph2PetriNet = (graph: IGraph<NodeData, EdgeData>) => {
  * for the renderer
  * First add each node found in S and T, then add each edge found in I and O
  */
-export const parsePetriNet2IGraph = (model: PetriNet) => {
+interface PetriSizeConfig {
+	S: {
+		width: number;
+		height: number;
+	};
+	T: {
+		width: number;
+		height: number;
+	};
+}
+const defaultSizeConfig: PetriSizeConfig = {
+	S: { width: 40, height: 40 },
+	T: { width: 40, height: 40 }
+};
+export const parsePetriNet2IGraph = (
+	model: PetriNet,
+	config: PetriSizeConfig = defaultSizeConfig
+) => {
 	const result: IGraph<NodeData, EdgeData> = {
 		width: 500,
 		height: 500,
 		nodes: [],
 		edges: []
 	};
-
-	const nodeHeight = 40;
-	const nodeWidth = 40;
 
 	// add each nodes in S
 	for (let i = 0; i < model.S.length; i++) {
@@ -212,8 +226,8 @@ export const parsePetriNet2IGraph = (model: PetriNet) => {
 			label: aNode.sname,
 			x: 0,
 			y: 0,
-			height: nodeHeight,
-			width: nodeWidth,
+			height: config.S.height,
+			width: config.S.width,
 			data: { type: NodeType.State, uid: aNode.uid },
 			nodes: []
 		});
@@ -227,8 +241,8 @@ export const parsePetriNet2IGraph = (model: PetriNet) => {
 			label: aTransition.tname,
 			x: 0,
 			y: 0,
-			height: nodeHeight,
-			width: nodeWidth,
+			height: config.T.height,
+			width: config.T.width,
 			data: { type: NodeType.Transition, uid: aTransition.uid },
 			nodes: []
 		});


### PR DESCRIPTION
### Summary
This makes a handful of tweaks and address some of the initial feedback to make the PetriNet renderer more usable.

- Add explicit state to turn edit on/off, change background colour to indicate editing state
- Remove a-star routing for now, this makes things too swiggly
- Pass in sizing configurations for petri-parsing to IGraph, this reduced hardwired numbers downstream
- Fix a few selection state issues (selected vs not-selected)
- Add a first pass of creating nodes though a context menu
- Tweak the edges and marker-ends to make the arrow a bit more visible

<img width="944" alt="image" src="https://user-images.githubusercontent.com/1220927/226063753-2f64317d-4dfa-495a-9500-3e530c2571d3.png">

Note some of these changes do not exactly align with the design, we will get there in several iterations.

### Test
In the model tab, click "edit model" to enter edit mode (background changes to yellow), here you can
- Select a node and create new edges
- Select a node and delete (backsapce/delete)
- Right click to create new node, currently you cannot modify the name

Once done click save. The model editor will be in readonly and none of the above actions will be available.


### TODO in next PR
- Actually saving the edited ACSet back into database
- Edit node names