### PR TITLE
fix: moved the edit button slot higher

### DIFF
--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -16,10 +16,22 @@
 		<header id="asset-top" ref="headerRef">
 			<template v-if="!hideHeader">
 				<section>
-					<span v-if="overline" class="overline">{{ overline }}</span>
+					<!-- put the buttons above the title if there is an overline -->
+					<div v-if="overline" class="vertically-center">
+						<span class="overline">{{ overline }}</span>
+						<slot name="edit-buttons" />
+					</div>
+
 					<!--For naming asset such as model or code file-->
-					<slot v-if="isCreatingAsset" name="name-input" />
-					<h4 v-else v-html="name" class="nudge-down" />
+					<div class="vertically-center">
+						<slot v-if="isCreatingAsset" name="name-input" />
+						<h4 v-else v-html="name" class="nudge-down" />
+
+						<div v-if="!overline" class="vertically-center">
+							<slot name="edit-buttons" />
+						</div>
+					</div>
+
 					<!--put model contributors here too-->
 					<span class="authors" v-if="authors">
 						<i :class="authors.includes(',') ? 'pi pi-users' : 'pi pi-user'" />
@@ -35,7 +47,6 @@
 					</div>
 				</section>
 				<aside class="spread-out">
-					<slot name="edit-buttons" />
 					<Button
 						v-if="!isEditable"
 						icon="pi pi-times"
@@ -179,6 +190,13 @@ header.shrinked aside {
 
 .nudge-down {
 	margin-top: 0.25rem;
+}
+
+.vertically-center {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 1rem;
 }
 main:deep(.p-inputtext.p-inputtext-sm) {
 	padding: 0.65rem 0.65rem 0.65rem 3rem;


### PR DESCRIPTION
The content switcher was in a bad place. It was greedy for all the space beneath it, leading to situations like this:

![Monosnap Terarium 🔊 2023-06-09 10-13-31](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/30245814-cf45-43c5-a4b8-81af162c698e)

This PR moves the content switcher to go beside the overline above the title (if there is one), or just beside the title (if there's no overline).
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/3341e61c-21ba-4919-a002-3226f4e9103f)
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/53aaac96-9281-4bc8-8146-e0a26d7c77d4)

It doesn't seem to break anything on Models or Datasets
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/993a3005-af44-4806-a989-188f2e5dc72d)
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/e96caa6f-6771-461e-8a5a-4320371accae)
