### PR TITLE
feat: add color to edges and input port labels for simulate only

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -75,6 +75,17 @@
 				<circle cx="5" cy="5" r="3" style="fill: var(--primary-color)" />
 			</marker>
 			<marker
+				v-for="i in wf.edges.length"
+				:key="i"
+				:id="`circle${i - 1}`"
+				markerWidth="8"
+				markerHeight="8"
+				refX="5"
+				refY="5"
+			>
+				<circle cx="5" cy="5" r="3" :style="`fill: ${getVariableColorByRunIdx(i - 1)}`" />
+			</marker>
+			<marker
 				id="arrow"
 				viewBox="0 0 16 16"
 				refX="8"
@@ -100,6 +111,24 @@
 			>
 				<path d="M 0 0 L 8 8 L 0 16 z" style="fill: var(--primary-color); fill-opacity: 1"></path>
 			</marker>
+			<marker
+				v-for="i in wf.edges.length"
+				:key="i"
+				:id="`smallArrow${i - 1}`"
+				viewBox="0 0 16 16"
+				refX="8"
+				refY="8"
+				orient="auto"
+				markerWidth="12"
+				markerHeight="12"
+				markerUnits="userSpaceOnUse"
+				xoverflow="visible"
+			>
+				<path
+					d="M 0 0 L 8 8 L 0 16 z"
+					:style="`fill: ${getVariableColorByRunIdx(i - 1)}; fill-opacity: 1`"
+				></path>
+			</marker>
 		</template>
 		<template #background>
 			<path
@@ -114,10 +143,10 @@
 			<path
 				v-for="(edge, index) of wf.edges"
 				:d="drawPath(interpolatePointsForCurve(edge.points[0], edge.points[1]))"
-				stroke="#1B8073"
+				:stroke="isEdgeTargetSim(edge) ? getVariableColorByRunIdx(index) : '#1B8073'"
 				stroke-width="2"
-				marker-start="url(#circle)"
-				marker-mid="url(#smallArrow)"
+				:marker-start="`url(#circle${isEdgeTargetSim(edge) ? index : ''})`"
+				:marker-mid="`url(#smallArrow${isEdgeTargetSim(edge) ? index : ''})`"
 				:key="index"
 				fill="none"
 			/>
@@ -176,6 +205,31 @@ const isMouseOverCanvas = ref<boolean>(false);
 
 const wf = ref<Workflow>(workflowService.emptyWorkflow());
 const contextMenu = ref();
+
+// FIXME: temporary function to color edges with simulate
+const VIRIDIS_14 = [
+	'#440154',
+	'#481c6e',
+	'#453581',
+	'#3d4d8a',
+	'#34618d',
+	'#2b748e',
+	'#24878e',
+	'#1f998a',
+	'#25ac82',
+	'#40bd72',
+	'#67cc5c',
+	'#98d83e',
+	'#cde11d',
+	'#fde725'
+];
+const getVariableColorByRunIdx = (edgeIdx: number) =>
+	wf.value.edges.length > 1
+		? VIRIDIS_14[Math.floor((edgeIdx / wf.value.edges.length) * VIRIDIS_14.length)]
+		: '#1B8073';
+const isEdgeTargetSim = (edge) =>
+	wf.value.nodes.find((node) => node.id === edge.target)?.operationType ===
+	WorkflowOperationTypes.SIMULATE;
 
 const testOperation: Operation = {
 	name: WorkflowOperationTypes.TEST,

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -32,7 +32,16 @@
 					@focusout="() => {}"
 				>
 					<div class="input port" />
-					{{ input.label }}
+					<div>
+						<span
+							v-for="(label, labelIdx) in input.label?.split(',') ?? []"
+							:key="labelIdx"
+							class="input-label"
+							:style="{ color: getInputLabelColor(labelIdx) }"
+						>
+							{{ label }}
+						</span>
+					</div>
 				</div>
 			</li>
 		</ul>
@@ -140,6 +149,30 @@ onMounted(() => {
 	document.addEventListener('mousemove', drag);
 	workflowNode.value.addEventListener('mouseup', stopDrag);
 });
+
+// FIXME: temporary function to color input port labels of simulate
+const VIRIDIS_14 = [
+	'#440154',
+	'#481c6e',
+	'#453581',
+	'#3d4d8a',
+	'#34618d',
+	'#2b748e',
+	'#24878e',
+	'#1f998a',
+	'#25ac82',
+	'#40bd72',
+	'#67cc5c',
+	'#98d83e',
+	'#cde11d',
+	'#fde725'
+];
+const getInputLabelColor = (edgeIdx: number) => {
+	const numRuns = props.node.inputs[0].value?.length ?? 0;
+	return numRuns > 1 && props.node.operationType === WorkflowOperationTypes.SIMULATE
+		? VIRIDIS_14[Math.floor((edgeIdx / numRuns) * VIRIDIS_14.length)]
+		: 'inherit';
+};
 
 function showNodeDrilldown() {
 	let pageType;
@@ -384,5 +417,13 @@ ul li {
 .inputs > .port-connected:hover .port,
 .outputs > .port-connected:hover .port {
 	background: var(--primary-color);
+}
+
+.input-label::after {
+	color: var(--text-color-primary);
+	content: ', ';
+}
+.input-label:last-child::after {
+	content: '';
 }
 </style>


### PR DESCRIPTION

<img width="827" alt="Screenshot 2023-06-13 at 10 06 18 AM" src="https://github.com/DARPA-ASKEM/Terarium/assets/14062458/ec005ef5-cda3-4859-bc32-d1a48710fe31">

temporary code to color edges IF AND ONLY IF the edge target is simulate AND there are multiple nodes going to simulate.

Resolves #(issue)
