### PR TITLE
refactor: replace `is-editable` instances with `feature-config` prop

### DIFF
--- a/packages/client/hmi-client/DEVELOPMENT.md
+++ b/packages/client/hmi-client/DEVELOPMENT.md
@@ -77,16 +77,17 @@ Basic rules to write organised code.
     </style>
     ```
 
-- Some components (e.g. `Model.vue`) will showcase an asset's attributes and allows users to edit them. However there are cases where we just want to show a more compact read-only version of these components. In these cases assign the flag `:is-editable="false"` for these components:
+- Asset components such as `tera-model.vue` will showcase an asset's attributes and allows users to edit them. However there are cases where we want a more read-only version these components as the user is outside of a working project (e.g. Explorer preview). In these cases assign the flag `:is-in-project="false"` for these components:
 
     ```html
-    <model 
+    <tera-model 
         :asset-id="previewItemId"
         :project="resources.activeProject" 
         :highlight="searchTerm"
-        :is-editable="false"
+        :is-in-project="false"
     />
     ```
+- By default components with the `is-in-project` prop is set to `true`. So this prop only has to specified if we want it to be `false`.
 
 ## Logging & Toasts
 

--- a/packages/client/hmi-client/DEVELOPMENT.md
+++ b/packages/client/hmi-client/DEVELOPMENT.md
@@ -77,17 +77,17 @@ Basic rules to write organised code.
     </style>
     ```
 
-- Asset components such as `tera-model.vue` will showcase an asset's attributes and allows users to edit them. However there are cases where we want a more read-only version these components as the user is outside of a working project (e.g. Explorer preview). In these cases assign the flag `:is-in-project="false"` for these components:
+- Asset components such as `tera-model.vue` will showcase an asset's attributes and allows users to edit them. However there are cases where we want a more read-only version these components as the user is outside of a working project (e.g. Explorer preview). In these cases assign the `feature-config` object for these components:
 
     ```html
     <tera-model 
         :asset-id="previewItemId"
         :project="resources.activeProject" 
         :highlight="searchTerm"
-        :is-in-project="false"
+        :feature-config="{ isPreview: true }"
     />
     ```
-- By default components with the `is-in-project` prop is set to `true`. So this prop only has to specified if we want it to be `false`.
+- By default components with the `isPreview` attribute is set to `false`. So this prop only has to specified if we want it to `true`. Feel free to add other attributes to the `feature-config` to further customize the component's features. 
 
 ## Logging & Toasts
 

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -73,7 +73,6 @@ defineExpose({
 	assetContainer
 });
 
-// Booleans default to false if not specified
 const props = defineProps({
 	name: {
 		type: String,
@@ -81,24 +80,25 @@ const props = defineProps({
 	},
 	overline: {
 		type: String,
-		default: ''
+		default: null
 	},
 	authors: {
 		type: String,
-		default: ''
+		default: null
 	},
 	doi: {
 		type: String,
-		default: ''
+		default: null
 	},
 	publisher: {
 		type: String,
-		default: ''
+		default: null
 	},
 	isInProject: {
 		type: Boolean,
 		default: true
 	},
+	// Booleans default to false if not specified
 	isNamingAsset: Boolean,
 	hideIntro: Boolean,
 	showStickyHeader: Boolean,

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -73,8 +73,7 @@ defineExpose({
 	assetContainer
 });
 
-// TODO: Look into getting rid of vue rule vue/require-default-prop - don't think its necessary
-// (Booleans default to false)
+// Booleans default to false if not specified
 const props = defineProps({
 	name: {
 		type: String,

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -6,7 +6,7 @@
 			<aside class="spread-out">
 				<slot name="edit-buttons" />
 				<Button
-					v-if="!isEditable"
+					v-if="isExplorerPreview"
 					icon="pi pi-times"
 					class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 					@click="emit('close-preview')"
@@ -49,7 +49,7 @@
 				</section>
 				<aside class="spread-out">
 					<Button
-						v-if="!isEditable"
+						v-if="isExplorerPreview"
 						icon="pi pi-times"
 						class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 						@click="emit('close-preview')"
@@ -73,18 +73,33 @@ defineExpose({
 	assetContainer
 });
 
-const props = defineProps<{
-	name: string;
-	overline?: string;
-	isEditable: boolean;
-	isNamingAsset?: boolean;
-	authors?: string;
-	doi?: string;
-	publisher?: string;
-	hideIntro?: boolean;
-	showStickyHeader?: boolean;
-	stretchContent?: boolean;
-}>();
+const props = defineProps({
+	name: {
+		type: String,
+		default: ''
+	},
+	overline: {
+		type: String,
+		default: ''
+	},
+	authors: {
+		type: String,
+		default: ''
+	},
+	doi: {
+		type: String,
+		default: ''
+	},
+	publisher: {
+		type: String,
+		default: ''
+	},
+	isExplorerPreview: Boolean,
+	isNamingAsset: Boolean,
+	hideIntro: Boolean,
+	showStickyHeader: Boolean,
+	stretchContent: Boolean
+});
 
 const emit = defineEmits(['close-preview']);
 

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -73,6 +73,8 @@ defineExpose({
 	assetContainer
 });
 
+// TODO: Look into getting rid of vue rule vue/require-default-prop - don't think its necessary
+// (Booleans default to false)
 const props = defineProps({
 	name: {
 		type: String,

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -6,7 +6,7 @@
 			<aside class="spread-out">
 				<slot name="edit-buttons" />
 				<Button
-					v-if="!isInProject"
+					v-if="featureConfig.isPreview"
 					icon="pi pi-times"
 					class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 					@click="emit('close-preview')"
@@ -49,7 +49,7 @@
 				</section>
 				<aside class="spread-out">
 					<Button
-						v-if="!isInProject"
+						v-if="featureConfig.isPreview"
 						icon="pi pi-times"
 						class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 						@click="emit('close-preview')"
@@ -64,8 +64,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, PropType } from 'vue';
 import Button from 'primevue/button';
+import { FeatureConfig } from '@/types/common';
 
 const assetContainer = ref();
 
@@ -94,9 +95,9 @@ const props = defineProps({
 		type: String,
 		default: null
 	},
-	isInProject: {
-		type: Boolean,
-		default: true
+	featureConfig: {
+		type: Object as PropType<FeatureConfig>,
+		default: { isPreview: false } as FeatureConfig
 	},
 	// Booleans default to false if not specified
 	isNamingAsset: Boolean,

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -6,7 +6,7 @@
 			<aside class="spread-out">
 				<slot name="edit-buttons" />
 				<Button
-					v-if="isExplorerPreview"
+					v-if="!isInProject"
 					icon="pi pi-times"
 					class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 					@click="emit('close-preview')"
@@ -49,7 +49,7 @@
 				</section>
 				<aside class="spread-out">
 					<Button
-						v-if="isExplorerPreview"
+						v-if="!isInProject"
 						icon="pi pi-times"
 						class="close p-button-icon-only p-button-text p-button-rounded p-button-icon-only-small"
 						@click="emit('close-preview')"
@@ -96,7 +96,10 @@ const props = defineProps({
 		type: String,
 		default: ''
 	},
-	isExplorerPreview: Boolean,
+	isInProject: {
+		type: Boolean,
+		default: true
+	},
 	isNamingAsset: Boolean,
 	hideIntro: Boolean,
 	showStickyHeader: Boolean,

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -2,7 +2,7 @@
 	<tera-asset
 		v-if="dataset"
 		:name="dataset?.name"
-		:is-explorer-preview="!isEditable"
+		:is-explorer-preview="!isInProject"
 		:stretch-content="datasetView === DatasetView.DATA"
 		@close-preview="emit('close-preview')"
 		ref="assetPanel"
@@ -24,7 +24,7 @@
 					:active="datasetView === DatasetView.DATA"
 				/>
 				<Button
-					v-if="isEditable"
+					v-if="isInProject"
 					class="p-button-secondary p-button-sm"
 					label="Transform"
 					icon="pi pi-sync"
@@ -32,7 +32,7 @@
 					:active="datasetView === DatasetView.LLM"
 				/>
 			</span>
-			<span v-if="datasetView === DatasetView.LLM && isEditable">
+			<span v-if="datasetView === DatasetView.LLM && isInProject">
 				<i class="pi pi-cog" @click="toggleSettingsMenu" />
 				<Menu ref="menu" id="overlay_menu" :model="items" :popup="true" />
 			</span>
@@ -326,7 +326,7 @@
 				</AccordionTab>
 			</Accordion>
 		</template>
-		<template v-else-if="datasetView === DatasetView.LLM && isEditable">
+		<template v-else-if="datasetView === DatasetView.LLM && isInProject">
 			<Suspense>
 				<tera-dataset-jupyter-panel
 					:asset-id="props.assetId"
@@ -340,7 +340,7 @@
 	</tera-asset>
 </template>
 <script setup lang="ts">
-import { computed, ref, watch, onUpdated, Ref } from 'vue';
+import { computed, ref, watch, onUpdated, Ref, PropType } from 'vue';
 import Accordion from 'primevue/accordion';
 import Button from 'primevue/button';
 import AccordionTab from 'primevue/accordiontab';
@@ -365,12 +365,24 @@ enum DatasetView {
 	DATA = 'data',
 	LLM = 'llm'
 }
-const props = defineProps<{
-	assetId: string;
-	isEditable: boolean;
-	highlight?: string;
-	project?: IProject;
-}>();
+const props = defineProps({
+	assetId: {
+		type: String,
+		required: true
+	},
+	isInProject: {
+		type: Boolean,
+		default: true
+	},
+	highlight: {
+		type: String,
+		default: null
+	},
+	project: {
+		type: Object as PropType<IProject> | null,
+		default: null
+	}
+});
 
 const gotEnrichedData = (payload) => {
 	enrichedData.value = payload;

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -2,7 +2,7 @@
 	<tera-asset
 		v-if="dataset"
 		:name="dataset?.name"
-		:is-editable="isEditable"
+		:is-explorer-preview="!isEditable"
 		:stretch-content="datasetView === DatasetView.DATA"
 		@close-preview="emit('close-preview')"
 		ref="assetPanel"
@@ -718,6 +718,7 @@ main :deep(.p-inputtext.p-inputtext-sm) {
 	display: flex;
 	justify-content: space-evenly;
 }
+
 .dataset-detail {
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -2,7 +2,7 @@
 	<tera-asset
 		v-if="dataset"
 		:name="dataset?.name"
-		:is-explorer-preview="!isInProject"
+		:is-in-project="isInProject"
 		:stretch-content="datasetView === DatasetView.DATA"
 		@close-preview="emit('close-preview')"
 		ref="assetPanel"

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -2,7 +2,7 @@
 	<tera-asset
 		v-if="dataset"
 		:name="dataset?.name"
-		:is-in-project="isInProject"
+		:feature-config="featureConfig"
 		:stretch-content="datasetView === DatasetView.DATA"
 		@close-preview="emit('close-preview')"
 		ref="assetPanel"
@@ -24,7 +24,7 @@
 					:active="datasetView === DatasetView.DATA"
 				/>
 				<Button
-					v-if="isInProject"
+					v-if="!featureConfig.isPreview"
 					class="p-button-secondary p-button-sm"
 					label="Transform"
 					icon="pi pi-sync"
@@ -32,7 +32,7 @@
 					:active="datasetView === DatasetView.LLM"
 				/>
 			</span>
-			<span v-if="datasetView === DatasetView.LLM && isInProject">
+			<span v-if="datasetView === DatasetView.LLM && !featureConfig.isPreview">
 				<i class="pi pi-cog" @click="toggleSettingsMenu" />
 				<Menu ref="menu" id="overlay_menu" :model="items" :popup="true" />
 			</span>
@@ -300,7 +300,7 @@
 				</AccordionTab>
 			</Accordion>
 		</template>
-		<template v-else-if="datasetView === DatasetView.LLM && isInProject">
+		<template v-else-if="datasetView === DatasetView.LLM && !featureConfig.isPreview">
 			<Suspense>
 				<tera-dataset-jupyter-panel
 					:asset-id="props.assetId"
@@ -332,6 +332,7 @@ import Menu from 'primevue/menu';
 import TeraRelatedPublications from '@/components/widgets/tera-related-publications.vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
+import { FeatureConfig } from '@/types/common';
 
 const enrichedData = ref();
 
@@ -345,9 +346,9 @@ const props = defineProps({
 		type: String,
 		required: true
 	},
-	isInProject: {
-		type: Boolean,
-		default: true
+	featureConfig: {
+		type: Object as PropType<FeatureConfig>,
+		default: { isPreview: false } as FeatureConfig
 	},
 	highlight: {
 		type: String,

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -260,18 +260,20 @@ const props = defineProps({
 		type: String,
 		required: true
 	},
+	highlight: {
+		type: String,
+		default: null
+	},
+	previewLineLimit: {
+		type: Number,
+		default: null
+	},
+
 	isInProject: {
 		type: Boolean,
 		default: true
 	},
-	highlight: {
-		type: [String, null],
-		default: null
-	},
-	previewLineLimit: {
-		type: [Number, null],
-		default: null
-	},
+
 	project: {
 		type: Object as PropType<IProject> | null,
 		default: null

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		v-if="doc"
-		:is-in-project="isInProject"
+		:feature-config="featureConfig"
 		:name="highlightSearchTerms(doc.title)"
 		:overline="highlightSearchTerms(doc.journal)"
 		:authors="formatDocumentAuthors(doc)"
@@ -14,7 +14,7 @@
 	>
 		<template #bottom-header-buttons>
 			<Button
-				v-if="!isInProject"
+				v-if="featureConfig.isPreview"
 				class="p-button-sm p-button-outlined"
 				icon="pi pi-external-link"
 				label="Open PDF"
@@ -149,7 +149,7 @@
 					<li class="extracted-item" v-for="(url, index) in githubUrls" :key="index">
 						<tera-import-github-file
 							:urlString="url"
-							:show-import-button="isInProject"
+							:show-import-button="!featureConfig.isPreview"
 							:project="project"
 							@open-code="openCode"
 						/>
@@ -238,7 +238,7 @@ import Message from 'primevue/message';
 import { getDocumentById, getXDDArtifacts } from '@/services/data';
 import { XDDExtractionType } from '@/types/XDD';
 import { getDocumentDoi, isModel, isDataset, isDocument } from '@/utils/data-util';
-import { CodeRequest, ResultType } from '@/types/common';
+import { CodeRequest, ResultType, FeatureConfig } from '@/types/common';
 import { getRelatedArtifacts } from '@/services/provenance';
 import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
 import TeraImportGithubFile from '@/components/widgets/tera-import-github-file.vue';
@@ -268,12 +268,10 @@ const props = defineProps({
 		type: Number,
 		default: null
 	},
-
-	isInProject: {
-		type: Boolean,
-		default: true
+	featureConfig: {
+		type: Object as PropType<FeatureConfig>,
+		default: { isPreview: false } as FeatureConfig
 	},
-
 	project: {
 		type: Object as PropType<IProject> | null,
 		default: null

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		v-if="doc"
-		:is-explorer-preview="!isInProject"
+		:is-in-project="isInProject"
 		:name="highlightSearchTerms(doc.title)"
 		:overline="highlightSearchTerms(doc.journal)"
 		:authors="formatDocumentAuthors(doc)"

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		v-if="doc"
-		:is-explorer-preview="!isEditable"
+		:is-explorer-preview="!isInProject"
 		:name="highlightSearchTerms(doc.title)"
 		:overline="highlightSearchTerms(doc.journal)"
 		:authors="formatDocumentAuthors(doc)"
@@ -14,7 +14,7 @@
 	>
 		<template #bottom-header-buttons>
 			<Button
-				v-if="!isEditable"
+				v-if="!isInProject"
 				class="p-button-sm p-button-outlined"
 				icon="pi pi-external-link"
 				label="Open PDF"
@@ -149,7 +149,7 @@
 					<li class="extracted-item" v-for="(url, index) in githubUrls" :key="index">
 						<tera-import-github-file
 							:urlString="url"
-							:show-import-button="isEditable"
+							:show-import-button="isInProject"
 							:project="project"
 							@open-code="openCode"
 						/>
@@ -227,7 +227,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch, onUpdated } from 'vue';
+import { computed, onMounted, ref, watch, onUpdated, PropType } from 'vue';
 import { isEmpty, isEqual, uniqWith } from 'lodash';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
@@ -255,13 +255,28 @@ enum DocumentView {
 	PDF = 'pdf'
 }
 
-const props = defineProps<{
-	xddUri: string;
-	isEditable: boolean;
-	highlight?: string;
-	previewLineLimit?: number;
-	project?: IProject;
-}>();
+const props = defineProps({
+	xddUri: {
+		type: String,
+		required: true
+	},
+	isInProject: {
+		type: Boolean,
+		default: true
+	},
+	highlight: {
+		type: [String, null],
+		default: null
+	},
+	previewLineLimit: {
+		type: [Number, null],
+		default: null
+	},
+	project: {
+		type: Object as PropType<IProject> | null,
+		default: null
+	}
+});
 
 const doc = ref<Document | null>(null);
 const pdfLink = ref<string | null>(null);

--- a/packages/client/hmi-client/src/components/documents/tera-document.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		v-if="doc"
-		:is-editable="isEditable"
+		:is-explorer-preview="!isEditable"
 		:name="highlightSearchTerms(doc.title)"
 		:overline="highlightSearchTerms(doc.journal)"
 		:authors="formatDocumentAuthors(doc)"

--- a/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-configuration.vue
@@ -7,7 +7,7 @@
 			<table class="p-datatable-table p-datatable-scrollable-table editable-cells-table">
 				<thead class="p-datatable-thead">
 					<!-- Table header 1st row: Column groups such asInitials, Parameters, Observables, etc. -->
-					<tr v-if="isEditable">
+					<tr v-if="!featureConfig.isPreview">
 						<th class="p-frozen-column"></th>
 						<th class="p-frozen-column second-frozen"></th>
 						<th v-for="({ name, colspan }, i) in tableHeaders" :colspan="colspan" :key="i">
@@ -277,6 +277,7 @@ import {
 } from '@/services/model-configurations';
 import { getModelConfigurations } from '@/services/model';
 import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
+import { FeatureConfig } from '@/types/common';
 
 enum ParamType {
 	CONSTANT = 'constant',
@@ -285,7 +286,7 @@ enum ParamType {
 }
 
 const props = defineProps<{
-	isEditable: boolean;
+	featureConfig: FeatureConfig;
 	model: Model;
 	calibrationConfig?: boolean;
 }>();
@@ -370,7 +371,7 @@ function openValueModal(
 	configIndex: number,
 	odeObjIndex: number
 ) {
-	if (props.isEditable) {
+	if (!props.featureConfig.isPreview) {
 		clearError();
 		activeIndex.value = 0;
 		openValueConfig.value = true;
@@ -598,6 +599,7 @@ onMounted(() => {
 	visibility: visible;
 	width: 100%;
 }
+
 .editable-cell-hidden {
 	display: flex;
 	justify-content: space-between;
@@ -626,6 +628,7 @@ td:has(.cell-input) {
 .p-datatable:deep(td) {
 	cursor: pointer;
 }
+
 .p-datatable:deep(td:focus) {
 	background-color: var(--primary-color-lighter);
 }
@@ -721,6 +724,7 @@ td:hover .cell-menu {
 	display: flex;
 	flex-direction: column;
 }
+
 .distribution-range {
 	white-space: nowrap;
 	color: var(--text-color-subdued);

--- a/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-diagram.vue
@@ -13,15 +13,13 @@
 								/>
 							</template>
 							<template #center>
-								<span class="toolbar-subgroup">
+								<span v-if="isEditing" class="toolbar-subgroup">
 									<Button
-										v-if="isEditing"
 										@click="prepareStateEdit()"
 										label="Add state"
 										class="p-button-sm p-button-outlined toolbar-button"
 									/>
 									<Button
-										v-if="isEditing"
 										@click="prepareTransitionEdit()"
 										label="Add transition"
 										class="p-button-sm p-button-outlined toolbar-button"
@@ -29,7 +27,7 @@
 								</span>
 							</template>
 							<template #end>
-								<span class="toolbar-subgroup">
+								<span v-if="isEditable" class="toolbar-subgroup">
 									<Button
 										v-if="isEditing"
 										@click="cancelEdit"
@@ -57,28 +55,26 @@
 				<TeraResizablePanel
 					:class="isEditingEQ ? `diagram-container-editing` : `diagram-container`"
 				>
-					<section class="controls">
-						<span v-if="props.isEditable" class="equation-edit-button">
-							<Button
-								v-if="isEditingEQ"
-								@click="cancelEditEquations"
-								label="Cancel"
-								class="p-button-sm p-button-outlined edit-button"
-								style="background-color: white"
-							/>
-							<Button
-								v-if="isEditingEQ"
-								@click="onClickUpdateModel"
-								label="Update model"
-								class="p-button-sm"
-							/>
-							<Button
-								v-else
-								@click="isEditingEQ = true"
-								label="Edit equation"
-								class="p-button-sm p-button-outlined edit-button"
-							/>
-						</span>
+					<section v-if="isEditable" class="controls">
+						<Button
+							v-if="isEditingEQ"
+							@click="cancelEditEquations"
+							label="Cancel"
+							class="p-button-sm p-button-outlined edit-button"
+							style="background-color: white"
+						/>
+						<Button
+							v-if="isEditingEQ"
+							@click="onClickUpdateModel"
+							label="Update model"
+							class="p-button-sm"
+						/>
+						<Button
+							v-else
+							@click="isEditingEQ = true"
+							label="Edit equation"
+							class="p-button-sm p-button-outlined edit-button"
+						/>
 					</section>
 					<section class="math-editor-container" :class="mathEditorSelected">
 						<tera-math-editor
@@ -109,23 +105,21 @@
 					:class="isEditingObservables ? `diagram-container-editing` : `diagram-container`"
 					:start-height="300"
 				>
-					<section class="controls">
-						<span v-if="props.isEditable" class="equation-edit-button">
-							<Button
-								v-if="isEditingObservables"
-								@click="cancelEditObservables"
-								label="Cancel"
-								class="p-button-sm p-button-outlined edit-button"
-							/>
-							<Button
-								@click="updateObservables"
-								:label="isEditingObservables ? 'Update observable' : 'Edit observables'"
-								:disabled="disableSaveObservable"
-								:class="
-									isEditingObservables ? 'p-button-sm' : 'p-button-sm p-button-outlined edit-button'
-								"
-							/>
-						</span>
+					<section v-if="isEditable" class="controls">
+						<Button
+							v-if="isEditingObservables"
+							@click="cancelEditObservables"
+							label="Cancel"
+							class="p-button-sm p-button-outlined edit-button"
+						/>
+						<Button
+							@click="updateObservables"
+							:label="isEditingObservables ? 'Update observable' : 'Edit observables'"
+							:disabled="disableSaveObservable"
+							:class="
+								isEditingObservables ? 'p-button-sm' : 'p-button-sm p-button-outlined edit-button'
+							"
+						/>
 					</section>
 					<section class="observable-editor-container">
 						<tera-math-editor
@@ -535,9 +529,9 @@ watch(
 		// Update the latex equations
 		if (latexEquationList.value.length > 0) {
 			/* TODO
-			    	We need to remedy the fact that the equations are not being updated;
-		        A proper merging of the equations is needed with a diff UI for the user.
-		        For now, we do nothing.
+					We need to remedy the fact that the equations are not being updated;
+				A proper merging of the equations is needed with a diff UI for the user.
+				For now, we do nothing.
 			 */
 		} else {
 			const latexFormula = await petriToLatex(convertAMRToACSet(props.model));

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		:name="name"
-		:is-in-project="isInProject"
+		:feature-config="featureConfig"
 		:is-naming-asset="isNamingModel"
 		:stretch-content="modelView === ModelView.MODEL"
 		@close-preview="emit('close-preview')"
@@ -38,7 +38,7 @@
 					:active="modelView === ModelView.NOTEBOOK"
 				/>
 			</span>
-			<template v-if="isInProject">
+			<template v-if="!featureConfig.isPreview">
 				<Button
 					icon="pi pi-ellipsis-v"
 					class="p-button-icon-only p-button-text p-button-rounded"
@@ -467,7 +467,7 @@
 		<template v-if="modelView === ModelView.MODEL">
 			<tera-model-diagram
 				:model="model"
-				:is-editable="isInProject"
+				:isEditable="!featureConfig.isPreview"
 				@update-model-content="updateModelContent"
 				@update-model-observables="updateModelObservables"
 			/>
@@ -476,9 +476,9 @@
 					<tera-stratified-model-configuration
 						v-if="model.semantics?.span"
 						:model="model"
-						:is-editable="isInProject"
+						:feature-config="featureConfig"
 					/>
-					<tera-model-configuration v-else :model="model" :is-editable="isInProject" />
+					<tera-model-configuration v-else :model="model" :feature-config="featureConfig" />
 				</AccordionTab>
 				<AccordionTab v-if="!isEmpty(relatedTerariumArtifacts)" header="Associated resources">
 					<DataTable :value="relatedTerariumModels">
@@ -575,7 +575,7 @@ import { getCuriesEntities } from '@/services/concept';
 import { createModel, addModelToProject, getModel, updateModel } from '@/services/model';
 import * as ProjectService from '@/services/project';
 import { getRelatedArtifacts } from '@/services/provenance';
-import { ResultType } from '@/types/common';
+import { ResultType, FeatureConfig } from '@/types/common';
 import { IProject, ProjectAssetTypes } from '@/types/Project';
 import { Model, Document, Dataset, ProvenanceType } from '@/types/Types';
 import { isModel, isDataset, isDocument } from '@/utils/data-util';
@@ -612,9 +612,9 @@ const props = defineProps({
 		default: '',
 		required: false
 	},
-	isInProject: {
-		type: Boolean,
-		default: true
+	featureConfig: {
+		type: Object as PropType<FeatureConfig>,
+		default: { isPreview: false } as FeatureConfig
 	}
 });
 

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		:name="name"
-		:is-editable="isEditable"
+		:is-explorer-preview="!isEditable"
 		:is-naming-asset="isNamingModel"
 		:stretch-content="modelView === ModelView.MODEL"
 		@close-preview="emit('close-preview')"

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -38,13 +38,14 @@
 					:active="modelView === ModelView.NOTEBOOK"
 				/>
 			</span>
-			<Button
-				v-if="isEditable"
-				icon="pi pi-ellipsis-v"
-				class="p-button-icon-only p-button-text p-button-rounded"
-				@click="toggleOptionsMenu"
-			/>
-			<Menu v-if="isEditable" ref="optionsMenu" :model="optionsMenuItems" :popup="true" />
+			<template v-if="isEditable">
+				<Button
+					icon="pi pi-ellipsis-v"
+					class="p-button-icon-only p-button-text p-button-rounded"
+					@click="toggleOptionsMenu"
+				/>
+				<Menu ref="optionsMenu" :model="optionsMenuItems" :popup="true" />
+			</template>
 			<Button
 				v-if="assetId === ''"
 				@click="createNewModel"
@@ -605,16 +606,12 @@ const props = defineProps({
 		type: String,
 		required: true
 	},
-	isEditable: {
-		type: Boolean,
-		default: false,
-		required: false
-	},
 	highlight: {
 		type: String,
 		default: '',
 		required: false
-	}
+	},
+	isEditable: Boolean
 });
 
 const openValueConfig = ref(false);

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		:name="name"
-		:is-explorer-preview="!isEditable"
+		:is-explorer-preview="!isInProject"
 		:is-naming-asset="isNamingModel"
 		:stretch-content="modelView === ModelView.MODEL"
 		@close-preview="emit('close-preview')"
@@ -38,7 +38,7 @@
 					:active="modelView === ModelView.NOTEBOOK"
 				/>
 			</span>
-			<template v-if="isEditable">
+			<template v-if="isInProject">
 				<Button
 					icon="pi pi-ellipsis-v"
 					class="p-button-icon-only p-button-text p-button-rounded"
@@ -466,7 +466,7 @@
 		<template v-if="modelView === ModelView.MODEL">
 			<tera-model-diagram
 				:model="model"
-				:is-editable="props.isEditable"
+				:is-editable="isInProject"
 				@update-model-content="updateModelContent"
 				@update-model-observables="updateModelObservables"
 			/>
@@ -475,9 +475,9 @@
 					<tera-stratified-model-configuration
 						v-if="model.semantics?.span"
 						:model="model"
-						:is-editable="props.isEditable"
+						:is-editable="isInProject"
 					/>
-					<tera-model-configuration v-else :model="model" :is-editable="props.isEditable" />
+					<tera-model-configuration v-else :model="model" :is-editable="isInProject" />
 				</AccordionTab>
 				<AccordionTab v-if="!isEmpty(relatedTerariumArtifacts)" header="Associated resources">
 					<DataTable :value="relatedTerariumModels">
@@ -611,7 +611,10 @@ const props = defineProps({
 		default: '',
 		required: false
 	},
-	isEditable: Boolean
+	isInProject: {
+		type: Boolean,
+		default: true
+	}
 });
 
 const openValueConfig = ref(false);

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-asset
 		:name="name"
-		:is-explorer-preview="!isInProject"
+		:is-in-project="isInProject"
 		:is-naming-asset="isNamingModel"
 		:stretch-content="modelView === ModelView.MODEL"
 		@close-preview="emit('close-preview')"

--- a/packages/client/hmi-client/src/components/models/tera-stratified-model-configuration.vue
+++ b/packages/client/hmi-client/src/components/models/tera-stratified-model-configuration.vue
@@ -6,7 +6,7 @@
 		<div class="p-datatable-wrapper">
 			<table class="p-datatable-table p-datatable-scrollable-table editable-cells-table">
 				<thead class="p-datatable-thead">
-					<tr v-if="isEditable">
+					<tr v-if="!featureConfig.isPreview">
 						<th class="p-frozen-column"></th>
 						<th class="p-frozen-column second-frozen"></th>
 						<th v-for="({ name, colspan }, i) in tableHeaders" :colspan="colspan" :key="i">
@@ -114,9 +114,10 @@ import {
 import { getModelConfigurations } from '@/services/model';
 import TeraStratifiedValueMatrix from '@/components/models/tera-stratified-value-matrix.vue';
 import { NodeType } from '@/model-representation/petrinet/petrinet-renderer';
+import { FeatureConfig } from '@/types/common';
 
 const props = defineProps<{
-	isEditable: boolean;
+	featureConfig: FeatureConfig;
 	model: Model;
 	calibrationConfig?: boolean;
 }>();
@@ -165,7 +166,7 @@ async function addModelConfiguration(config: ModelConfiguration) {
 }
 
 function openValueModal(id: string, configIndex: number) {
-	if (props.isEditable) {
+	if (!props.featureConfig.isPreview) {
 		const nodeType = baseModelStates.value.includes(id) ? NodeType.State : NodeType.Transition;
 
 		activeIndex.value = 0;

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
@@ -1,6 +1,6 @@
 <template>
 	<!--Probably rename tera-asset to something even more abstract-->
-	<tera-asset :name="'Calibrate & Simulate (probabilistic)'" is-editable stretch-content>
+	<tera-asset :name="'Calibrate & Simulate (probabilistic)'" stretch-content>
 		<template #edit-buttons>
 			<span class="p-buttonset">
 				<Button
@@ -283,11 +283,13 @@ watch(
 	padding: 0rem 0.25rem 0.5rem 0rem !important;
 	border: none !important;
 }
+
 .mapping-table:deep(th) {
 	padding: 0rem 0.25rem 0.5rem 0.25rem !important;
 	border: none !important;
 	width: 50%;
 }
+
 .dropdown-button {
 	width: 156px;
 	height: 25px;
@@ -308,11 +310,13 @@ watch(
 th {
 	text-align: left;
 }
+
 .column-header {
 	color: var(--text-color-primary);
 	font-size: var(--font-body-small);
 	font-weight: var(--font-weight-semibold);
 }
+
 .emptyState {
 	align-self: center;
 	display: flex;

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-julia.vue
@@ -1,6 +1,6 @@
 <template>
 	<!--Probably rename tera-asset to something even more abstract-->
-	<tera-asset :name="'Calibrate (deterministic)'" is-editable stretch-content>
+	<tera-asset :name="'Calibrate (deterministic)'" stretch-content>
 		<template #edit-buttons>
 			<span class="p-buttonset">
 				<Button
@@ -264,11 +264,13 @@ watch(
 	padding: 0rem 0.25rem 0.5rem 0rem !important;
 	border: none !important;
 }
+
 .mapping-table:deep(th) {
 	padding: 0rem 0.25rem 0.5rem 0.25rem !important;
 	border: none !important;
 	width: 50%;
 }
+
 .dropdown-button {
 	width: 156px;
 	height: 25px;
@@ -289,6 +291,7 @@ watch(
 th {
 	text-align: left;
 }
+
 .column-header {
 	color: var(--text-color-primary);
 	font-size: var(--font-body-small);
@@ -311,6 +314,7 @@ th {
 	width: 90%;
 	margin-top: 1rem;
 }
+
 img {
 	width: 20%;
 }

--- a/packages/client/hmi-client/src/components/workflow/tera-dataset-workflow-wrapper.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-dataset-workflow-wrapper.vue
@@ -1,6 +1,5 @@
 <template>
-	<tera-dataset :project="props.project" :asset-id="props.node.state.datasetId" :is-editable="true">
-	</tera-dataset>
+	<tera-dataset :project="props.project" :asset-id="props.node.state.datasetId" />
 </template>
 
 <script setup lang="ts">

--- a/packages/client/hmi-client/src/components/workflow/tera-model-workflow-wrapper.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-model-workflow-wrapper.vue
@@ -1,6 +1,5 @@
 <template>
-	<tera-model :project="props.project" :asset-id="props.node.state.modelId" :is-editable="true">
-	</tera-model>
+	<tera-model :project="props.project" :asset-id="props.node.state.modelId" />
 </template>
 
 <script setup lang="ts">

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
@@ -96,11 +96,15 @@
 				<Accordion :multiple="true" :active-index="[0, 1, 2]">
 					<AccordionTab>
 						<template #header> Model </template>
-						<model-diagram v-if="model" :model="model" :is-editable="false" />
+						<tera-model-diagram v-if="model" :model="model" :is-editable="false" />
 					</AccordionTab>
 					<AccordionTab>
 						<template #header> Model configuration </template>
-						<tera-model-configuration v-if="model" :model="model" :is-editable="false" />
+						<tera-model-configuration
+							v-if="model"
+							:model="model"
+							:feature-config="{ isPreview: true }"
+						/>
 					</AccordionTab>
 					<AccordionTab>
 						<template #header> Simulation time range </template>
@@ -173,7 +177,7 @@ import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { getModel } from '@/services/model';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { getRunResultCiemss } from '@/services/models/simulation-service';
-import ModelDiagram from '@/components/models/tera-model-diagram.vue';
+import TeraModelDiagram from '@/components/models/tera-model-diagram.vue';
 import TeraModelConfiguration from '@/components/models/tera-model-configuration.vue';
 import SimulateChart from '@/components/workflow/tera-simulate-chart.vue';
 import { SimulateCiemssOperationState } from '@/components/workflow/simulate-ciemss-operation';
@@ -395,9 +399,11 @@ const rawDataRenderedRows = computed(() =>
 	margin: 0.5em;
 	position: relative;
 }
+
 .datatable-header-select-container {
 	min-width: 0;
 }
+
 .datatable-header-title {
 	white-space: nowrap;
 	margin-right: 1em;

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -26,7 +26,7 @@
 				:asset-id="previewItemId"
 				:project="(resources.activeProject as IProject)"
 				:highlight="searchTerm"
-				:is-editable="false"
+				:is-in-project="false"
 				@close-preview="closePreview"
 			/>
 		</template>

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -18,7 +18,7 @@
 				v-else-if="previewItemResourceType === ResourceType.DATASET"
 				:asset-id="previewItemId"
 				:highlight="searchTerm"
-				:is-editable="false"
+				:is-in-project="false"
 				@close-preview="closePreview"
 			/>
 			<tera-model

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -11,14 +11,14 @@
 				:xdd-uri="previewItemId"
 				:previewLineLimit="3"
 				:highlight="searchTerm"
-				:is-in-project="false"
+				:feature-config="{ isPreview: true }"
 				@close-preview="closePreview"
 			/>
 			<tera-dataset
 				v-else-if="previewItemResourceType === ResourceType.DATASET"
 				:asset-id="previewItemId"
 				:highlight="searchTerm"
-				:is-in-project="false"
+				:feature-config="{ isPreview: true }"
 				@close-preview="closePreview"
 			/>
 			<tera-model
@@ -26,7 +26,7 @@
 				:asset-id="previewItemId"
 				:project="(resources.activeProject as IProject)"
 				:highlight="searchTerm"
-				:is-in-project="false"
+				:feature-config="{ isPreview: true }"
 				@close-preview="closePreview"
 			/>
 		</template>

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -11,7 +11,7 @@
 				:xdd-uri="previewItemId"
 				:previewLineLimit="3"
 				:highlight="searchTerm"
-				:is-editable="false"
+				:is-in-project="false"
 				@close-preview="closePreview"
 			/>
 			<tera-dataset

--- a/packages/client/hmi-client/src/page/project/components/code-editor.vue
+++ b/packages/client/hmi-client/src/page/project/components/code-editor.vue
@@ -1,5 +1,5 @@
 <template>
-	<tera-asset name="New file" overline="Python" is-editable>
+	<tera-asset name="New file" overline="Python">
 		<template #edit-buttons>
 			<Button
 				label="Extract model"

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -1,11 +1,11 @@
 <template>
-	<div class="scrollable">
+	<main>
 		<tera-asset
 			:name="project?.name"
 			:authors="project?.username"
 			:is-naming-asset="isRenamingProject"
 			:publisher="`Last updated ${DateUtils.formatLong(project?.timestamp)}`"
-			is-editable
+			is-in-project
 			class="overview-banner"
 		>
 			<template #name-input>
@@ -276,9 +276,7 @@
 				</template>
 			</tera-modal>
 		</Teleport>
-	</div>
-	<!-- empty white div to fill bottom of screen -->
-	<div class="bottom-white-patch"></div>
+	</main>
 </template>
 
 <script setup lang="ts">
@@ -507,12 +505,15 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.scrollable {
+main {
 	overflow-y: auto;
-	-ms-overflow-style: none; /* IE and Edge */
-	scrollbar-width: none; /* Firefox */
+	-ms-overflow-style: none;
+	/* IE and Edge */
+	scrollbar-width: none;
+	/* Firefox */
 }
-.scrollable::-webkit-scrollbar {
+
+main::-webkit-scrollbar {
 	display: none;
 }
 
@@ -685,6 +686,7 @@ ul {
 	padding: 0;
 	padding: 0.375rem 1rem;
 }
+
 :deep(.p-datatable .p-datatable-thead > tr > th) {
 	background: var(--gray-100);
 	padding: 1rem;
@@ -735,10 +737,6 @@ ul {
 .no-results-found-message {
 	text-align: center;
 	width: 40%;
-}
-.bottom-white-patch {
-	background-color: var(--surface-0);
-	flex: 1;
 }
 
 :deep(.p-datatable-emptymessage > td) {

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -5,7 +5,6 @@
 			:authors="project?.username"
 			:is-naming-asset="isRenamingProject"
 			:publisher="`Last updated ${DateUtils.formatLong(project?.timestamp)}`"
-			is-in-project
 			class="overview-banner"
 		>
 			<template #name-input>

--- a/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
@@ -5,7 +5,6 @@
 		:project="project"
 		@update-tab-name="updateTabName"
 		@asset-loaded="emit('asset-loaded')"
-		is-editable
 	/>
 	<code-editor
 		v-else-if="pageType === ProjectAssetTypes.CODE"

--- a/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
@@ -48,7 +48,6 @@
 			:xdd-uri="getXDDuri(assetId)"
 			:previewLineLimit="10"
 			:project="project"
-			is-editable
 			@open-code="openCode"
 			@asset-loaded="emit('asset-loaded')"
 		/>

--- a/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
@@ -55,7 +55,6 @@
 			v-else-if="pageType === ProjectAssetTypes.DATASETS"
 			:project="project"
 			:asset-id="assetId"
-			is-editable
 			@asset-loaded="emit('asset-loaded')"
 		/>
 	</template>

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -15,6 +15,10 @@ export type Annotation = {
 	section: string;
 };
 
+export type FeatureConfig = {
+	isPreview: boolean;
+};
+
 // TODO: Wherever these are used - investigate using an actual map instead, this has been avoided due to v-model not playing well with maps
 // But a solution might be found here: https://stackoverflow.com/questions/37130105/does-vue-support-reactivity-on-map-and-set-data-types/64512468#64512468
 export interface StringValueMap {


### PR DESCRIPTION
# Description

Replace the prop `is-editable` with a `feature-config` object that is clearer and more customizable for configuring the features we want to use depending on the context.
