### PR TITLE
fix: buggy selection state after rerender

### DIFF
--- a/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
@@ -348,7 +348,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			const id = this.nodeSelection.datum().id;
 			this.nodeSelection = this.chart
 				.selectAll('.node-ui')
-				.filter((d) => d.id === id) as D3SelectionINode<NodeData>;
+				.filter((d: any) => d.id === id) as D3SelectionINode<NodeData>;
 
 			if (this.nodeSelection) {
 				this.selectNode(this.nodeSelection);


### PR DESCRIPTION
### Summary
After a re-renderer, the existing selection state can be messed up, we need to reassign them, if applicable.

Closes  https://github.com/DARPA-ASKEM/Terarium/issues/908


### Testing
In model view
- enter edit mode
- select a transition, create a new edge 
- click the background, there should be no console errors