### PR TITLE
feat: search by example pops up while asset is being dragged

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
@@ -1,5 +1,10 @@
 <template>
-	<div class="asset-card" draggable="true" @dragstart="startDrag(asset, resourceType)">
+	<div
+		class="asset-card"
+		draggable="true"
+		@dragstart="startDrag(asset, resourceType)"
+		@dragend="deleteDragData('asset')"
+	>
 		<main>
 			<div class="type-and-filters">
 				{{ resourceType.toUpperCase() }}
@@ -244,7 +249,7 @@ const formatFeatures = () => {
 	return featuresNames.length < max ? featuresNames : featuresNames.slice(0, max);
 };
 
-const { setDragData } = useDragEvent();
+const { setDragData, deleteDragData } = useDragEvent();
 
 function startDrag(asset, resourceType) {
 	setDragData('asset', asset);
@@ -329,6 +334,7 @@ function startDrag(asset, resourceType) {
 	border-radius: 24px;
 	font-size: 10px;
 }
+
 .asset-nav-arrows .asset-pages {
 	display: flex;
 	justify-content: space-between;

--- a/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
@@ -3,7 +3,7 @@
 		class="asset-card"
 		draggable="true"
 		@dragstart="startDrag(asset, resourceType)"
-		@dragend="stopDrag"
+		@dragend="endDrag"
 	>
 		<main>
 			<div class="type-and-filters">
@@ -256,7 +256,7 @@ function startDrag(asset, resourceType) {
 	setDragData('resourceType', resourceType);
 }
 
-function stopDrag() {
+function endDrag() {
 	deleteDragData('asset');
 	deleteDragData('resourceType');
 }

--- a/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/asset-card.vue
@@ -3,7 +3,7 @@
 		class="asset-card"
 		draggable="true"
 		@dragstart="startDrag(asset, resourceType)"
-		@dragend="deleteDragData('asset')"
+		@dragend="stopDrag"
 	>
 		<main>
 			<div class="type-and-filters">
@@ -254,6 +254,11 @@ const { setDragData, deleteDragData } = useDragEvent();
 function startDrag(asset, resourceType) {
 	setDragData('asset', asset);
 	setDragData('resourceType', resourceType);
+}
+
+function stopDrag() {
+	deleteDragData('asset');
+	deleteDragData('resourceType');
 }
 </script>
 

--- a/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
@@ -18,12 +18,6 @@
 					@item-select="initiateSearch"
 					@dragover.prevent
 					@dragenter.prevent
-					@drop="
-						{
-							isSearchByExampleVisible = true;
-							onDrop();
-						}
-					"
 				>
 					<template #option="prop">
 						<span class="auto-complete-term">
@@ -38,7 +32,7 @@
 			<Button
 				class="p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small search-by-example-button"
 				icon="pi pi-upload"
-				@click="isSearchByExampleVisible = !isSearchByExampleVisible"
+				@click="searchByExampleToggle = !searchByExampleToggle"
 				:active="isSearchByExampleVisible"
 			/>
 		</div>
@@ -48,8 +42,8 @@
 				<Button
 					class="p-button-rounded"
 					icon="pi pi-times"
-					@click="isSearchByExampleVisible = !isSearchByExampleVisible"
-				></Button>
+					@click="searchByExampleToggle = !searchByExampleToggle"
+				/>
 			</header>
 			<section class="search-drag-drop-area">
 				<section
@@ -74,8 +68,7 @@
 						v-if="searchByExampleSelectedAsset && searchByExampleSelectedResourceType"
 						class="clear-search-by-example"
 						@click="searchByExampleSelectedAsset = null"
-					>
-					</Button>
+					/>
 					<span v-else class="drop-zone">
 						<i class="pi pi-upload big-icon" />
 						Drag and drop a paper, model, or dataset here</span
@@ -151,7 +144,7 @@ const query = ref<string>('');
 const searchBarRef = ref();
 const autocompleteMenuItems = ref<string[]>([]);
 
-const isSearchByExampleVisible = ref(false);
+const searchByExampleToggle = ref(false);
 const isDraggedOver = ref(false);
 const searchByExampleSelectedAsset = ref();
 const searchByExampleSelectedResourceType = ref();
@@ -176,7 +169,7 @@ const initiateSearch = () => {
 
 function initiateSearchByExample() {
 	searchByExampleOptions.value = { ...selectedSearchByExampleOptions.value };
-	isSearchByExampleVisible.value = false;
+	searchByExampleToggle.value = false;
 }
 
 function addToQuery(term: string) {
@@ -203,6 +196,10 @@ const fillAutocomplete = async () => {
 	});
 };
 
+const isSearchByExampleVisible = computed(
+	() => getDragData('asset') || searchByExampleToggle.value
+);
+
 const dragOverStyle = computed(() => {
 	if (isDraggedOver.value) {
 		return {
@@ -223,6 +220,7 @@ const dragOverStyle = computed(() => {
 const { getDragData } = useDragEvent();
 
 function onDrop() {
+	searchByExampleToggle.value = true; // Maintains open search by example popup once an asset is successfully dropped
 	searchByExampleSelectedAsset.value = getDragData('asset');
 	searchByExampleSelectedResourceType.value = getDragData('resourceType');
 	searchByExampleItem.value = searchByExampleSelectedAsset.value;
@@ -398,9 +396,11 @@ i {
 	gap: 0.75rem;
 	pointer-events: none;
 }
+
 .asset-card-in-searchByExample-dropzone {
 	width: 100%;
 }
+
 .clear-search-by-example {
 	height: fit-content;
 }

--- a/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/search-bar.vue
@@ -228,11 +228,11 @@ onMounted(() => {
 	query.value = q?.toString() ?? query.value;
 });
 
+// Clear search by example input once popup closes
 watch(
 	() => isSearchByExampleVisible.value,
 	() => {
 		if (!isSearchByExampleVisible.value) {
-			// Clear search by example input once popup closes
 			searchByExampleSelectedAsset.value = null;
 			searchByExampleSelectedResourceType.value = null;
 		}

--- a/packages/client/hmi-client/src/services/drag-drop.ts
+++ b/packages/client/hmi-client/src/services/drag-drop.ts
@@ -13,5 +13,8 @@ export function useDragEvent() {
 	function setDragData(key: string, value: object) {
 		data.value.set(key, value);
 	}
-	return { getDragData, setDragData };
+	function deleteDragData(key: string) {
+		data.value.delete(key);
+	}
+	return { getDragData, setDragData, deleteDragData };
 }


### PR DESCRIPTION
# Description

The search by example popup is on if 
- an asset is being dragged
- an asset has just been successfully dropped in
- if the popup toggle is on.

https://user-images.githubusercontent.com/28237258/232125300-af2b9671-607e-42d5-a7f3-99604d4cd35b.mov

