### PR TITLE
fix: 954 math viewer design ux tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
+++ b/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
@@ -175,23 +175,15 @@ const cancelEditEquation = () => {
 
 <style scoped>
 math-field {
-	background-color: var(--surface);
 	border-radius: 4px;
-	border: 1px solid var(--gray-0);
 	padding: 5px;
 	margin: 10px;
 	font-size: 1em;
 	transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out, opacity 0.3s ease-in-out;
 }
 
-math-field:focus-within {
-	outline: 2px solid var(--primary-color);
-	border-radius: var(--border-radius);
-}
-
 math-field[disabled] {
 	opacity: 1;
-	background-color: var(--surface-secondary);
 }
 
 .controls {

--- a/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
+++ b/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
@@ -34,7 +34,6 @@
 				ref="mathLiveField"
 				virtual-keyboard-mode="false"
 				:disabled="!isEditingEq"
-				:style="{ borderColor: isMathMlValid ? 'inherit' : 'red' }"
 				><slot v-if="mathMode === MathEditorModes.LIVE"></slot
 			></math-field>
 		</section>
@@ -175,6 +174,7 @@ const cancelEditEquation = () => {
 
 <style scoped>
 math-field {
+	background-color: var(--gray-100);
 	border-radius: 4px;
 	padding: 5px;
 	margin: 10px;
@@ -183,6 +183,7 @@ math-field {
 }
 
 math-field[disabled] {
+	background-color: var(--gray-0);
 	opacity: 1;
 }
 

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -615,8 +615,7 @@ const validateMathML = async (mathMlString: string, editMode: boolean) => {
 		logger.error(
 			'Empty MathML cannot be converted to a Petrinet.  Please try again or click cancel.'
 		);
-	}
-	if (!editMode) {
+	} else if (!editMode) {
 		try {
 			const newPetri = await mathmlToPetri(cleanedMathML);
 			if (
@@ -634,6 +633,8 @@ const validateMathML = async (mathMlString: string, editMode: boolean) => {
 		} catch (e) {
 			isMathMLValid.value = false;
 		}
+	} else if (editMode) {
+		isMathMLValid.value = true;
 	}
 };
 
@@ -747,6 +748,7 @@ section math-editor {
 
 .math-editor-error {
 	outline: 2px solid red;
+	transition: outline 0.3s ease-in-out, color 0.3s ease-in-out, opacity 0.3s ease-in-out;
 }
 
 .model_diagram {

--- a/packages/client/hmi-client/src/components/models/Model.vue
+++ b/packages/client/hmi-client/src/components/models/Model.vue
@@ -53,7 +53,7 @@
 									:minSize="mathPanelMinSize"
 									:maxSize="mathPanelMaxSize"
 								>
-									<section class="math-editor-container">
+									<section class="math-editor-container" :class="mathEditorSelected">
 										<tera-math-editor
 											:is-editable="isEditable"
 											:latex-equation="equationLatex"
@@ -293,12 +293,12 @@ const showForecastLauncher = ref(false);
 const switchWidthPercent = ref<number>(50); // switch model layout when the size of the model window is < 50%
 
 const equationPanelSize = ref<number>(50);
-const equationPanelMinSize = ref<number>(1);
-const equationPanelMaxSize = ref<number>(99);
+const equationPanelMinSize = ref<number>(0);
+const equationPanelMaxSize = ref<number>(100);
 
 const mathPanelSize = ref<number>(50);
-const mathPanelMinSize = ref<number>(1);
-const mathPanelMaxSize = ref<number>(99);
+const mathPanelMinSize = ref<number>(0);
+const mathPanelMaxSize = ref<number>(100);
 
 const updateLayout = () => {
 	if (splitterContainer.value) {
@@ -322,6 +322,17 @@ onMounted(() => {
 onUnmounted(() => {
 	window.removeEventListener('resize', handleResize);
 });
+
+const mathEditorSelected = computed(() => {
+	if (!isMathMLValid.value) {
+		return 'math-editor-error';
+	}
+	if (isEditingEQ.value) {
+		return 'math-editor-selected';
+	}
+	return '';
+});
+
 const betterStates = computed(() => {
 	const statesFromParams = model.value?.parameters.filter((p) => p.state_variable);
 	const statesFromContent: any[] = model.value?.content?.S ?? [];
@@ -717,6 +728,17 @@ section math-editor {
 	width: 100%;
 	flex-grow: 1;
 	flex-direction: column;
+	border-width: 2px;
+	border-color: red;
+	height: 100%;
+}
+
+.math-editor-selected {
+	outline: 2px solid var(--primary-color);
+}
+
+.math-editor-error {
+	outline: 2px solid red;
 }
 
 .model_diagram {


### PR DESCRIPTION
# Description

Made the suggested updates by @jamiewaese-uncharted .

1)  Removed background and border from the non-edit mode, applied `edit` border around the entire frame of the math equation panel

2)  Repositioned "edit" button

3)  When resizing you can make the model diagram disappear.

4)  Vertical constraints

Resolves #(issue)
