### PR TITLE
fix: delete timeseries when undefined

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
@@ -416,11 +416,11 @@ function setModelParameters() {
 			delete modelParameter.distribution;
 		} else if (extractions.value[activeIndex.value].type === ParamType.DISTRIBUTION) {
 			modelParameter.distribution = extractions.value[activeIndex.value].distribution;
-			delete modelMetadata.timeseries[modelParameter.id];
+			delete modelMetadata.timeseries?.[modelParameter.id];
 		} else {
 			// A constant
 			delete modelParameter.distribution;
-			delete modelMetadata.timeseries[modelParameter.id];
+			delete modelMetadata.timeseries?.[modelParameter.id];
 		}
 
 		updateModelConfigValue();


### PR DESCRIPTION
# Description

* do not throw an error when the timeseries parameter is undefined

Resolves #(issue)
