### PR TITLE
fix: reset port connect status if there are no remaining connections

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -153,6 +153,15 @@ export const removeEdge = (wf: Workflow, id: string) => {
 
 	// Edge re-assignment
 	wf.edges = wf.edges.filter((edge) => edge.id !== id);
+
+	// If there are no more references reset the connected status of the source node
+	if (wf.edges.filter((e) => e.source === edgeToRemove.source).length === 0) {
+		const sourceNode = wf.nodes.find((d) => d.id === edgeToRemove.source);
+		if (!sourceNode) return;
+		const sourcePort = sourceNode.outputs.find((d) => d.id === edgeToRemove.sourcePortId);
+		if (!sourcePort) return;
+		sourcePort.status = WorkflowPortStatus.NOT_CONNECTED;
+	}
 };
 
 export const removeNode = (wf: Workflow, id: string) => {


### PR DESCRIPTION
### Summary
Fix disconnect logic so the workflow node does not have weird status like this when you remove node/edge


<img width="345" alt="image" src="https://github.com/DARPA-ASKEM/Terarium/assets/1220927/9bc35848-af02-4b93-aaae-ea16f5dcd82f">

### Test
- add model, add smulate
- connect model to simulate
- remove simulate