### PR TITLE
feat: datasets limit increase

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/DataExplorer.vue
@@ -602,7 +602,7 @@ onUnmounted(() => {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	height: var(--nav-bar-height);
+	height: var(--navbar-outer-height);
 }
 
 .facets-panel {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/DatasetProxy.java
@@ -87,7 +87,7 @@ public interface DatasetProxy {
 
 	@GET
 	List<Dataset> getDatasets(
-		@DefaultValue("500") @QueryParam("page_size") Integer pageSize,
+		@DefaultValue("1000") @QueryParam("page_size") Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") Integer page
 	);
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
@@ -165,7 +165,7 @@ public class DatasetResource extends DataStorageResource implements SnakeCaseRes
 
 	@GET
 	public List<Dataset> getDatasets(
-		@DefaultValue("500") @QueryParam("page_size") final Integer pageSize,
+		@DefaultValue("1000") @QueryParam("page_size") final Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") final Integer page
 	) {
 		return datasetProxy.getDatasets(pageSize, page);


### PR DESCRIPTION
# Description

We might have an issue or we are limited to 100 datasets at the time, and it might be because of `page_size` call to `data-service`.  It wasn't the case, but why not raise it to 1000 and call it a day.