### PR TITLE
fix(hmi): unable to add datasets

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -228,11 +228,11 @@ const assets = computed(() => {
 	// Run through all the assets type within the project
 	Object.keys(projectAssets).forEach((type) => {
 		if (isProjectAssetTypes(type) && !isEmpty(projectAssets[type])) {
-			const projectAssetType = type as ProjectAssetTypes;
+			const projectAssetType: ProjectAssetTypes = type as ProjectAssetTypes;
 			const typeAssets = projectAssets[projectAssetType].map((asset) => {
 				const assetName = (asset?.name || asset?.title || asset?.id)?.toString();
 				const pageType = asset?.type ?? projectAssetType;
-				const assetId = asset?.id.toString();
+				const assetId = asset?.id ?? '';
 				return { assetName, pageType, assetId };
 			});
 			result.push(...typeAssets);

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -80,6 +80,8 @@ async function getAll(): Promise<IProject[] | null> {
 
 /**
  * Get project assets for a given project per id
+ * @param projectId projet id to get assets for
+ * @param types optional list of types. If none are given we assume you want it all
  * @return ProjectAssets|null - the appropriate project, or null if none returned by API
  */
 async function getAssets(projectId: string, types?: string[]): Promise<ProjectAssets | null> {
@@ -90,6 +92,9 @@ async function getAssets(projectId: string, types?: string[]): Promise<ProjectAs
 				// add URL with format: ...?types=A&types=B&types=C
 				url += `${indx === 0 ? '?' : '&'}types=${type}`;
 			});
+		} else {
+			url +=
+				'?types=datasets&types=model_configurations&types=models&types=publications&types=simulations&types=workflows';
 		}
 		const response = await API.get(url);
 		const { status, data } = response;

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -83,7 +83,7 @@ export interface Simulation {
 
 export interface Dataset {
     id?: string;
-    timestamp?: Date;
+    timestamp?: any;
     username?: string;
     name: string;
     description?: string;

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/dataset/Dataset.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/dataset/Dataset.java
@@ -22,8 +22,9 @@ public class Dataset {
 	private String id; //Is this a UUID?
 
 	/** Timestamp of when the dataset was created **/
+	//TODO: This should be "Instant" but there is an issue and a time crunch here...
 	@TSOptional
-	private Instant timestamp;
+	private Object timestamp;
 
 	/** Username of the user who created the dataset **/
 	@TSOptional

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -28,7 +29,7 @@ public interface DatasetProxy {
 	@Path("/features")
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response createFeatures(
-		Feature feature
+		JsonNode feature
 	);
 
 	@GET
@@ -48,7 +49,7 @@ public interface DatasetProxy {
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response updateFeature(
 		@PathParam("id") String id,
-		Feature feature
+		JsonNode feature
 	);
 
 	@GET
@@ -62,7 +63,7 @@ public interface DatasetProxy {
 	@Path("/qualifiers")
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response createQualifiers(
-		Qualifier qualifier
+		JsonNode qualifier
 	);
 
 	@GET
@@ -82,7 +83,7 @@ public interface DatasetProxy {
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response updateQualifier(
 		@PathParam("id") String id,
-		Qualifier qualifier
+		JsonNode qualifier
 	);
 
 	@GET
@@ -94,7 +95,7 @@ public interface DatasetProxy {
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response createDatasets(
-		Dataset dataset
+		JsonNode dataset
 	);
 
 	@GET
@@ -114,7 +115,7 @@ public interface DatasetProxy {
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response updateDataset(
 		@PathParam("id") String id,
-		Dataset dataset
+		JsonNode dataset
 	);
 
 	@POST

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
@@ -1,5 +1,10 @@
 package software.uncharted.terarium.hmiserver.resources.dataservice;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import org.apache.james.mime4j.dom.field.FieldName;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -59,7 +64,7 @@ public class DatasetResource {
 	public Response createFeatures(
 		final Feature feature
 	) {
-		return proxy.createFeatures(feature);
+		return proxy.createFeatures(convertObjectToSnakeCaseJsonNode(feature));
 	}
 
 	@GET
@@ -85,7 +90,7 @@ public class DatasetResource {
 		@PathParam("id") final String id,
 		final Feature feature
 	) {
-		return proxy.updateFeature(id, feature);
+		return proxy.updateFeature(id, convertObjectToSnakeCaseJsonNode(feature));
 	}
 
 	@GET
@@ -103,7 +108,7 @@ public class DatasetResource {
 	public Response createQualifiers(
 		final Qualifier qualifier
 	) {
-		return proxy.createQualifiers(qualifier);
+		return proxy.createQualifiers(convertObjectToSnakeCaseJsonNode(qualifier));
 	}
 
 	@GET
@@ -129,7 +134,7 @@ public class DatasetResource {
 		@PathParam("id") final String id,
 		final Qualifier qualifier
 	) {
-		return proxy.updateQualifier(id, qualifier);
+		return proxy.updateQualifier(id, convertObjectToSnakeCaseJsonNode(qualifier));
 	}
 
 	@GET
@@ -142,10 +147,11 @@ public class DatasetResource {
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
-	public Response createDatasets(
+	public Response createDataset(
 		final Dataset dataset
 	) {
-		return proxy.createDatasets(dataset);
+		JsonNode node = convertObjectToSnakeCaseJsonNode(dataset);
+		return proxy.createDatasets(node);
 	}
 
 	@GET
@@ -171,7 +177,7 @@ public class DatasetResource {
 		@PathParam("id") final String id,
 		final Dataset dataset
 	) {
-		return proxy.updateDataset(id, dataset);
+		return proxy.updateDataset(id, convertObjectToSnakeCaseJsonNode(dataset));
 	}
 
 	@POST
@@ -349,4 +355,19 @@ public class DatasetResource {
 	public PresignedURL getDownloadUrl(@PathParam("id") final String id,  @QueryParam("filename") String filename) {
 		return proxy.getDownloadUrl(id, filename);
 	}
+
+	/**
+	 * Serialize a given object to be in snake-case instead of camelCase, as may be
+	 * required by the proxied endpoint.
+	 * @param object
+	 * @return
+	 */
+	private JsonNode convertObjectToSnakeCaseJsonNode(Object object) {
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+		mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+		return mapper.convertValue(object, JsonNode.class);
+	}
+
 }


### PR DESCRIPTION
This fix correctly sends up the expected snake_case to TDS instead of camelCase. A few other odds and ends fixes here as well.

NOTE that this still requires a pt 2 fix in orchestration for setting up buckets correctly for local dev.


Resolves #1200 
