### PR TITLE
Feature: Handling for multiple datasets

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,8 @@ services:
       - data-service-port=8000
       - model-service-host=model-service
       - model-service-port=8888
+    volumes:
+      - ./packages/services/hmi-server:/hmi-server/packages/services/hmi-server
   terarium-db:
     image: postgres:15.1
     expose:
@@ -58,7 +60,7 @@ services:
       SQL_PORT: 5432
       SQL_USER: dev
       SQL_PASSWORD: dev
-      NEO4J_ENABLED:
+      NEO4J_ENABLED: true
       NEO4J_driver: neo4j://neo4j:7687
       AWS_ACCESS_KEY_ID: miniouser
       AWS_SECRET_ACCESS_KEY: miniopass
@@ -176,7 +178,7 @@ services:
       - SQL_USER=dev
       - SQL_PASSWORD=dev
       - SQL_DB=askem
-      - NEO4J_ENABLED=
+      - NEO4J_ENABLED=true
       - NEO4J_driver=neo4j://neo4j:7687
       - AWS_ACCESS_KEY_ID=miniouser
       - AWS_SECRET_ACCESS_KEY=miniopass

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
@@ -58,11 +58,13 @@
 			:jupyter-session="jupyterSession"
 			:kernel-status="kernelStatus"
 			:auto-expand-preview="autoExpandPreview"
+			@update-kernel-state="updateKernelState"
 			@update-kernel-status="updateKernelStatus"
 			@new-dataset-saved="onNewDatasetSaved"
 			@download-response="onDownloadResponse"
 		/>
-		<div>
+		<div v-if="kernelState">
+			<Dropdown v-model="actionTarget" :options="Object.keys(kernelState || [])" />
 			<Button
 				class="save-button p-button p-button-secondary p-button-sm"
 				title="Saves the current version of df as a new Terarium asset"
@@ -143,8 +145,10 @@ const props = defineProps<{
 
 const chat = ref();
 const kernelStatus = ref(<string>'');
+const kernelState = ref(null);
 const showKernels = ref(<boolean>false);
 const autoExpandPreview = ref(<boolean>true);
+const actionTarget = ref('df');
 
 const newCsvContent: any = ref(null);
 const newCsvHeader: any = ref(null);
@@ -231,6 +235,10 @@ onUnmounted(() => {
 	jupyterSession.shutdown();
 });
 
+const updateKernelState = (newKernelState) => {
+	kernelState.value = newKernelState;
+};
+
 // Save file function
 const saveAsNewDataset = async () => {
 	if (!hasValidDatasetName.value || saveAsName.value === null) {
@@ -258,7 +266,8 @@ const saveAsNewDataset = async () => {
 		channel: 'shell',
 		content: {
 			parent_dataset_id: String(props.assetId),
-			name: datasetName
+			name: datasetName,
+			var_name: actionTarget.value
 		},
 		msgType: 'save_dataset_request',
 		msgId: createMessageId('save_dataset_request')
@@ -375,7 +384,9 @@ const downloadDataset = () => {
 	const messageBody = {
 		session: session?.name || '',
 		channel: 'shell',
-		content: {},
+		content: {
+			var_name: actionTarget.value
+		},
 		msgType: 'download_dataset_request',
 		msgId: createMessageId('download_dataset_request')
 	};

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
@@ -79,7 +79,7 @@
 								class="tera-dataset-datatable"
 								paginatorPosition="bottom"
 								:rows="10"
-								:raw-content="(m.content[selectedPreviewDataset] as CsvAsset)"
+								:raw-content="(m.content[(selectedPreviewDataset || 'df')] as CsvAsset)"
 								:preview-mode="true"
 								:showGridlines="true"
 								table-style="width: 100%; font-size: small;"

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
@@ -66,12 +66,15 @@
 						"
 					>
 						<AccordionTab header="Preview (click to collapse/expand)">
+							<div>
+								<!-- TODO: Put dataframe selector here? -->
+							</div>
 							<tera-dataset-datatable
 								v-if="m.header.msg_type === 'dataset'"
 								class="tera-dataset-datatable"
 								paginatorPosition="bottom"
 								:rows="10"
-								:raw-content="(m.content as CsvAsset)"
+								:raw-content="(m.content['df'] as CsvAsset)"
 								:preview-mode="true"
 								:showGridlines="true"
 								table-style="width: 100%; font-size: small;"

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
@@ -67,14 +67,19 @@
 					>
 						<AccordionTab header="Preview (click to collapse/expand)">
 							<div>
-								<!-- TODO: Put dataframe selector here? -->
+								Dataset to preview:
+								<Dropdown
+									v-model="selectedPreviewDataset"
+									:options="Object.keys(m.content).map(String)"
+									@change="previewSelected"
+								/>
 							</div>
 							<tera-dataset-datatable
 								v-if="m.header.msg_type === 'dataset'"
 								class="tera-dataset-datatable"
 								paginatorPosition="bottom"
 								:rows="10"
-								:raw-content="(m.content['df'] as CsvAsset)"
+								:raw-content="(m.content[selectedPreviewDataset] as CsvAsset)"
 								:preview-mode="true"
 								:showGridlines="true"
 								table-style="width: 100%; font-size: small;"
@@ -98,6 +103,7 @@ import { JupyterMessage } from '@/services/jupyter';
 import { SessionContext } from '@jupyterlab/apputils';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
+import Dropdown from 'primevue/dropdown';
 import TeraChattyCodeCell from '@/components/llm/tera-chatty-response-code-cell.vue';
 import TeraJupyterResponseThought from '@/components/llm/tera-chatty-response-thought.vue';
 import Button from 'primevue/button';
@@ -106,7 +112,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { CsvAsset } from '@/types/Types';
 import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
 
-const emit = defineEmits(['cell-updated']);
+const emit = defineEmits(['cell-updated', 'preview-selected', 'update-kernel-state']);
 
 const props = defineProps<{
 	jupyterSession: SessionContext;
@@ -121,10 +127,12 @@ const props = defineProps<{
 	isExecutingCode: boolean;
 	assetId?: string;
 	autoExpandPreview?: boolean;
+	defaultPreview?: string;
 }>();
 
 const codeCell = ref(null);
 const resp = ref(<HTMLElement | null>null);
+const selectedPreviewDataset = ref(props.defaultPreview);
 // Reference for showThought, initially set to false
 const showThought = ref(false);
 
@@ -152,6 +160,10 @@ const chatWindowMenuItems = ref([
 	},
 	{ label: 'Delete', icon: 'pi pi-fw pi-trash', command: () => console.log('Delete prompt') }
 ]);
+
+const previewSelected = () => {
+	emit('preview-selected', selectedPreviewDataset.value);
+};
 
 // show the chat window menu
 const showChatWindowMenu = (event: Event) => chatWindowMenu.value.toggle(event);

--- a/packages/client/hmi-client/src/components/models/tera-model-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model-jupyter-panel.vue
@@ -74,6 +74,7 @@
 			:jupyter-session="jupyterSession"
 			:kernel-status="kernelStatus"
 			:auto-expand-preview="autoExpandPreview"
+			@update-kernel-state="updateKernelState"
 			@update-kernel-status="updateKernelStatus"
 			@new-model-saved="onNewModelSaved"
 		/>
@@ -155,6 +156,7 @@ const noSelectionDefault = {
 
 const chat = ref();
 const kernelStatus = ref(<string>'');
+const kernelState = ref(null);
 const showKernels = ref(<boolean>false);
 const autoExpandPreview = ref(<boolean>true);
 const modelConfigurations = ref(<
@@ -274,6 +276,10 @@ onMounted(async () => {
 onUnmounted(() => {
 	jupyterSession.shutdown();
 });
+
+const updateKernelState = (newKernelState) => {
+	kernelState.value = newKernelState;
+};
 
 // Save file function
 const saveAsNewModel = async () => {


### PR DESCRIPTION
On the dataset transform page, you can now define, preview, save as, and download multiple datasets. The preview and download/save as functions have a drop-down of identified dataframes in the environment.

The LLM will also be able to work with all the datasets, allowing you to ask the LLM to do things like asking the llm to merge two datasets or to compare them in various ways.