### PR TITLE
fix: add guard to prevent weird prop values

### DIFF
--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -431,8 +431,12 @@ tabStore.$subscribe(() => {
 });
 
 async function getAndPopulateAnnotations() {
-	annotations.value = await getAnnotations(props.assetId, props.pageType);
-	selectedNoteSection.value = annotations.value?.map((note) => note.section);
+	if (props.assetId && props.pageType) {
+		annotations.value = await getAnnotations(props.assetId, props.pageType);
+		selectedNoteSection.value = annotations.value?.map((note) => note.section);
+	} else {
+		selectedNoteSection.value = [];
+	}
 }
 
 const addNote = async () => {


### PR DESCRIPTION
### Summary
This adds a guard to prevent quirky values getting sent into the API in the project-page.

For some reason the props can be `undefined` or empty string `""` depends on how one navigates to the page, the former will cause an error.


### Test
- Navigate from the Home page to Project page, open up publications accordion in the side-pane, no error should occur
- In the project page, refresh the page, open up publications accordion in the side-pane, no error should occur
