### PR TITLE
fix: search by related similar is not working in data explorer

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -265,6 +265,7 @@ const executeSearch = async () => {
 		// find related documents (which utilizes the xDD doc2vec API through the HMI server)
 		//
 		if (isDocument(searchByExampleItem.value) && searchParams.xdd) {
+			searchParams.xdd.dataset = xddDataset.value;
 			if (searchByExampleOptions.value.similarContent) {
 				searchParams.xdd.similar_search_enabled = executeSearchByExample.value;
 			}
@@ -390,28 +391,26 @@ const onSearchByExample = async (searchOptions: SearchByExampleOptions) => {
 
 // helper function to bypass the search-by-example modal
 //  by executing a search by example and refreshing the output
-const onFindRelatedContent = (item: ResultType) => {
-	searchByExampleItem.value = item;
-	const searchOptions: SearchByExampleOptions = {
+const onFindRelatedContent = (item) => {
+	searchByExampleItem.value = item.item;
+	searchByExampleOptions.value = {
 		similarContent: false,
 		forwardCitation: false,
 		backwardCitation: false,
 		relatedContent: true
 	};
-	searchByExampleOptions.value = searchOptions;
 };
 
 // helper function to bypass the search-by-example modal
 //  by executing a search by example and refreshing the output
-const onFindSimilarContent = (item: ResultType) => {
-	searchByExampleItem.value = item;
-	const searchOptions: SearchByExampleOptions = {
+const onFindSimilarContent = (item) => {
+	searchByExampleItem.value = item.item;
+	searchByExampleOptions.value = {
 		similarContent: true,
 		forwardCitation: false,
 		backwardCitation: false,
 		relatedContent: false
 	};
-	searchByExampleOptions.value = searchOptions;
 };
 
 const toggleDataItemSelected = (dataItem: { item: ResultType; type?: string }) => {
@@ -526,6 +525,8 @@ onMounted(async () => {
 	if (!isEmpty(xddDatasets.value) && xddDataset.value === null) {
 		xddDatasetSelectionChanged(xddDatasets.value[xddDatasets.value.length - 1]);
 		xddDatasets.value.push(ResourceType.ALL);
+	} else {
+		resources.setXDDDataset('xdd-covid-19'); // give xdd dataset a default value
 	}
 	executeNewQuery();
 });

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -399,7 +399,6 @@ const onFindRelatedContent = (item: ResultType) => {
 		relatedContent: true
 	};
 	searchByExampleOptions.value = searchOptions;
-	onSearchByExample(searchByExampleOptions.value);
 };
 
 // helper function to bypass the search-by-example modal
@@ -413,7 +412,6 @@ const onFindSimilarContent = (item: ResultType) => {
 		relatedContent: false
 	};
 	searchByExampleOptions.value = searchOptions;
-	onSearchByExample(searchByExampleOptions.value);
 };
 
 const toggleDataItemSelected = (dataItem: { item: ResultType; type?: string }) => {

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -378,6 +378,7 @@ const onSearchByExample = async (searchOptions: SearchByExampleOptions) => {
 	// REVIEW: executing a related content search means to find related artifacts to the one selected:
 	//         if a model/dataset/document is selected then find related artifacts from TDS
 	if (searchOptions.similarContent || searchOptions.relatedContent) {
+		isSliderFacetsOpen.value = false;
 		// NOTE the executeSearch will set proper search-by-example search parameters
 		//  and let the data service handles the fetch
 		executeSearchByExample.value = true;


### PR DESCRIPTION
# Description
Fixing search by similar and search by related in data-explorer.

In terms of search by related it sends back a regular 100 with facets ect. I think these may be the same results but it is hitting the correct call

In terms of search by similar it is getting 10 back (I am assuming this is expected) and no facets (again assume expected) so I have just closed the facet bar when this is clicked as it wont be necessary 

https://user-images.githubusercontent.com/17088680/227028617-c2ac92e2-185b-4595-bb16-39a4d6317b02.mov

https://user-images.githubusercontent.com/17088680/227028672-bed0c316-061e-456b-ab30-44ad65b53a28.mov




Resolves #(issue)
#889

