### PR TITLE
feat: workflow service

### DIFF
--- a/packages/client/hmi-client/package.json
+++ b/packages/client/hmi-client/package.json
@@ -41,6 +41,7 @@
 		"primeicons": "6.0.1",
 		"primevue": "3.25.0",
 		"sass": "1.56.1",
+		"uuid": "^9.0.0",
 		"vue": "3.2.47",
 		"vue-feather": "2.0.0",
 		"vue-router": "4.1.6",

--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -146,6 +146,11 @@ function toggleContextMenu(event) {
 
 function saveTransform(newTransform: { k: number; x: number; y: number }) {
 	canvasTransform = newTransform;
+
+	const t = wf.value.transform;
+	t.x = newTransform.x;
+	t.y = newTransform.y;
+	t.k = newTransform.k;
 }
 
 function createNewEdge(node: WorkflowNode, port: WorkflowPort) {

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -56,7 +56,6 @@ let tempY = 0;
 let dragStart = false;
 
 const startDrag = (evt: MouseEvent) => {
-	console.log('start', evt.x, evt.y);
 	tempX = evt.x;
 	tempY = evt.y;
 	dragStart = true;
@@ -74,8 +73,7 @@ const drag = (evt: MouseEvent) => {
 	tempY = evt.y;
 };
 
-const stopDrag = (evt: MouseEvent) => {
-	console.log('end', evt.x, evt.y);
+const stopDrag = (/* evt: MouseEvent */) => {
 	tempX = 0;
 	tempY = 0;
 	dragStart = false;

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -1,0 +1,108 @@
+// Captures common actions performed on workflow nodes/edges
+import { v4 as uuidv4 } from 'uuid';
+import {
+	Workflow,
+	Operation,
+	WorkflowNode,
+	WorkflowStatus,
+	Position,
+	WorkflowEdge
+} from '@/types/workflow';
+
+/// /////////////////////////////////////////////////////////////////////////////
+// TODO:
+// - Should update workflow node status on modification???
+// - Remove node...this also remove edges
+/// /////////////////////////////////////////////////////////////////////////////
+
+export const addNode = (wf: Workflow, op: Operation, pos: Position) => {
+	const node: WorkflowNode = {
+		id: uuidv4(),
+		workflowId: wf.id,
+		operationType: op.name,
+		x: pos.x,
+		y: pos.y,
+
+		inputs: op.inputs.map((o) => ({
+			id: uuidv4(),
+			type: o.type,
+			value: null
+		})),
+		outputs: op.outputs.map((o) => ({
+			id: uuidv4(),
+			type: o.type,
+			value: null
+		})),
+		statusCode: WorkflowStatus.INVALID,
+
+		// Not currently in use. May 2023
+		width: 100,
+		height: 100
+	};
+
+	wf.nodes.push(node);
+};
+
+export const addEdge = (
+	wf: Workflow,
+	sourceId: string,
+	sourceOutputPortId: string,
+	targetId: string,
+	targetInputPortId: string,
+	points: Position[]
+) => {
+	// Find the nodes and ports instances, not particulary efficient however the workflow is not expected to be large
+	const sourceNode = wf.nodes.find((d) => d.id === sourceId);
+	const targetNode = wf.nodes.find((d) => d.id === targetId);
+	if (!sourceNode) return;
+	if (!targetNode) return;
+
+	const sourceOutputPort = sourceNode.outputs.find((d) => d.id === sourceOutputPortId);
+	const targetInputPort = targetNode.inputs.find((d) => d.id === targetInputPortId);
+
+	if (!sourceOutputPort) return;
+	if (!targetInputPort) return;
+
+	// Check if edge already exist
+	const existingEdge = wf.edges.find(
+		(d) =>
+			d.source === sourceId &&
+			d.sourcePortId === sourceOutputPortId &&
+			d.target === targetId &&
+			d.targetPortId === targetInputPortId
+	);
+
+	if (existingEdge) return;
+
+	// Check if type is compatible
+	if (sourceOutputPort.value === null) return;
+	if (sourceOutputPort.type !== targetInputPort.type) return;
+
+	// Transfer data value/reference
+	targetInputPort.value = sourceOutputPort.value;
+
+	const edge: WorkflowEdge = {
+		id: uuidv4(),
+		workflowId: wf.id,
+		source: sourceId,
+		sourcePortId: sourceOutputPortId,
+		target: targetId,
+		targetPortId: targetInputPortId,
+		points
+	};
+
+	wf.edges.push(edge);
+};
+
+export const removeEdge = (wf: Workflow, id: string) => {
+	const edgeToRemove = wf.edges.find((d) => d.id === id);
+	if (!edgeToRemove) return;
+
+	// Remove the data refernece at the targetPort
+	const targetNode = wf.nodes.find((d) => d.id === edgeToRemove.target);
+	if (!targetNode) return;
+	const targetPort = targetNode.inputs.find((d) => d.id === edgeToRemove.targetPortId);
+	if (!targetPort) return;
+
+	targetPort.value = null;
+};

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -1,4 +1,3 @@
-// Captures common actions performed on workflow nodes/edges
 import { v4 as uuidv4 } from 'uuid';
 import {
 	Workflow,
@@ -9,11 +8,14 @@ import {
 	WorkflowEdge
 } from '@/types/workflow';
 
-/// /////////////////////////////////////////////////////////////////////////////
-// TODO:
-// - Should update workflow node status on modification???
-// - Remove node...this also remove edges
-/// /////////////////////////////////////////////////////////////////////////////
+/**
+ * Captures common actions performed on workflow nodes/edges. The functions here are
+ * not optimized, on the account that we don't expect most workflow graphs to
+ * exceed say ... 10-12 nodes with 30-40 edges.
+ *
+ * TODO:
+ * - Should we update workflow node status on modification???
+ */
 
 export const addNode = (wf: Workflow, op: Operation, pos: Position) => {
 	const node: WorkflowNode = {
@@ -51,7 +53,6 @@ export const addEdge = (
 	targetInputPortId: string,
 	points: Position[]
 ) => {
-	// Find the nodes and ports instances, not particulary efficient however the workflow is not expected to be large
 	const sourceNode = wf.nodes.find((d) => d.id === sourceId);
 	const targetNode = wf.nodes.find((d) => d.id === targetId);
 	if (!sourceNode) return;
@@ -103,6 +104,20 @@ export const removeEdge = (wf: Workflow, id: string) => {
 	if (!targetNode) return;
 	const targetPort = targetNode.inputs.find((d) => d.id === edgeToRemove.targetPortId);
 	if (!targetPort) return;
-
 	targetPort.value = null;
+
+	// Edge re-assignment
+	wf.edges = wf.edges.filter((edge) => edge.id !== id);
+};
+
+export const removeNode = (wf: Workflow, id: string) => {
+	// Remove all the edges first
+	const edgesToRemove = wf.edges.filter((d) => d.source === id || d.target === id);
+	const edgeIds = edgesToRemove.map((d) => d.id);
+	edgeIds.forEach((edgeId) => {
+		removeEdge(wf, edgeId);
+	});
+
+	// Remove the node
+	wf.nodes = wf.nodes.filter((node) => node.id !== id);
 };

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import _ from 'lodash';
 import {
 	Workflow,
 	Operation,
@@ -17,6 +18,19 @@ import {
  * - Should we update workflow node status on modification???
  */
 
+export const create = () => {
+	const workflow: Workflow = {
+		id: uuidv4(),
+		name: 'test',
+		description: '',
+
+		transform: { x: 0, y: 0, k: 1 },
+		nodes: [],
+		edges: []
+	};
+	return workflow;
+};
+
 export const addNode = (wf: Workflow, op: Operation, pos: Position) => {
 	const node: WorkflowNode = {
 		id: uuidv4(),
@@ -25,14 +39,16 @@ export const addNode = (wf: Workflow, op: Operation, pos: Position) => {
 		x: pos.x,
 		y: pos.y,
 
-		inputs: op.inputs.map((o) => ({
+		inputs: op.inputs.map((port) => ({
 			id: uuidv4(),
-			type: o.type,
+			type: port.type,
+			label: port.label,
 			value: null
 		})),
-		outputs: op.outputs.map((o) => ({
+		outputs: op.outputs.map((port) => ({
 			id: uuidv4(),
-			type: o.type,
+			type: port.type,
+			label: port.label,
 			value: null
 		})),
 		statusCode: WorkflowStatus.INVALID,
@@ -89,7 +105,7 @@ export const addEdge = (
 		sourcePortId: sourceOutputPortId,
 		target: targetId,
 		targetPortId: targetInputPortId,
-		points
+		points: _.cloneDeep(points)
 	};
 
 	wf.edges.push(edge);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,6 +7103,7 @@ cors@latest:
     primevue: 3.25.0
     sass: 1.56.1
     typescript: 4.9.5
+    uuid: ^9.0.0
     vite: 3.2.5
     vite-svg-loader: 4.0.0
     vitest: 0.24.5
@@ -12075,6 +12076,15 @@ send@latest:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
This PR adds a workflow service to house the CRUD and execution functions for a workflow. For example: add/remove nodes/edges, run a node, run a subgraph, invalidation...etc.

Currently node/edges CRUD have been implemented.

Ids are generated via uuidv4

Made some modifications to testOperation to illustrate a working workflow

![image](https://user-images.githubusercontent.com/1220927/236377148-022a336c-4b3c-4e73-8584-a3234b535434.png)


### Testing
You need to `yarn install`.

This is a re-organization change, workflow canvas should work as before.