### PR TITLE
feat: smaller buttons in footer, fixed bug when launching About modal

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -25,22 +25,16 @@
 	<footer class="footer">
 		<img src="@assets/svg/uncharted-logo-dark.svg" alt="logo" class="ml-2" />
 		<div class="footer-group">
-			<a target="_blank" rel="noopener noreferrer" :href="documentation">documentation</a>
-			<a
-				target="_blank"
-				rel="noopener noreferrer"
-				href="javascript:void;"
-				@click="isAboutModalVisible = true"
-				>about</a
-			>
+			<a target="_blank" rel="noopener noreferrer" @click="isAboutModalVisible = true">About</a>
+			<a target="_blank" rel="noopener noreferrer" :href="documentation">Documentation</a>
 			<a target="_blank" rel="noopener noreferrer" href="https://terarium.canny.io/report-an-issue"
-				>report an issue</a
+				>Report an issue</a
 			>
 			<a
 				target="_blank"
 				rel="noopener noreferrer"
 				href="https://terarium.canny.io/request-a-feature"
-				>request a feature</a
+				>Request a feature</a
 			>
 		</div>
 	</footer>
@@ -230,6 +224,7 @@ footer {
 }
 
 .footer-group {
+	font-size: var(--font-caption);
 	margin: 0 2rem;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Four small things here: 
1) Made text buttons in footer smaller to make them less prominent
2) Capitalized them because everything in the app is sentence case.
3) Swapped the order of About and Documentation to be alphabetical, and in order of importance
4) I fixed a bug that occurs when you launch the About modal. Currently it tries to load a page in a new tab because of the` href="javascript:void;"` line. You then have to close that tab to see the modal. I removed that and everything's groovy.

ORIGINAL
![Monosnap Terarium 2023-07-06 17-29-58](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/81022a48-fa61-4eb2-8634-9c1999286cd2)

WITH THIS PR
![Monosnap Terarium 2023-07-06 17-30-56](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/8f2899a8-89eb-4073-b856-f727a975d657)


Here's that bug I fixed by removing the unwanted href:
![about modal bug](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/c4a33bde-40bf-4a06-8c2f-fa89ebace410)
