### PR TITLE
feat: add timespan to simulate and calibrate node

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/calibrate-operation-ciemss.ts
+++ b/packages/client/hmi-client/src/components/workflow/calibrate-operation-ciemss.ts
@@ -3,6 +3,7 @@ import { WorkflowPort, Operation, WorkflowOperationTypes } from '@/types/workflo
 // import { makeCalibrateJob } from '@/services/models/simulation-service';
 import { getModel } from '@/services/model';
 import { ChartConfig } from '@/types/SimulateConfig';
+import { TimeSpan } from '@/types/Types';
 
 export interface CalibrateMap {
 	modelVariable: string;
@@ -12,6 +13,7 @@ export interface CalibrateMap {
 export interface CalibrationOperationStateCiemss {
 	chartConfigs: ChartConfig[];
 	mapping: CalibrateMap[];
+	timeSpan: TimeSpan;
 }
 
 export const CalibrationOperationCiemss: Operation = {
@@ -52,7 +54,8 @@ export const CalibrationOperationCiemss: Operation = {
 	initState: () => {
 		const init: CalibrationOperationStateCiemss = {
 			chartConfigs: [],
-			mapping: [{ modelVariable: '', datasetVariable: '' }]
+			mapping: [{ modelVariable: '', datasetVariable: '' }],
+			timeSpan: { start: 0, end: 90 }
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
@@ -76,6 +76,19 @@
 					<Slider v-model="trainTestValue" />
 				</section>
 			</AccordionTab>
+			<AccordionTab>
+				<template #header> Simulation time range </template>
+				<div class="sim-tspan-container">
+					<div class="sim-tspan-group">
+						<label for="2">Start date</label>
+						<InputNumber id="2" class="p-inputtext-sm" v-model="timespan.start" />
+					</div>
+					<div class="sim-tspan-group">
+						<label for="3">End date</label>
+						<InputNumber id="3" class="p-inputtext-sm" v-model="timespan.end" />
+					</div>
+				</div>
+			</AccordionTab>
 		</Accordion>
 		<Accordion
 			v-if="calibrationView === CalibrationView.OUTPUT && modelConfig"
@@ -136,7 +149,7 @@ import AccordionTab from 'primevue/accordiontab';
 import TeraAsset from '@/components/asset/tera-asset.vue';
 import TeraModelDiagram from '@/components/models/tera-model-diagram.vue';
 import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
-import { CsvAsset, ModelConfiguration } from '@/types/Types';
+import { CsvAsset, ModelConfiguration, TimeSpan } from '@/types/Types';
 import Slider from 'primevue/slider';
 import InputNumber from 'primevue/inputnumber';
 import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
@@ -159,6 +172,7 @@ enum CalibrationView {
 const modelColumnNames = ref<string[] | undefined>();
 
 const calibrationView = ref(CalibrationView.INPUT);
+const timespan = ref<TimeSpan>(props.node.state.timeSpan);
 
 const trainTestValue = ref(80);
 
@@ -315,6 +329,19 @@ th {
 	width: 90%;
 	margin-top: 1rem;
 }
+
+.sim-tspan-container {
+	display: flex;
+	gap: 1em;
+}
+
+.sim-tspan-group {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+	flex-basis: 0;
+}
+
 img {
 	width: 20%;
 }

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
@@ -190,6 +190,8 @@ const runCalibrate = async () => {
 	const initialsObj = {};
 	const paramsObj = {};
 
+	const state = props.node.state;
+
 	initials.forEach((d) => {
 		initialsObj[d] = Math.random() * 100;
 	});
@@ -210,8 +212,8 @@ const runCalibrate = async () => {
 			method: method.value
 		},
 		timespan: {
-			start: 0,
-			end: 90
+			start: state.timeSpan.start,
+			end: state.timeSpan.end
 		},
 		engine: 'ciemss'
 	};


### PR DESCRIPTION
# Description

* Add timespan to simulate and calibrate node - it can now be populated from the sidepanel rather than it being statically added as `timespan: {start: 0, end: 90}`

<img width="1008" alt="Screenshot 2023-07-19 at 2 21 27 PM" src="https://github.com/DARPA-ASKEM/Terarium/assets/33158416/6860d06e-a71f-472b-8999-0393cd836dc5">
