### PR TITLE
fix: graph zoom and showing transition equations

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -402,14 +402,25 @@ export abstract class Renderer<V, E> extends EventEmitter {
 
 	setToDefaultZoom() {
 		const svg = d3.select(this.svgEl);
-		let scale = 1;
+		let scaleFactor = 1;
+		let translateX = 1;
+		let translateY = 100;
 		if (this.chart) {
-			scale = this.chartSize.width / (this.graph.width ?? 1);
+			const graphCenterX = (this.graph.width ?? 0) / 2;
+			const graphCenterY = (this.graph.height ?? 0) / 2;
+			scaleFactor = Math.min(
+				this.chartSize.width / (this.graph.width ?? 1),
+				this.chartSize.height / (this.graph.height ?? 1)
+			);
+
+			// Calculate the translation to center the graph
+			translateX = this.chartSize.width / 2 - scaleFactor * graphCenterX;
+			translateY = this.chartSize.height / 2 - scaleFactor * graphCenterY;
 		}
 
 		svg.call(
 			this.zoom?.transform as any,
-			d3.zoomIdentity.translate(1, 100).scale(scale).translate(0, 0)
+			d3.zoomIdentity.translate(translateX, translateY).scale(scaleFactor)
 		);
 	}
 

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -10,6 +10,7 @@ import * as petrinetService from '@/model-representation/petrinet/petrinet-servi
 export interface NodeData {
 	type: string;
 	strataType?: string;
+	expression?: string;
 }
 
 export interface EdgeData {
@@ -152,7 +153,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.on('mouseover', handleMouseOver)
 			.on('mouseout', handleMouseOut);
 
-		// transitions text
+		// transitions label text
 		transitions
 			.append('text')
 			.attr('y', () => 5)
@@ -167,6 +168,20 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.style('pointer-events', 'none')
 			.html((d) => d.label);
 
+		// transitions expression text
+		transitions
+			.append('text')
+			.attr('y', (d) => -d.height / 2 - 5)
+			.style('text-anchor', 'middle')
+			.style('paint-order', 'stroke')
+			.style('stroke', (d) =>
+				d.data.strataType ? strataTypeColors[strataTypes.indexOf(d.data.strataType)] : '#FFF'
+			)
+			.style('stroke-width', '3px')
+			.style('stroke-linecap', 'butt')
+			.style('fill', 'var(--text-color-primary')
+			.style('pointer-events', 'none')
+			.html((d) => d.data.expression ?? null);
 		// species
 		species
 			.append('circle')

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -174,9 +174,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.attr('y', (d) => -d.height / 2 - 5)
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
-			.style('stroke', (d) =>
-				d.data.strataType ? strataTypeColors[strataTypes.indexOf(d.data.strataType)] : '#FFF'
-			)
+			.style('stroke', '#FFF')
 			.style('stroke-width', '3px')
 			.style('stroke-linecap', 'butt')
 			.style('fill', 'var(--text-color-primary')

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -96,7 +96,7 @@ export const convertToIGraph = (amr: Model) => {
 			(map) => map.length === 2 && transition.id === map[0]
 		);
 
-		const targetNode = amr.semantics?.ode.rates.find((node) => transition.id === node.target);
+		const targetRate = amr.semantics?.ode.rates.find((rate) => transition.id === rate.target);
 
 		const strataType = typeMap?.[1] ?? '';
 		result.nodes.push({
@@ -107,7 +107,7 @@ export const convertToIGraph = (amr: Model) => {
 			y: 0,
 			width: 40,
 			height: 40,
-			data: { type: 'transition', strataType, expression: targetNode?.expression },
+			data: { type: 'transition', strataType, expression: targetRate?.expression },
 			nodes: []
 		});
 	});

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -6,6 +6,7 @@ import { PetriNet } from '@/petrinet/petrinet-service';
 export interface NodeData {
 	type: string;
 	strataType?: string;
+	expression?: string;
 }
 
 export interface EdgeData {
@@ -94,6 +95,9 @@ export const convertToIGraph = (amr: Model) => {
 		const typeMap = amr.semantics?.typing?.type_map.find(
 			(map) => map.length === 2 && transition.id === map[0]
 		);
+
+		const targetNode = amr.semantics?.ode.rates.find((node) => transition.id === node.target);
+
 		const strataType = typeMap?.[1] ?? '';
 		result.nodes.push({
 			id: transition.id,
@@ -101,9 +105,9 @@ export const convertToIGraph = (amr: Model) => {
 			type: 'transition',
 			x: 0,
 			y: 0,
-			width: 100,
-			height: 100,
-			data: { type: 'transition', strataType },
+			width: 40,
+			height: 40,
+			data: { type: 'transition', strataType, expression: targetNode?.expression },
 			nodes: []
 		});
 	});


### PR DESCRIPTION
# Description
- fix graph zoom so that it now centers and showing the entire model diagram
- adding equations above the transition node for better visibility

Showing Transition Nodes

https://github.com/DARPA-ASKEM/Terarium/assets/33158416/866aa412-0c71-4b2d-8719-72bc06405c5e

Showing zoom fix

https://github.com/DARPA-ASKEM/Terarium/assets/33158416/0ca04f23-5c48-4786-afac-c4a471df1ef7




Resolves #(issue)
https://github.com/DARPA-ASKEM/Terarium/issues/1351