### PR TITLE
fix: issue where duplicate and blank publication appears when adding for the first time

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-header-pane.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-selected-resources-header-pane.vue
@@ -68,11 +68,6 @@ const addResourcesToProject = async (projectId: string) => {
 				// then, link and store in the project assets
 				const assetsType = AssetType.Publications;
 				await ProjectService.addAsset(projectId, assetsType, documentId);
-
-				// TODO: Find a way for documents to be added without this
-				// update local copy of project assets
-				// @ts-ignore
-				resources.activeProject?.assets?.[AssetType.Publications].push(documentId, body);
 			}
 		}
 		if (isModel(selectedItem)) {


### PR DESCRIPTION
# Description

* Fixed an issue where added publications to a project would cause duplicate an empty publication and a blank publication
* removed line of code which added the publications to the project locally but this is no necessary since the project page is reloaded when we navigate to the page


https://github.com/DARPA-ASKEM/Terarium/assets/33158416/7f2a8aed-4add-4445-9c73-57ebef2d5d35


