### PR TITLE
fix: persists timeseries variable when there is no metadata on the configuration

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
@@ -404,6 +404,9 @@ function setModelParameters() {
 			modelConfigurations.value[configIndex].configuration.semantics.ode[odeType][odeObjIndex];
 		modelParameter[valueName] = extractions.value[activeIndex.value].value;
 
+		if (!modelConfigurations.value[configIndex].configuration.metadata) {
+			modelConfigurations.value[configIndex].configuration.metadata = {};
+		}
 		const modelMetadata = modelConfigurations.value[configIndex].configuration.metadata;
 
 		modelParameter.name = extractions.value[activeIndex.value].name;


### PR DESCRIPTION
# Description

* timeseries variables will now persist when there is no metadata key on the model configuration.  The metadata key will be created
<img width="526" alt="Screenshot 2023-07-17 at 3 22 39 PM" src="https://github.com/DARPA-ASKEM/Terarium/assets/33158416/8d397e6f-b4b7-4e2c-baab-688077ba80d6">


https://github.com/DARPA-ASKEM/Terarium/assets/33158416/664d3ac4-403c-456d-ab1f-28587b931fc5




Resolves #(issue)
