### PR TITLE
chore: ignore pyodide

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,9 @@
 	"reviewersSampleSize": 1,
 	"semanticCommitType": "build",
 	"automergeStrategy": "squash",
+	"ignoreDeps": [
+		"pyodide"
+	],
 	"packageRules": [
 		{
 			"description": "Trigger breaking release for major updates",


### PR DESCRIPTION
### Summary
Pyodide is a python/wasm library, the dependencies are determined and resolved at runtime (currently we point to a CDN with python modules that had been compiled into wasm). Because of this, it is not a good idea to have renovate-bot update versions if we don't know if the content of the CDN are also updated.