### PR TITLE
bug(hmi): xDD extractions of images are not coming through

### DIFF
--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/ExtractionProxy.java
@@ -11,7 +11,7 @@ import software.uncharted.terarium.hmiserver.resources.documentservice.responses
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
-@RegisterRestClient(configKey = "xdd-document-service")
+@RegisterRestClient(configKey = "xdd-dev-service")
 @Produces(MediaType.APPLICATION_JSON)
 @RegisterProvider(HmiResponseExceptionMapper.class)
 public interface ExtractionProxy {


### PR DESCRIPTION
For some reason this call returns no results on xdd prod. I've let the xdd team know to look into it


Resolves #1726
