### PR TITLE
fix: drilldown tab not showing

### DIFF
--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -43,7 +43,7 @@
 				<tera-tab-group
 					v-if="workflowNode"
 					class="tab-group"
-					:tabs="[]"
+					:tabs="[{ assetName: workflowNode.displayName }]"
 					:active-tab-index="0"
 					:loading-tab-index="null"
 					@close-tab="


### PR DESCRIPTION
### Summary
The previous assetName/tab changes accidentally removed the single-tab mechanism we currently have in the drilldown panel. This restores this functionality.

Note the drilldown is acting a bit strange, when opening with different zoom levels on the workflow canvas the tab can be rendered incorrectly. Not exactly sure why.


### Testing
Goto workflow
- select a node and open drilldown
- should be able to close drilldown