### PR TITLE
feat: update workflow menu items and context menu to match design

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-context-menu.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-context-menu.vue
@@ -1,0 +1,126 @@
+<template>
+	<Portal :appendTo="props.appendTo">
+		<div class="tera-context-menu" ref="container">
+			<Menu v-if="isVisible" :model="props.model" />
+		</div>
+	</Portal>
+</template>
+
+<script setup lang="ts">
+import { ref, onUnmounted, PropType } from 'vue';
+import Portal from 'primevue/portal';
+import Menu from 'primevue/menu';
+import { MenuItem } from 'primevue/menuitem';
+import { DomHandler, ZIndexUtils } from 'primevue/utils';
+
+const props = defineProps({
+	model: {
+		type: Array as PropType<MenuItem[]>,
+		default: null
+	},
+	appendTo: {
+		type: String,
+		required: false,
+		default: 'body'
+	},
+	baseZIndex: {
+		type: Number,
+		required: false,
+		default: 0
+	}
+});
+
+const container = ref<HTMLElement>();
+const isVisible = ref(false);
+let pageX = 0;
+let pageY = 0;
+
+const DEFAULT_ZINDEX_MENU = 1000;
+
+const show = (event) => {
+	const containerVal = container.value;
+	if (!containerVal) return;
+
+	pageX = event.pageX;
+	pageY = event.pageY;
+	isVisible.value = true;
+	setPosition();
+
+	event.stopPropagation();
+	event.preventDefault();
+
+	ZIndexUtils.set('menu', containerVal, props.baseZIndex + DEFAULT_ZINDEX_MENU);
+};
+const hide = () => {
+	const containerVal = container.value;
+	if (!containerVal) return;
+
+	isVisible.value = false;
+	ZIndexUtils.clear(containerVal);
+};
+defineExpose({
+	show,
+	hide
+});
+
+// adapted from `position` method of primevue/contextmenu
+const setPosition = () => {
+	const containerVal = container.value;
+	if (!containerVal) return;
+
+	let left = pageX + 1;
+	let top = pageY + 1;
+	const width = containerVal.offsetParent
+		? containerVal.offsetWidth
+		: DomHandler.getHiddenElementOuterWidth(containerVal);
+	const height = containerVal.offsetParent
+		? containerVal.offsetHeight
+		: DomHandler.getHiddenElementOuterHeight(containerVal);
+	const viewport = DomHandler.getViewport();
+
+	// flip
+	if (left + width - document.body.scrollLeft > viewport.width) {
+		left -= width;
+	}
+
+	// flip
+	if (top + height - document.body.scrollTop > viewport.height) {
+		top -= height;
+	}
+
+	// fit
+	if (left < document.body.scrollLeft) {
+		left = document.body.scrollLeft;
+	}
+
+	// fit
+	if (top < document.body.scrollTop) {
+		top = document.body.scrollTop;
+	}
+
+	containerVal.style.left = `${left}px`;
+	containerVal.style.top = `${top}px`;
+};
+
+const CLICK_EVENT = 'click';
+// adapted from `outsideClickListener` method of primevue/contextmenu
+const outsideClickListener = (event) => {
+	const containerVal = container.value;
+	const isOutsideContainer = containerVal && !containerVal.contains(event.target);
+
+	if (isOutsideContainer) {
+		hide();
+	}
+};
+document.addEventListener(CLICK_EVENT, outsideClickListener);
+onUnmounted(() => {
+	document.removeEventListener(CLICK_EVENT, outsideClickListener);
+	ZIndexUtils.clear(container.value as HTMLElement);
+});
+</script>
+
+<style scoped>
+.tera-context-menu {
+	position: absolute;
+}
+</style>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate.vue
@@ -17,7 +17,7 @@
 				:active="activeTab === SimulateTabs.output"
 				@click="activeTab = SimulateTabs.output"
 			/>
-			<span class="simulate-header-label">Simulate</span>
+			<span class="simulate-header-label">Simulate (deterministic)</span>
 		</div>
 		<div
 			v-if="activeTab === SimulateTabs.output && node?.outputs.length"

--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -179,7 +179,7 @@ import { ModelOperation } from '@/components/workflow/model-operation';
 import { CalibrationOperation } from '@/components/workflow/calibrate-operation';
 import { SimulateOperation } from '@/components/workflow/simulate-operation';
 import { StratifyOperation } from '@/components/workflow/stratify-operation';
-import ContextMenu from 'primevue/contextmenu';
+import ContextMenu from '@/components/widgets/tera-context-menu.vue';
 import Button from 'primevue/button';
 import Menu from 'primevue/menu';
 import * as workflowService from '@/services/workflow';
@@ -298,27 +298,47 @@ const contextMenuItems = ref([
 		}
 	},
 	{
-		label: 'Calibrate',
-		command: () => {
-			workflowService.addNode(wf.value, CalibrationOperation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Simulate',
-		command: () => {
-			workflowService.addNode(wf.value, SimulateOperation, newNodePosition, {
-				width: 420,
-				height: 220
-			});
-			workflowDirty = true;
-		}
-	},
-	{
 		label: 'Stratify',
 		command: () => {
 			workflowService.addNode(wf.value, StratifyOperation, newNodePosition);
 		}
+	},
+	{
+		label: 'Deterministic',
+		items: [
+			{
+				label: 'Simulate',
+				command: () => {
+					workflowService.addNode(wf.value, SimulateOperation, newNodePosition, {
+						width: 420,
+						height: 220
+					});
+					workflowDirty = true;
+				}
+			},
+			{
+				label: 'Calibrate',
+				command: () => {
+					workflowService.addNode(wf.value, CalibrationOperation, newNodePosition);
+					workflowDirty = true;
+				}
+			}
+		]
+	},
+	{
+		label: 'Probabilistic',
+		items: [
+			{
+				label: 'Simulate',
+				disabled: true,
+				command: () => {}
+			},
+			{
+				label: 'Calibrate & Simulate',
+				disabled: true,
+				command: () => {}
+			}
+		]
 	}
 ]);
 const addComponentMenu = ref();
@@ -354,6 +374,7 @@ function onDrop(event) {
 }
 
 function toggleContextMenu(event) {
+	console.log('hi');
 	contextMenu.value.show(event);
 	updateNewNodePosition(event);
 }

--- a/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulation-workflow.vue
@@ -374,7 +374,6 @@ function onDrop(event) {
 }
 
 function toggleContextMenu(event) {
-	console.log('hi');
 	contextMenu.value.show(event);
 	updateNewNodePosition(event);
 }


### PR DESCRIPTION
# Description

* Update workflow menu items list to differentiate between deterministic & probabilistic sim/calibrate.
    * Use disabled menu items for not yet built probabilistic options
* Update simulate drilldown panel header to `Simulate (deterministic)`

<img width="682" alt="Screenshot 2023-06-26 at 3 19 12 PM" src="https://github.com/DARPA-ASKEM/Terarium/assets/14062458/51548050-756c-472f-a2ad-c4d624353618">


Note: since `primevue/contextmenu` does not support headers in the context menu (which is required in the design), a workaround was used to allow the `primevue/menu` component to be used as a contextmenu.

Resolves #(issue)
