### PR TITLE
fix(hmi-client): fixing performance of dataset preview

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
@@ -3,6 +3,9 @@
 	<DataTable
 		tableStyle="width:auto"
 		:class="previewMode ? 'p-datatable-xsm' : 'p-datatable-sm'"
+		paginator="true"
+		paginatorPosition="both"
+		:rows="50"
 		:value="csvContent?.slice(1, csvContent.length)"
 		removableSort
 		resizable-columns

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
@@ -346,7 +346,7 @@ public class DatasetResource {
 			double meanValue = Stats.meanOf(numberList);
 			double medianValue = Quantiles.median().compute(numberList);
 			double sdValue = Stats.of(numberList).populationStandardDeviation();
-			int binCount = 50;
+			int binCount = 10;
 			//Set up bins
 			for (int i = 0; i < binCount; i++){
 				bins.add(0);


### PR DESCRIPTION
Adding pagination to dataset table. In addition there is a sneaky fix here for bucket counts on our histograms as requested by @jamiewaese-uncharted 

Resolves #1264 
