### PR TITLE
fix: cors added to ajax call

### DIFF
--- a/packages/client/hmi-client/src/stores/auth.ts
+++ b/packages/client/hmi-client/src/stores/auth.ts
@@ -27,7 +27,12 @@ const useAuthStore = defineStore('auth', {
 				this.isUser = true;
 			} else {
 				// Fetch or refresh the access token
-				const response = await fetch('/ua/user');
+				const response = await fetch('/ua/user', {
+					mode: 'cors',
+					headers: {
+						'Access-Control-Allow-Origin': '*'
+					}
+				});
 
 				const data = await response.json();
 				if (response.ok) {


### PR DESCRIPTION
# Description

CORS violation occurring on AJAX call for /ua/user.  The Keycloak server has been updated to contain `Web origins: https://app.staging.terarium.ai` but I added this additional code to the AJAX call just in case.

I cannot seem to test locally if this works or not (though it does not seem to produce any errors locally).  If this is needed for staging we will have to deploy and see what happens.

Resolves #(issue)

Might help resolve: 

https://github.com/DARPA-ASKEM/orchestration/issues/176
