### PR TITLE
bug(hmi): Show/hide column in the dataset does not hide right column

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
@@ -20,7 +20,7 @@
 	<!-- Datable -->
 	<DataTable
 		:class="previewMode ? 'p-datatable-xsm' : 'p-datatable-sm'"
-		:value="csvContent?.slice(1, csvContent.length)"
+		:value="csvContent"
 		:rows="props.rows"
 		paginator
 		:paginatorPosition="paginatorPosition ? paginatorPosition : `bottom`"
@@ -34,7 +34,7 @@
 		<Column
 			v-for="(colName, index) of selectedColumns"
 			:key="index"
-			:field="index.toString()"
+			:field="colName"
 			:header="colName"
 			:style="previousHeaders && !previousHeaders.includes(colName) ? 'border-color: green' : ''"
 			sortable
@@ -100,7 +100,7 @@ const MINBARLENGTH = 1;
 
 const showSummaries = ref(true);
 
-const csvContent = computed(() => props.rawContent?.csv);
+const csvContent = computed(() => props.rawContent?.data);
 const csvHeaders = computed(() => props.rawContent?.headers);
 const chartData = computed(() =>
 	props.rawContent?.stats?.map((stat) => setBarChartData(stat.bins))

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -58,6 +58,7 @@ export interface CsvAsset {
     stats?: CsvColumnStats[];
     headers: string[];
     rowCount: number;
+    data: { [index: string]: string }[];
 }
 
 export interface CsvColumnStats {

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/CsvAsset.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/CsvAsset.java
@@ -17,6 +17,25 @@ import java.util.*;
 @AllArgsConstructor
 public class CsvAsset implements Serializable {
 
+	public CsvAsset(List<List<String>> csv, List<CsvColumnStats> stats, List<String> headers, Integer rowCount) {
+		this.csv = csv;
+		this.stats = stats;
+		this.headers = headers;
+		this.rowCount = rowCount;
+		this.data = new ArrayList<>();
+		for(int i = 1; i < csv.size(); i++){
+			Map<String,String> row = new HashMap<>();
+			for(int j = 0; j < headers.size(); j++){
+				row.put(headers.get(j), csv.get(i).get(j));
+			}
+			data.add(row);
+		}
+
+
+
+	}
+
+
 	/** The csv data. Note that this may be incomplete if the dataset is too large. **/
 	List<List<String>> csv;
 
@@ -29,5 +48,8 @@ public class CsvAsset implements Serializable {
 
 	/** The number of rows in the CSV file. This may be a larger value than the csv object contained within **/
 	Integer rowCount;
+
+	/** The CSV represented in a map form, where each entry in the list is a row. Column names are keys **/
+	List<Map<String,String>> data;
 
 }


### PR DESCRIPTION
# Description



We were representing CSV data as a 2D Array of strings which doesn't quite work with primevue's datatable for filtering.  Each row needs to be its own object or map with a property/key name to filter off of


Resolves #1678 
