### PR TITLE
fix(hmi-client): facet number wraps

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/facets/tera-categorical-facet.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/facets/tera-categorical-facet.vue
@@ -110,7 +110,7 @@ export default defineComponent({
 				values.push({
 					label: labelName,
 					ratio: b.value / this.max,
-					value: `${b.selectedValue}/${b.value}`
+					value: `${b.selectedValue}`
 				});
 			}
 			return {


### PR DESCRIPTION
After design review with @jamiewaese-uncharted , opting to get rid of denominator since its just the document count and just keep the facet count

Resolves #1277
