### PR TITLE
fix: dont show all related publications when a dataset is added to a project

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -87,7 +87,7 @@
 			<tera-related-publications
 				@extracted-metadata="gotEnrichedData"
 				:dialog-flavour="'dataset'"
-				:publications="props.project?.assets?.publications"
+				:publications="publications"
 				:project="project"
 				:assetId="assetId"
 			/>
@@ -378,6 +378,8 @@ const pd = computed(() =>
 		  )
 		: []
 );
+
+const publications = computed(() => []);
 
 const headers = ref({
 	AUTHOR_NAME: 'Author Name',


### PR DESCRIPTION

# Description

* There's an issue where any dataset on a project will show all publications in that project under the related publications section
* I followed what we are currently doing with the model related publications which is showing an empty list
* It looks like enrichments for datasets and models aren't being handled correctly so far but this will be addressed in another PR

Showing nothing under related publications
![Screenshot 2023-08-16 at 1 14 52 PM](https://github.com/DARPA-ASKEM/Terarium/assets/33158416/6c529715-b650-4e77-b7db-6901e28fa667)


Resolves #(issue)
https://github.com/DARPA-ASKEM/Terarium/issues/1670
