### PR TITLE
feat: polling utility

### DIFF
--- a/packages/client/hmi-client/src/api/api.ts
+++ b/packages/client/hmi-client/src/api/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { logger } from '@/utils/logger';
 import { ToastSummaries } from '@/services/toast';
 import useAuthStore from '../stores/auth';
@@ -47,5 +47,118 @@ API.interceptors.response.use(
 		return null; // return null
 	}
 );
+
+// eslint-disable-next-line no-promise-executor-return
+const timeout = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const NOOP = () => {};
+
+export enum PollerState {
+	Done = 'done',
+	Failed = 'failed',
+	ExceedThreshold = 'ExceedThreshold'
+}
+
+interface PollerResult<T> {
+	state: PollerState;
+	data: T | null;
+}
+export class Poller<T> {
+	pollingId = 0;
+
+	pollingInterval = 2000;
+
+	pollingThreshold = 10;
+
+	keepGoing = false;
+
+	poll: Function = NOOP;
+
+	successCheck: Function = NOOP;
+
+	progressAction: Function = NOOP;
+
+	numPolls = 0;
+
+	setInterval(v: number) {
+		this.pollingInterval = v;
+		return this;
+	}
+
+	setThreshold(v: number) {
+		this.pollingThreshold = v;
+		return this;
+	}
+
+	setSuccessCheck(f: Function) {
+		this.successCheck = f;
+		return this;
+	}
+
+	setProgressAction(f: Function) {
+		this.progressAction = f;
+		return this;
+	}
+
+	// Start polling, there are 4 foreseeable exit conditions
+	// 1. Done, we have the result
+	// 2. Failed, request returned with 4xx or 5xx status
+	// 3. Failed, any unexpected errors
+	// 4. ExceedThreshold, took longer than allotted time
+	async start(): Promise<PollerResult<T>> {
+		this.keepGoing = true;
+		this.numPolls = 0;
+
+		let response: AxiosResponse<T, any>;
+
+		while (this.numPolls < this.pollingThreshold) {
+			this.numPolls++;
+			if (!this.keepGoing) {
+				break;
+			}
+
+			try {
+				// eslint-disable-next-line no-await-in-loop
+				response = (await this.poll()) as AxiosResponse<T, any>;
+				const { status, data } = response;
+				console.log(status, data);
+
+				if (status >= 400) {
+					return {
+						state: PollerState.Failed,
+						data: null
+					};
+				}
+
+				if (this.successCheck(data)) {
+					return {
+						state: PollerState.Done,
+						data
+					};
+				}
+
+				// We are still in progress
+				this.progressAction(data, this.numPolls, this.pollingThreshold);
+			} catch (error) {
+				return {
+					state: PollerState.Failed,
+					data: null
+				};
+			}
+
+			// eslint-disable-next-line no-await-in-loop
+			await timeout(this.pollingInterval);
+		}
+
+		return {
+			state: PollerState.ExceedThreshold,
+			data: null
+		};
+	}
+
+	// Not really a fluent API, but convienent
+	stop() {
+		this.keepGoing = false;
+	}
+}
 
 export default API;

--- a/packages/client/hmi-client/tests/unit/api/api.spec.ts
+++ b/packages/client/hmi-client/tests/unit/api/api.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { Poller } from '@/api/api';
+
+describe('API utilities test', () => {
+	it('polling immediate', async () => {
+		const poller = new Poller<number[]>()
+			.setInterval(1000)
+			.setThreshold(5)
+			.setPollAction(async () => ({ data: [1, 2, 3], error: null }));
+
+		const result = await poller.start();
+		expect(result.data).deep.eq([1, 2, 3]);
+	});
+
+	it('polling several times and return data', async () => {
+		let c = 0;
+		const start = Date.now();
+		const poller = new Poller<number[]>()
+			.setInterval(1000)
+			.setThreshold(5)
+			.setPollAction(async () => {
+				c++;
+				if (c <= 3) {
+					return { data: null, error: null };
+				}
+				return { data: [1, 2, 3], error: null };
+			});
+
+		const result2 = await poller.start();
+		const end = Date.now();
+
+		expect(end - start).gt(2000);
+		expect(result2.data).deep.eq([1, 2, 3]);
+	});
+
+	it('polling exceeds threshold', async () => {
+		let c = 0;
+		const poller = new Poller<number[]>()
+			.setInterval(1000)
+			.setThreshold(3)
+			.setPollAction(async () => {
+				c++;
+				if (c <= 10) {
+					return { data: null, error: null };
+				}
+				return { data: [1, 2, 3], error: null };
+			});
+
+		const result = await poller.start();
+		expect(result.state).eq('ExceedThreshold');
+	});
+});


### PR DESCRIPTION
### Summary
Add poller utility for working with asynchronous requests. The key function is the `setPollAction` which sets a callback function that returns: 

```
{ data: T, error: any, progress: any }
```

Where, in precedence:
- A non-null `error` will trigger the the poller to fail
- A non-null `data` will return data and end the polling
- `progress` is currently not used but is meant to track and convey intermediate results

It is expected the callback function to follow this convention.


### Testing
Basic tests can be exercised with 
```
yarn workspace hmi-client run test
```