### PR TITLE
feat: project page tweaks from slides

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -59,7 +59,7 @@ const showSuggestions = computed(() => {
  * As we use only one Project per application instance.
  * It is loaded at the root and passed to all views as prop.
  */
-const resources = useResourcesStore();
+const resourcesStore = useResourcesStore();
 const project = shallowRef<IProject | null>(null);
 const projects = shallowRef<IProject[] | null>(null);
 
@@ -88,8 +88,8 @@ watch(
 			// fetch project metadata
 			project.value = await ProjectService.get(id);
 			// fetch basic metadata about project assets and save them into a global store/cache
-			resources.activeProjectAssets = await ProjectService.getAssets(id);
-			resources.setActiveProject(project.value);
+			resourcesStore.activeProjectAssets = await ProjectService.getAssets(id);
+			resourcesStore.setActiveProject(project.value);
 		} else {
 			project.value = null;
 		}
@@ -102,7 +102,7 @@ watch(
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-resources.$subscribe((mutation, state) => {
+resourcesStore.$subscribe((mutation, state) => {
 	project.value = state.activeProject;
 });
 </script>

--- a/packages/client/hmi-client/src/components/widgets/Modal.vue
+++ b/packages/client/hmi-client/src/components/widgets/Modal.vue
@@ -18,9 +18,13 @@
 	<Transition name="modal">
 		<aside @click.self="$emit('modalMaskClicked')">
 			<main>
-				<slot name="header"></slot>
+				<header>
+					<slot name="header"></slot>
+				</header>
 				<slot></slot>
-				<slot name="footer"> </slot>
+				<footer>
+					<slot name="footer"></slot>
+				</footer>
 			</main>
 		</aside>
 	</Transition>
@@ -49,6 +53,18 @@ main {
 	transition: all 0.1s ease;
 	min-width: max-content;
 	width: 30rem;
+}
+
+header {
+	margin-bottom: 1rem;
+}
+
+footer {
+	display: flex;
+	flex-direction: row-reverse;
+	gap: 1rem;
+	justify-content: end;
+	margin-top: 2rem;
 }
 
 .modal-enter-from,

--- a/packages/client/hmi-client/src/components/widgets/tera-tab-group.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-tab-group.vue
@@ -32,7 +32,7 @@ function calcTabWidthPercentage() {
 		<template v-for="(tab, index) in tabs" :key="index">
 			<header :style="`width: ${calcTabWidthPercentage()}%`">
 				<div class="tab" @click="emit('select-tab', tab)" :active="activeTabIndex === index">
-					<Chip :label="tab.assetType" />
+					<Chip v-if="tab.assetType !== 'overview'" :label="tab.assetType" />
 					<span class="name">
 						{{ tab.assetName }}
 					</span>

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import ToastService from 'primevue/toastservice';
 import PrimeVue from 'primevue/config';
+import Tooltip from 'primevue/tooltip';
 import useAuthStore from './stores/auth';
 import router from './router';
 import App from './App.vue';
@@ -13,6 +14,7 @@ app.use(ToastService);
 app.use(createPinia());
 app.use(router);
 app.use(PrimeVue, { ripple: true });
+app.directive('tooltip', Tooltip);
 
 const auth = useAuthStore();
 await auth.fetchSSO();

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -130,8 +130,10 @@
 				class="modal"
 				@modal-mask-clicked="isNewProjectModalVisible = false"
 			>
+				<template #header>
+					<h4>Create project</h4>
+				</template>
 				<template #default>
-					<div class="new-project-modal-header">Create project</div>
 					<form>
 						<label for="new-project-name">Name</label>
 						<InputText
@@ -151,12 +153,10 @@
 					</form>
 				</template>
 				<template #footer>
-					<footer>
-						<Button @click="createNewProject">Create</Button>
-						<Button class="p-button-secondary" @click="isNewProjectModalVisible = false"
-							>Cancel</Button
-						>
-					</footer>
+					<Button @click="createNewProject">Create</Button>
+					<Button class="p-button-secondary" @click="isNewProjectModalVisible = false"
+						>Cancel</Button
+					>
 				</template>
 			</Modal>
 		</Teleport>
@@ -430,12 +430,6 @@ li {
 	padding: 1rem;
 }
 
-.modal h3 {
-	margin-bottom: 1em;
-	font-weight: 400;
-	font-size: 24px;
-}
-
 .modal label {
 	display: block;
 	margin-bottom: 0.5em;
@@ -446,21 +440,6 @@ li {
 	display: block;
 	margin-bottom: 2rem;
 	width: 100%;
-}
-
-.modal footer {
-	display: flex;
-	flex-direction: row-reverse;
-	gap: 1rem;
-	justify-content: end;
-	margin-top: 2rem;
-}
-
-.modal header {
-	font-weight: 500;
-	font-size: 12px;
-	line-height: 12px;
-	color: var(--text-color-subdued);
 }
 
 .selected-document-modal header {
@@ -541,14 +520,6 @@ a {
 
 .new-project-button {
 	padding: 0;
-}
-
-.new-project-modal-header {
-	font-size: var(--font-body-large);
-	font-weight: var(--font-weight-semibold);
-	color: var(--text-color-primary);
-	padding-bottom: 1rem;
-	width: 50rem;
 }
 
 #new-project-name,

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -38,7 +38,7 @@
 							</ul>
 							<ul v-else>
 								<li v-for="(project, index) in projects?.slice().reverse()" :key="index">
-									<project-card :project="project" @click="openProject(project)" />
+									<project-card :project="project" @click="openProject(project.id)" />
 								</li>
 								<li>
 									<section class="new-project-card" @click="isNewProjectModalVisible = true">
@@ -261,6 +261,10 @@ const scroll = (direction: 'right' | 'left', event: MouseEvent) => {
 	cardListElement.style.marginLeft = `${newMarginLeft > 0 ? 0.5 : newMarginLeft}rem`;
 };
 
+function openProject(projectId: string) {
+	router.push({ name: RouteName.ProjectRoute, params: { projectId } });
+}
+
 async function createNewProject() {
 	const author = auth.name ?? '';
 	const project = await ProjectService.create(
@@ -269,13 +273,9 @@ async function createNewProject() {
 		author
 	);
 	if (project) {
-		router.push(`/projects/${project.id}`);
+		openProject(project.id);
 		isNewProjectModalVisible.value = false;
 	}
-}
-
-function openProject(chosenProject: IProject) {
-	router.push({ name: RouteName.ProjectRoute, params: { projectId: chosenProject.id } });
 }
 
 function listAuthorNames(authors) {

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -160,7 +160,7 @@ function removeAsset(assetToRemove: Tab = props.openedAssetRoute) {
 
 	// If asset to be removed is open in a tab, close it
 	const tabIndex = props.tabs.findIndex((tab: Tab) => isEqual(tab, assetToRemove));
-	if (tabIndex) emit('close-tab', tabIndex);
+	if (tabIndex !== undefined) emit('close-tab', tabIndex);
 
 	isConfirmRemovalModalVisible.value = false;
 	logger.info(`${assetName} was removed.`);

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -1,15 +1,16 @@
 <template>
 	<nav>
 		<header>
-			<Button icon="pi pi-file-edit" class="p-button-icon-only p-button-text p-button-rounded" />
+			<!-- <Button icon="pi pi-file-edit" class="p-button-icon-only p-button-text p-button-rounded" />
 			<Button icon="pi pi-folder" class="p-button-icon-only p-button-text p-button-rounded" />
 			<Button
 				icon="pi pi-sort-amount-down"
 				class="p-button-icon-only p-button-text p-button-rounded"
 			/>
-			<Button icon="pi pi-arrows-v" class="p-button-icon-only p-button-text p-button-rounded" />
+			<Button icon="pi pi-arrows-v" class="p-button-icon-only p-button-text p-button-rounded" /> -->
 			<Button
 				icon="pi pi-trash"
+				v-tooltip="'Delete chosen asset'"
 				class="p-button-icon-only p-button-text p-button-rounded"
 				@click="removeAsset"
 			/>
@@ -51,6 +52,7 @@ import { useRoute, useRouter } from 'vue-router';
 import Tree from 'primevue/tree';
 import Button from 'primevue/button';
 import Chip from 'primevue/chip';
+
 import { DocumentAsset } from '@/types/Types';
 import { Model } from '@/types/Model';
 import { Dataset } from '@/types/Dataset';

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -13,12 +13,12 @@
 			v-if="!isEmpty(resources)"
 			:value="resources"
 			selectionMode="single"
-			v-on:node-select="emit('open-asset', $event.data)"
+			v-on:node-select="emit('open-asset', $event.asset)"
 		>
 			<template #default="slotProps">
 				<span :active="route.params.assetName === slotProps.node.label">
 					{{ slotProps.node.label }}
-					<Chip :label="slotProps.node.data.assetType" />
+					<Chip :label="slotProps.node.asset.assetType" />
 				</span>
 			</template>
 		</tree>
@@ -86,8 +86,10 @@ const resources = computed(() => {
 		resourceTreeNodes.push({
 			key: 'Overview',
 			label: 'Overview',
-			data: {
-				assetType: 'overview'
+			asset: {
+				assetName: 'Overview',
+				assetType: 'overview',
+				assetId: ''
 			},
 			selectable: true
 		});
@@ -96,8 +98,10 @@ const resources = computed(() => {
 		resourceTreeNodes.push({
 			key: 'New file',
 			label: 'New file',
-			data: {
-				assetType: ProjectAssetTypes.CODE
+			asset: {
+				assetName: 'New file',
+				assetType: ProjectAssetTypes.CODE,
+				assetId: ''
 			},
 			selectable: true
 		});
@@ -111,7 +115,7 @@ const resources = computed(() => {
 				resourceTreeNodes.push({
 					key: j.toString(),
 					label: assets[j]?.name || assets[j]?.title || assets[j]?.id,
-					data: {
+					asset: {
 						// Matches Tab type
 						assetName: assets[j]?.name || assets[j]?.title || assets[j]?.id,
 						assetType: projectAssetTypes[i],

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -7,7 +7,7 @@
 			direction="left"
 		>
 			<template v-slot:content>
-				<tera-resource-sidebar />
+				<tera-resource-sidebar :project="project" />
 			</template>
 		</slider-panel>
 		<section>

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -112,6 +112,9 @@ const props = defineProps<{
 	assetType?: ProjectAssetTypes | 'overview' | '';
 }>();
 
+// if I have two models with the same name, they won't open in separate tabs
+// they will just replace the existing tab with the same name
+
 const tabStore = useTabStore();
 const router = useRouter();
 

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -7,7 +7,12 @@
 			direction="left"
 		>
 			<template v-slot:content>
-				<tera-resource-sidebar :project="project" />
+				<tera-resource-sidebar
+					:tabs="tabs"
+					:project="project"
+					@open-asset="openAsset"
+					@close-tab="removeClosedTab"
+				/>
 			</template>
 		</slider-panel>
 		<section>
@@ -118,7 +123,7 @@ const code = ref<string>();
 
 // Associated with tab storage
 const projectContext = computed(() => props.project?.id.toString());
-const tabs = computed(() => tabStore.getTabs(projectContext.value));
+const tabs = computed(() => tabStore.getTabs(projectContext.value) ?? []);
 const activeTabIndex = computed(() => tabStore.getActiveTabIndex(projectContext.value));
 
 function openAsset(assetToOpen: Tab = tabs.value[activeTabIndex.value], newCode?: string) {

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -51,7 +51,7 @@
 				/>
 			</template>
 			<code-editor v-else-if="assetType === ProjectAssetTypes.CODE" :initial-code="code" />
-			<tera-project-overview v-else-if="assetName === 'Overview'" :project="project" />
+			<tera-project-overview v-else-if="assetType === 'overview'" :project="project" />
 		</section>
 		<slider-panel
 			class="slider"
@@ -104,7 +104,7 @@ const props = defineProps<{
 	project: IProject;
 	assetName?: string;
 	assetId?: string;
-	assetType?: ProjectAssetTypes;
+	assetType?: ProjectAssetTypes | 'overview' | '';
 }>();
 
 const tabStore = useTabStore();
@@ -149,9 +149,9 @@ watch(
 				isEmpty(tabs.value)
 			) {
 				tabStore.addTab(projectContext.value, {
-					assetName: props.assetName ?? 'Overview',
+					assetName: props.assetName === '' || !props.assetName ? 'Overview' : props.assetName,
 					assetId: props.assetId,
-					assetType: props.assetType
+					assetType: props.assetType === '' || !props.assetType ? 'overview' : props.assetType
 				});
 			}
 			// Tab switch

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -82,6 +82,6 @@ export type SidePanelTab = {
 export type Tab = {
 	assetName: string;
 	icon?: string;
-	assetId?: string | number;
+	assetId?: string;
 	assetType?: ProjectAssetTypes | 'overview';
 };

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -83,5 +83,5 @@ export type Tab = {
 	assetName: string;
 	icon?: string;
 	assetId?: string;
-	assetType?: ProjectAssetTypes | 'overview';
+	assetType?: ProjectAssetTypes | 'overview' | '';
 };

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -83,5 +83,5 @@ export type Tab = {
 	assetName: string;
 	icon?: string;
 	assetId?: string | number;
-	assetType?: ProjectAssetTypes;
+	assetType?: ProjectAssetTypes | 'overview';
 };


### PR DESCRIPTION
# Description

- Empty page behaviour when there are no tabs + remove empty tab case
- Remove buttons that aren't used (just keep delete button)
- Add "Are you sure" popup for removing an asset from project
- Tabs are identified more uniquely, some used to be identified as the same (eg. in the case where they have the same name)


https://user-images.githubusercontent.com/28237258/226956405-f6808f87-9a16-4c32-9fd6-9199d05672fb.mov
