### PR TITLE
feat: add route timing

### DIFF
--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -53,7 +53,7 @@ logger.info('Application Mounted', { showToast: false, silent: true });
 let previousRoute;
 let routeStartedMillis = Date.now();
 const resources = useResourcesStore();
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
 	if (previousRoute) {
 		const nowMillis = Date.now();
 		const timeSpent = nowMillis - routeStartedMillis;

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -61,12 +61,14 @@ router.beforeEach((to, from, next) => {
 			EventType.RouteTiming,
 			resources.activeProject?.id,
 			JSON.stringify({
-				name: previousRoute,
+				name: previousRoute.name,
+				path: previousRoute.path,
+				fullPath: previousRoute.fullPath,
 				timeSpent
 			})
 		);
 	}
-	previousRoute = to.name;
+	previousRoute = to;
 	routeStartedMillis = Date.now();
 	next();
 });

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -10,6 +10,9 @@ import VueFeather from 'vue-feather';
 import VueGtag from 'vue-gtag';
 import { MathfieldElement } from 'mathlive';
 import VueKatex from '@hsorby/vue3-katex';
+import { EventType } from '@/types/Types';
+import * as EventService from '@/services/event';
+import useResourcesStore from '@/stores/resources';
 import useAuthStore from './stores/auth';
 import router from './router';
 import '@node_modules/katex/dist/katex.min.css';
@@ -46,6 +49,27 @@ await auth.fetchSSO();
 
 app.mount('body');
 logger.info('Application Mounted', { showToast: false, silent: true });
+
+let previousRoute;
+let routeStartedMillis = Date.now();
+const resources = useResourcesStore();
+router.beforeEach((to, from, next) => {
+	if (previousRoute) {
+		const nowMillis = Date.now();
+		const timeSpent = nowMillis - routeStartedMillis;
+		EventService.create(
+			EventType.RouteTiming,
+			resources.activeProject?.id,
+			JSON.stringify({
+				name: previousRoute,
+				timeSpent
+			})
+		);
+	}
+	previousRoute = to.name;
+	routeStartedMillis = Date.now();
+	next();
+});
 
 // Allow the use of CSS custom properties
 declare module '@vue/runtime-dom' {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -492,6 +492,7 @@ export interface MetadataDataset {
 export enum EventType {
     Search = "SEARCH",
     EvaluationScenario = "EVALUATION_SCENARIO",
+    RouteTiming = "ROUTE_TIMING",
 }
 
 export enum FileType {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/EventType.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 public enum EventType {
 	SEARCH(true),
-	EVALUATION_SCENARIO(false);
+	EVALUATION_SCENARIO(false),
+	ROUTE_TIMING(false);
 
 	EventType(boolean persistent) {
 		this.persistent = persistent;


### PR DESCRIPTION
This adds a hook on route navigation the measures the time spent on each route and logs it as a transient event.  Example output:

```
2023-07-13 11:28:00,683 INFO  [sof.unc.ter.hmi.ser.StructuredLog] (executor-thread-7) EVENT | adam | Event(id=c47fdb8b-7d05-4b25-a9dc-6723bd9332d9, timestampMillis=1689262080683, projectId=1, username=adam, type=ROUTE_TIMING, value={"name":"project","path":"/projects/1","fullPath":"/projects/1","timeSpent":561})
```

In this case, the user spent 20 seconds on the home screen