### PR TITLE
feat: darker text in content switcher buttons

### DIFF
--- a/packages/client/hmi-client/src/assets/css/buttonset.scss
+++ b/packages/client/hmi-client/src/assets/css/buttonset.scss
@@ -1,5 +1,8 @@
 // Styles reused in Document.vue and DataExplorer.vue - TODO: look into changing prime vue styling to reflect this
 .p-buttonset {
+    white-space: nowrap;
+	margin-left: 0.5rem;
+
     .p-button.p-button-secondary {
         border: 1px solid var(--surface-border);
         box-shadow: none;
@@ -10,13 +13,13 @@
     .p-button[active='false'].p-button-secondary:enabled {
         border-color: var(--surface-border);
         background-color: var(--surface-0);
-        color: var(--text-color-subdued);
+        color: var(--text-color-primary);
     }
 
     .p-button[active='false'].p-button-secondary:hover {
         border-color: var(--surface-border);
         background-color: var(--surface-100);
-        color: var(--text-color-subdued);
+        color: var(--text-color-primary);
     }
 
     .p-button[active='true'].p-button-secondary,
@@ -30,7 +33,7 @@
     .p-button[active='true'].p-button-secondary:hover {
         border-color: var(--surface-border);
         background-color: var(--surface-highlight);
-        color: var(--text-color-subdued);
+        color: var(--text-color-primary);
     }
 
     .p-button.p-button-sm {

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -477,11 +477,6 @@ onUpdated(() => {
 	border-width: 0px 0px 0px 6px;
 }
 
-.p-buttonset {
-	white-space: nowrap;
-	margin-left: 0.5rem;
-}
-
 .extracted-item {
 	border: 1px solid var(--surface-border-light);
 	padding: 1rem;


### PR DESCRIPTION
The subdued text in the unselected content switcher buttons looked too much like "disabled" text, suggesting those tabs aren't available. I changed the color to primary so it reads better.

BEFORE
![Monosnap Terarium 2023-07-13 10-33-08](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/be5f4f3d-0b40-49e9-be24-eabaea527521)


AFTER
![Monosnap Terarium 2023-07-13 10-32-27](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/eabfaaaf-8e67-4279-b623-36a0f24e671e)
