### PR TITLE
fix: clear explorer search

### DIFF
--- a/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
@@ -299,9 +299,7 @@ const searchBarRef = ref();
 const terms = ref<string[]>([]);
 
 async function updateRelatedTerms(query?: string) {
-	// Don't update related terms if the query is empty as we will stay in the previous one
-	// Accept the empty query once we get out of the data explorer route
-	if (!isEmpty(query) || !isDataExplorer.value) terms.value = await getRelatedTerms(query);
+	if (query || query === '' || !isDataExplorer.value) terms.value = await getRelatedTerms(query);
 }
 
 function searchByExampleModalToggled() {

--- a/packages/client/hmi-client/src/components/navbar/tera-searchbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-searchbar.vue
@@ -167,7 +167,7 @@ function clearQuery() {
 
 const initiateSearch = () => {
 	emit('query-changed', query.value);
-	router.push({ name: RouteName.DataExplorerRoute, query: { q: query.value } });
+	router.push({ name: RouteName.DataExplorerRoute, query: { q: query.value, byExample: 'false' } });
 	EventService.create(EventType.Search, resources.activeProject?.id, query.value);
 };
 
@@ -180,6 +180,7 @@ function initiateSearchByExample() {
 	searchByExampleAssetCardProp.value = { ...searchByExampleItem.value };
 	// used to update the search bar text with the name of the search by example asset
 	query.value = extractResourceName(searchByExampleItem.value);
+	router.push({ name: RouteName.DataExplorerRoute, query: { q: query.value, byExample: 'true' } });
 }
 
 function addToQuery(term: string) {

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -521,12 +521,11 @@ const clearItemSelected = () => {
 // };
 
 async function executeNewQuery() {
-	// If search query is not empty update the search term
-	if (!isEmpty(route.query?.q?.toString()) && route.query?.q?.toString()) {
+	if (route.query?.q?.toString() === '' && route.query?.q?.toString()) {
 		searchTerm.value = route.query?.q?.toString();
 	}
 
-	// If the search term is empty or is the same as the previous term don't execute a search
+	// If the search term is the same as the previous term don't execute a search
 
 	// search term has changed, so all search results are dirty; need re-fetch
 	disableSearchByExample();

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -521,12 +521,10 @@ const clearItemSelected = () => {
 // };
 
 async function executeNewQuery() {
-	// If search query is not empty update the search term
-	if (!isEmpty(route.query?.q?.toString()) && route.query?.q?.toString()) {
+	if (route.query?.q?.toString() === '' || route.query?.q?.toString()) {
 		searchTerm.value = route.query?.q?.toString();
 	}
-
-	// If the search term is empty or is the same as the previous term don't execute a search
+	// If the search term is the same as the previous term don't execute a search
 
 	// search term has changed, so all search results are dirty; need re-fetch
 	disableSearchByExample();
@@ -562,10 +560,17 @@ watch(clientFilters, async (n, o) => {
 // Gets query from search-bar.vue
 watch(
 	() => route.query,
-	() => executeNewQuery()
+	() => {
+		// Adding another query param 'byExample' for what should be a better way to determine whether we are searching by example or not.
+		// For now this is just a boolean string but this can be looked into further to maybe add additional parameters when searching by example.
+		// i.e. refreshing will land the user on the page with the example resource type already populated and used to search
+		if (route.query.byExample === 'true') {
+			onSearchByExample(searchByExampleOptions.value);
+		} else {
+			executeNewQuery();
+		}
+	}
 );
-
-watch(searchByExampleOptions, () => onSearchByExample(searchByExampleOptions.value));
 
 // Default query on reload
 onMounted(async () => {

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -521,7 +521,7 @@ const clearItemSelected = () => {
 // };
 
 async function executeNewQuery() {
-	if (route.query?.q?.toString() === '' && route.query?.q?.toString()) {
+	if (route.query?.q?.toString() === '' || route.query?.q?.toString()) {
 		searchTerm.value = route.query?.q?.toString();
 	}
 

--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -521,10 +521,12 @@ const clearItemSelected = () => {
 // };
 
 async function executeNewQuery() {
-	if (route.query?.q?.toString() === '' || route.query?.q?.toString()) {
+	// If search query is not empty update the search term
+	if (!isEmpty(route.query?.q?.toString()) && route.query?.q?.toString()) {
 		searchTerm.value = route.query?.q?.toString();
 	}
-	// If the search term is the same as the previous term don't execute a search
+
+	// If the search term is empty or is the same as the previous term don't execute a search
 
 	// search term has changed, so all search results are dirty; need re-fetch
 	disableSearchByExample();
@@ -564,13 +566,11 @@ watch(
 		// Adding another query param 'byExample' for what should be a better way to determine whether we are searching by example or not.
 		// For now this is just a boolean string but this can be looked into further to maybe add additional parameters when searching by example.
 		// i.e. refreshing will land the user on the page with the example resource type already populated and used to search
-		if (route.query.byExample === 'true') {
-			onSearchByExample(searchByExampleOptions.value);
-		} else {
-			executeNewQuery();
-		}
+		if (route.query.byExample !== 'true') executeNewQuery();
 	}
 );
+
+watch(searchByExampleOptions, () => onSearchByExample(searchByExampleOptions.value));
 
 // Default query on reload
 onMounted(async () => {


### PR DESCRIPTION
# Description

* ability to clear your search (search for an empty string)
* adding a url param to determine if we are searching by example or not in order to trigger a route change for the watcher to pickup.  This helps when clearing search when searching by example


https://github.com/DARPA-ASKEM/Terarium/assets/33158416/9a9f0c72-9a55-408d-aa7e-5f1ee539d598


Resolves #(issue)
