### PR TITLE
fix: bug observables equations no saving name

### DIFF
--- a/packages/client/graph-scaffolder/src/types/index.ts
+++ b/packages/client/graph-scaffolder/src/types/index.ts
@@ -19,6 +19,7 @@ export interface INode<T> {
 	label: string;
 	type?: string;
 	state?: string;
+	expression?: string;
 	x: number;
 	y: number;
 	width: number;

--- a/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
+++ b/packages/client/hmi-client/src/components/mathml/tera-math-editor.vue
@@ -16,11 +16,7 @@
 					@click="isEditingEq ? (isEditingEquation = true) : null"
 					@focus="showKeyboard"
 					@blur="hideKeyboard"
-					@keyup="
-						latexTextInput = mathLiveField?.getValue('latex-unstyled')
-							? mathLiveField?.getValue('latex-unstyled')
-							: ''
-					"
+					@keyup="updateEquationMathField"
 				>
 				</math-field>
 				<section class="menu">
@@ -46,7 +42,7 @@
 						type="text"
 						aria-label="latexInput"
 						:unstyled="true"
-						@keyup="updateEquation"
+						@keyup="updateEquationLatex"
 						@click="isEditingEq ? (isEditingEquation = true) : null"
 					/>
 				</section>
@@ -75,6 +71,7 @@
 						class="control-button"
 						label="Save"
 						aria-label="Save"
+						:disabled="props.id === ''"
 						@click="isEditingEquation = false"
 					></Button>
 					<Button
@@ -134,11 +131,11 @@ const props = defineProps({
 	},
 	id: {
 		type: String,
-		default: 'New Id'
+		default: ''
 	},
 	name: {
 		type: String,
-		default: 'Name'
+		default: ''
 	},
 	showMetadata: {
 		type: Boolean,
@@ -189,7 +186,14 @@ const mathFieldStyle = computed(() => {
 	return props.isEditingEq ? `mathlive-equation editing` : `mathlive-equation`;
 });
 
-const updateEquation = () => {
+const updateEquationMathField = () => {
+	latexTextInput.value = mathLiveField.value?.getValue('latex-unstyled')
+		? mathLiveField.value?.getValue('latex-unstyled')
+		: '';
+	updateEquationLatex();
+};
+
+const updateEquationLatex = () => {
 	emit(
 		'equation-updated',
 		props.index,
@@ -218,6 +222,8 @@ watch(
 		if (props.latexEquation === '') {
 			isEditingEquation.value = true;
 		}
+		name.value = props.name;
+		id.value = props.id;
 		renderEquations();
 	}
 );

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -276,7 +276,6 @@ const editNodeObj = ref<AddStateObj>({
 let previousId: any = null;
 
 const addObservable = () => {
-	console.log('here');
 	isEditingObservables.value = true;
 	const obs: Observable = {
 		id: '',

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -376,14 +376,12 @@ const updateObservables = () => {
 		// update
 		emit(
 			'update-model-observables',
-			observablesRefs.value.map((eq, index) => ({
-				id: observablesRefs.value[index].id,
-				name: observablesRefs.value[index].name,
-				expression: observablesRefs.value[index].mathLiveField.value,
-				expression_mathml: observablesRefs.value[index].mathLiveField.getValue('math-ml'),
-				states: extractVariablesFromMathML(
-					observablesRefs.value[index].mathLiveField.getValue('math-ml')
-				)
+			observablesRefs.value.map((eq) => ({
+				id: eq.target.id,
+				name: eq.target.name,
+				expression: eq.target.mathLiveField.value,
+				expression_mathml: eq.target.mathLiveField.getValue('math-ml'),
+				states: extractVariablesFromMathML(eq.target.mathLiveField.getValue('math-ml'))
 			}))
 		);
 		observablesRefs.value.forEach((eq) => {

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -120,7 +120,7 @@
 							<Button
 								@click="updateObservables"
 								:label="isEditingObservables ? 'Update observable' : 'Edit observables'"
-								:disabled="observervablesList.filter((ob) => ob.id).length === 0"
+								:disabled="disableSaveObservable"
 								:class="
 									isEditingObservables ? 'p-button-sm' : 'p-button-sm p-button-outlined edit-button'
 								"
@@ -276,6 +276,7 @@ const editNodeObj = ref<AddStateObj>({
 let previousId: any = null;
 
 const addObservable = () => {
+	console.log('here');
 	isEditingObservables.value = true;
 	const obs: Observable = {
 		id: '',
@@ -336,6 +337,18 @@ const setNewObservables = (index: number, latexEq: string, mathmlEq: string) => 
 	emit('update-model-observables', observervablesList.value);
 };
 
+const disableSaveObservable = computed(() => {
+	const numEmptyObjservables = observervablesList.value.filter((ob) => ob.id === '').length;
+	if (observervablesList.value.length > 0 && numEmptyObjservables === 0) {
+		return false;
+	}
+	if (numEmptyObjservables > 0) {
+		return true;
+	}
+
+	return false;
+});
+
 // Updates the transition equations
 const updateRateEquation = (_index: number, latexEquation: string, mathml: string) => {
 	editNodeObj.value.expression = latexEquation;
@@ -365,11 +378,13 @@ const updateObservables = () => {
 		emit(
 			'update-model-observables',
 			observablesRefs.value.map((eq, index) => ({
-				id: eq.id || observablesRefs.value[index].id,
-				name: eq.name || observablesRefs.value[index].name,
-				expression: eq.mathLiveField.value,
-				expression_mathml: eq.mathLiveField.getValue('math-ml'),
-				states: extractVariablesFromMathML(eq.mathLiveField.getValue('math-ml'))
+				id: observablesRefs.value[index].id,
+				name: observablesRefs.value[index].name,
+				expression: observablesRefs.value[index].mathLiveField.value,
+				expression_mathml: observablesRefs.value[index].mathLiveField.getValue('math-ml'),
+				states: extractVariablesFromMathML(
+					observablesRefs.value[index].mathLiveField.getValue('math-ml')
+				)
 			}))
 		);
 		observablesRefs.value.forEach((eq) => {

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -118,9 +118,9 @@
 								class="p-button-sm p-button-outlined edit-button"
 							/>
 							<Button
-								v-if="observervablesList.length !== 0"
 								@click="updateObservables"
 								:label="isEditingObservables ? 'Update observable' : 'Edit observables'"
+								:disabled="observervablesList.filter((ob) => ob.id).length === 0"
 								:class="
 									isEditingObservables ? 'p-button-sm' : 'p-button-sm p-button-outlined edit-button'
 								"

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -304,6 +304,7 @@ export const updateRateExpressionWithParam = (
 		expressionMathml = transitionExpression;
 	}
 
+	rate.target = transition.id;
 	rate.expression = expression;
 	rate.expression_mathml = expressionMathml;
 };

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/extractionservice/ExtractionResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/extractionservice/ExtractionResource.java
@@ -1,6 +1,4 @@
 package software.uncharted.terarium.hmiserver.resources.extractionservice;
-
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;


### PR DESCRIPTION
# Description

Fixes the observable saving problem.  You **have to** make sure your equation contains an `=` sign in order for it to be valid.  It then assigns the left hand variables to the `ID` & `Name` for the `Observable`. 

Also includes other bug fixes such as double click to edit only enabled  in model editing mode and transitions equations not showing up after changing the transition id.