### PR TITLE
fix: parsing mira_ids and mira_context are optional

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/petrinet/SpeciesJsonDeserializer.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/petrinet/SpeciesJsonDeserializer.java
@@ -27,17 +27,21 @@ public class SpeciesJsonDeserializer extends JsonDeserializer<Species> {
 			.setMiraIds(new ArrayList<>())
 			.setMiraContext(new ArrayList<>());
 
-		final String nodeMiraIds = node.get("mira_ids").asText();
-		if (nodeMiraIds.length() > 3) {
-			for (String ontology : nodeMiraIds.split("\\), \\(")) {
-				species.getMiraIds().add(new Ontology(ontology));
+		if (node.get("mira_ids") != null) {
+			final String nodeMiraIds = node.get("mira_ids").asText();
+			if (nodeMiraIds.length() > 3) {
+				for (String ontology : nodeMiraIds.split("\\), \\(")) {
+					species.getMiraIds().add(new Ontology(ontology));
+				}
 			}
 		}
 
-		final String nodeMiraContext = node.get("mira_context").asText();
-		if (nodeMiraContext.length() > 3) {
-			for (String ontology : nodeMiraContext.split("\\), \\(")) {
-				species.getMiraContext().add(new Ontology(ontology));
+		if (node.get("mira_context") != null) {
+			final String nodeMiraContext = node.get("mira_context").asText();
+			if (nodeMiraContext.length() > 3) {
+				for (String ontology : nodeMiraContext.split("\\), \\(")) {
+					species.getMiraContext().add(new Ontology(ontology));
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary
A somewhat temporary fix so we don't assume mira_ids and mira_contexts are always there. 

The caveat is we have not settled upon a metadata representation so this is likely going to change, but the PR here will prevent unexpected errors in the meantime.

### Testing
Should be able to fetch all models

```
curl -v -H "content-type: application/json" -XGET -H "${AUTHORIZATION_HEADER}" http://localhost:3000/api/models/{id}
```