### PR TITLE
chore: clean up, cancel-poll hook

### DIFF
--- a/packages/client/hmi-client/src/api/api.ts
+++ b/packages/client/hmi-client/src/api/api.ts
@@ -60,8 +60,8 @@ export enum PollerState {
 
 interface PollResponse<T> {
 	error: any;
-	progress: any;
-	data: T;
+	progress?: any;
+	data: T | null;
 }
 
 type PollerCallback<T> = (...args: any[]) => Promise<PollResponse<T>>;

--- a/packages/client/hmi-client/tests/unit/api/api.spec.ts
+++ b/packages/client/hmi-client/tests/unit/api/api.spec.ts
@@ -49,4 +49,27 @@ describe('API utilities test', () => {
 		const result = await poller.start();
 		expect(result.state).eq('ExceedThreshold');
 	});
+
+	it('polling can be cancelled', async () => {
+		let c = 0;
+		const poller = new Poller<number[]>()
+			.setInterval(1000)
+			.setThreshold(10)
+			.setPollAction(async () => {
+				c++;
+				if (c <= 99) {
+					return { data: null, error: null };
+				}
+				return { data: [1, 2, 3], error: null };
+			});
+
+		// Cancel between 2nd and 3rd iteration
+		setTimeout(() => {
+			poller.stop();
+		}, 2500);
+		const result = await poller.start();
+		expect(result.state).eq('Cancelled');
+		expect(c).gt(1);
+		expect(c).lt(4);
+	});
 });


### PR DESCRIPTION
### Summary
Clean up the interface a bit to have better typing information

Hook in logic for cancel

### Testing
Run tests `yarn workspace hmi-client run test`