### PR TITLE
chore: group temp model-clean hack in one place

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-forecast-launcher.vue
+++ b/packages/client/hmi-client/src/components/models/tera-forecast-launcher.vue
@@ -35,6 +35,7 @@ import InputText from 'primevue/inputtext';
 import Button from 'primevue/button';
 import { makeForecast, createSimulation } from '@/services/models/simulation-service';
 import { Simulation, SimulationParams } from '@/types/Types';
+import { shimPetriModel } from '@/services/models/petri-shim';
 
 interface StringValueMap {
 	[key: string]: string;
@@ -61,20 +62,6 @@ props.model.content.T.forEach((s) => {
 const emit = defineEmits(['close', 'launch-forecast']);
 
 const launch = async () => {
-	// FIXME: current need to strip out metadata, should do serverside
-	const cleanedModel: PetriNet = {
-		S: [],
-		T: [],
-		I: [],
-		O: []
-	};
-	if (props.model) {
-		cleanedModel.S = props.model.content.S.map((s) => ({ sname: s.sname }));
-		cleanedModel.T = props.model.content.T.map((t) => ({ tname: t.tname }));
-		cleanedModel.I = props.model.content.I;
-		cleanedModel.O = props.model.content.O;
-	}
-
 	const initials: NumericValueMap = {};
 	const params: NumericValueMap = {};
 
@@ -87,7 +74,7 @@ const launch = async () => {
 	});
 
 	const payload: SimulationParams = {
-		model: JSON.stringify(cleanedModel),
+		model: shimPetriModel(props.model),
 		initials,
 		params,
 		tspan: [0, 50]

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node.vue
@@ -44,8 +44,8 @@ import { CalibrationParams, CsvAsset } from '@/types/Types';
 import { ModelConfig } from '@/types/ModelConfig';
 import Dropdown from 'primevue/dropdown';
 import { downloadRawFile } from '@/services/dataset';
-import { PetriNet } from '@/petrinet/petrinet-service';
 import { WorkflowNode } from '@/types/workflow';
+import { shimPetriModel } from '@/services/models/petri-shim';
 // import { calibrationParamExample } from '@/temp/calibrationExample';
 
 const props = defineProps<{
@@ -66,20 +66,7 @@ const featureMap = ref();
 
 const startCalibration = async () => {
 	// Make calibration job.
-	// FIXME: current need to strip out metadata, should do serverside
-	const cleanedModel: PetriNet = {
-		S: [],
-		T: [],
-		I: [],
-		O: []
-	};
 	if (modelConfig.value) {
-		// Take out all the extra content in model.content
-		cleanedModel.S = modelConfig.value.model.content.S.map((s) => ({ sname: s.sname }));
-		cleanedModel.T = modelConfig.value.model.content.T.map((t) => ({ tname: t.tname }));
-		cleanedModel.I = modelConfig.value.model.content.I;
-		cleanedModel.O = modelConfig.value.model.content.O;
-
 		if (featureMap.value) {
 			const featureObject: { [index: string]: string } = {};
 			// Go from 2D array to a index: value like they want
@@ -89,7 +76,7 @@ const startCalibration = async () => {
 			}
 
 			const calibrationParam: CalibrationParams = {
-				model: JSON.stringify(cleanedModel),
+				model: shimPetriModel(modelConfig.value.model),
 				initials: modelConfig.value.initialValues,
 				params: modelConfig.value.parameterValues,
 				timesteps_column: timestepColumnName.value,

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-node.vue
@@ -20,10 +20,9 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { PetriNet } from '@/petrinet/petrinet-service';
-import { ITypedModel } from '@/types/Model';
 import Button from 'primevue/button';
 import { csvParse } from 'd3';
+import { shimPetriModel } from '@/services/models/petri-shim';
 
 import MultiSelect from 'primevue/multiselect';
 import Chart from 'primevue/chart';
@@ -83,29 +82,11 @@ const chartOptions = {
 	}
 };
 
-// FIXME: adapt to new model representation
-// FIXME: adapt to new simulation-service id-based API
-const scrubModel = (model: ITypedModel<PetriNet>) => {
-	const cleanedModel: PetriNet = {
-		S: [],
-		T: [],
-		I: [],
-		O: []
-	};
-	if (model) {
-		cleanedModel.S = model.content.S.map((s) => ({ sname: s.sname }));
-		cleanedModel.T = model.content.T.map((t) => ({ tname: t.tname }));
-		cleanedModel.I = model.content.I;
-		cleanedModel.O = model.content.O;
-	}
-	return JSON.stringify(cleanedModel);
-};
-
 const runSimulate = async () => {
 	const port = props.node.inputs[0];
 	if (port && port.value) {
 		const payload = {
-			model: scrubModel(port.value.model),
+			model: shimPetriModel(port.value.model),
 			initials: port.value.initialValues,
 			params: port.value.parameterValues,
 			tspan: [0, 100]

--- a/packages/client/hmi-client/src/services/models/petri-shim.ts
+++ b/packages/client/hmi-client/src/services/models/petri-shim.ts
@@ -1,0 +1,19 @@
+/** FIXME: A temporary shim until the official mdoel-representation comes online - May 2023 * */
+import { PetriNet } from '@/petrinet/petrinet-service';
+import { ITypedModel } from '@/types/Model';
+
+export const shimPetriModel = (model: ITypedModel<PetriNet>) => {
+	const cleanedModel: PetriNet = {
+		S: [],
+		T: [],
+		I: [],
+		O: []
+	};
+	if (model) {
+		cleanedModel.S = model.content.S.map((s) => ({ sname: s.sname }));
+		cleanedModel.T = model.content.T.map((t) => ({ tname: t.tname }));
+		cleanedModel.I = model.content.I;
+		cleanedModel.O = model.content.O;
+	}
+	return JSON.stringify(cleanedModel);
+};


### PR DESCRIPTION
### Summary
This just groups the temporary hack in one place where we need to send a "model" over to the simulation-service. Once the model-representations are in and the various converters are in place, this should be removed and we should instead send in a model-id.