### PR TITLE
resolve _id vs id, _base vs base

### DIFF
--- a/packages/client/hmi-client/src/components/models/tera-stratified-value-matrix.vue
+++ b/packages/client/hmi-client/src/components/models/tera-stratified-value-matrix.vue
@@ -161,22 +161,17 @@ function configureMatrix() {
 	// Get only the states/transitions that are mapped to the base model
 	const matrixData =
 		props.nodeType === NodeType.State
-			? result.stateMatrixData.filter((d) => d._base === props.id)
-			: result.transitionMatrixData.filter((d) => d._base === props.id);
+			? result.stateMatrixData.filter((d) => d.base === props.id)
+			: result.transitionMatrixData.filter((d) => d.base === props.id);
 
 	if (isEmpty(matrixData)) return;
 
 	// Grab dimension names from the first matrix row
 	const dimensions = [cloneDeep(matrixData)[0]].map((d) => {
-		delete d._id;
-		delete d._base;
+		delete d.id;
+		delete d.base;
 		return Object.keys(d);
 	})[0];
-
-	// FIXME: resolve id vs _id
-	matrixData.forEach((d) => {
-		d.id = d._id;
-	});
 
 	rowDimensions.push(...dimensions);
 	colDimensions.push(...dimensions);

--- a/packages/client/hmi-client/src/model-representation/petrinet/catlab-petri.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/catlab-petri.ts
@@ -48,8 +48,8 @@ export const getCatlabStratasDataPoint = (amr: Model, id: string) => {
 		key = span[0].map.find((d: any) => d[0] === key)[1];
 		span = span[0].system.semantics.span;
 		if (!span) {
-			result._id = id;
-			result._base = key;
+			result.id = id;
+			result.base = key;
 			break;
 		}
 	}
@@ -91,8 +91,8 @@ export const getCatlabTransitionsMatrixData = (amr: Model) => {
 			key = span[0].map.find((d: any) => d[0] === key)[1];
 			span = span[0].system.semantics.span;
 			if (!span) {
-				result._base = key;
-				result._id = transition.id;
+				result.base = key;
+				result.id = transition.id;
 				break;
 			}
 		}

--- a/packages/client/hmi-client/src/model-representation/petrinet/mira-petri.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/mira-petri.ts
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import { Model, PetriNetTransition } from '@/types/Types';
 
+/**
+ * Note "id" and "base" used for building the compact graph, they should not be used as strata dimensions
+ */
 export const getStates = (amr: Model) => {
 	const model = amr.model;
 	const lookup = new Map();
@@ -14,7 +17,7 @@ export const getStates = (amr: Model) => {
 		const grounding = state.grounding;
 
 		const obj: any = {};
-		obj._id = state.id;
+		obj.id = state.id;
 
 		if (grounding && grounding.modifiers) {
 			const modifierKeys = Object.keys(grounding.modifiers);
@@ -23,7 +26,7 @@ export const getStates = (amr: Model) => {
 				str = str.replace(`_${grounding.modifiers[key]}`, '');
 				obj[key] = grounding.modifiers[key];
 			});
-			obj._base = str;
+			obj.base = str;
 
 			lookup.set(state.id, str);
 			if (!dupe.has(str)) {
@@ -35,7 +38,7 @@ export const getStates = (amr: Model) => {
 			}
 			dupe.add(str);
 		} else {
-			obj._base = state.id;
+			obj.base = state.id;
 			lookup.set(state.id, state.id);
 			if (!dupe.has(state.id)) {
 				uniqueStates.push({
@@ -51,6 +54,9 @@ export const getStates = (amr: Model) => {
 	return { uniqueStates, lookup, matrixData };
 };
 
+/**
+ * Note "id" and "base" used for building the compact graph, they should not be used as strata dimensions
+ */
 export const getTransitions = (amr: Model, lookup: Map<string, string>) => {
 	const model = amr.model;
 	const uniqueTransitions: Partial<PetriNetTransition>[] = [];
@@ -77,7 +83,7 @@ export const getTransitions = (amr: Model, lookup: Map<string, string>) => {
 		const newTransition = { id: '', input, output };
 
 		// Build matrixData array
-		obj._id = transition.id;
+		obj.id = transition.id;
 		transition.input.forEach((sid) => {
 			const modifiers = stateModifierMap.get(sid);
 			if (modifiers) {
@@ -93,9 +99,9 @@ export const getTransitions = (amr: Model, lookup: Map<string, string>) => {
 			const newId = `T${c++}`;
 			newTransition.id = newId;
 			uniqueTransitions.push(_.cloneDeep(newTransition));
-			obj._base = newId;
+			obj.base = newId;
 		} else {
-			obj._base = existingTransition.id;
+			obj.base = existingTransition.id;
 		}
 		matrixData.push(obj);
 	}

--- a/packages/client/hmi-client/src/temp/AMRPetriTest.vue
+++ b/packages/client/hmi-client/src/temp/AMRPetriTest.vue
@@ -80,12 +80,12 @@ onMounted(async () => {
 				// 1. Find what are the strata dimensions
 				const stateMatrixData = presentationData.stateMatrixData.map((d) => {
 					const temp: any = _.cloneDeep(d);
-					delete temp._id;
-					delete temp._base;
+					delete temp.id;
+					delete temp.base;
 					return Object.keys(temp);
 				});
 				const dims = _.uniq(_.flatten(stateMatrixData));
-				dims.unshift('_base');
+				dims.unshift('base');
 				const nestedMap = extractNestedStratas(presentationData.stateMatrixData, dims);
 
 				renderer = new NestedPetrinetRenderer({


### PR DESCRIPTION
### Summary
Cleans up field name usage. Previous I have used `_id` and `_base` to avoid naming collisions, but I think this is causing additional confusions elsewhere while avoid a potential problem that is not likely to occur: it is unlikely someone will call a strata "base" or "id". 

I think it is worth the risk here to just use "id" and "base" and avoid developer confusions. 