### PR TITLE
fix: update simulation.csv to result.csv

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-ciemss.vue
@@ -33,7 +33,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 			<Button
@@ -408,7 +408,7 @@ const addChart = () => {
 const watchCompletedRunList = async () => {
 	if (!completedRunId.value) return;
 
-	const output = await getRunResultCiemss(completedRunId.value, 'simulation.csv');
+	const output = await getRunResultCiemss(completedRunId.value, 'result.csv');
 	runResults.value = output.runResults;
 };
 

--- a/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibrate-ensemble-node-ciemss.vue
@@ -23,7 +23,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 		</section>
@@ -228,7 +228,7 @@ watch(
 	async () => {
 		if (!simulationIds.value) return;
 
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'simulation.csv');
+		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
 		runResults.value = output.runResults;
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-ciemss.vue
@@ -109,7 +109,7 @@
 					text
 					:outlined="true"
 					@click="addChart"
-					label="Add Chart"
+					label="Add chart"
 					icon="pi pi-plus"
 				></Button>
 			</AccordionTab>
@@ -267,7 +267,7 @@ watch(
 		// console.log(csvData);
 		// runResults.value[simulationIds.value[0].runId] = csvData as any;
 
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'simulation.csv');
+		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
 		runResults.value = output.runResults;
 		parameterResult.value = await getRunResult(simulationIds.value[0].runId, 'visualization.json');
 	},

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-ciemss.vue
@@ -43,7 +43,7 @@
 					text
 					:outlined="true"
 					@click="addChart"
-					label="Add Chart"
+					label="Add chart"
 					icon="pi pi-plus"
 				></Button>
 			</AccordionTab>
@@ -335,7 +335,7 @@ watch(
 		// runResults.value[simulationIds.value[0].runId] = csvData as any;
 		// parameterResult.value = await getRunResult(simulationIds.value[0].runId, 'parameters.json');
 
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'simulation.csv');
+		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
 		runResults.value = output.runResults;
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/workflow/tera-calibration-node-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-calibration-node-julia.vue
@@ -40,7 +40,7 @@
 					text
 					:outlined="true"
 					@click="addChart"
-					label="Add Chart"
+					label="Add chart"
 					icon="pi pi-plus"
 				></Button>
 			</AccordionTab>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
@@ -5,7 +5,7 @@
 			v-model="selectedVariable"
 			:selection-limit="hasMultiRuns ? 1 : undefined"
 			:options="stateVariablesList"
-			placeholder="Select a State Variable"
+			placeholder="Select a state variable"
 			@update:model-value="updateSelectedVariable"
 		>
 			<template v-slot:value>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss-node.vue
@@ -16,7 +16,7 @@
 				size="small"
 				text
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			></Button>
 			<Button size="small" label="Run" @click="runSimulate" icon="pi pi-play"></Button>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ciemss.vue
@@ -78,7 +78,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 			<Button

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-ciemss.vue
@@ -33,7 +33,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 			<Button
@@ -387,7 +387,7 @@ const addChart = () => {
 const watchCompletedRunList = async () => {
 	if (!completedRunId.value) return;
 
-	const output = await getRunResultCiemss(completedRunId.value, 'simulation.csv');
+	const output = await getRunResultCiemss(completedRunId.value, 'result.csv');
 	runResults.value = output.runResults;
 };
 

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-ensemble-node-ciemss.vue
@@ -23,7 +23,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 		</section>
@@ -197,7 +197,7 @@ watch(
 	async () => {
 		if (!simulationIds.value) return;
 
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'simulation.csv');
+		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
 		runResults.value = output.runResults;
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-julia-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-julia-node.vue
@@ -11,7 +11,7 @@
 				:colorByRun="true"
 			/>
 		</div>
-		<Button class="add-chart" text @click="addChart" label="Add Chart" icon="pi pi-plus"></Button>
+		<Button class="add-chart" text @click="addChart" label="Add chart" icon="pi pi-plus"></Button>
 	</section>
 	<section v-else>
 		<tera-progress-bar :value="progress.value" :status="progress.status" />

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-julia.vue
@@ -38,7 +38,7 @@
 				text
 				:outlined="true"
 				@click="addChart"
-				label="Add Chart"
+				label="Add chart"
 				icon="pi pi-plus"
 			/>
 			<Button


### PR DESCRIPTION
# Description

* Verified with Five that the `simulation.csv` filename should indeed always be `result.csv` (apparently the change was made about a month ago).
* Also updated some strings to use sentence case as per Jamie's request
