### PR TITLE
Update integration-issues.yml

### DIFF
--- a/.github/workflows/integration-issues.yml
+++ b/.github/workflows/integration-issues.yml
@@ -9,6 +9,8 @@ on:
     types:
       - reopened
       - opened
+      - labeled
+      - edited      
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This fix enables the Github action that pushes issues to the `Integration` project board to run when the issue is labelled or edited, not just when it is opened/closed.
