### PR TITLE
feat: fixed ugly line wrapping in navigation menu

### DIFF
--- a/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
@@ -300,5 +300,6 @@ i {
  */
 .navigation-menu {
 	margin-top: 0.25rem;
+	min-width: fit-content !important;
 }
 </style>


### PR DESCRIPTION
Yes, i used an `!important` to overwrite a min-width setting that this menu is inheriting from somewhere. I couldn't find where it was coming from. Feel free to suggest a better way to do this. In the meantime this works, and fixes the unnecessary line wrapping in the navigation menu.

BEFORE
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/6384bde6-ec37-489c-9450-2ff2237b4612)

NOW
![image](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/d652e9fe-5f75-4908-9936-e08b8f941f5e)
