### PR TITLE
chore: remove status display, this is not ready yet and is a source o…

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -1,7 +1,7 @@
 <template>
 	<main :style="nodeStyle" ref="workflowNode">
 		<header>
-			<h5 class="truncate">{{ node.operationType }} ({{ node.statusCode }})</h5>
+			<h5 class="truncate">{{ node.operationType }}</h5>
 			<span>
 				<Button
 					icon="pi pi-sign-in"


### PR DESCRIPTION
### Summary
Remove the status in the workflow node header, to reduce confusion as the status-code is not fully in-use yet.

<img width="321" alt="image" src="https://github.com/DARPA-ASKEM/Terarium/assets/1220927/0463c36d-3d06-48af-8f46-3a1e06a7be29">
