### PR TITLE
feat: add the userid to GA data

### DIFF
--- a/packages/client/hmi-client/src/stores/auth.ts
+++ b/packages/client/hmi-client/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { config } from 'vue-gtag';
 
 /**
  * Decode the OIDC token for additional information
@@ -76,6 +77,11 @@ const useAuthStore = defineStore('auth', {
 
 						this.name = tokenInfo.name;
 						this.email = tokenInfo.email;
+
+						// Configure Google Analytics user_id property.  The preferred username is
+						// the username within Keycloak, or, when using GitHub authentication, the GitHub
+						// username.
+						config({ user_id: tokenInfo.preferred_username });
 					} catch (error) {
 						console.error('Unable to decode authentication token for additional user information');
 						this.name = null;


### PR DESCRIPTION
add the user_id field with either the github user or the anonymous user from keycloak