### PR TITLE
feat: dragging cavas objects

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -3,7 +3,12 @@
 		<template #foreground></template>
 		<template #data>
 			<ContextMenu ref="contextMenu" :model="contextMenuItems" />
-			<tera-workflow-node v-for="(node, index) in nodes" :key="index" :node="node">
+			<tera-workflow-node
+				v-for="(node, index) in nodes"
+				:key="index"
+				:node="node"
+				@dragging="updatePosition(node, $event)"
+			>
 				<template #body>
 					<tera-model-node
 						v-if="node.operationType === 'ModelOperation' && models"
@@ -105,4 +110,9 @@ function toggleContextMenu(event) {
 function saveTransform(newTransform: { k: number; x: number; y: number }) {
 	canvasTransform = newTransform;
 }
+
+const updatePosition = (node: WorkflowNode, { x, y }) => {
+	node.x += x;
+	node.y += y;
+};
 </script>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -112,7 +112,7 @@ function saveTransform(newTransform: { k: number; x: number; y: number }) {
 }
 
 const updatePosition = (node: WorkflowNode, { x, y }) => {
-	node.x += x;
-	node.y += y;
+	node.x += x / canvasTransform.k;
+	node.y += y / canvasTransform.k;
 };
 </script>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -21,7 +21,7 @@
 
 <script setup lang="ts">
 import { WorkflowNode } from '@/types/workflow';
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 
 const emit = defineEmits(['dragging']);
 
@@ -29,12 +29,12 @@ const props = defineProps<{
 	node: WorkflowNode;
 }>();
 
-const nodeStyle = ref({
+const nodeStyle = computed(() => ({
 	minWidth: `${props.node.width}px`,
 	minHeight: `${props.node.height}px`,
 	top: `${props.node.y}px`,
 	left: `${props.node.x}px`
-});
+}));
 
 const workflowNode = ref<HTMLElement>();
 
@@ -55,7 +55,6 @@ const drag = (evt: MouseEvent) => {
 	const dx = evt.x - tempX;
 	const dy = evt.y - tempY;
 
-	console.log('move', dx, dy);
 	emit('dragging', { x: dx, y: dy });
 
 	tempX = evt.x;
@@ -73,14 +72,14 @@ onMounted(() => {
 	if (!workflowNode.value) return;
 
 	workflowNode.value.addEventListener('mousedown', startDrag);
-	workflowNode.value.addEventListener('mousemove', drag);
+	document.addEventListener('mousemove', drag);
 	workflowNode.value.addEventListener('mouseup', stopDrag);
 });
 
 onBeforeUnmount(() => {
 	if (workflowNode.value) {
 		workflowNode.value.removeEventListener('mousedown', startDrag);
-		workflowNode.value.removeEventListener('mousemove', drag);
+		document.removeEventListener('mousemove', drag);
 		workflowNode.value.removeEventListener('mouseup', stopDrag);
 	}
 });

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -1,5 +1,5 @@
 <template>
-	<section class="container" :style="nodeStyle">
+	<section class="container" :style="nodeStyle" ref="workflowNode">
 		<header>
 			<h5>{{ node.operationType }}</h5>
 		</header>
@@ -21,7 +21,9 @@
 
 <script setup lang="ts">
 import { WorkflowNode } from '@/types/workflow';
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+const emit = defineEmits(['dragging']);
 
 const props = defineProps<{
 	node: WorkflowNode;
@@ -34,7 +36,54 @@ const nodeStyle = ref({
 	left: `${props.node.x}px`
 });
 
-onMounted(() => {});
+const workflowNode = ref<HTMLElement>();
+
+let tempX = 0;
+let tempY = 0;
+let dragStart = false;
+
+const startDrag = (evt: MouseEvent) => {
+	console.log('start', evt.x, evt.y);
+	tempX = evt.x;
+	tempY = evt.y;
+	dragStart = true;
+};
+
+const drag = (evt: MouseEvent) => {
+	if (dragStart === false) return;
+
+	const dx = evt.x - tempX;
+	const dy = evt.y - tempY;
+
+	console.log('move', dx, dy);
+	emit('dragging', { x: dx, y: dy });
+
+	tempX = evt.x;
+	tempY = evt.y;
+};
+
+const stopDrag = (evt: MouseEvent) => {
+	console.log('end', evt.x, evt.y);
+	tempX = 0;
+	tempY = 0;
+	dragStart = false;
+};
+
+onMounted(() => {
+	if (!workflowNode.value) return;
+
+	workflowNode.value.addEventListener('mousedown', startDrag);
+	workflowNode.value.addEventListener('mousemove', drag);
+	workflowNode.value.addEventListener('mouseup', stopDrag);
+});
+
+onBeforeUnmount(() => {
+	if (workflowNode.value) {
+		workflowNode.value.removeEventListener('mousedown', startDrag);
+		workflowNode.value.removeEventListener('mousemove', drag);
+		workflowNode.value.removeEventListener('mouseup', stopDrag);
+	}
+});
 </script>
 
 <style scoped>
@@ -51,6 +100,7 @@ section {
 	border-radius: var(--border-radius);
 	position: absolute;
 	padding: 0.5rem;
+	user-select: none;
 }
 
 .outputs {


### PR DESCRIPTION
### Summary
Add drag-related event listeners for the workflow nodes, you will be able to drag the nodes around the canvas.

Note this is sort of a stand-in replacement for using the vue3-draggable-resizable library, as it doesn't account for the transforms on the parent-container (dragging with zoom <> 1.0 is weird). We may switch out back to the lib later on, or to a different lib.


### Testing
Create nodes on the workflow, you can drag nodes around.