### PR TITLE
task(hmi-client): restrict xdd search results for performance reasons

### DIFF
--- a/packages/client/hmi-client/src/types/XDD.ts
+++ b/packages/client/hmi-client/src/types/XDD.ts
@@ -76,7 +76,7 @@ export type XDDSearchParams = {
 	githubUrls?: string;
 };
 
-export const XDD_RESULT_DEFAULT_PAGE_SIZE = 100;
+export const XDD_RESULT_DEFAULT_PAGE_SIZE = 20;
 
 //
 // XDD Field names


### PR DESCRIPTION
This is a temporary fix until xdd has paging fixed (And we implement paging).  Restricting our search to 20 items as objects are expensive/slow to retrieve.

Resolves #noissue
