### PR TITLE
feat(hmi): delete a project

### DIFF
--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -1,25 +1,3 @@
-<script setup lang="ts">
-import { IProject, ProjectAssetTypes } from '@/types/Project';
-import Button from 'primevue/button';
-import Card from 'primevue/card';
-import Skeleton from 'primevue/skeleton';
-import { formatDdMmmYyyy } from '@/utils/date';
-import { placeholder } from '@/utils/project-card';
-
-const props = defineProps<{ project?: IProject }>();
-
-const stats = !props.project
-	? null
-	: {
-			contributors: 1,
-			models: props.project?.assets?.[ProjectAssetTypes.MODELS]?.length ?? 0,
-			datasets: props.project?.assets?.[ProjectAssetTypes.DATASETS]?.length ?? 0,
-			papers: props.project?.assets?.[ProjectAssetTypes.DOCUMENTS]?.length ?? 0
-	  };
-
-const image = stats ? placeholder(stats) : undefined;
-</script>
-
 <template>
 	<Card v-if="project">
 		<template #content>
@@ -62,6 +40,28 @@ const image = stats ? placeholder(stats) : undefined;
 		</template>
 	</Card>
 </template>
+
+<script setup lang="ts">
+import { IProject, ProjectAssetTypes } from '@/types/Project';
+import Button from 'primevue/button';
+import Card from 'primevue/card';
+import Skeleton from 'primevue/skeleton';
+import { formatDdMmmYyyy } from '@/utils/date';
+import { placeholder } from '@/utils/project-card';
+
+const props = defineProps<{ project?: IProject }>();
+
+const stats = !props.project
+	? null
+	: {
+			contributors: 1,
+			models: props.project?.assets?.[ProjectAssetTypes.MODELS]?.length ?? 0,
+			datasets: props.project?.assets?.[ProjectAssetTypes.DATASETS]?.length ?? 0,
+			papers: props.project?.assets?.[ProjectAssetTypes.DOCUMENTS]?.length ?? 0
+	  };
+
+const image = stats ? placeholder(stats) : undefined;
+</script>
 
 <style scoped>
 .p-card {

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -14,8 +14,13 @@
 			<div class="project-description">{{ project.description }}</div>
 			<div class="project-footer">
 				<span>Last updated {{ formatDdMmmYyyy(project.timestamp) }}</span>
-				<Button icon="pi pi-ellipsis-v" class="p-button-rounded p-button-secondary" />
+				<Button
+					icon="pi pi-ellipsis-v"
+					class="p-button-rounded p-button-secondary"
+					@click.stop="showProjectMenu"
+				/>
 			</div>
+			<Menu ref="projectMenu" :model="projectMenuItems" :popup="true" />
 		</template>
 	</Card>
 	<Card v-else>
@@ -42,12 +47,16 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { IProject, ProjectAssetTypes } from '@/types/Project';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
+import Menu from 'primevue/menu';
 import Skeleton from 'primevue/skeleton';
 import { formatDdMmmYyyy } from '@/utils/date';
 import { placeholder } from '@/utils/project-card';
+import { logger } from '@/utils/logger';
+import * as ProjectService from '@/services/project';
 
 const props = defineProps<{ project?: IProject }>();
 
@@ -61,6 +70,23 @@ const stats = !props.project
 	  };
 
 const image = stats ? placeholder(stats) : undefined;
+
+async function removeProject() {
+	if (!props.project) return;
+	const isDeleted = await ProjectService.remove(props.project?.id);
+	if (isDeleted) {
+		logger.info(`The project ${props.project?.name} was removed`, { showToast: true });
+	} else {
+		logger.error(`Unable to delete the project ${props.project?.name}`, { showToast: true });
+	}
+}
+
+/*
+ * User Menu
+ */
+const projectMenu = ref();
+const projectMenuItems = ref([{ label: 'Remove', command: removeProject }]);
+const showProjectMenu = (event) => projectMenu.value.toggle(event);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/projects/ProjectCard.vue
+++ b/packages/client/hmi-client/src/components/projects/ProjectCard.vue
@@ -21,6 +21,17 @@
 				/>
 			</div>
 			<Menu ref="projectMenu" :model="projectMenuItems" :popup="true" />
+			<Dialog :header="`Remove ${project.name}`" v-model:visible="isRemoveDialog">
+				<p>
+					You are about to remove project <em>{{ project.name }}</em
+					>.
+				</p>
+				<p>Are you sure?</p>
+				<template #footer>
+					<Button label="Cancel" class="p-button-secondary" @click="closeRemoveDialog" />
+					<Button label="Remove project" @click="removeProject" />
+				</template>
+			</Dialog>
 		</template>
 	</Card>
 	<Card v-else>
@@ -51,6 +62,7 @@ import { ref } from 'vue';
 import { IProject, ProjectAssetTypes } from '@/types/Project';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
+import Dialog from 'primevue/dialog';
 import Menu from 'primevue/menu';
 import Skeleton from 'primevue/skeleton';
 import { formatDdMmmYyyy } from '@/utils/date';
@@ -59,6 +71,9 @@ import { logger } from '@/utils/logger';
 import * as ProjectService from '@/services/project';
 
 const props = defineProps<{ project?: IProject }>();
+const emit = defineEmits<{
+	(e: 'removed', projectId: IProject['id']): void;
+}>();
 
 const stats = !props.project
 	? null
@@ -71,22 +86,31 @@ const stats = !props.project
 
 const image = stats ? placeholder(stats) : undefined;
 
-async function removeProject() {
-	if (!props.project) return;
-	const isDeleted = await ProjectService.remove(props.project?.id);
-	if (isDeleted) {
-		logger.info(`The project ${props.project?.name} was removed`, { showToast: true });
-	} else {
-		logger.error(`Unable to delete the project ${props.project?.name}`, { showToast: true });
-	}
-}
-
 /*
  * User Menu
  */
+const isRemoveDialog = ref(false);
+const openRemoveDialog = () => {
+	isRemoveDialog.value = true;
+};
+const closeRemoveDialog = () => {
+	isRemoveDialog.value = false;
+};
 const projectMenu = ref();
-const projectMenuItems = ref([{ label: 'Remove', command: removeProject }]);
+const projectMenuItems = ref([{ label: 'Remove', command: openRemoveDialog }]);
 const showProjectMenu = (event) => projectMenu.value.toggle(event);
+
+const removeProject = async () => {
+	if (!props.project) return;
+	const isDeleted = await ProjectService.remove(props.project?.id);
+	closeRemoveDialog();
+	if (isDeleted) {
+		logger.info(`The project ${props.project?.name} was removed`, { showToast: true });
+		emit('removed', props.project.id);
+	} else {
+		logger.error(`Unable to delete the project ${props.project?.name}`, { showToast: true });
+	}
+};
 </script>
 
 <style scoped>
@@ -183,5 +207,9 @@ const showProjectMenu = (event) => projectMenu.value.toggle(event);
 .p-button.p-button-icon-only.p-button-rounded {
 	height: 2rem;
 	width: 2rem;
+}
+
+.p-dialog em {
+	font-weight: var(--font-weight-semibold);
 }
 </style>

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -32,7 +32,7 @@
 								<i class="pi pi-chevron-right" />
 							</div>
 							<ul v-if="isLoadingProjects">
-								<li v-for="i in [0, 1, 2, 3, 4, 5]" :key="i">
+								<li v-for="i in [0, 1, 2]" :key="i">
 									<project-card />
 								</li>
 							</ul>
@@ -172,7 +172,6 @@ import { DocumentType } from '@/types/Document';
 import { searchXDDDocuments } from '@/services/data';
 import useResourcesStore from '@/stores/resources';
 import useQueryStore from '@/stores/query';
-import API from '@/api/api';
 import ProjectCard from '@/components/projects/ProjectCard.vue';
 import DocumentCard from '@/components/documents/DocumentCard.vue';
 import Button from 'primevue/button';
@@ -214,7 +213,7 @@ onMounted(async () => {
 	resourcesStore.reset(); // Project related resources saved.
 	queryStore.reset(); // Facets queries.
 
-	projects.value = (await API.get('/home')).data as IProject[];
+	projects.value = (await ProjectService.home()) ?? [];
 
 	// Get all relevant documents (latest on section)
 	const allDocuments = await searchXDDDocuments(relevantSearchTerm, relevantSearchParams);

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -37,8 +37,12 @@
 								</li>
 							</ul>
 							<ul v-else>
-								<li v-for="(project, index) in projects?.slice().reverse()" :key="index">
-									<project-card :project="project" @click="openProject(project.id)" />
+								<li v-for="project in projects" :key="project.id">
+									<project-card
+										:project="project"
+										@click="openProject(project.id)"
+										@removed="removeProject"
+									/>
 								</li>
 								<li>
 									<section class="new-project-card" @click="isNewProjectModalVisible = true">
@@ -213,7 +217,7 @@ onMounted(async () => {
 	resourcesStore.reset(); // Project related resources saved.
 	queryStore.reset(); // Facets queries.
 
-	projects.value = (await ProjectService.home()) ?? [];
+	projects.value = ((await ProjectService.home()) ?? []).slice().reverse();
 
 	// Get all relevant documents (latest on section)
 	const allDocuments = await searchXDDDocuments(relevantSearchTerm, relevantSearchParams);
@@ -280,6 +284,10 @@ async function createNewProject() {
 function listAuthorNames(authors) {
 	return authors.map((author) => author.name).join(', ');
 }
+
+const removeProject = (projectId: IProject['id']) => {
+	projects.value = projects.value?.filter((project) => project.id !== projectId);
+};
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -60,6 +60,21 @@ async function get(projectId: string): Promise<IProject | null> {
 }
 
 /**
+ * Remove a project (soft-delete)
+ * @param projectId {IProject["id"]} - the id of the project to be removed
+ * @return boolean - if the removal was succesful
+ */
+async function remove(projectId: IProject['id']): Promise<boolean> {
+	try {
+		const { status } = await API.delete(`/projects/${projectId}`);
+		return status === 200;
+	} catch (error) {
+		logger.error(error);
+		return false;
+	}
+}
+
+/**
  * Get all projects
  * @return Array<Project>|null - the list of all projects, or null if none returned by API
  */
@@ -126,4 +141,19 @@ async function deleteAsset(projectId: string, assetsType: string, assetId) {
 	return response?.data ?? null;
 }
 
-export { create, update, get, getAll, addAsset, deleteAsset, getAssets };
+/**
+ * Get all informations for the homepage
+ */
+async function home(): Promise<IProject[] | null> {
+	try {
+		const response = await API.get('/home');
+		const { status, data } = response;
+		if (status !== 200 || !data) return null;
+		return data;
+	} catch (error) {
+		logger.error(error);
+		return null;
+	}
+}
+
+export { create, update, get, remove, getAll, addAsset, deleteAsset, getAssets, home };

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/HomeResource.java
@@ -67,8 +67,15 @@ public class HomeResource {
 				.status(Response.Status.INTERNAL_SERVER_ERROR)
 				.type(MediaType.APPLICATION_JSON)
 				.build();
-
 		}
+
+		// Remove non active (soft-deleted) projects
+		// TODO - this should be done in the data-service
+		allProjects = allProjects
+			.stream()
+			.filter(Project::getActive)
+			.toList();
+		
 		//Get project's related documents and add them to the project.
 		//Currently related documents is really stupid. It just grabs the first publication in the project and will get related documents of that publication.
 		//TODO: Make this smarter than grabbing first publication and then its related

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
@@ -27,9 +27,18 @@ public class ProjectResource {
 		@DefaultValue("50") @QueryParam("page_size") final Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") final Integer page
 	) {
+		List<Project> projects = proxy.getProjects(pageSize, page);
+
+		// Remove non active (soft-deleted) projects
+		// TODO - this should be done in the data-service
+		projects = projects
+			.stream()
+			.filter(Project::getActive)
+			.toList();
+
 		return Response
 			.status(Response.Status.OK)
-			.entity(proxy.getProjects(pageSize, page))
+			.entity(projects)
 			.build();
 	}
 


### PR DESCRIPTION
# Description

* Update `hmi-server` to not return _soft-deleted_ projects for the `/home` and `/projects` endpoints.
* Added a _Project Menu_ with a `Remove` option.
* Added a Confirmation dialog to prompt the user to remove the project.
* Show a toast in case of success or error of removal.
* Remove the project from the homepage by listening to the `removed` event emitted by the project card.

# Video

https://user-images.githubusercontent.com/636801/227049317-df358ac2-c097-4e8a-9314-3839d3196767.mov

