### PR TITLE
fix: dismiss context meun on background click

### DIFF
--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -533,7 +533,11 @@ watch(
 			if (!renderer?.editMode) return;
 			eventX = pos.x;
 			eventY = pos.y;
-			menu.value.toggle(evt);
+			menu.value.show(evt);
+		});
+
+		renderer.on('background-click', () => {
+			if (menu.value) menu.value.hide();
 		});
 
 		// Render graph


### PR DESCRIPTION
### Summary
Dismiss the vue-context menu on background click


### Testing
In model page:
- go into edit mode
- right click to get context menu
- click anywhere on the background to dismiss context menu