### PR TITLE
feat: add sciml calibrate extras

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/calibrate-operation-julia.ts
+++ b/packages/client/hmi-client/src/components/workflow/calibrate-operation-julia.ts
@@ -9,9 +9,23 @@ export interface CalibrateMap {
 	datasetVariable: string;
 }
 
+export interface CalibrateExtraJulia {
+	numChains: number;
+	numIterations: number;
+	odeMethod: string;
+	calibrateMethod: string;
+}
+
+export enum CalibrateMethodOptions {
+	BAYESIAN = 'bayesian',
+	LOCAL = 'local',
+	GLOBAL = 'global'
+}
+
 export interface CalibrationOperationStateJulia {
 	chartConfigs: ChartConfig[];
 	mapping: CalibrateMap[];
+	extra: CalibrateExtraJulia;
 }
 
 export const CalibrationOperationJulia: Operation = {
@@ -52,7 +66,13 @@ export const CalibrationOperationJulia: Operation = {
 	initState: () => {
 		const init: CalibrationOperationStateJulia = {
 			chartConfigs: [],
-			mapping: [{ modelVariable: '', datasetVariable: '' }]
+			mapping: [{ modelVariable: '', datasetVariable: '' }],
+			extra: {
+				numChains: 4,
+				numIterations: 50,
+				odeMethod: 'default',
+				calibrateMethod: CalibrateMethodOptions.GLOBAL
+			}
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
@@ -139,12 +139,12 @@ import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vu
 import { CsvAsset, ModelConfiguration } from '@/types/Types';
 import Slider from 'primevue/slider';
 import InputNumber from 'primevue/inputnumber';
-import { setupModelInputJulia, setupDatasetInputJulia } from '@/services/calibrate-workflow';
+import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
 import { workflowEventBus } from '@/services/workflow';
 import TeraSimulateChart from './tera-simulate-chart.vue';
-import { CalibrationOperationStateJulia, CalibrateMap } from './calibrate-operation-julia';
+import { CalibrationOperationStateCiemss, CalibrateMap } from './calibrate-operation-ciemss';
 
 const props = defineProps<{
 	node: WorkflowNode;
@@ -177,7 +177,7 @@ const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
 
 // Tom TODO: Make this generic... its copy paste from node.
 const chartConfigurationChange = (index: number, config: ChartConfig) => {
-	const state: CalibrationOperationStateJulia = _.cloneDeep(props.node.state);
+	const state: CalibrationOperationStateCiemss = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
 	workflowEventBus.emitNodeStateChange({
@@ -188,7 +188,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 };
 
 const addChart = () => {
-	const state: CalibrationOperationStateJulia = _.cloneDeep(props.node.state);
+	const state: CalibrationOperationStateCiemss = _.cloneDeep(props.node.state);
 	state.chartConfigs.push(_.last(state.chartConfigs) as ChartConfig);
 
 	workflowEventBus.emitNodeStateChange({
@@ -206,7 +206,7 @@ function addMapping() {
 		datasetVariable: ''
 	});
 
-	const state: CalibrationOperationStateJulia = _.cloneDeep(props.node.state);
+	const state: CalibrationOperationStateCiemss = _.cloneDeep(props.node.state);
 	state.mapping = mapping.value;
 
 	workflowEventBus.emitNodeStateChange({
@@ -220,7 +220,7 @@ function addMapping() {
 watch(
 	() => modelConfigId.value,
 	async () => {
-		const { modelConfiguration, modelColumnNameOptions } = await setupModelInputJulia(
+		const { modelConfiguration, modelColumnNameOptions } = await setupModelInput(
 			modelConfigId.value
 		);
 		modelConfig.value = modelConfiguration;
@@ -234,7 +234,7 @@ watch(
 watch(
 	() => datasetId.value,
 	async () => {
-		const { filename, csv } = await setupDatasetInputJulia(datasetId.value);
+		const { filename, csv } = await setupDatasetInput(datasetId.value);
 		currentDatasetFileName.value = filename;
 		csvAsset.value = csv;
 		datasetColumnNames.value = csv?.headers;

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-julia.vue
@@ -138,7 +138,7 @@ import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vu
 import { CsvAsset, ModelConfiguration } from '@/types/Types';
 import Slider from 'primevue/slider';
 import InputNumber from 'primevue/inputnumber';
-import { setupModelInputJulia, setupDatasetInputJulia } from '@/services/calibrate-workflow';
+import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
 import { workflowEventBus } from '@/services/workflow';
@@ -219,7 +219,7 @@ function addMapping() {
 watch(
 	() => modelConfigId.value,
 	async () => {
-		const { modelConfiguration, modelColumnNameOptions } = await setupModelInputJulia(
+		const { modelConfiguration, modelColumnNameOptions } = await setupModelInput(
 			modelConfigId.value
 		);
 		modelConfig.value = modelConfiguration;
@@ -233,7 +233,7 @@ watch(
 watch(
 	() => datasetId.value,
 	async () => {
-		const { filename, csv } = await setupDatasetInputJulia(datasetId.value);
+		const { filename, csv } = await setupDatasetInput(datasetId.value);
 		currentDatasetFileName.value = filename;
 		csvAsset.value = csv;
 		datasetColumnNames.value = csv?.headers;

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
@@ -117,7 +117,7 @@ import {
 	getSimulation,
 	getRunResultCiemss
 } from '@/services/models/simulation-service';
-import { setupModelInputJulia, setupDatasetInputJulia } from '@/services/calibrate-workflow';
+import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { workflowEventBus } from '@/services/workflow';
 import _ from 'lodash';
@@ -284,7 +284,7 @@ const addChart = () => {
 watch(
 	() => modelConfigId.value,
 	async () => {
-		const { modelConfiguration, modelColumnNameOptions } = await setupModelInputJulia(
+		const { modelConfiguration, modelColumnNameOptions } = await setupModelInput(
 			modelConfigId.value
 		);
 		modelConfig.value = modelConfiguration;
@@ -298,7 +298,7 @@ watch(
 watch(
 	() => datasetId.value,
 	async () => {
-		const { filename, csv } = await setupDatasetInputJulia(datasetId.value);
+		const { filename, csv } = await setupDatasetInput(datasetId.value);
 		currentDatasetFileName.value = filename;
 		csvAsset.value = csv;
 		datasetColumnNames.value = csv?.headers;

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -4,7 +4,7 @@ import { downloadRawFile, getDataset } from '@/services/dataset';
 
 // Used in the setup of calibration node and drill down
 // Takes a model config Id and grabs relevant objects
-export const setupModelInputJulia = async (modelConfigId: string | undefined) => {
+export const setupModelInput = async (modelConfigId: string | undefined) => {
 	if (modelConfigId) {
 		const modelConfiguration: ModelConfiguration = await getModelConfigurationById(modelConfigId);
 		// modelColumnNames.value = modelConfig.value.configuration.model.states.map((state) => state.name);
@@ -19,7 +19,7 @@ export const setupModelInputJulia = async (modelConfigId: string | undefined) =>
 
 // Used in the setup of calibration node and drill down
 // takes a datasetId and grabs relevant objects
-export const setupDatasetInputJulia = async (datasetId: string | undefined) => {
+export const setupDatasetInput = async (datasetId: string | undefined) => {
 	if (datasetId) {
 		// Get dataset:
 		const dataset: Dataset | null = await getDataset(datasetId);

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -73,8 +73,7 @@ export const addNode = (
 		width: options?.size?.width ?? defaultNodeSize.width,
 		height: options?.size?.height ?? defaultNodeSize.height
 	};
-
-	if (op.initState && !options.state) {
+	if (op.initState && _.isEmpty(node.state)) {
 		node.state = op.initState();
 	}
 


### PR DESCRIPTION
# Description

Cant test right now

Getting errors with Julia Calibrate.
1) timestep field needs to be timestamp field for them? (unlike ciemss)
2) Some unable to convert error:

Error: A job has failed: 9142270539727932323:
│   exception =
│    MethodError: Cannot `convert` an object of type Nothing to an object of type Tuple{Float64, Float64}
│
│    Closest candidates are:
│      convert(::Type{T}, ::T) where T<:Tuple
│       @ Base essentials.jl:411
│      convert(::Type{T}, ::Tuple{Vararg{Any, N}}) where {N, T<:Tuple}
│       @ Base essentials.jl:412
│      convert(::Type{T}, ::CartesianIndex) where T<:Tuple
│       @ Base multidimensional.jl:128
│      ...
│
│    Stacktrace:
│      [1] SimulationService.Calibrate(sys::ModelingToolkit.ODESystem, timespan::Nothing, priors::Vector{Union{Nothing, Pair{SymbolicUtils.BasicSymbolic{Real}, Distributions.Uniform{Float64}}}}, data::Vector{Pair{SymbolicUtils.BasicSymbolic{Real}, Tuple{Vector{Float64}, Vector{Float64}}}}, num_chains::Int64, num_iterations::Int64, calibrate_method::String, ode_method::Nothing)
│        @ SimulationService ~/simulation-scheduler/src/operations.jl:150
│      [2] SimulationService.Calibrate(o::SimulationService.OperationRequest)
│        @ SimulationService ~/simulation-scheduler/src/operations.jl:176
│      [3] solve(o::SimulationService.OperationRequest)
│        @ SimulationService ~/simulation-scheduler/src/SimulationService.jl:230
│      [4] macro expansion
│        @ ~/simulation-scheduler/src/SimulationService.jl: