### PR TITLE
fix: improved error handling on poller

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
@@ -77,7 +77,6 @@ const modelConfigIds = computed<string[]>(() => props.node.inputs[0].value as st
 const datasetId = computed(() => props.node.inputs[1].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
 
-const startedRunId = ref<string>();
 const completedRunId = ref<string>();
 const disableRunButton = computed(
 	() => !ensembleConfigs?.value[0]?.weight || !datasetId.value || !currentDatasetFileName.value
@@ -91,7 +90,7 @@ const simulationIds: ComputedRef<any | undefined> = computed(
 	<any | undefined>(() => props.node.outputs[0]?.value)
 );
 const datasetColumnNames = ref<string[]>();
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 const poller = new Poller();
 
@@ -124,8 +123,7 @@ const runEnsemble = async () => {
 		}
 	};
 	const response = await makeEnsembleCiemssCalibration(params);
-	startedRunId.value = response.simulationId;
-	if (response.simulationId) {
+	if (response?.simulationId) {
 		getStatus(response.simulationId);
 	}
 };

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
@@ -156,7 +156,7 @@ const simulationIds: ComputedRef<any | undefined> = computed(
 const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const showSpinner = ref(false);
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 // EXTRA section
 const numSamples = ref(100);
@@ -237,7 +237,7 @@ const runCalibrate = async () => {
 	};
 	const response = await makeCalibrateJobCiemss(calibrationRequest);
 
-	if (response.simulationId) {
+	if (response?.simulationId) {
 		getStatus(response.simulationId);
 	}
 };

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-julia.vue
@@ -149,7 +149,6 @@ const modelConfigId = computed(() => props.node.inputs[0].value?.[0] as string |
 const datasetId = computed(() => props.node.inputs[1].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
 const modelConfig = ref<ModelConfiguration>();
-const startedRunId = ref<string>();
 const completedRunId = ref<string>();
 const parameterResult = ref<{ [index: string]: any }>();
 
@@ -166,7 +165,7 @@ const timeSpan = ref<TimeSpan>(props.node.state.timeSpan);
 
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const showSpinner = ref(false);
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 const poller = new Poller();
 
@@ -231,8 +230,7 @@ const runCalibrate = async () => {
 		timespan: timeSpan.value
 	};
 	const response = await makeCalibrateJobJulia(calibrationRequest);
-	startedRunId.value = response.simulationId;
-	if (response.simulationId) {
+	if (response?.simulationId) {
 		getStatus(response.simulationId);
 	}
 };
@@ -250,11 +248,11 @@ const getStatus = async (simulationId: string) => {
 
 	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
 		// throw if there are any failed runs for now
-		console.error('Failed', startedRunId.value);
+		console.error('Failed', simulationId);
 		showSpinner.value = false;
 		throw Error('Failed Runs');
 	}
-	completedRunId.value = startedRunId.value;
+	completedRunId.value = simulationId;
 	updateOutputPorts(completedRunId);
 	showSpinner.value = false;
 };

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
@@ -74,7 +74,7 @@ const ciemssMethodOptions = ref(['dopri5', 'euler']);
 const completedRunIdList = ref<string[]>([]);
 const runResults = ref<RunResults>({});
 const runConfigs = ref<{ [paramKey: string]: number[] }>({});
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 const poller = new Poller();
 

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
@@ -81,7 +81,7 @@ const runResults = ref<RunResults>({});
 const simulationIds: ComputedRef<any | undefined> = computed(
 	<any | undefined>(() => props.node.outputs[0]?.value)
 );
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 const poller = new Poller();
 
@@ -104,7 +104,7 @@ const runEnsemble = async () => {
 		extra: { num_samples: numSamples.value }
 	};
 	const response = await makeEnsembleCiemssSimulation(params);
-	if (response.simulationId) {
+	if (response?.simulationId) {
 		getStatus(response.simulationId);
 	}
 };

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-julia-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-julia-node.vue
@@ -52,7 +52,7 @@ const runResults = ref<RunResults>({});
 
 const modelConfiguration = ref<ModelConfiguration | null>(null);
 const modelConfigId = computed<string | undefined>(() => props.node.inputs[0].value?.[0]);
-const progress = ref({ status: ProgressState.QUEUED, value: 0 });
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
 const poller = new Poller();
 

--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -283,6 +283,22 @@ export async function simulationPollAction(
 		};
 	}
 
+	// check if there's a simulation job that does not include these statuses, for now we will throw an error whenever there is at least 1 job that is not in the queued, running, complete statuses
+	if (
+		response.find(
+			(simulation) =>
+				simulation?.status !== ProgressState.QUEUED &&
+				simulation?.status !== ProgressState.RUNNING &&
+				simulation?.status !== ProgressState.COMPLETE
+		)
+	) {
+		return {
+			data: response,
+			progress: null,
+			error: true
+		};
+	}
+
 	return {
 		data: null,
 		progress: null,

--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -266,6 +266,7 @@ export async function simulationPollAction(
 			error: null
 		};
 	}
+
 	if (
 		response.find(
 			(simulation) =>
@@ -281,27 +282,23 @@ export async function simulationPollAction(
 			status: ProgressState.RUNNING,
 			value: 0
 		};
-	}
-
-	// check if there's a simulation job that does not include these statuses, for now we will throw an error whenever there is at least 1 job that is not in the queued, running, complete statuses
-	if (
-		response.find(
-			(simulation) =>
-				simulation?.status !== ProgressState.QUEUED &&
-				simulation?.status !== ProgressState.RUNNING &&
-				simulation?.status !== ProgressState.COMPLETE
-		)
-	) {
+		// keep polling
 		return {
-			data: response,
+			data: null,
 			progress: null,
-			error: true
+			error: null
 		};
 	}
 
+	// remove all simulations for now if there is an unhandled state
+	const newState = deleteSimulationInProgress(node, simulationIds);
+	if (!isEqual(node.state, newState)) {
+		emitFn('update-state', newState);
+	}
+
 	return {
-		data: null,
+		data: response,
 		progress: null,
-		error: null
+		error: true
 	};
 }

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -133,6 +133,7 @@ export interface Size {
 }
 
 export enum ProgressState {
+	RETRIEVING = 'retrieving',
 	QUEUED = 'queued',
 	RUNNING = 'running',
 	COMPLETE = 'complete'


### PR DESCRIPTION
# Description

* handle poller states when they are not queued, running, or complete - we will create an error for now instead of the node running indefinitely
* some cleanup of the logic and unused variables

Resolves #(issue)
