### PR TITLE
feat: drag asset directly into searchbar

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
@@ -16,6 +16,14 @@
 					@complete="fillAutocomplete"
 					@keyup.enter="initiateSearch"
 					@item-select="initiateSearch"
+					@dragover.prevent
+					@dragenter.prevent
+					@drop="
+						{
+							isSearchByExampleVisible = true;
+							onDrop();
+						}
+					"
 				>
 					<template #option="prop">
 						<span class="auto-complete-term">
@@ -64,6 +72,7 @@
 						text
 						v-if="searchByExampleSelectedAsset && searchByExampleSelectedResourceType"
 						class="clear-search-by-example"
+						@click="searchByExampleSelectedAsset = null"
 					>
 					</Button>
 					<span v-else class="drop-zone">


### PR DESCRIPTION
# Description

Dragging and dropping an asset into search bar opens search by example modal. 

https://user-images.githubusercontent.com/16358728/226952019-95a16513-868b-4b70-a4b9-351a0310eee3.mov

Resolves #786 
