### PR TITLE
feat: adjusted styling of nodes in petrinet diagram

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/_variables.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/_variables.scss
@@ -851,10 +851,10 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 //petrinet
-$petri-nodeBorder: var(--gray-800);
-$petri-nodeFill: var(--surface);
+$petri-nodeBorder: var(--gray-500);
+$petri-nodeFill: var(--gray-500);
 $petri-lineColor: var(--gray-700);
-$petri-inputBox: var(--gray-300);
+$petri-inputBox: var(--surface-0);
 
 
 :root {
@@ -931,8 +931,8 @@ $petri-inputBox: var(--gray-300);
 	--text-color-danger: #{$dangerTextButton};
 	--constrain-width: 55rem;
 	color-scheme: light;
-	--petri-nodeBorder: #{$petri-nodeBorder};
-	--petri-nodeFill: var(--surface);
+	--petri-nodeBorder: var(--gray-300);
+	--petri-nodeFill: var(--gray-300);
 	--petri-lineColor: #{$petri-lineColor};
 	--petri-inputBox: #{$petri-inputBox};
 	--port-base-size: 8px;

--- a/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/petrinet/petrinet-renderer.ts
@@ -89,7 +89,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.attr('x', (d) => -d.width * 0.5)
 			.attr('rx', '6')
 			.attr('ry', '6')
-			.style('fill', '#FFF')
+			.style('fill', 'var(--petri-nodeFill')
 			.style('cursor', 'pointer')
 			.attr('stroke', 'var(--petri-nodeBorder)')
 			.attr('stroke-width', 1);
@@ -133,9 +133,8 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
 			.style('stroke', '#FFF')
-			.style('stroke-width', '6px')
+			.style('stroke-width', '3px')
 			.style('stroke-linecap', 'butt')
-			.style('stroke-linejoin', 'matter')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
 			.text((d) => d.label);
@@ -145,7 +144,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.append('circle')
 			.classed('shape selectableNode', true)
 			.attr('r', (d) => 0.55 * d.width) // FIXME: need to adjust edge from sqaure mapping to circle
-			.attr('fill', '#FFF')
+			.attr('fill', 'var(--petri-nodeFill)')
 			.attr('stroke', 'var(--petri-nodeBorder)')
 			.attr('stroke-width', 1)
 			.style('cursor', 'pointer');
@@ -175,9 +174,8 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
 			.style('stroke', '#FFF')
-			.style('stroke-width', '6px')
-			.style('stroke-linecap', 'butt')
-			.style('stroke-linejoin', 'matter')
+			.style('stroke-width', '3px')
+			.style('stroke-linecap', 'round')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
 			.text((d) => d.label);
@@ -214,7 +212,6 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 				.style('stroke', 'var(--gray-50)')
 				.style('stroke-width', '6px')
 				.style('stroke-linecap', 'butt')
-				.style('stroke-linejoin', 'matter')
 				.style('fill', 'var(--text-color-primary')
 				.text((d) => d.data?.numEdges as number);
 		});
@@ -241,7 +238,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 				'style',
 				`width:${
 					w * 0.8
-				}px; height:30px; background: var(--petri-inputBox); border-radius:var(--border-radius); border: 2px solid transparent; text-align:center; position: absolute; top:50%; left:50%; transform: translate(-50%, -50%);`
+				}px; height:30px; background: var(--petri-inputBox); border-radius:var(--border-radius); border: 2px solid transparent; text-align:center; position: absolute; top:50%; left:50%; transform: translate(-50%, -50%); padding-left:2px; padding-right:2px;`
 			)
 			.attr('value', selection.datum().label);
 	}


### PR DESCRIPTION
I made adjusted the styling of the nodes in the petrinet diagram:
- grey fill, same as border
- smaller stroke around the text
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/46a4df3c-69e4-4656-92b1-1c8893dd4608)


Also reduced the left and right padding of the input box so it's less annoying
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/ba99aae4-6394-44fa-88d6-303365a02f5a)
