### PR TITLE
fix: minor ui changes to resource sidebar

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -50,7 +50,7 @@
 				<span class="p-button-label">Overview</span>
 			</span>
 		</Button>
-		<Accordion v-if="!isEmpty(assets)" :multiple="true">
+		<Accordion v-if="!isEmpty(assets)" :multiple="true" :active-index="[0, 1, 2, 3, 4]">
 			<AccordionTab v-for="[type, tabs] in assets" :key="type">
 				<template #header>
 					<template v-if="type === ProjectAssetTypes.DOCUMENTS">Publications & Documents</template>

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -2,7 +2,7 @@
 	<main>
 		<tera-slider-panel
 			v-model:is-open="isResourcesSliderOpen"
-			content-width="300px"
+			content-width="240px"
 			header="Resources"
 			direction="left"
 			class="resource-panel"

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -195,6 +195,7 @@ const icons = new Map<string | ProjectAssetTypes, string | Component>([
 	[ProjectAssetTypes.SIMULATIONS, 'settings'],
 	[ProjectAssetTypes.SIMULATION_RUNS, ResultsIcon],
 	[ProjectAssetTypes.CODE, 'code'],
+	[ProjectAssetTypes.SIMULATION_WORKFLOW, 'git-merge'],
 	['overview', 'layout']
 ]);
 


### PR DESCRIPTION
# Description

* Set Resource panel width to 240px to match the width of the Notes panel
* Update the workflows icon
* Have all the Resource panel accordion tabs be "open" by default
* Video demo: https://capture.dropbox.com/DzfIbaqxqwVLjrlU
