### PR TITLE
fix: katex to live

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -115,7 +115,7 @@
 											:latex-equation="equationLatex"
 											:is-editing-eq="isEditingEQ"
 											:is-math-ml-valid="isMathMLValid"
-											:math-mode="MathEditorModes.KATEX"
+											:math-mode="MathEditorModes.LIVE"
 											@cancel-editing="cancelEditng"
 											@equation-updated="setNewLatexFormula"
 											@validate-mathml="validateMathML"


### PR DESCRIPTION
# Description
changed model math renderer back to live.

Resolves #(issue)
