### PR TITLE
fix: stable zoom/pan

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -385,7 +385,17 @@ export abstract class Renderer<V, E> extends EventEmitter {
 		}
 		svg.call(this.zoom as any).on('dblclick.zoom', null);
 
-		this.setToDefaultZoom();
+		if (this.options.useStableZoomPan && this.zoomTransformObject) {
+			const zoomLevel = this.zoomTransformObject.k;
+			const zoomX = this.zoomTransformObject.x / zoomLevel;
+			const zoomY = this.zoomTransformObject.y / zoomLevel;
+			svg.call(
+				this.zoom.transform,
+				d3.zoomIdentity.translate(0, 0).scale(zoomLevel).translate(zoomX, zoomY)
+			);
+		} else {
+			this.setToDefaultZoom();
+		}
 	}
 
 	setToDefaultZoom() {

--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -389,6 +389,8 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			const zoomLevel = this.zoomTransformObject.k;
 			const zoomX = this.zoomTransformObject.x / zoomLevel;
 			const zoomY = this.zoomTransformObject.y / zoomLevel;
+
+			// @ts-ignore
 			svg.call(
 				this.zoom.transform,
 				d3.zoomIdentity.translate(0, 0).scale(zoomLevel).translate(zoomX, zoomY)

--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -390,8 +390,8 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			const zoomX = this.zoomTransformObject.x / zoomLevel;
 			const zoomY = this.zoomTransformObject.y / zoomLevel;
 
-			// @ts-ignore
 			svg.call(
+				// @ts-ignore
 				this.zoom.transform,
 				d3.zoomIdentity.translate(0, 0).scale(zoomLevel).translate(zoomX, zoomY)
 			);

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -311,26 +311,6 @@ const updatePetriNet = async (model: Model) => {
 	// Convert PetriNet into a graph
 	const graphData: IGraph<NodeData, EdgeData> = convertToIGraph(model);
 
-	// Create renderer
-	renderer = new PetrinetRenderer({
-		el: graphElement.value as HTMLDivElement,
-		useAStarRouting: false,
-		useStableZoomPan: true,
-		runLayout: runDagreLayout,
-		dragSelector: 'no-drag'
-	});
-
-	renderer.on('add-edge', (_evtName, _evt, _selection, d) => {
-		renderer?.addEdge(d.source, d.target);
-	});
-
-	renderer.on('background-contextmenu', (_evtName, evt, _selection, _renderer, pos: any) => {
-		if (!renderer?.editMode) return;
-		eventX = pos.x;
-		eventY = pos.y;
-		menu.value.toggle(evt);
-	});
-
 	// Render graph
 	await renderer?.setData(graphData);
 	await renderer?.render();


### PR DESCRIPTION
### Summary
Fix stability and jumpiness issues with model editing via the graph. It seemed like sometime ago we removed the stability checks. This PR brings it back.


### Testing
- To to a model, click edit, try to add nodes and edges - the viewport should not rest. 
- Cancel edit