### PR TITLE
feat: add logging modal for evaluation scenarios

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -457,6 +457,7 @@ export interface MetadataDataset {
 
 export enum EventType {
     Search = "SEARCH",
+    EvaluationScenario = "EVALUATION_SCENARIO",
 }
 
 export enum FileType {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
@@ -3,7 +3,8 @@ package software.uncharted.terarium.hmiserver.models;
 import lombok.Getter;
 
 public enum EventType {
-	SEARCH(true);
+	SEARCH(true),
+	EVALUATION_SCENARIO(false);
 
 	EventType(boolean persistent) {
 		this.persistent = persistent;


### PR DESCRIPTION
# Description
This PR adds a loggin modal for recording evaluation scenarios.  It assumes we use local storage and are running one scenario at a time.

The evaluation modal is available app-wide from the top right drop down:
<img width="1128" alt="image" src="https://github.com/DARPA-ASKEM/Terarium/assets/4606322/2928228c-6bc1-4142-8dc9-c642b7afc7ac">

The modal records the specified fields and persists until the current scenario is "stopped":
<img width="1272" alt="image" src="https://github.com/DARPA-ASKEM/Terarium/assets/4606322/63cc142d-c2af-41c8-8d86-838b9fcc0651">

Log messages are recorded with the corresponding metadata:
```text
2023-07-07 18:55:41,818 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-10) EVENT | adam | Event(id=aabf1597-a595-43f7-8b88-3e20241cf269, timestampMillis=1688770541817, projectId=null, username=null, type=EVALUATION_SCENARIO, value={"name":"Test","task":"Task","description":"My description","notes":"my notes!","action":"start"})
2023-07-07 18:55:46,669 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-10) EVENT | adam | Event(id=ababc52f-8ac6-4f88-b525-008362cb088c, timestampMillis=1688770546669, projectId=null, username=null, type=EVALUATION_SCENARIO, value={"name":"Test","task":"Task","description":"My description","notes":"my notes!","action":"pause"})
2023-07-07 18:55:50,960 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-10) EVENT | adam | Event(id=48ee1e40-cc16-4b6a-8c01-6cea21daa9ef, timestampMillis=1688770550959, projectId=null, username=null, type=EVALUATION_SCENARIO, value={"name":"Test","task":"Task","description":"My description","notes":"my notes!","action":"stop"})
```



