### PR TITLE
feat: reduce logspam by ignoring EventResource and LoggingResource

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/annotations/IgnoreRequestLogging.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/annotations/IgnoreRequestLogging.java
@@ -1,0 +1,11 @@
+package software.uncharted.terarium.hmiserver.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IgnoreRequestLogging {
+}

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/configuration/RequestLoggingRequestFilter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/configuration/RequestLoggingRequestFilter.java
@@ -1,6 +1,8 @@
 package software.uncharted.terarium.hmiserver.configuration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
+import software.uncharted.terarium.hmiserver.annotations.IgnoreRequestLogging;
 import software.uncharted.terarium.hmiserver.services.StructuredLog;
 
 import javax.inject.Inject;
@@ -20,11 +22,14 @@ public class RequestLoggingRequestFilter implements ContainerRequestFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws IOException {
-		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
-		structuredLog.log(StructuredLog.Type.REQUEST_STARTED, user,
-			"uri", requestContext.getUriInfo().getPath(),
-			"method", requestContext.getRequest().getMethod()
-		);
-		requestContext.setProperty(REQUEST_START_TIMESTAMP_MS, Instant.now().toEpochMilli());
+		final boolean shouldLog = ((PostMatchContainerRequestContext) requestContext).getResourceMethod().getMethod().getAnnotation(IgnoreRequestLogging.class) == null;
+		if (shouldLog) {
+			final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+			structuredLog.log(StructuredLog.Type.REQUEST_STARTED, user,
+				"uri", requestContext.getUriInfo().getPath(),
+				"method", requestContext.getRequest().getMethod()
+			);
+			requestContext.setProperty(REQUEST_START_TIMESTAMP_MS, Instant.now().toEpochMilli());
+		}
 	}
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/configuration/RequestLoggingResponseFilter.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/configuration/RequestLoggingResponseFilter.java
@@ -19,12 +19,15 @@ public class RequestLoggingResponseFilter implements ContainerResponseFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-		final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
-		final long durationMs = Instant.now().toEpochMilli() - (long)requestContext.getProperty(RequestLoggingRequestFilter.REQUEST_START_TIMESTAMP_MS);
-		structuredLog.log(StructuredLog.Type.REQUEST_COMPLETED, user,
-			"uri", requestContext.getUriInfo().getPath(),
-			"method", requestContext.getRequest().getMethod(),
-			"duration", durationMs
-		);
+		final boolean shouldLog = requestContext.getProperty(RequestLoggingRequestFilter.REQUEST_START_TIMESTAMP_MS) != null;
+		if (shouldLog) {
+			final String user = requestContext.getSecurityContext().getUserPrincipal() != null ? requestContext.getSecurityContext().getUserPrincipal().getName() : "Anonymous";
+			final long durationMs = Instant.now().toEpochMilli() - (long) requestContext.getProperty(RequestLoggingRequestFilter.REQUEST_START_TIMESTAMP_MS);
+			structuredLog.log(StructuredLog.Type.REQUEST_COMPLETED, user,
+				"uri", requestContext.getUriInfo().getPath(),
+				"method", requestContext.getRequest().getMethod(),
+				"duration", durationMs
+			);
+		}
 	}
 }

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/EventResource.java
@@ -3,6 +3,7 @@ package software.uncharted.terarium.hmiserver.resources;
 import io.quarkus.security.identity.SecurityIdentity;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import software.uncharted.terarium.hmiserver.annotations.IgnoreRequestLogging;
 import software.uncharted.terarium.hmiserver.entities.Event;
 import software.uncharted.terarium.hmiserver.models.EventType;
 import software.uncharted.terarium.hmiserver.services.StructuredLog;
@@ -56,6 +57,7 @@ public class EventResource {
 	 */
 	@POST
 	@Transactional
+	@IgnoreRequestLogging
 	public Response postEvent(final Event event) {
 		event.setUsername(securityIdentity.getPrincipal().getName());
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/loggingservice/LoggingResource.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.resources.loggingservice;
 
 import io.quarkus.security.identity.SecurityIdentity;
+import software.uncharted.terarium.hmiserver.annotations.IgnoreRequestLogging;
 import software.uncharted.terarium.hmiserver.services.LogMessage;
 import software.uncharted.terarium.hmiserver.services.LoggingService;
 
@@ -24,6 +25,7 @@ public class LoggingResource {
 
 	@POST
 	@Path("/logs")
+	@IgnoreRequestLogging
 	public Response echoLogs(LoggingService logData) {
 		for (LogMessage log : logData.getLogs()) {
 			logData.logMessage(log, securityIdentity.getPrincipal().getName());

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/services/LoggingService.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/services/LoggingService.java
@@ -14,6 +14,9 @@ public class LoggingService {
 	private List<LogMessage> logs;
 
 	public void logMessage(LogMessage logObj, String name) {
+		if (logObj.message == null || logObj.message.trim().isEmpty()) {
+			return;
+		}
 		String level = logObj.level;
 		String message = "HMI_LOG | " + name + " | " + logObj.message;
 		switch (level) {


### PR DESCRIPTION
Since these methods also produce descriptive logs, we should disable the request timing for them to improve readability of these logs.