### PR TITLE
fix: change copy on search by example

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
@@ -71,7 +71,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.similarContent"
 					/>
-					<label for="similarContent">SIMILAR<br />CONTENT</label>
+					<label for="similarContent">Similar<br />Content</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -79,7 +79,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.forwardCitation"
 					/>
-					<label for="forwardCitation">FORWARD<br />CITATION</label>
+					<label for="forwardCitation">Forward<br />Citation</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -87,7 +87,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.backwardCitation"
 					/>
-					<label for="forwardCitation">BACKWARD<br />CITATION</label>
+					<label for="backwardCitation">Backward<br />Citation</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -95,7 +95,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.relatedContent"
 					/>
-					<label for="relatedContent">MODELS AND<br />DATASETS</label>
+					<label for="relatedContent">Related<br />Resources</label>
 				</div>
 				<Button label="SEARCH" @click="initiateSearchByExample()" />
 			</footer>

--- a/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
@@ -71,7 +71,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.similarContent"
 					/>
-					<label for="similarContent">Similar<br />Content</label>
+					<label for="similarContent">Similar<br />content</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -79,7 +79,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.forwardCitation"
 					/>
-					<label for="forwardCitation">Forward<br />Citation</label>
+					<label for="forwardCitation">Forward<br />citation</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -87,7 +87,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.backwardCitation"
 					/>
-					<label for="backwardCitation">Backward<br />Citation</label>
+					<label for="backwardCitation">Backward<br />citation</label>
 				</div>
 				<div class="field-checkbox">
 					<Checkbox
@@ -95,7 +95,7 @@
 						binary
 						v-model="selectedSearchByExampleOptions.relatedContent"
 					/>
-					<label for="relatedContent">Related<br />Resources</label>
+					<label for="relatedContent">Related<br />resources</label>
 				</div>
 				<Button label="SEARCH" @click="initiateSearchByExample()" />
 			</footer>


### PR DESCRIPTION
# Description

* `MODELS AND DATASETS` to `Related Resources`

![Screenshot 2023-03-17 at 15 00 28](https://user-images.githubusercontent.com/636801/225994717-7a9ee9fb-db66-462c-8e41-ae97e96e6f2e.png)

Resolves https://docs.google.com/presentation/d/18macftUe871RshB87QhEgNXY_14YrW0jVlaW-NRY1lQ/edit?disco=AAAAtHtVK5E
