### PR TITLE
refactor: move emit functions where they belong and pass appropriate props (merges into split view)

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -317,14 +317,11 @@ import TeraAsset from '@/components/asset/tera-asset.vue';
 import Toolbar from 'primevue/toolbar';
 import { FilterMatchMode } from 'primevue/api';
 import ModelParameterList from '@/components/models/tera-model-parameter-list.vue';
-import { IProject } from '@/types/Project';
+import { IProject, ProjectAssetTypes } from '@/types/Project';
 import TeraResizablePanel from '../widgets/tera-resizable-panel.vue';
 
 // Get rid of these emits
 const emit = defineEmits(['update-tab-name', 'close-preview', 'asset-loaded']);
-
-const extractions = ref([]);
-const resources = useResourcesStore();
 
 const props = defineProps({
 	project: {
@@ -347,6 +344,10 @@ const props = defineProps({
 	}
 });
 
+const resources = useResourcesStore();
+const router = useRouter();
+
+const extractions = ref([]);
 const relatedTerariumArtifacts = ref<ResultType[]>([]);
 const menu = ref();
 
@@ -766,7 +767,18 @@ const createNewModel = async () => {
 		};
 		const newModelResp = await createModel(newModel);
 		if (newModelResp) {
-			await addModelToProject(props.project.id, newModelResp.id.toString(), resources);
+			const modelId = newModelResp.id.toString();
+			await addModelToProject(props.project.id, modelId, resources);
+
+			// Go to the model you just created
+			router.push({
+				name: RouteName.ProjectRoute,
+				params: {
+					assetName: newModelName.value,
+					assetId: modelId,
+					assetType: ProjectAssetTypes.MODELS
+				}
+			});
 		}
 		isEditingEQ.value = false;
 		isMathMLValid.value = true;
@@ -805,7 +817,6 @@ const validateMathML = async (mathMlString: string, editMode: boolean) => {
 	}
 };
 
-const router = useRouter();
 const goToSimulationRunPage = () => {
 	showForecastLauncher.value = false;
 	router.push({

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -321,7 +321,7 @@ import { IProject, ProjectAssetTypes } from '@/types/Project';
 import TeraResizablePanel from '../widgets/tera-resizable-panel.vue';
 
 // Get rid of these emits
-const emit = defineEmits(['update-tab-name', 'close-preview', 'asset-loaded']);
+const emit = defineEmits(['update-tab-name', 'close-preview', 'asset-loaded', 'close-current-tab']);
 
 const props = defineProps({
 	project: {
@@ -768,6 +768,7 @@ const createNewModel = async () => {
 		const newModelResp = await createModel(newModel);
 		if (newModelResp) {
 			const modelId = newModelResp.id.toString();
+			emit('close-current-tab');
 			await addModelToProject(props.project.id, modelId, resources);
 
 			// Go to the model you just created

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -6,15 +6,27 @@
 		:is-open="Boolean(previewItem)"
 	>
 		<template v-slot:content>
-			<component
-				v-if="assetComponent"
-				:is="assetComponent"
-				:is-editable="false"
-				:project="resources.activeProject"
+			<tera-document
+				v-if="previewItemResourceType === ResourceType.XDD"
 				:xdd-uri="previewItemId"
-				:asset-id="previewItemId"
 				:previewLineLimit="3"
 				:highlight="searchTerm"
+				:is-editable="false"
+				@close-preview="closePreview"
+			/>
+			<tera-dataset
+				v-else-if="previewItemResourceType === ResourceType.DATASET"
+				:asset-id="previewItemId"
+				:highlight="searchTerm"
+				:is-editable="false"
+				@close-preview="closePreview"
+			/>
+			<tera-model
+				v-else-if="previewItemResourceType === ResourceType.MODEL"
+				:asset-id="previewItemId"
+				:project="(resources.activeProject as IProject)"
+				:highlight="searchTerm"
+				:is-editable="false"
 				@close-preview="closePreview"
 			/>
 		</template>
@@ -45,6 +57,7 @@ import TeraModel from '@/components/models/tera-model.vue';
 import TeraDataset from '@/components/dataset/tera-dataset.vue';
 import TeraSlider from '@/components/widgets/tera-slider.vue';
 import TeraDocument from '@/components/documents/tera-document.vue';
+import { IProject } from '@/types/Project';
 
 const resources = useResourcesStore();
 
@@ -91,19 +104,6 @@ const previewItemId = computed(() => {
 		return previewItemState.value.gddId;
 	}
 	return previewItemState.value.id as string;
-});
-
-const assetComponent = computed(() => {
-	switch (previewItemResourceType.value) {
-		case ResourceType.XDD:
-			return TeraDocument;
-		case ResourceType.MODEL:
-			return TeraModel;
-		case ResourceType.DATASET:
-			return TeraDataset;
-		default:
-			return null;
-	}
 });
 
 const emit = defineEmits(['update:previewItem', 'toggle-data-item-selected']);

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -6,29 +6,15 @@
 		:is-open="Boolean(previewItem)"
 	>
 		<template v-slot:content>
-			<tera-document
-				v-if="previewItemResourceType === ResourceType.XDD"
+			<component
+				v-if="assetComponent"
+				:is="assetComponent"
+				:is-editable="false"
+				:project="resources.activeProject"
 				:xdd-uri="previewItemId"
+				:asset-id="previewItemId"
 				:previewLineLimit="3"
-				:project="resources.activeProject"
 				:highlight="searchTerm"
-				:is-editable="false"
-				@close-preview="closePreview"
-			/>
-			<tera-dataset
-				v-else-if="previewItemResourceType === ResourceType.DATASET"
-				:asset-id="previewItemId"
-				:project="resources.activeProject"
-				:highlight="searchTerm"
-				:is-editable="false"
-				@close-preview="closePreview"
-			/>
-			<tera-model
-				v-else-if="previewItemResourceType === ResourceType.MODEL"
-				:asset-id="previewItemId"
-				:project="resources.activeProject"
-				:highlight="searchTerm"
-				:is-editable="false"
 				@close-preview="closePreview"
 			/>
 		</template>
@@ -76,7 +62,6 @@ const props = defineProps({
 		type: String,
 		default: '0'
 	},
-
 	// slider-panel props
 	selectedSearchItems: {
 		type: Array as PropType<ResultType[]>,
@@ -100,6 +85,27 @@ const props = defineProps({
 const previewItemState = ref(props.previewItem);
 const previewItemResourceType = ref<ResourceType | null>(null);
 
+const previewItemId = computed(() => {
+	if (!previewItemState.value) return '';
+	if (isDocument(previewItemState.value)) {
+		return previewItemState.value.gddId;
+	}
+	return previewItemState.value.id as string;
+});
+
+const assetComponent = computed(() => {
+	switch (previewItemResourceType.value) {
+		case ResourceType.XDD:
+			return TeraDocument;
+		case ResourceType.MODEL:
+			return TeraModel;
+		case ResourceType.DATASET:
+			return TeraDataset;
+		default:
+			return null;
+	}
+});
+
 const emit = defineEmits(['update:previewItem', 'toggle-data-item-selected']);
 
 watch(
@@ -115,14 +121,6 @@ watch(
 function closePreview() {
 	emit('update:previewItem', null);
 }
-
-const previewItemId = computed(() => {
-	if (!previewItemState.value) return '';
-	if (isDocument(previewItemState.value)) {
-		return previewItemState.value.gddId;
-	}
-	return previewItemState.value.id as string;
-});
 
 const previewItemSelected = computed(() =>
 	props.selectedSearchItems.some((selectedItem) => selectedItem === props.previewItem)

--- a/packages/client/hmi-client/src/page/project/components/tera-tab-content.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-tab-content.vue
@@ -7,6 +7,7 @@
 		@open-code="openCode"
 		@open-workflow="openWorkflow"
 		@update-tab-name="updateTabName"
+		@close-current-tab="emit('close-current-tab')"
 	/>
 	<section v-else>
 		<img src="@assets/svg/seed.svg" alt="Seed" />
@@ -42,7 +43,7 @@ const props = defineProps<{
 	isDrilldown?: boolean; // temp just to preview one workflow node
 }>();
 
-const emit = defineEmits(['update:tabs', 'asset-loaded', 'update-tab-name']);
+const emit = defineEmits(['update:tabs', 'asset-loaded', 'update-tab-name', 'close-current-tab']);
 
 const router = useRouter();
 
@@ -91,6 +92,7 @@ const currentComponent = computed(() => {
 	}
 });
 
+// This conversion should maybe be done in the document component - tera-preview-panel.vue does this conversion differently though...
 const getXDDuri = (assetId: Tab['assetId']): string =>
 	ProjectService.getDocumentAssetXddUri(props?.project, assetId) ?? '';
 

--- a/packages/client/hmi-client/src/page/project/components/tera-tab-content.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-tab-content.vue
@@ -21,7 +21,6 @@
 			v-if="assetType === ProjectAssetTypes.DOCUMENTS"
 			:xdd-uri="getXDDuri(assetId)"
 			:previewLineLimit="10"
-			:project="project"
 			is-editable
 			@open-code="openCode"
 			@asset-loaded="emit('asset-loaded')"
@@ -29,20 +28,15 @@
 		<tera-dataset
 			v-else-if="assetType === ProjectAssetTypes.DATASETS"
 			:asset-id="assetId"
-			:project="project"
 			is-editable
 			@asset-loaded="emit('asset-loaded')"
 		/>
 		<simulation-plan
 			v-else-if="assetType === ProjectAssetTypes.PLANS"
-			:asset-id="assetId"
-			:project="project"
 			@asset-loaded="emit('asset-loaded')"
 		/>
 		<simulation-run
 			v-else-if="assetType === ProjectAssetTypes.SIMULATION_RUNS"
-			:asset-id="assetId"
-			:project="project"
 			@asset-loaded="emit('asset-loaded')"
 		/>
 	</template>

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -35,6 +35,7 @@
 					:asset-type="assetType"
 					v-model:tabs="tabs"
 					@asset-loaded="setActiveTab"
+					@close-current-tab="removeClosedTab(activeTabIndex as number)"
 				/>
 			</SplitterPanel>
 			<SplitterPanel v-if="openedWorkflowNodeStore.workflowNode" :size="20">

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -507,14 +507,6 @@ section,
 	border: none;
 }
 
-.no-open-tabs {
-	justify-content: center;
-	gap: 2rem;
-	margin-bottom: 8rem;
-	align-items: center;
-	color: var(--text-color-subdued);
-}
-
 .p-tabmenu:deep(.p-tabmenuitem) {
 	display: inline;
 	max-width: 15rem;


### PR DESCRIPTION
I have transferred some functions that were emitted from `tera-tab-content.vue` into an asset component into the actual component (`tera-model` and `code-editor`). Instead of emitting the functions the `project` prop had to be used in these asset components. Also some of the asset components were passed props that aren't even used so I got rid of those.