### PR TITLE
bug(client): related documents on home page broken

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -155,7 +155,7 @@ watch(
 		}
 
 		// Refetch the list of all projects
-		projects.value = await ProjectService.getAll();
+		projects.value = (await ProjectService.getAll()) as unknown as IProject[];
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/components/documents/tera-selected-document-pane.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-selected-document-pane.vue
@@ -86,7 +86,7 @@ const addAssetsToProject = async (projectName) => {
 };
 
 onMounted(async () => {
-	const all = await ProjectService.getAll();
+	const all = (await ProjectService.getAll()) as unknown as IProject[];
 	if (all !== null) {
 		projectsList.value = all;
 	}

--- a/packages/client/hmi-client/src/components/home/tera-project-card.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-card.vue
@@ -83,9 +83,9 @@ const stats = computed(() =>
 		? null
 		: {
 				contributors: 1,
-				models: props.project?.metadata['models-count'],
-				datasets: props.project?.metadata['datasets-count'],
-				papers: props.project?.metadata['publications-count']
+				models: props.project?.metadata?.['models-count'] ?? 0,
+				datasets: props.project?.metadata?.['datasets-count'] ?? 0,
+				papers: props.project?.metadata?.['publications-count'] ?? 0
 		  }
 );
 

--- a/packages/client/hmi-client/src/components/home/tera-project-card.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-card.vue
@@ -61,7 +61,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { IProject, ProjectAssetTypes } from '@/types/Project';
+import { Project } from '@/types/Types';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
 import Dialog from 'primevue/dialog';
@@ -73,9 +73,9 @@ import { logger } from '@/utils/logger';
 import * as ProjectService from '@/services/project';
 import DatasetIcon from '@/assets/svg/icons/dataset.svg?component';
 
-const props = defineProps<{ project?: IProject }>();
+const props = defineProps<{ project?: Project }>();
 const emit = defineEmits<{
-	(e: 'removed', projectId: IProject['id']): void;
+	(e: 'removed', projectId: Project['id']): void;
 }>();
 
 const stats = computed(() =>
@@ -83,9 +83,9 @@ const stats = computed(() =>
 		? null
 		: {
 				contributors: 1,
-				models: props.project?.assets?.[ProjectAssetTypes.MODELS]?.length ?? 0,
-				datasets: props.project?.assets?.[ProjectAssetTypes.DATASETS]?.length ?? 0,
-				papers: props.project?.assets?.[ProjectAssetTypes.DOCUMENTS]?.length ?? 0
+				models: props.project?.metadata['models-count'],
+				datasets: props.project?.metadata['datasets-count'],
+				papers: props.project?.metadata['publications-count']
 		  }
 );
 

--- a/packages/client/hmi-client/src/components/home/tera-project-card.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-card.vue
@@ -83,9 +83,9 @@ const stats = computed(() =>
 		? null
 		: {
 				contributors: 1,
-				models: props.project?.metadata?.['models-count'] ?? 0,
-				datasets: props.project?.metadata?.['datasets-count'] ?? 0,
-				papers: props.project?.metadata?.['publications-count'] ?? 0
+				models: parseInt(props.project?.metadata?.['models-count'] ?? '0', 10),
+				datasets: parseInt(props.project?.metadata?.['datasets-count'] ?? '0', 10),
+				papers: parseInt(props.project?.metadata?.['publications-count'] ?? '0', 10)
 		  }
 );
 
@@ -106,8 +106,8 @@ const projectMenuItems = ref([{ label: 'Remove', command: openRemoveDialog }]);
 const showProjectMenu = (event) => projectMenu.value.toggle(event);
 
 const removeProject = async () => {
-	if (!props.project) return;
-	const isDeleted = await ProjectService.remove(props.project?.id);
+	if (!props.project || !props.project?.id) return;
+	const isDeleted = await ProjectService.remove(props.project.id);
 	closeRemoveDialog();
 	if (isDeleted) {
 		logger.info(`The project ${props.project?.name} was removed`, { showToast: true });

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -170,9 +170,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import TeraSelectedDocumentPane from '@/components/documents/tera-selected-document-pane.vue';
-import { IProject } from '@/types/Project';
 import { XDDSearchParams } from '@/types/XDD';
-import { Document } from '@/types/Types';
+import { Document, Project } from '@/types/Types';
 import { searchXDDDocuments, getRelatedDocuments } from '@/services/data';
 import useResourcesStore from '@/stores/resources';
 import useQueryStore from '@/stores/query';
@@ -191,14 +190,14 @@ import Skeleton from 'primevue/skeleton';
 import { isEmpty } from 'lodash';
 import TeraProjectCard from '@/components/home/tera-project-card.vue';
 
-const projects = ref<IProject[]>();
+const projects = ref<Project[]>();
 // Only display first 2 projects with at least one related document
 const projectsToDisplay = computed(() =>
 	projects.value?.filter((project) => !isEmpty(project.relatedDocuments)).slice(0, 2)
 );
 const relevantDocuments = ref<Document[]>([]);
 const relevantSearchTerm = 'COVID-19';
-const relevantSearchParams: XDDSearchParams = { perPage: 15 }; // , fields: "abstract,title" };
+const relevantSearchParams: XDDSearchParams = { perPage: 15 };
 const selectedDocument = ref<Document>();
 
 const resourcesStore = useResourcesStore();
@@ -280,8 +279,8 @@ async function createNewProject() {
 		author
 	);
 	if (project?.id) {
-		openProject(project.id);
 		isNewProjectModalVisible.value = false;
+		openProject(project.id);
 	}
 }
 
@@ -289,7 +288,7 @@ function listAuthorNames(authors) {
 	return authors.map((author) => author.name).join(', ');
 }
 
-const removeProject = (projectId: IProject['id']) => {
+const removeProject = (projectId: Project['id']) => {
 	projects.value = projects.value?.filter((project) => project.id !== projectId);
 };
 </script>

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -189,6 +189,7 @@ import { RouteName } from '@/router/routes';
 import Skeleton from 'primevue/skeleton';
 import { isEmpty } from 'lodash';
 import TeraProjectCard from '@/components/home/tera-project-card.vue';
+import { ProjectAssetTypes } from '@/types/Project';
 
 const projects = ref<Project[]>();
 // Only display first 2 projects with at least one related document
@@ -218,8 +219,14 @@ onMounted(async () => {
 	projects.value = (await ProjectService.getAll()) ?? [];
 
 	projects.value.forEach(async (project) => {
-		project.assets = await ProjectService.getAssets(project.id);
-		project.relatedDocuments = await getRelatedDocuments(project.id, null);
+		if (project.id) {
+			const publications = await ProjectService.getAssets(project.id, ['publications'])?.[
+				ProjectAssetTypes.DOCUMENTS
+			];
+			if (!isEmpty(publications)) {
+				project.relatedDocuments = await getRelatedDocuments(publications[0].id);
+			}
+		}
 	});
 
 	// Get all relevant documents (latest on section)

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -9,7 +9,7 @@
 						label="New project"
 						size="large"
 						@click="isNewProjectModalVisible = true"
-					></Button>
+					/>
 				</header>
 				<TabView>
 					<TabPanel header="My projects">
@@ -69,7 +69,6 @@
 				<header>
 					<h3>Papers related to your projects</h3>
 				</header>
-
 				<div v-for="(project, index) in projectsToDisplay" :key="index">
 					<p>{{ project.name }}</p>
 					<div class="carousel">
@@ -193,10 +192,9 @@ import { isEmpty } from 'lodash';
 import TeraProjectCard from '@/components/home/tera-project-card.vue';
 
 const projects = ref<IProject[]>();
-// Only display projects with at least one related document
-// Only display at most 5 projects
+// Only display first 2 projects with at least one related document
 const projectsToDisplay = computed(() =>
-	projects.value?.filter((project) => project.relatedDocuments !== undefined).slice(0, 5)
+	projects.value?.filter((project) => !isEmpty(project.relatedDocuments)).slice(0, 2)
 );
 const relevantDocuments = ref<Document[]>([]);
 const relevantSearchTerm = 'COVID-19';

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -40,6 +40,7 @@
 							<ul v-else>
 								<li v-for="project in projects" :key="project.id">
 									<tera-project-card
+										v-if="project.id"
 										:project="project"
 										@click="openProject(project.id)"
 										@removed="removeProject"

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -215,7 +215,7 @@ onMounted(async () => {
 	resourcesStore.reset(); // Project related resources saved.
 	queryStore.reset(); // Facets queries.
 
-	projects.value = ((await ProjectService.getAll()) ?? []).slice().reverse();
+	projects.value = (await ProjectService.getAll()) ?? [];
 
 	projects.value.forEach(async (project) => {
 		project.assets = await ProjectService.getAssets(project.id);

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-header-pane.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-header-pane.vue
@@ -113,7 +113,7 @@ const addAssetsToProject = async (projectName) => {
 };
 
 onMounted(async () => {
-	const projects = await ProjectService.getAll();
+	const projects = (await ProjectService.getAll()) as unknown as IProject[];
 	if (projects !== null) {
 		projectsList.value = projects;
 	}

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-options-pane.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-options-pane.vue
@@ -68,7 +68,7 @@ const getType = (item: ResultType) => {
 };
 
 onMounted(async () => {
-	const all = await ProjectService.getAll();
+	const all = (await ProjectService.getAll()) as unknown as IProject[];
 	if (all !== null) {
 		projectsList.value = all;
 	}

--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -439,22 +439,14 @@ const getAssets = async (params: GetAssetsParams) => {
 };
 
 /**
- * fetch list of related documented utilizing
- *  semantic similarity (i.e., document embedding) from XDD via the HMI server
- *
- * TODO: this should probably be deprecated at some point now that we're using
- * the "/documents?similar_to=<id>" endpoint as an alternative
+ * fetch list of related documented based on the given document ID
  */
-const getRelatedDocuments = async (docid: string, dataset: string | null) => {
+const getRelatedDocuments = async (docid: string) => {
 	if (docid === '') {
 		return [] as Document[];
 	}
 
-	// https://xdd.wisc.edu/sets/xdd-covid-19/doc2vec/api/similar?doi=10.1002/pbc.28600
-	// dataset=xdd-covid-19
-	// doi=10.1002/pbc.28600
-	// docid=5ebd1de8998e17af826e810e
-	const url = `/document/related/document?docid=${docid}&set=${dataset || 'xdd-covid-19'}`;
+	const url = `/documents?max=10&similar_to=${docid}`;
 
 	const res = await API.get(url);
 	if (res) {

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -77,12 +77,12 @@ async function remove(projectId: IProject['id']): Promise<boolean> {
  * Get all projects
  * @return Array<Project>|null - the list of all projects, or null if none returned by API
  */
-async function getAll(): Promise<IProject[] | null> {
+async function getAll(): Promise<Project[] | null> {
 	try {
 		const response = await API.get('/projects');
 		const { status, data } = response;
 		if (status !== 200 || !data) return null;
-		return data;
+		return (data as Project[]).reverse();
 	} catch (error) {
 		logger.error(error);
 		return null;

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -10,7 +10,7 @@ import DatasetIcon from '@/assets/svg/icons/dataset.svg?component';
 import { Component } from 'vue';
 import useResourcesStore from '@/stores/resources';
 import * as EventService from '@/services/event';
-import { EventType, Project } from '@/types/Types';
+import { DocumentAsset, EventType, Project } from '@/types/Types';
 
 /**
  * Create a project
@@ -115,6 +115,25 @@ async function getAssets(projectId: string, types?: string[]): Promise<ProjectAs
 		logger.error(error);
 		return null;
 	}
+}
+
+/**
+ * Get projects publication assets for a given project per id
+ * @param projectId projet id to get assets for
+ * @return DocumentAsset[] the documents assets for the project
+ */
+async function getPublicationAssets(projectId: string): Promise<DocumentAsset[]> {
+	try {
+		const url = `/projects/${projectId}/assets?types=${ProjectAssetTypes.DOCUMENTS}`;
+		const response = await API.get(url);
+		const { status, data } = response;
+		if (status === 200) {
+			return data?.[ProjectAssetTypes.DOCUMENTS] ?? ([] as DocumentAsset[]);
+		}
+	} catch (error) {
+		logger.error(error);
+	}
+	return [] as DocumentAsset[];
 }
 
 /**
@@ -239,5 +258,6 @@ export {
 	deleteAsset,
 	getAssets,
 	getAssetIcon,
+	getPublicationAssets,
 	getDocumentAssetXddUri
 };

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -102,6 +102,7 @@ export interface Project {
     active: boolean;
     concept?: Concept;
     assets?: Assets;
+    metadata?: { [index: string]: string };
     username: string;
     id?: string;
     relatedDocuments?: Document[];

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -11,6 +11,7 @@ import lombok.experimental.Accessors;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 
@@ -40,6 +41,10 @@ public class Project implements Serializable {
 
 	@TSOptional
 	private Assets assets;
+
+	@TSOptional
+	// Metadata that can be useful for the UI
+	private Map<String, String> metadata;
 
 	private String username;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
@@ -38,12 +38,12 @@ public class ProjectResource {
 		projects.forEach(project -> {
 			Assets assets = proxy.getAssets(project.getProjectID(), Arrays.asList("datasets", "models", "publications"));
 			Map metadata = new HashMap();
-			metadata.put("datasets", assets.getDatasets() == null ? "0" : String.valueOf(assets.getDatasets().size()));
-			metadata.put("extractions", assets.getExtractions() == null ? "0" : String.valueOf(assets.getExtractions().size()));
-			metadata.put("models", assets.getModels() == null ? "0" : String.valueOf(assets.getModels().size()));
-			metadata.put("publications", assets.getPublications() == null ? "0" : String.valueOf(assets.getPublications().size()));
-			metadata.put("workflows", assets.getWorkflows() == null ? "0" : String.valueOf(assets.getWorkflows().size()));
-			metadata.put("artifacts", assets.getArtifacts() == null ? "0" : String.valueOf(assets.getArtifacts().size()));
+			metadata.put("datasets-count", assets.getDatasets() == null ? "0" : String.valueOf(assets.getDatasets().size()));
+			metadata.put("extractions-count", assets.getExtractions() == null ? "0" : String.valueOf(assets.getExtractions().size()));
+			metadata.put("models-count", assets.getModels() == null ? "0" : String.valueOf(assets.getModels().size()));
+			metadata.put("publications-count", assets.getPublications() == null ? "0" : String.valueOf(assets.getPublications().size()));
+			metadata.put("workflows-count", assets.getWorkflows() == null ? "0" : String.valueOf(assets.getWorkflows().size()));
+			metadata.put("artifacts-count", assets.getArtifacts() == null ? "0" : String.valueOf(assets.getArtifacts().size()));
 			project.setMetadata(metadata);
 		});
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ProjectResource.java
@@ -36,11 +36,14 @@ public class ProjectResource {
 			.toList();
 
 		projects.forEach(project -> {
-			Assets assets = proxy.getAssets(project.getProjectID(), Arrays.asList("dataset", "model", "publication"));
+			Assets assets = proxy.getAssets(project.getProjectID(), Arrays.asList("datasets", "models", "publications"));
 			Map metadata = new HashMap();
-			metadata.put("datasets", assets.getDatasets().size());
-			metadata.put("models", assets.getModels().size());
-			metadata.put("publications", assets.getPublications().size());
+			metadata.put("datasets", assets.getDatasets() == null ? "0" : String.valueOf(assets.getDatasets().size()));
+			metadata.put("extractions", assets.getExtractions() == null ? "0" : String.valueOf(assets.getExtractions().size()));
+			metadata.put("models", assets.getModels() == null ? "0" : String.valueOf(assets.getModels().size()));
+			metadata.put("publications", assets.getPublications() == null ? "0" : String.valueOf(assets.getPublications().size()));
+			metadata.put("workflows", assets.getWorkflows() == null ? "0" : String.valueOf(assets.getWorkflows().size()));
+			metadata.put("artifacts", assets.getArtifacts() == null ? "0" : String.valueOf(assets.getArtifacts().size()));
 			project.setMetadata(metadata);
 		});
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/DocumentResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/documentservice/DocumentResource.java
@@ -35,7 +35,7 @@ public class DocumentResource {
 	@Path("/documents")
 	@APIResponses({
 		@APIResponse(responseCode = "500", description = "An error occurred retrieving documents"),
-		@APIResponse(responseCode = "204", description = "Request received successfully, but there are documents"),
+		@APIResponse(responseCode = "204", description = "Request received successfully, but there are no documents"),
 		@APIResponse(responseCode = "400", description = "Query must contain one of docid, doi or term") })
 	public Response getDocuments(
 		@QueryParam("docid") String docid,


### PR DESCRIPTION
# Description

* Change the calls made to `hmi-server` to only get projects, with some metadata about assets counts to avoid to do that job on the front-end
* Reduce to 3 the number of projects to which we fetch Related documents
* Reduct to 8 the number of related documents we fetch per project

Resolves #1668

