### PR TITLE
feat: first pass at edit node labels

### DIFF
--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -288,6 +288,11 @@ let eventX = 0;
 let eventY = 0;
 
 const editorKeyHandler = (event: KeyboardEvent) => {
+	// Ignore backspace if the current focus is a text/input box
+	if ((event.target as HTMLElement).tagName === 'INPUT') {
+		return;
+	}
+
 	if (event.key === 'Backspace' && renderer) {
 		if (renderer && renderer.nodeSelection) {
 			const nodeData = renderer.nodeSelection.datum();


### PR DESCRIPTION
### Summary
First pass at allowing node labels to be edited.

To edit node labels
- Enter edit mode
- Select a node, you should have a text input box to change the name
- Click outside of the node trigger the change

Also fixed edge styles to use splines instead of alternating back and forth

Notes
- Right now saving the model after name change will corrupt the data, likely this has to do with mira serializations. The UI doesn't expect mira but the API side expects to see it
- Needs better handlers, e.g. hook in the "enter" key to save a node-label instead of clicking out side