### PR TITLE
chore: clean use of simulate chart

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-ciemss.vue
@@ -25,8 +25,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="chartConfigurationChange(index, $event)"
 			/>
 			<Button
@@ -276,20 +274,6 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 		state
 	});
 };
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
-});
 
 const calculateWeights = () => {
 	if (!ensembleConfigs.value) return;

--- a/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
@@ -15,8 +15,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="chartConfigurationChange(index, $event)"
 			/>
 			<Button
@@ -174,20 +172,6 @@ const addChart = () => {
 		state
 	});
 };
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
-});
 
 // Set up csv + dropdown names
 // Note: Same as calibrate side panel

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
@@ -30,6 +30,13 @@ import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 
 const emit = defineEmits(['configuration-change']);
 
+const props = defineProps<{
+	runResults: RunResults;
+	chartConfig: ChartConfig;
+	lineColorArray?: string[];
+	lineWidthArray?: string[];
+}>();
+
 type DatasetType = {
 	data: number[];
 	label: string;
@@ -77,13 +84,6 @@ const CHART_OPTIONS = {
 		}
 	}
 };
-
-const props = defineProps<{
-	runResults: RunResults;
-	chartConfig: ChartConfig;
-	lineColorArray?: string[];
-	lineWidthArray?: string[];
-}>();
 
 // data for rendering ui
 let stateVariablesList: string[] = [];

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
@@ -34,24 +34,25 @@ const props = defineProps<{
 	runResults: RunResults;
 	chartConfig: ChartConfig;
 	lineColorArray?: string[];
-	lineWidthArray?: string[];
+	lineWidthArray?: number[];
 }>();
 
-const lineColorArray = computed(() => {
-	if (props.lineColorArray) return props.lineColorArray;
-
-	const output = Array(Math.max(Object.keys(props.runResults.value).length ?? 0 - 1, 0)).fill(
+const lineColorArray = computed<string[]>(() => {
+	if (props.lineColorArray !== undefined) {
+		return props.lineColorArray;
+	}
+	const output = Array(Math.max(Object.keys(props.runResults).length - 1 ?? 0 - 1, 0)).fill(
 		'#00000020'
 	);
 	output.push('#1b8073');
 	return output;
 });
 
-const lineWidthArray = computed(() => {
+const lineWidthArray = computed<number[]>(() => {
 	if (props.lineWidthArray) return props.lineWidthArray;
 
-	const output = Array(Math.max(Object.keys(props.runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
+	const output = Array(Math.max(Object.keys(props.runResults).length - 1 ?? 0 - 1, 0)).fill(1);
+	output.push(3);
 	return output;
 });
 
@@ -175,8 +176,8 @@ const renderGraph = () => {
 					label: `${runIdList[runIdx]} - ${variable}`,
 					fill: false,
 					tension: 0.4,
-					borderColor: lineColorArray[runIdx],
-					borderWidth: lineWidthArray[runIdx]
+					borderColor: lineColorArray.value[runIdx],
+					borderWidth: lineWidthArray.value[runIdx]
 				};
 				datasets.push(dataset);
 			})

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
@@ -37,6 +37,24 @@ const props = defineProps<{
 	lineWidthArray?: string[];
 }>();
 
+const lineColorArray = computed(() => {
+	if (props.lineColorArray) return props.lineColorArray;
+
+	const output = Array(Math.max(Object.keys(props.runResults.value).length ?? 0 - 1, 0)).fill(
+		'#00000020'
+	);
+	output.push('#1b8073');
+	return output;
+});
+
+const lineWidthArray = computed(() => {
+	if (props.lineWidthArray) return props.lineWidthArray;
+
+	const output = Array(Math.max(Object.keys(props.runResults.value).length ?? 0 - 1, 0)).fill(1);
+	output.push(2);
+	return output;
+});
+
 type DatasetType = {
 	data: number[];
 	label: string;
@@ -114,26 +132,10 @@ const getVariableColorByVar = (variableName: string) => {
 	return VIRIDIS_14[Math.floor((codeIdx / selectedVariable.value.length) * VIRIDIS_14.length)];
 };
 
-const getVariableColorByRunIdx = (runIdx: number) => {
-	const runIdList = Object.keys(props.runResults) as string[];
-	return VIRIDIS_14[Math.floor((runIdx / runIdList.length) * VIRIDIS_14.length)];
-};
-
 const hasMultiRuns = computed(() => {
 	const runIdList = Object.keys(props.runResults) as string[];
 	return runIdList.length > 1;
 });
-
-const getLineColor = (variableName: string, runIdx: number) => {
-	if (props.lineColorArray) {
-		return props.lineColorArray[runIdx];
-	}
-	return hasMultiRuns.value
-		? getVariableColorByRunIdx(runIdx)
-		: getVariableColorByVar(variableName);
-};
-
-const getLineWidth = (runIdx: number) => (props.lineWidthArray ? props.lineWidthArray[runIdx] : 2);
 
 const watchRunResults = async (runResults) => {
 	const runIdList = Object.keys(props.runResults) as string[];
@@ -173,8 +175,8 @@ const renderGraph = () => {
 					label: `${runIdList[runIdx]} - ${variable}`,
 					fill: false,
 					tension: 0.4,
-					borderColor: getLineColor(variable, runIdx),
-					borderWidth: getLineWidth(runIdx)
+					borderColor: lineColorArray[runIdx],
+					borderWidth: lineWidthArray[runIdx]
 				};
 				datasets.push(dataset);
 			})

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
@@ -6,8 +6,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="configurationChange(index, $event)"
 			/>
 		</div>
@@ -40,7 +38,7 @@
 
 <script setup lang="ts">
 import _ from 'lodash';
-import { ref, watch, computed, onMounted } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import Button from 'primevue/button';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
@@ -74,20 +72,6 @@ const completedRunIdList = ref<string[]>([]);
 const runResults = ref<RunResults>({});
 const runConfigs = ref<{ [paramKey: string]: number[] }>({});
 const renderedRuns = ref<RunResults>({});
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
-});
 
 const runSimulate = async () => {
 	const modelConfigurationList = props.node.inputs[0].value;

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
@@ -70,8 +70,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="configurationChange(index, $event)"
 			/>
 			<Button
@@ -267,20 +265,6 @@ onMounted(async () => {
 	parsedRawData.value = output.parsedRawData;
 	runResults.value = output.runResults;
 	runConfigs.value = output.runConfigs;
-});
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
 });
 
 // process run result data to create mean run line

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
@@ -107,17 +107,6 @@
 					<AccordionTab>
 						<template #header> Simulation time range </template>
 						<div class="sim-tspan-container">
-							<!--
-							<div class="sim-tspan-group">
-								<label for="1">Units</label>
-								<Dropdown
-									id="1"
-									class="p-inputtext-sm"
-									v-model=""
-									:options="TspanUnitList"
-								/>
-							</div>
-							-->
 							<div class="sim-tspan-group">
 								<label for="2">Start date</label>
 								<InputNumber

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-ciemss.vue
@@ -25,8 +25,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="chartConfigurationChange(index, $event)"
 			/>
 			<Button
@@ -259,20 +257,6 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 		state
 	});
 };
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
-});
 
 const calculateWeights = () => {
 	if (!ensembleConfigs.value) return;

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
@@ -15,8 +15,6 @@
 				:key="index"
 				:run-results="renderedRuns"
 				:chartConfig="cfg"
-				:line-color-array="lineColorArray"
-				:line-width-array="lineWidthArray"
 				@configuration-change="chartConfigurationChange(index, $event)"
 			/>
 			<Button
@@ -155,20 +153,6 @@ const updateOutputPorts = async (runId) => {
 		value: { runId }
 	});
 };
-
-const lineColorArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(
-		'#00000020'
-	);
-	output.push('#1b8073');
-	return output;
-});
-
-const lineWidthArray = computed(() => {
-	const output = Array(Math.max(Object.keys(runResults.value).length ?? 0 - 1, 0)).fill(1);
-	output.push(2);
-	return output;
-});
 
 watch(
 	() => modelConfigIds.value,

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-julia.vue
@@ -59,17 +59,6 @@
 					<AccordionTab>
 						<template #header> Simulation time range </template>
 						<div class="sim-tspan-container">
-							<!--
-							<div class="sim-tspan-group">
-								<label for="1">Units</label>
-								<Dropdown
-									id="1"
-									class="p-inputtext-sm"
-									v-model=""
-									:options="TspanUnitList"
-								/>
-							</div>
-							-->
 							<div class="sim-tspan-group">
 								<label for="2">Start date</label>
 								<InputNumber

--- a/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
@@ -115,10 +115,6 @@ const openWorkflow = async () => {
 	}
 	const wf = emptyWorkflow(wfName, '');
 
-	// FIXME: TDS bug thinks that k is z, June 2023
-	// @ts-ignore
-	wf.transform.z = 1;
-
 	// Add the workflow to the project
 	const response = await createWorkflow(wf);
 	const workflowId = response.id;


### PR DESCRIPTION
# Description
lets default the widths and colours and use those defaults instead of all the copy paste for same result
