### PR TITLE
chore: update workflow related definitions per latest dicussion points

### DIFF
--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -1,3 +1,11 @@
+export enum WorkflowStatus {
+	INVALID = 'invalid',
+	FAILED = 'failed',
+	COMPLETED = 'completed',
+	IN_PROGRESS = 'in progress',
+	ERROR = 'error'
+}
+
 // Defines the type of data an operation can consume and output
 export interface OperationData {
 	type: string;
@@ -8,7 +16,11 @@ export interface OperationData {
 export interface Operation {
 	name: string;
 	description: string;
-	action: Function;
+
+	// The operation is self-runnable, that is, given just the inputs we can derive the outputs
+	isRunnable: boolean;
+
+	action?: Function;
 	validation?: Function;
 
 	inputs: OperationData[];
@@ -18,7 +30,7 @@ export interface Operation {
 // Defines the data-exchange between WorkflowNode
 // In most cases the value here will be an assetId
 export interface WorkflowPort {
-	id?: string; // FIXME: Investigate using unique-ids across dynamic port allocation
+	id: string;
 	type: string;
 	value?: any;
 }
@@ -41,7 +53,7 @@ export interface WorkflowNode {
 
 	// FIXME: The section below is slated to be further spec'ed out later.
 	// State and progress, tracking of intermediate results
-	statusCode?: string; // not-run, completed, in-progress, error, invalid
+	statusCode: WorkflowStatus;
 	intermediateIds?: WorkflowPort[];
 }
 
@@ -51,10 +63,10 @@ export interface WorkflowEdge {
 	points: { x: number; y: number }[];
 
 	source: WorkflowNode['id'];
-	sourcePort: number;
+	sourcePortId: string;
 
 	target: WorkflowNode['id'];
-	targetPort: number;
+	targetPortId: string;
 }
 
 export interface Workflow {

--- a/packages/client/hmi-client/tests/unit/workflow/workflow.spec.ts
+++ b/packages/client/hmi-client/tests/unit/workflow/workflow.spec.ts
@@ -19,9 +19,9 @@ const addOperation: Operation = {
 	// and returns an outputs to the node
 	action: (v: WorkflowPort[]) => {
 		if (v.length && v[0].type === 'number') {
-			return [{ type: 'number', value: v[0].value + v[1].value }];
+			return [{ id: '0', type: 'number', value: v[0].value + v[1].value }];
 		}
-		return [{ type: null, value: null }];
+		return [{ id: '0', type: null, value: null }];
 	}
 };
 
@@ -45,7 +45,7 @@ const addEdge = (
 	if (d) {
 		const targetNode = wf.nodes.find((n) => n.id === target);
 		if (targetNode) {
-			const targetNodePort = targetNode?.outputs.find((o) => o.id === targetPortId);
+			const targetNodePort = targetNode.inputs.find((o) => o.id === targetPortId);
 			if (targetNodePort) {
 				targetNodePort.type = d.type;
 				targetNodePort.value = d.value;
@@ -75,7 +75,9 @@ const runNode = (node: WorkflowNode): void => {
 	const operation = operationLib.get(opType);
 
 	if (!operation) return;
-	node.outputs = operation.action(node.inputs);
+	if (operation.action) {
+		node.outputs = operation.action(node.inputs);
+	}
 };
 
 const plusNode = (id: string) =>
@@ -83,8 +85,12 @@ const plusNode = (id: string) =>
 		id,
 		workflowId: '0',
 		operationType: 'add',
-		inputs: [],
-		outputs: [],
+		inputs: operationLib
+			.get('add')
+			?.inputs.map((d, i) => ({ id: `${i}`, type: d.type, value: null })),
+		outputs: operationLib
+			.get('add')
+			?.inputs.map((d, i) => ({ id: `${i}`, type: d.type, value: null })),
 		x: 0,
 		y: 0,
 		width: 0,
@@ -107,17 +113,29 @@ describe('basic tests to make sure it all works', () => {
 		workflow.nodes.push(Z);
 
 		// Pretend we are linking connections
-		X.inputs.push({ id: '1', type: 'number', value: 1 });
-		X.inputs.push({ id: '2', type: 'number', value: 2 });
-
-		Y.inputs.push({ id: '3', type: 'number', value: 3 });
-		Y.inputs.push({ id: '4', type: 'number', value: 4 });
+		let temp: WorkflowPort | undefined;
+		temp = X.inputs.find((d) => d.id === '0');
+		if (temp) {
+			temp.value = 1;
+		}
+		temp = X.inputs.find((d) => d.id === '1');
+		if (temp) {
+			temp.value = 2;
+		}
+		temp = Y.inputs.find((d) => d.id === '0');
+		if (temp) {
+			temp.value = 3;
+		}
+		temp = Y.inputs.find((d) => d.id === '1');
+		if (temp) {
+			temp.value = 4;
+		}
 
 		runNode(X); // should be 3
 		runNode(Y); // should be 7
 
-		addEdge(workflow, 'X', 0, 'Z', 0);
-		addEdge(workflow, 'Y', 0, 'Z', 1);
+		addEdge(workflow, 'X', '0', 'Z', '0');
+		addEdge(workflow, 'Y', '0', 'Z', '1');
 		runNode(Z); // should be 10
 
 		// Run


### PR DESCRIPTION
### Summary
Update definitions after discussion on generic vs specialized run cases. Mostly it introduces an `isRunnable` flag to allow flagging operations for custom executions. #1041 

Not sure if adding ids to ports made things better, the constructions are a bit more complicated so we will see.


### Testing
`yarn workspace hmi-client run test`