### PR TITLE
Model editor tweak2

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -346,6 +346,7 @@ export abstract class Renderer<V, E> extends EventEmitter {
 		// Zoom control
 		// FIXME: evt type
 		const zoomed = (evt: any) => {
+			console.log('zoomed................');
 			if (this.options.useZoom === false) return;
 			if (chart) chart.attr('transform', evt.transform);
 
@@ -373,7 +374,6 @@ export abstract class Renderer<V, E> extends EventEmitter {
 
 		const minZoom = 0.05;
 		const maxZoom = Math.max(2, Math.floor((this.graph.width as number) / this.chartSize.width));
-		let zoomLevel = Math.min(1, 1 / ((this.graph.height as number) / this.chartSize.height));
 
 		if (this.options.zoomRange) {
 			this.zoom = d3
@@ -386,17 +386,28 @@ export abstract class Renderer<V, E> extends EventEmitter {
 		}
 		svg.call(this.zoom as any).on('dblclick.zoom', null);
 
-		let zoomX =
-			(-((this.graph.width as number) * zoomLevel * 0.5) + 0.5 * this.chartSize.width) / zoomLevel;
-		let zoomY =
-			(-((this.graph.height as number) * zoomLevel * 0.5) + 0.5 * this.chartSize.height) /
-			zoomLevel;
+		// let zoomX =
+		// 	(-((this.graph.width as number) * zoomLevel * 0.5) + 0.5 * this.chartSize.width) / zoomLevel;
+		// let zoomY =
+		// 	(-((this.graph.height as number) * zoomLevel * 0.5) + 0.5 * this.chartSize.height) /
+		// 	zoomLevel;
+
+		// Align the zoom to the height of the container, then try to center against the width
+		let zoomLevel = 1;
+		let zoomX = 0;
+		let zoomY = 0;
+		if (this.chart) {
+			const graphRect: DOMRect = (this.chart.node() as SVGGElement).getBoundingClientRect();
+			zoomLevel = Math.min(1, this.chartSize.height / (graphRect.height + 1)); // Div by zero
+			zoomX = -(graphRect.width * zoomLevel - this.chartSize.width) * 0.5;
+		}
 
 		if (this.options.useStableZoomPan === true && this.zoomTransformObject !== null) {
 			zoomLevel = this.zoomTransformObject.k;
 			zoomX = this.zoomTransformObject.x / zoomLevel;
 			zoomY = this.zoomTransformObject.y / zoomLevel;
 		}
+
 		svg.call(
 			this.zoom.transform as any,
 			d3.zoomIdentity.translate(0, 0).scale(zoomLevel).translate(zoomX, zoomY)

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -6,6 +6,12 @@
 				<h4 v-html="title" />
 				<span v-if="isEditable">
 					<Button
+						v-if="isEditing"
+						@click="cancelEdit"
+						label="Cancel"
+						class="p-button-sm p-button-outlined"
+					/>
+					<Button
 						@click="toggleEditMode"
 						:label="isEditing ? 'Save model' : 'Edit model'"
 						class="p-button-sm p-button-outlined"
@@ -374,6 +380,25 @@ const toggleEditMode = () => {
 	if (!isEditing.value && model.value && renderer) {
 		model.value.content = parseIGraph2PetriNet(renderer.graph);
 		updateModel(model.value);
+	}
+};
+
+// Cancel existing edits, currently this will:
+// - Resets changs to the model structure
+const cancelEdit = async () => {
+	isEditing.value = false;
+
+	// Convert petri net into a graph with raw input data
+	const g: IGraph<NodeData, EdgeData> = parsePetriNet2IGraph(model.value.content, {
+		S: { width: 60, height: 60 },
+		T: { width: 40, height: 40 }
+	});
+
+	if (renderer) {
+		renderer.setEditMode(false);
+		await renderer.setData(g);
+		renderer.isGraphDirty = true;
+		await renderer.render();
 	}
 };
 


### PR DESCRIPTION
### Summary
Added a "cancel" button to cancel existing save buffer - currently this only applies to the model's structural changes

Better? default zoom and alignment


### Testing
1. In model view, go into edit-mode, remove a few nodes then click cancel. The graph should restore to the default loaded state.

2. Browser several models and observing the initial zoom state, this is rather subjective but they shouldn't look too weird.
