### PR TITLE
Jamie subtle transition on mouseover of workflow nodes

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow-node.vue
@@ -244,10 +244,26 @@ main {
 	user-select: none;
 	box-shadow: var(--overlayMenuShadow);
 }
+main::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	border-radius: var(--border-radius);
+	box-shadow: var(--overlayMenuShadowHover);
+	z-index: -1;
+	opacity: 0;
+	transition: opacity 0.075s ease-out;
+}
 
 main:hover {
-	box-shadow: var(--overlayMenuShadowHover);
 	z-index: 2;
+}
+
+main:hover::after {
+	opacity: 1;
 }
 
 main:hover > header {
@@ -264,6 +280,7 @@ header {
 	white-space: nowrap;
 	border-top-right-radius: var(--border-radius);
 	border-top-left-radius: var(--border-radius);
+	transition: background-color 0.075s ease-out;
 }
 
 header:hover {


### PR DESCRIPTION
I added a 75ms transition effect to the box-shadow and node header when hovering over the workflow nodes.

For good performance, I created an ::after element with the box-shadow and then animate the opacity of that instead of animating the box-shadow properties directly. If you're interested, I found the technique here: [https://tobiasahlin.com/blog/how-to-animate-box-shadow/](https://tobiasahlin.com/blog/how-to-animate-box-shadow).

BEFORE
![workflow nodes shadow no transition](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/23dc0357-c956-4ae0-8b61-f10845aceb2f)


AFTER
It's subtle but it feels more "complete".
![workflow nodes shadow transition](https://github.com/DARPA-ASKEM/Terarium/assets/120480244/13ad7c4b-a29b-4475-904d-81cd2c51860d)
