### PR TITLE
fix: added extraction server to bakefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ version=3.81
 
 PROJECT_DIR ?= .
 
-
-
 .SECONDEXPANSION:
 
 .PHONY: all
@@ -38,8 +36,10 @@ image-hmi-server-native: clean-hmi-server-native
 	./gradlew :packages:services:hmi-server:build -Dquarkus.package.type=native
 	mv $(PROJECT_DIR)/packages/services/hmi-server/build $(PROJECT_DIR)/packages/services/hmi-server/docker/native/build
 
+TARGETS += hmi-extraction-server
 
-
+image-hmi-extraction-server:
+	docker build -t hmi-extraction-server -f ./packages/services/extraction-server/docker/Dockerfile ./packages/services/extraction-server/
 
 
 TARGETS += hmi-client


### PR DESCRIPTION
# Description

Trying to get the new `hmi-extraction-service` container to build and published to github so I can get the orchestration all hooked up.

Resolves #(issue)
I'm hoping this fixes this. 

![image](https://github.com/DARPA-ASKEM/Terarium/assets/98172806/ae8b4bc2-8351-4418-a84c-a11eac3ba1f7)
