### PR TITLE
feat: add structured timing logs for all proxy calls

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/annotations/LogRestClientTime.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/annotations/LogRestClientTime.java
@@ -1,0 +1,14 @@
+package software.uncharted.terarium.hmiserver.annotations;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogRestClientTime {
+	String group() default "";
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/RestClientTimingInterceptor.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/RestClientTimingInterceptor.java
@@ -22,6 +22,21 @@ public class RestClientTimingInterceptor {
 
 	@Inject
 	StructuredLog structuredLog;
+
+	/**
+	 * Create a structured log of the proxy being called.  Logs:
+	 * 	- PROXY_REQUEST identifier
+	 * 	- The username of the user making the proxy, Anonymous if it is done on behalf of the system itself
+	 * 	- The name of the proxy method (in Java)
+	 * 	- The name of the parent class (the actual rest client)
+	 * 	- The rest path being executed
+	 * 	- The method type (GET, POST, etc)
+	 * 	- An optional group that can be specified on the annotation, if not provided, defaults to the package name for grouping
+	 * 	- The time in ms the call took
+	 * @param context	Invocation context
+	 * @return				the next interceptor in the chain
+	 * @throws Exception
+	 */
 	@AroundInvoke
 	public Object measureInvocationTime(InvocationContext context) throws Exception {
 		long startTime = System.currentTimeMillis();
@@ -41,6 +56,11 @@ public class RestClientTimingInterceptor {
 		}
 	}
 
+	/**
+	 * Get the method type of the rest call being made
+	 * @param context	Invocation context
+	 * @return				The method type (GET, POST, etc)
+	 */
 	private String getType(InvocationContext context) {
 		if (context.getMethod().getAnnotation(javax.ws.rs.GET.class) != null) {
 			return "GET";
@@ -60,6 +80,11 @@ public class RestClientTimingInterceptor {
 		return null;
 	}
 
+	/**
+	 * Gets the @Path annotation for the method being called prefixed with the parent class
+	 * @param context	Invocation context
+	 * @return
+	 */
 	private String getPath(InvocationContext context) {
 		String parentPath = getPath(context.getMethod().getDeclaringClass());
 		String methodPath = getPath(context.getMethod());
@@ -69,12 +94,23 @@ public class RestClientTimingInterceptor {
 		return methodPath;
 	}
 
+	/**
+	 * Gets the @Path annotation for the class
+	 * @param clazz	The class to get the path for
+	 * @return			The value of the annotation or an empty string if it doesn't exist
+	 */
 	private String getPath(Class<?> clazz) {
 		if (clazz.getAnnotation(javax.ws.rs.Path.class) != null) {
 			return clazz.getAnnotation(javax.ws.rs.Path.class).value();
 		}
 		return "";
 	}
+
+	/**
+	 * Gets the @Path annotation for the method
+	 * @param method	The method to get the path for
+	 * @return				The value of the annotation or an empty string if it doesn't exist
+	 */
 	private String getPath(Method method) {
 		if (method.getAnnotation(javax.ws.rs.Path.class) != null) {
 			return method.getAnnotation(javax.ws.rs.Path.class).value();
@@ -82,6 +118,11 @@ public class RestClientTimingInterceptor {
 		return "";
 	}
 
+	/**
+	 * Gets the parent package of the class
+	 * @param context	Invocation context
+	 * @return				The parent package name
+	 */
 	private String parentPackage(InvocationContext context) {
 		final String fullyQualifiedPackage = context.getMethod().getDeclaringClass().getPackage().getName();
 		return fullyQualifiedPackage.split("\\.")[fullyQualifiedPackage.split("\\.").length - 1];

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/RestClientTimingInterceptor.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/RestClientTimingInterceptor.java
@@ -1,0 +1,93 @@
+package software.uncharted.terarium.hmiserver.proxies;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
+import software.uncharted.terarium.hmiserver.services.StructuredLog;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+
+@Interceptor
+@LogRestClientTime
+@Priority(Interceptor.Priority.PLATFORM_BEFORE)
+@Slf4j
+public class RestClientTimingInterceptor {
+	@Inject
+	SecurityIdentity securityIdentity;
+
+	@Inject
+	StructuredLog structuredLog;
+	@AroundInvoke
+	public Object measureInvocationTime(InvocationContext context) throws Exception {
+		long startTime = System.currentTimeMillis();
+		try {
+			return context.proceed();
+		} finally {
+			final long endTime = System.currentTimeMillis();
+			final long executionTime = endTime - startTime;
+			final String user = securityIdentity.getPrincipal() != null ? securityIdentity.getPrincipal().getName() : null;
+			structuredLog.log(StructuredLog.Type.PROXY_REQUEST, user,
+				"method", context.getMethod().getName(),
+				"class", context.getMethod().getDeclaringClass().getName(),
+				"path", getPath(context),
+				"type", getType(context),
+				"group", context.getMethod().getAnnotation(LogRestClientTime.class).group().equals("") ? parentPackage(context) : context.getMethod().getAnnotation(LogRestClientTime.class).group(),
+				"duration", executionTime);
+		}
+	}
+
+	private String getType(InvocationContext context) {
+		if (context.getMethod().getAnnotation(javax.ws.rs.GET.class) != null) {
+			return "GET";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.POST.class) != null) {
+			return "POST";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.PUT.class) != null) {
+			return "PUT";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.DELETE.class) != null) {
+			return "DELETE";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.HEAD.class) != null) {
+			return "HEAD";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.OPTIONS.class) != null) {
+			return "OPTIONS";
+		} else if (context.getMethod().getAnnotation(javax.ws.rs.PATCH.class) != null) {
+			return "PATCH";
+		}
+		return null;
+	}
+
+	private String getPath(InvocationContext context) {
+		String parentPath = getPath(context.getMethod().getDeclaringClass());
+		String methodPath = getPath(context.getMethod());
+		if (!parentPath.equals("")) {
+			return parentPath + methodPath;
+		}
+		return methodPath;
+	}
+
+	private String getPath(Class<?> clazz) {
+		if (clazz.getAnnotation(javax.ws.rs.Path.class) != null) {
+			return clazz.getAnnotation(javax.ws.rs.Path.class).value();
+		}
+		return "";
+	}
+	private String getPath(Method method) {
+		if (method.getAnnotation(javax.ws.rs.Path.class) != null) {
+			return method.getAnnotation(javax.ws.rs.Path.class).value();
+		}
+		return "";
+	}
+
+	private String parentPackage(InvocationContext context) {
+		final String fullyQualifiedPackage = context.getMethod().getDeclaringClass().getPackage().getName();
+		return fullyQualifiedPackage.split("\\.")[fullyQualifiedPackage.split("\\.").length - 1];
+	}
+}
+
+
+
+

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ArtifactProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ArtifactProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Artifact;
 import software.uncharted.terarium.hmiserver.models.dataservice.dataset.PresignedURL;
 
@@ -19,30 +20,36 @@ import java.util.List;
 public interface ArtifactProxy {
 
 	@GET
+	@LogRestClientTime
 	List<Artifact> getArtifacts( @DefaultValue("100") @QueryParam("page_size") Integer pageSize,
 															 @DefaultValue("0") @QueryParam("page") Integer page);
 
 	@POST
+	@LogRestClientTime
 	Artifact createArtifact(JsonNode artifact);
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Artifact getArtifact(@PathParam("id") String artifactId);
 
 	@PUT
 	@Path("/{id}")
+	@LogRestClientTime
 	Artifact updateArtifact(@PathParam("id") String artifactId, Artifact artifact);
 
 	@DELETE
 	@Path("/{id}")
+	@LogRestClientTime
 	Response deleteArtifact(@PathParam("id") String artifactId);
 
 	@GET
 	@Path("/{id}/download-url")
+	@LogRestClientTime
 	PresignedURL getArtifactDownloadUrl(@PathParam("id") String artifactId, @QueryParam("filename") String filename);
 
 	@GET
 	@Path("/{id}/upload-url")
+	@LogRestClientTime
 	PresignedURL getArtifactUploadUrl(@PathParam("id") String artifactId, @QueryParam("filename") String filename);
-
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ConceptProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ConceptProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Concept;
 
 import java.util.List;
@@ -14,11 +15,13 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 public interface ConceptProxy {
 	@GET
+	@LogRestClientTime
 	Response searchConcept(
 		@QueryParam("curie") String curie
 	);
 
 	@POST
+	@LogRestClientTime
 	@Consumes(MediaType.APPLICATION_JSON)
 	Response createConcept(
 		Concept concept
@@ -26,6 +29,7 @@ public interface ConceptProxy {
 
 	@GET
 	@Path("/definitions")
+	@LogRestClientTime
 	Response searchConceptDefinitions(
 		@QueryParam("term") String term,
 		@DefaultValue("100") @QueryParam("limit") Integer limit,
@@ -34,18 +38,21 @@ public interface ConceptProxy {
 
 	@GET
 	@Path("/definitions/{curie}")
+	@LogRestClientTime
 	Response getConceptDefinitions(
 		@PathParam("curie") String curie
 	);
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Response getConcept(
 		@PathParam("id") String id
 	);
 
 	@DELETE
 	@Path("/{id}")
+	@LogRestClientTime
 	Response deleteConcept(
 		@PathParam("id") String id
 	);
@@ -53,6 +60,7 @@ public interface ConceptProxy {
 	@PATCH
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateConcept(
 		@PathParam("id") String id,
 		Concept concept
@@ -60,6 +68,7 @@ public interface ConceptProxy {
 
 	@GET
 	@Path("/facets")
+	@LogRestClientTime
 	Response searchConceptsUsingFacets(
 		@QueryParam("types") List<String> types,
 		@QueryParam("curies") List<String> curies

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
@@ -2,11 +2,8 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
-import software.uncharted.terarium.hmiserver.models.dataservice.Feature;
-import software.uncharted.terarium.hmiserver.models.dataservice.Qualifier;
 import software.uncharted.terarium.hmiserver.models.dataservice.dataset.PresignedURL;
 
 import javax.ws.rs.*;
@@ -18,6 +15,8 @@ import java.util.List;
 @Path("/datasets")
 @Produces(MediaType.APPLICATION_JSON)
 public interface DatasetProxy {
+
+	@LogRestClientTime
 	@GET
 	@Path("/features")
 	Response getFeatures(

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ExternalProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ExternalProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.models.dataservice.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.Software;
@@ -18,12 +19,14 @@ public interface ExternalProxy {
 
 	@GET
 	@Path("/software/{id}")
+	@LogRestClientTime
 	Response getSoftware(
 		@PathParam("id") String id
 	);
 
 	@DELETE
 	@Path("/software/{id}")
+	@LogRestClientTime
 	Response deleteSoftware(
 		@PathParam("id") String id
 	);
@@ -31,18 +34,21 @@ public interface ExternalProxy {
 	@POST
 	@Path("/software")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createSoftware(
 		Software software
 	);
 
 	@GET
 	@Path("/publications/{id}")
+	@LogRestClientTime
 	Response getPublication(
 		@PathParam("id") String id
 	);
 
 	@DELETE
 	@Path("/publications/{id}")
+	@LogRestClientTime
 	Response deletePublication(
 		@PathParam("id") String id
 	);
@@ -50,6 +56,7 @@ public interface ExternalProxy {
 	@POST
 	@Path("/publications")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createPublication(
 		DocumentAsset publication
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelConfigurationProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelConfigurationProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.models.dataservice.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.Model;
@@ -18,16 +19,19 @@ import javax.ws.rs.core.Response;
 public interface ModelConfigurationProxy {
 
 	@GET
+	@LogRestClientTime
 	Response getModelConfigurations();
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createModelConfiguration(
 		JsonNode config
 	);
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	ModelConfiguration getModelConfiguration(
 		@PathParam("id") String id
 	);
@@ -35,6 +39,7 @@ public interface ModelConfigurationProxy {
 	@PUT
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateModelConfiguration(
 		@PathParam("id") String id,
 		JsonNode config
@@ -43,6 +48,7 @@ public interface ModelConfigurationProxy {
 	@DELETE
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response deleteModelConfiguration(
 		@PathParam("id") String id
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ModelProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.ModelFramework;
 import software.uncharted.terarium.hmiserver.models.dataservice.ModelOperationCopy;
@@ -20,24 +21,28 @@ public interface ModelProxy {
 	@POST
 	@Path("/frameworks")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createFramework(
 		ModelFramework framework
 	);
 
 	@GET
 	@Path("/frameworks/{name}")
+	@LogRestClientTime
 	Response getFramework(
 		@PathParam("name") String name
 	);
 
 	@DELETE
 	@Path("/frameworks/{name}")
+	@LogRestClientTime
 	Response deleteFramework(
 		@PathParam("name") String name
 	);
 
 	@GET
 	@Path("/descriptions")
+	@LogRestClientTime
 	Response getDescriptions(
 		@DefaultValue("100") @QueryParam("page_size") Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") Integer page
@@ -45,12 +50,14 @@ public interface ModelProxy {
 
 	@GET
 	@Path("/{id}/descriptions")
+	@LogRestClientTime
 	Response getDescription(
 		@PathParam("id") String id
 	);
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Model getModel(
 		@PathParam("id") String id
 	);
@@ -58,6 +65,7 @@ public interface ModelProxy {
 	@PUT
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateModel(
 		@PathParam("id") String id,
 		Model model
@@ -65,6 +73,7 @@ public interface ModelProxy {
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createModel(
 		Model model
 	);
@@ -72,12 +81,14 @@ public interface ModelProxy {
 	@POST
 	@Path("/opts/copy")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response copyModel(
 		ModelOperationCopy modelOperationCopy
 	);
 
 	@GET
 	@Path("/{id}/model_configurations")
+	@LogRestClientTime
 	List<ModelConfiguration> getModelConfigurations(
 			@PathParam("id") String id,
 			@QueryParam("page_size") int pageSize

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/PersonProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/PersonProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Association;
 import software.uncharted.terarium.hmiserver.models.dataservice.Person;
 
@@ -14,12 +15,14 @@ import javax.ws.rs.core.Response;
 public interface PersonProxy {
 	@GET
 	@Path("/associations/{id}")
+	@LogRestClientTime
 	Response getAssociation(
 		@PathParam("id") String id
 	);
 
 	@DELETE
 	@Path("/associations/{id}")
+	@LogRestClientTime
 	Response deleteAssociation(
 		@PathParam("id") String id
 	);
@@ -27,6 +30,7 @@ public interface PersonProxy {
 	@PATCH
 	@Path("/associations/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateAssociation(
 		@PathParam("id") String id,
 		Association association
@@ -35,11 +39,13 @@ public interface PersonProxy {
 	@POST
 	@Path("/associations")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createAssociation(
 		Association association
 	);
 
 	@GET
+	@LogRestClientTime
 	Response getPersons(
 		@DefaultValue("100") @QueryParam("page_size") Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") Integer page
@@ -47,18 +53,21 @@ public interface PersonProxy {
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createPerson(
 		Person person
 	);
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Response getPerson(
 		@PathParam("id") String id
 	);
 
 	@DELETE
 	@Path("/{id}")
+	@LogRestClientTime
 	Response deletePerson(
 		@PathParam("id") String id
 	);
@@ -66,6 +75,7 @@ public interface PersonProxy {
 	@PATCH
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updatePerson(
 		@PathParam("id") String id,
 		Person person

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProjectProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProjectProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.models.dataservice.Assets;
 import software.uncharted.terarium.hmiserver.models.dataservice.Project;
@@ -19,6 +20,7 @@ import java.util.*;
 public interface ProjectProxy {
 
 	@GET
+	@LogRestClientTime
 	List<Project> getProjects(
 		@DefaultValue("50") @QueryParam("page_size") Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") Integer page
@@ -26,12 +28,14 @@ public interface ProjectProxy {
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Response getProject(
 		@PathParam("id") String id
 	);
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createProject(
 		Project project
 	);
@@ -39,6 +43,7 @@ public interface ProjectProxy {
 	@PUT
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateProject(
 		@PathParam("id") String id,
 		Project project
@@ -47,12 +52,14 @@ public interface ProjectProxy {
 	@DELETE
 	@Path("/{id}")
 	@Produces(MediaType.TEXT_PLAIN)
+	@LogRestClientTime
 	Response deleteProject(
 		@PathParam("id") String id
 	);
 
 	@GET
 	@Path("/{project_id}/assets")
+	@LogRestClientTime
 	Assets getAssets(
 		@PathParam("project_id") String projectId,
 		@QueryParam("types") final List<String> types
@@ -60,6 +67,7 @@ public interface ProjectProxy {
 
 	@POST
 	@Path("/{project_id}/assets/{resource_type}/{resource_id}")
+	@LogRestClientTime
 	Response createAsset(
 		@PathParam("project_id") String projectId,
 		@PathParam("resource_type") String type, // ResourceType
@@ -68,6 +76,7 @@ public interface ProjectProxy {
 
 	@DELETE
 	@Path("/{project_id}/assets/{resource_type}/{resource_id}")
+	@LogRestClientTime
 	Response deleteAsset(
 		@PathParam("project_id") String projectId,
 		@PathParam("resource_type") String type, // ResourceType

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProvenanceProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProvenanceProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Provenance;
 import software.uncharted.terarium.hmiserver.models.dataservice.ProvenanceQueryParam;
 
@@ -13,16 +14,19 @@ import javax.ws.rs.core.Response;
 @Produces(MediaType.APPLICATION_JSON)
 public interface ProvenanceProxy {
 	@GET
+	@LogRestClientTime
 	Response getProvenance();
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createProvenance(
 		Provenance provenance
 	);
 
 	@POST
 	@Path("/search")
+	@LogRestClientTime
 	Response search(
 		ProvenanceQueryParam body,
 		@QueryParam("search_type") String searchType
@@ -30,10 +34,12 @@ public interface ProvenanceProxy {
 
 	@DELETE
 	@Path("/hanging_nodes")
+	@LogRestClientTime
 	Response deleteHangingNodes();
 
 	@DELETE
 	@Path("/{id}")
+	@LogRestClientTime
 	Response deleteProvenance(
 		@PathParam("id") String id
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/SimulationProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/SimulationProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.PresignedURL;
 
@@ -17,17 +18,20 @@ public interface SimulationProxy {
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Simulation getSimulation(
 		@PathParam("id") String id
 	);
 
 	@POST
+	@LogRestClientTime
 	Simulation createSimulation(
 		JsonNode simulation
 	);
 
 	@PATCH
 	@Path("/{id}")
+	@LogRestClientTime
 	Simulation updateSimulation(
 		@PathParam("id") String id,
 		Simulation simulation
@@ -35,12 +39,14 @@ public interface SimulationProxy {
 
 	@DELETE
 	@Path("/{id}")
+	@LogRestClientTime
 	String deleteSimulation(
 		@PathParam("id") String id
 	);
 
 	@GET
 	@Path("/{id}/upload-url")
+	@LogRestClientTime
 	PresignedURL getUploadURL(
 		@PathParam("id") String id,
 		@QueryParam("filename") String filename
@@ -48,6 +54,7 @@ public interface SimulationProxy {
 
 	@GET
 	@Path("/{id}/download-url")
+	@LogRestClientTime
 	PresignedURL getDownloadURL(
 		@PathParam("id") String id,
 		@QueryParam("filename") String filename

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/WorkflowProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/WorkflowProxy.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.proxies.dataservice;
 
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.dataservice.Workflow;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -17,10 +18,12 @@ import java.util.*;
 public interface WorkflowProxy {
 	@GET
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response getWorkflows();
 
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response createWorkflow(
 		Workflow workflow
 	);
@@ -28,6 +31,7 @@ public interface WorkflowProxy {
 	@PUT
 	@Path("/{id}")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response updateWorkflow(
 		@PathParam("id") String id,
 		Workflow workflow
@@ -36,6 +40,7 @@ public interface WorkflowProxy {
 
 	@GET
 	@Path("/{id}")
+	@LogRestClientTime
 	Response getWorkflowById(
 		@PathParam("id") String id
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.documentservice;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.*;
 
@@ -14,6 +15,7 @@ import javax.ws.rs.core.MediaType;
 public interface DocumentProxy {
 	@GET
 	@Path("/api/v2/articles")
+	@LogRestClientTime
 	XDDResponse<DocumentsResponseOK> getDocuments(
 		@QueryParam("api_key") String apiKey,
 		@QueryParam("docid") String docid,

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ESSearchProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ESSearchProxy.java
@@ -1,11 +1,8 @@
 package software.uncharted.terarium.hmiserver.proxies.documentservice;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 
 import javax.ws.rs.HeaderParam;
@@ -14,7 +11,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
 
 /**
  * This is a temporary proxy as currently the ES endpoint is just on xDD's development
@@ -35,6 +31,7 @@ public interface ESSearchProxy {
 	 */
 	@POST
 	@Path("/es")
+	@LogRestClientTime
 	Response search(@HeaderParam("x-api-key") final String apiKey, final String data);
 
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
@@ -2,15 +2,14 @@ package software.uncharted.terarium.hmiserver.proxies.documentservice;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.models.documentservice.autocomplete.AutoComplete;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDExtractionsResponseOK;
 import software.uncharted.terarium.hmiserver.resources.documentservice.responses.XDDResponse;
 
-import javax.management.Query;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @RegisterRestClient(configKey = "xdd-document-service")
 @Produces(MediaType.APPLICATION_JSON)
@@ -18,6 +17,7 @@ import javax.ws.rs.core.Response;
 public interface ExtractionProxy {
 	@GET
 	@Path("/askem/object")
+	@LogRestClientTime
 	XDDResponse<XDDExtractionsResponseOK> getExtractions(
 		@QueryParam("doi") final String doi,
 		@QueryParam("query_all") final String queryAll,
@@ -29,6 +29,7 @@ public interface ExtractionProxy {
 
 	@GET
 	@Path("askem_autocomplete/{term}")
+	@LogRestClientTime
 	AutoComplete getAutocomplete(
 		@PathParam("term") final String term
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/github/GithubProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/github/GithubProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.github;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.code.GithubFile;
 
 import javax.ws.rs.*;
@@ -10,9 +11,10 @@ import java.util.List;
 
 @RegisterRestClient(configKey = "github")
 public interface GithubProxy {
-    @GET
+	@GET
 	@Path("/repos/{repoOwnerAndName}/contents/{path}")
-		List<GithubFile> getGithubRepositoryContent(
+	@LogRestClientTime
+	List<GithubFile> getGithubRepositoryContent(
 		@PathParam("repoOwnerAndName") String repoOwnerAndName,
 		@PathParam("path") String path
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/jsdelivr/JsDelivrProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/jsdelivr/JsDelivrProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.jsdelivr;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 
 import javax.ws.rs.*;
 import javax.ws.rs.GET;
@@ -9,8 +10,9 @@ import javax.ws.rs.core.Response;
 
 @RegisterRestClient(configKey = "jsdelivr")
 public interface JsDelivrProxy {
-    @GET
+	@GET
 	@Path("/gh/{repoOwnerAndName}@latest/{path}")
+	@LogRestClientTime
 	String getGithubCode(
 		@PathParam("repoOwnerAndName") String repoOwnerAndName,
 		@PathParam("path") String path

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/mira/DKGProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/mira/DKGProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.mira;
 
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.exceptions.HmiResponseExceptionMapper;
 import software.uncharted.terarium.hmiserver.models.mira.DKG;
 
@@ -17,12 +18,14 @@ import java.util.List;
 public interface DKGProxy {
 	@GET
 	@Path("/entity/{curie}")
+	@LogRestClientTime
 	DKG getEntity(
 		@PathParam("curie") final String curie
 	);
 
 	@GET
 	@Path("/entities/{curies}")
+	@LogRestClientTime
 	List<DKG> getEntities(
 		@PathParam("curies") final String curies
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/mit/MitProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/mit/MitProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.mit;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.modelservice.PetriNet;
 
 import javax.ws.rs.GET;
@@ -14,21 +15,25 @@ import java.util.List;
 public interface MitProxy {
 	@POST
 	@Path("/petri/get_places")
+	@LogRestClientTime
 	String getPlaces(
 		@QueryParam("code") final String code);
 
 	@POST
 	@Path("/petri/get_transitions")
+	@LogRestClientTime
 	String getTransitions(
 		@QueryParam("code") final String code);
 
 	@POST
 	@Path("/petri/get_arcs")
+	@LogRestClientTime
 	String getArcs(
 		@QueryParam("code") final String code);
 
 	@POST
 	@Path("/petri/get_pyacset")
+	@LogRestClientTime
 	String getPyAcset(
 		@QueryParam("places_str") final String places,
 		@QueryParam("transitions_str") final String transitions,
@@ -37,6 +42,7 @@ public interface MitProxy {
 
 	@POST
 	@Path("/annotation/find_text_vars")
+	@LogRestClientTime
 	String findTextVars(
 		@QueryParam("async") final String async,
 		@QueryParam("text") final String text
@@ -44,6 +50,7 @@ public interface MitProxy {
 
 	@POST
 	@Path("/annotation/link_annos_to_pyacset")
+	@LogRestClientTime
 	String linkAnnotationsToAcset(
 		@QueryParam("pyacset_str") final String pyacset,
 		@QueryParam("annotations_str") final String annotations,
@@ -52,6 +59,7 @@ public interface MitProxy {
 
 	@POST
 	@Path("/annotation/link_dataset_col_to_dkg")
+	@LogRestClientTime
 	String linkDatasetColToDKG(
 		@QueryParam("csv_str") final String csv,
 		@QueryParam("doc") final String doc
@@ -59,5 +67,6 @@ public interface MitProxy {
 
 	@GET
 	@Path("/response")
+	@LogRestClientTime
 	String getResponse(@QueryParam("id") final String id);
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/modelservice/ModelServiceProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/modelservice/ModelServiceProxy.java
@@ -4,6 +4,7 @@ import software.uncharted.terarium.hmiserver.models.modelservice.StratifyRequest
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.modelservice.PetriNet;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -16,6 +17,7 @@ public interface ModelServiceProxy {
 	@Path("/api/petri-to-latex")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.TEXT_PLAIN)
+	@LogRestClientTime
 	Response petrinetToLatex(
 			PetriNet content
 	);
@@ -24,6 +26,7 @@ public interface ModelServiceProxy {
 	@Path("/api/stratify")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response stratify(
 			StratifyRequest req
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/simulationservice/SimulationServiceProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/simulationservice/SimulationServiceProxy.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.simulationservice.SimulationRequest;
 import software.uncharted.terarium.hmiserver.models.simulationservice.CalibrationRequest;
 import software.uncharted.terarium.hmiserver.models.simulationservice.JobResponse;
@@ -17,6 +19,7 @@ public interface SimulationServiceProxy {
 	@POST
 	@Path("/simulate")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	JobResponse makeForecastRun(
 		JsonNode request
 	);
@@ -24,6 +27,7 @@ public interface SimulationServiceProxy {
 	@POST
 	@Path("/calibrate")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	JobResponse makeCalibrateJob(
 		JsonNode request
 	);
@@ -31,6 +35,7 @@ public interface SimulationServiceProxy {
 	@GET
 	@Path("/runs/{runId}/status")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response getRunStatus(
 		@PathParam("runId") String runId
 	);
@@ -38,6 +43,7 @@ public interface SimulationServiceProxy {
 	@GET
 	@Path("/runs/{runId}/result")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response getRunResult(
 		@PathParam("runId") String runId
 	);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaProxy.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.proxies.skema;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 import software.uncharted.terarium.hmiserver.models.code.CodeRequest;
 
 import javax.ws.rs.POST;
@@ -19,5 +20,6 @@ public interface SkemaProxy {
 	@POST
 	@Path("/fn-given-filepaths")
 	@Produces(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response getFunctionNetwork(CodeRequest request);
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaRustProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaRustProxy.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.proxies.skema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import software.uncharted.terarium.hmiserver.annotations.LogRestClientTime;
 
 import java.util.List;
 import javax.ws.rs.Consumes;
@@ -23,6 +24,7 @@ public interface SkemaRustProxy {
 	@POST
 	@Path("/models")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response addModel(String functionNetwork);
 
 	/**
@@ -32,6 +34,7 @@ public interface SkemaRustProxy {
 	 */
 	@GET
 	@Path("/models/{modelId}/named_opis")
+	@LogRestClientTime
 	Response getModelNamedOpis(@PathParam("modelId") String modelId);
 
 	/**
@@ -41,16 +44,19 @@ public interface SkemaRustProxy {
 	 */
 	@GET
 	@Path("/models/{modelId}/named_opos")
+	@LogRestClientTime
 	Response getModelNamedOpos(@PathParam("modelId") String modelId);
 
 
 	@PUT
 	@Path("/mathml/acset")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response convertMathML2ACSet(List<String> mathML);
 
 	@PUT
 	@Path("/mathml/amr")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@LogRestClientTime
 	Response convertMathML2AMR(JsonNode request);
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/services/StructuredLog.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/services/StructuredLog.java
@@ -18,7 +18,8 @@ public class StructuredLog {
 	public enum Type {
 		REQUEST_STARTED,
 		REQUEST_COMPLETED,
-		EVENT
+		EVENT,
+		PROXY_REQUEST
 	}
 
 	@ConfigProperty(name = "quarkus.log.console.json", defaultValue = "false")
@@ -46,7 +47,9 @@ public class StructuredLog {
 
 			if (keyValuePairs != null) {
 				for (int i = 0; i < keyValuePairs.length; i += 2) {
-					data.put(keyValuePairs[i].toString(), keyValuePairs[i + 1]);
+					if (keyValuePairs[i + 1] != null) {
+						data.put(keyValuePairs[i].toString(), keyValuePairs[i + 1]);
+					}
 				}
 			}
 			log.info(asJsonString(data));


### PR DESCRIPTION
This adds an annotation for recording structured timing logs for all proxy calls in terarium. 

**NOTE: This is a bit annoying/manual but was unfortunately the cleanest way I could get this to work in Quarkus.**

Example usage:
```java
package software.uncharted.terarium.hmiserver.proxies.myservice;

@RegisterRestClient(configKey = "test")
@Path("/hello")
public interface ExternalPerformerProxy {
	
	@Path("/world")
        @POST
	@LogRestClientTime(group = "external-performer-services")
	Response foo(String bar);
}
```

Would output
```
PROXY_REQUEST | adam | foo | software.uncharted.terarium.hmiserver.proxies.myservice.ExternalPerformerProxy | /hello/world | POST | external-performer-services | 104
```

We log:
- `PROXY_REQUEST` identifier
- The username of the user making the proxy, `Anonymous` if it is done on behalf of the system itself
- The name of the proxy method (in Java)
- The name of the parent class (the actual rest client)
- The rest path being executed
- The method type (`GET`, `POST`, etc)
- An optional `group` that can be specified on the annotation, if not provided, defaults to the package name for grouping
- The time in ms the call took


Example of output:
```
2023-07-13 10:29:52,656 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getProjects | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects | GET | dataservice | 45
2023-07-13 10:29:53,084 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getAssets | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects/{project_id}/assets | GET | dataservice | 428
2023-07-13 10:29:53,147 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getAssets | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects/{project_id}/assets | GET | dataservice | 62
2023-07-13 10:29:53,644 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getDocuments | software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy | /api/v2/articles | GET | documentservice | 419
2023-07-13 10:29:54,412 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-1) PROXY_REQUEST | adam | getDocuments | software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy | /api/v2/articles | GET | documentservice | 1813
2023-07-13 10:29:54,541 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-1) PROXY_REQUEST | adam | searchConceptsUsingFacets | software.uncharted.terarium.hmiserver.proxies.dataservice.ConceptProxy | /concepts/facets | GET | dataservice | 6
2023-07-13 10:30:14,356 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-1) PROXY_REQUEST | adam | getProjects | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects | GET | dataservice | 5
2023-07-13 10:30:14,358 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getProject | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects/{id} | GET | dataservice | 6
2023-07-13 10:30:14,683 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-0) PROXY_REQUEST | adam | getAssets | software.uncharted.terarium.hmiserver.proxies.dataservice.ProjectProxy | /projects/{project_id}/assets | GET | dataservice | 301
```
