### PR TITLE
fix: prioritize keyboard zindex to modal zindex

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/_variables.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/_variables.scss
@@ -940,5 +940,6 @@ $petri-inputBox: var(--surface-0);
 	--overlayMenuShadowHover: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px 0 rgba(0, 0, 0, 0.3);
 	--node-header: #7b8498;
 	--node-header-hover: var(--text-color-subdued);
-	--z-index-modal: 1000
+	--z-index-modal: 1000;
+	--keyboard-zindex: calc(var(--z-index-modal) + 100);
 }


### PR DESCRIPTION
# Description

* A small fix to fix an issue where the modal was showing over the keyboard
* The z-index of the keyboard will now be dependant on the z-index of the modal + 100 so that it will always show over the modal
* used the css property to define the keyboard style for MathLive https://cortexjs.io/mathlive/guides/virtual-keyboards/

Resolves #(issue)
