### PR TITLE
chore: askem model representation update

### DIFF
--- a/packages/client/graph-scaffolder/src/types/index.ts
+++ b/packages/client/graph-scaffolder/src/types/index.ts
@@ -39,6 +39,10 @@ export interface IEdge<T> {
 export interface IGraph<V, E> {
 	nodes: INode<V>[];
 	edges: IEdge<E>[];
+
+	// Serve as pass-thru for akem-models
+	parameters?: any;
+	metadata?: any;
 	width?: number;
 	height?: number;
 }

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -84,6 +84,23 @@ export const convertToGraph = (petri: PetriNetModel) => {
 			});
 		});
 	});
+	return result;
+};
 
+export const convertToPetriNetModel = (g: IGraph<PetriNetState | PetriNetTransition, EdgeData>) => {
+	const result: PetriNetModel = {
+		states: [],
+		transitions: [],
+		metadata: undefined,
+		parameters: undefined
+	};
+
+	// Copy
+	result.metadata = g.metadata;
+	result.parameters = g.parameters;
+	result.states = g.nodes.filter((d) => d.type === 'state').map((d) => d.data) as PetriNetState[];
+	result.transitions = g.nodes
+		.filter((d) => d.type === 'transition')
+		.map((d) => d.data) as PetriNetTransition[];
 	return result;
 };

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -1,0 +1,89 @@
+import { IGraph } from '@graph-scaffolder/types';
+import { PetriNetModel, PetriNetState, PetriNetTransition } from '@/types/Types';
+
+interface EdgeData {
+	numEdges: number;
+}
+
+export const convertToGraph = (petri: PetriNetModel) => {
+	const result: IGraph<PetriNetState | PetriNetTransition, EdgeData> = {
+		width: 500,
+		height: 500,
+		parameters: petri.parameters,
+		metadata: petri.metadata,
+		nodes: [],
+		edges: []
+	};
+
+	petri.states.forEach((state) => {
+		result.nodes.push({
+			id: state.id,
+			label: state.id,
+			type: 'state',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 100,
+			data: state,
+			nodes: []
+		});
+	});
+
+	petri.transitions.forEach((transition) => {
+		result.nodes.push({
+			id: transition.id,
+			label: transition.id,
+			type: 'transition',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 100,
+			data: transition,
+			nodes: []
+		});
+	});
+
+	petri.transitions.forEach((transition) => {
+		transition.input.forEach((input) => {
+			const key = `${input}:${transition.id}`;
+
+			// Collapse hyper edges
+			const existingEdge = result.edges.find((edge) => edge.id === key);
+			if (existingEdge && existingEdge.data) {
+				existingEdge.data.numEdges++;
+				return;
+			}
+
+			result.edges.push({
+				id: key,
+				source: input,
+				target: transition.id,
+				points: [],
+				data: { numEdges: 1 }
+			});
+		});
+	});
+
+	petri.transitions.forEach((transition) => {
+		transition.output.forEach((output) => {
+			const key = `${transition.id}:${output}`;
+
+			// Collapse hyper edges
+			const existingEdge = result.edges.find((edge) => edge.id === key);
+			if (existingEdge && existingEdge.data) {
+				existingEdge.data.numEdges++;
+				return;
+			}
+
+			result.edges.push({
+				id: key,
+				source: transition.id,
+				target: output,
+				points: [],
+				data: { numEdges: 1 }
+			});
+		});
+	});
+
+	return result;
+};

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -31,6 +31,17 @@ export interface DocumentAsset {
     xdd_uri: string;
 }
 
+export interface Model {
+    id: string;
+    name: string;
+    description: string;
+    schema: string;
+    model: { [index: string]: any };
+    properties: { [index: string]: any };
+    metadata: ModelMetadata;
+    content: ModelContent;
+}
+
 export interface ProvenanceQueryParam {
     rootId?: number;
     rootType?: ProvenanceType;
@@ -44,6 +55,13 @@ export interface Simulation {
     simulationParams: SimulationParams;
     result?: string;
     modelId: number;
+}
+
+export interface PetriNetModel {
+    states: PetriNetState[];
+    transitions: PetriNetTransition[];
+    parameters?: ModelParameter[];
+    metadata?: ModelMetadata;
 }
 
 export interface CalibrationParams {
@@ -63,11 +81,48 @@ export interface DocumentsResponseOK extends XDDResponseOK {
     facets: { [index: string]: XDDFacetsItemResponse };
 }
 
+export interface ModelMetadata {
+    processed_at: number;
+    processed_by: string;
+    variable_statements: VariableStatement[];
+}
+
+export interface ModelContent {
+    metadata: any;
+    I: { [index: string]: number }[];
+    O: { [index: string]: number }[];
+    S: Species[];
+    T: { [index: string]: string }[];
+}
+
 export interface SimulationParams {
     model: string;
     initials: { [index: string]: number };
     tspan: number[];
     params: { [index: string]: number };
+}
+
+export interface PetriNetState {
+    id: string;
+    name: string;
+    grounding: ModelGrounding;
+    initial: ModelExpression;
+}
+
+export interface PetriNetTransition {
+    id: string;
+    input: string[];
+    output: string[];
+    grounding: ModelGrounding;
+    properties: PetriNetTransitionProperties;
+}
+
+export interface ModelParameter {
+    id: string;
+    description: string;
+    value: number;
+    grounding: ModelGrounding;
+    distribution: ModelDistribution;
 }
 
 export interface Document {
@@ -105,6 +160,41 @@ export interface XDDResponseOK {
     license: string;
 }
 
+export interface VariableStatement {
+    id: string;
+    variable: Variable;
+    value: StatementValue;
+    metadata: VariableStatementMetadata[];
+    provenance: ProvenanceInfo;
+}
+
+export interface Species {
+    sname: string;
+    miraIds: Ontology[];
+    miraContext: Ontology[];
+}
+
+export interface ModelGrounding {
+    identifiers: { [index: string]: any };
+    context: { [index: string]: any };
+}
+
+export interface ModelExpression {
+    expression: string;
+    expression_mathml: string;
+}
+
+export interface PetriNetTransitionProperties {
+    name: string;
+    grounding: ModelGrounding;
+    rate: ModelExpression;
+}
+
+export interface ModelDistribution {
+    type: string;
+    parameters: { [index: string]: any };
+}
+
 export interface Extraction {
     id: number;
     askemClass: string;
@@ -123,6 +213,40 @@ export interface KnownEntities {
 export interface XDDFacetBucket {
     key: string;
     docCount: string;
+}
+
+export interface Variable {
+    id: string;
+    name: string;
+    metadata: VariableMetadata[];
+    column: DataColumn[];
+    paper: Paper;
+    equations: Equation[];
+    dkg_groundings: DKGConcept[];
+}
+
+export interface StatementValue {
+    value: string;
+    type: string;
+    dkg_grounding: DKGConcept;
+}
+
+export interface VariableStatementMetadata {
+    type: string;
+    value: string;
+}
+
+export interface ProvenanceInfo {
+    method: string;
+    description: string;
+}
+
+export interface Ontology {
+    name: string;
+    curie: string;
+    title: string;
+    description: string;
+    link: string;
 }
 
 export interface ExtractionProperties {
@@ -148,6 +272,41 @@ export interface XDDUrlExtraction {
     url: string;
     resourceTitle: string;
     extractedFrom: string[];
+}
+
+export interface VariableMetadata {
+    type: string;
+    value: string;
+}
+
+export interface DataColumn {
+    id: string;
+    name: string;
+    dataset: Dataset;
+}
+
+export interface Paper {
+    id: string;
+    doi: string;
+    file_directory: string;
+}
+
+export interface Equation {
+    id: string;
+    text: string;
+    image: string;
+}
+
+export interface DKGConcept {
+    id: string;
+    name: string;
+    score: number;
+}
+
+export interface Dataset {
+    id: string;
+    name: string;
+    metadata: string;
 }
 
 export enum EventType {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.annotation.Nulls;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
-package software.uncharted.terarium.hmiserver.models.dataservice.ModelMetadata;
-
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Map;
+
 @Data
 @Accessors(chain = true)
 public class Model implements Serializable {
@@ -22,6 +21,9 @@ public class Model implements Serializable {
 	private String description = "";
 
 	private String schema;
+
+	// FIXME: Remove
+	private ModelContent content;
 
 	private Map<String, Object> model;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.models.dataservice;
 
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -13,6 +14,7 @@ import java.util.Map;
 
 @Data
 @Accessors(chain = true)
+@TSModel
 public class Model implements Serializable {
 
 	private String id;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -22,12 +22,12 @@ public class Model implements Serializable {
 
 	private String schema;
 
-	// FIXME: Remove
-	private ModelContent content;
-
 	private Map<String, Object> model;
 
 	private Map<String, Object> properties;
 
 	private ModelMetadata metadata;
+
+	// FIXME: deprecated, remove
+	private ModelContent content;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.Nulls;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+package software.uncharted.terarium.hmiserver.models.dataservice.ModelMetadata;
+
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,20 +14,18 @@ import java.util.List;
 @Accessors(chain = true)
 public class Model implements Serializable {
 
-	private Long id;
+	private String id;
 
 	private String name;
 
 	@JsonSetter(nulls = Nulls.SKIP)
 	private String description = "";
 
-	private String framework;
+	private String schema;
 
-	private LocalDateTime timestamp;
+	private Map<String, Object> model;
 
-	private ModelContent content;
+	private Map<String, Object> properties;
 
-	private Concept concept;
-
-	private List<Object> parameters;
+	private ModelMetadata metadata;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -1,5 +1,7 @@
 package software.uncharted.terarium.hmiserver.models.dataservice;
 
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import lombok.Data;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ModelMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ModelMetadata.java
@@ -1,0 +1,11 @@
+package software.uncharted.terarium.hmiserver.models.dataservice;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+@Data
+@Accessors(chain = true)
+public class ModelMetadata implements Serializable {
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ModelParameter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/ModelParameter.java
@@ -1,0 +1,19 @@
+package software.uncharted.terarium.hmiserver.models.dataservice;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class ModelParameter {
+	private String id;
+
+	private String description;
+
+	private Double value;
+
+	// FIXME:
+	private String grounding;
+	private String distribution;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelDistribution.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelDistribution.java
@@ -1,0 +1,14 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class ModelDistribution {
+	private String type;
+	private Map<String, Object> parameters;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelExpression.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelExpression.java
@@ -1,0 +1,18 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+
+@Data
+@Accessors(chain = true)
+public class ModelExpression {
+	private String expression;
+
+	@JsonAlias("expression_mathml")
+	@JsonSetter("expression_mathml")
+	private String expressionMathml;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelGrounding.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelGrounding.java
@@ -1,0 +1,14 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class ModelGrounding {
+	private Map<String, Object> identifiers;
+	private Map<String, Object> context;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
@@ -1,4 +1,4 @@
-package software.uncharted.terarium.hmiserver.models.dataservice;
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
 
 import lombok.Data;
 import lombok.experimental.Accessors;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
@@ -3,9 +3,24 @@ package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
 import java.io.Serializable;
 
 @Data
 @Accessors(chain = true)
 public class ModelMetadata implements Serializable {
+	@JsonAlias("processed_at")
+	@JsonSetter("processed_at")
+	private Long processedAt;
+
+	@JsonAlias("processed_by")
+	@JsonSetter("processed_by")
+	private String processedBy;
+
+
+	@JsonAlias("variable_statements")
+	@JsonSetter("variable_statements")
+	private List<VariableStatement> variableStatements;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
@@ -6,11 +6,12 @@ import lombok.experimental.Accessors;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import java.io.Serializable;
+import java.util.List;
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata.VariableStatement;
 
 @Data
 @Accessors(chain = true)
-public class ModelMetadata implements Serializable {
+public class ModelMetadata {
 	@JsonAlias("processed_at")
 	@JsonSetter("processed_at")
 	private Long processedAt;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelParameter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelParameter.java
@@ -1,4 +1,4 @@
-package software.uncharted.terarium.hmiserver.models.dataservice;
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -12,8 +12,8 @@ public class ModelParameter {
 
 	private Double value;
 
-	// FIXME:
-	private String grounding;
-	private String distribution;
+	private ModelGrounding grounding;
+
+	private ModelDistribution distribution;
 }
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/DKGConcept.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/DKGConcept.java
@@ -1,0 +1,15 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class DKGConcept {
+	private String id;
+	private String name;
+	private Double score;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/DataColumn.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/DataColumn.java
@@ -1,0 +1,15 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class DataColumn {
+	private String id;
+	private String name;
+	private Dataset dataset;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Dataset.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Dataset.java
@@ -1,0 +1,15 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class Dataset {
+	private String id;
+	private String name;
+	private String metadata;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Equation.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Equation.java
@@ -1,0 +1,13 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class Equation {
+	private String id;
+	private String text;
+	private String image;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Paper.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Paper.java
@@ -1,0 +1,20 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+
+@Data
+@Accessors(chain = true)
+public class Paper {
+	private String id;
+
+	@JsonAlias("file_directory")
+	@JsonSetter("file_directory")
+	private String fileDirectory;
+
+	private String doi;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/ProvenanceInfo.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/ProvenanceInfo.java
@@ -1,0 +1,12 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class ProvenanceInfo {
+	private String method;
+	private String description;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/StatementValue.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/StatementValue.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class StatementValue {
+	private String value;
+	private String type;
+
+	@JsonAlias("dkg_grounding")
+	@JsonSetter("dkg_grounding")
+	private DKGConcept dkgGrounding;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Variable.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Variable.java
@@ -19,7 +19,7 @@ public class Variable {
 	@JsonSetter("dkg_groundings")
 	private List<DKGConcept> dkgGroundings;
 
-	private List<Datacolumn> column;
+	private List<DataColumn> column;
 
 	private Paper paper;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Variable.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Variable.java
@@ -1,0 +1,28 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class Variable {
+	private String id;
+	private String name;
+	private List<VariableMetadata> metadata;
+
+	@JsonAlias("dkg_groundings")
+	@JsonSetter("dkg_groundings")
+	private List<DKGConcept> dkgGroundings;
+
+	private List<Datacolumn> column;
+
+	private Paper paper;
+
+	private List<Equation> equations;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableMetadata.java
@@ -1,0 +1,12 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class VariableMetadata {
+	private String type;
+	private String value;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableStatement.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableStatement.java
@@ -1,0 +1,16 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class VariableStatement {
+	private String id;
+	private Variable variable;
+	private StatementValue value;
+	private List<VariableStatementMetadata> metadata;
+	private ProvenanceInfo provenance;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableStatementMetadata.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/VariableStatementMetadata.java
@@ -1,0 +1,12 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class VariableStatementMetadata {
+	private String type;
+	private String value;
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelParameter;
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
 
 import java.util.List;
 
@@ -13,4 +14,5 @@ public class PetriNetModel {
 	private List<PetriNetState> states;
 	private List<PetriNetTransition> transitions;
 	private List<ModelParameter> parameters;
+	private ModelMetadata metadata;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
@@ -3,7 +3,7 @@ package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
-import software.uncharted.terarium.hmiserver.models.dataservice.ModelParameter;
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelParameter;
 
 import java.util.List;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
@@ -1,5 +1,8 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
 
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.annotations.TSOptional;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -10,9 +13,14 @@ import java.util.List;
 
 @Data
 @Accessors(chain = true)
+@TSModel
 public class PetriNetModel {
 	private List<PetriNetState> states;
 	private List<PetriNetTransition> transitions;
+
+	@TSOptional
 	private List<ModelParameter> parameters;
+
+	@TSOptional
 	private ModelMetadata metadata;
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetModel.java
@@ -1,0 +1,16 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import software.uncharted.terarium.hmiserver.models.dataservice.ModelParameter;
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class PetriNetModel {
+	private List<PetriNetState> states;
+	private List<PetriNetTransition> transitions;
+	private List<ModelParameter> parameters;
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetState.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetState.java
@@ -1,0 +1,10 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class PetriNetState {
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetState.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetState.java
@@ -6,5 +6,8 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(chain = true)
 public class PetriNetState {
+	private String id;
+	private String name;
+
 }
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransition.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransition.java
@@ -1,10 +1,19 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
 
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelGrounding;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
+
+import java.util.List;
 
 @Data
 @Accessors(chain = true)
 public class PetriNetTransition {
+	private String id;
+	private List<String> input;
+	private List<String> output;
+	private ModelGrounding grounding;
+  private PetriNetTransitionProperties properties;
 }
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransition.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransition.java
@@ -1,0 +1,10 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.petrinet;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class PetriNetTransition {
+}
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransitionProperties.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/petrinet/PetriNetTransitionProperties.java
@@ -8,12 +8,9 @@ import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
-public class PetriNetState {
-	private String id;
-
+public class PetriNetTransitionProperties {
 	private String name;
-
 	private ModelGrounding grounding;
-
-	private ModelExpression initial;
+	private ModelExpression rate;
 }
+


### PR DESCRIPTION
### Summary
Update to model-representation schema

### TODO list, roughly in sequence
- [x] Copy model schemas from https://github.com/DARPA-ASKEM/Model-Representations
- [x] Create converter to go from AMR-Petri to IGraph for rendering/editing
- [ ] Update to petrinet-renderer (AMR -> Graph)
- [ ] Update model-page to use new schema
  - [ ] Model page update
  - [ ] Discussion on parameter vs config as first-class citizens in TDS when creating new config/parameters
- [ ] Second round of updating and refinement of schemas from https://github.com/DARPA-ASKEM/Model-Representations, because some things are likely to change...
- [ ] Update to data explorer
  - [ ] Breaking changes to facets
  - [ ] Breaking changes to search
  - [ ] Breaking changes to search items 
- [ ] HMI Server cleanup, remove unneeded entities and classes
- [ ] HMI Client cleanup, typing and things

### TODO list, can do in parallel
- [ ] TA1 Equation API changes
- [ ] TA1 model extraction API changes
- [ ] TA2 Stratification changes. in model-service
  - [ ] Check stratification can take in new model format
  - [ ] Check the result of stratification can be converted back into new format
- [ ] TA3 Simulation service API changes
  - [ ] Check new model format is supported
  - [ ] Check if we can reset ENABLE_TDS flag back to true
