### PR TITLE
chore: amr header fixes

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -15,7 +15,7 @@
 				</tr>
 				<tr>
 					<td class="framework">{{ model?.header.schema_name }}</td>
-					<td>{{ model?.model_version }}</td>
+					<td>{{ model?.header.model_version }}</td>
 					<td>{{ model?.metadata?.processed_at }}</td>
 					<td>{{ model?.metadata?.annotations?.authors?.join(', ') }}</td>
 					<td>{{ model?.metadata?.processed_by }}</td>

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -14,7 +14,7 @@
 					<th>Source</th>
 				</tr>
 				<tr>
-					<td class="framework">{{ model?.schema_name }}</td>
+					<td class="framework">{{ model?.header.schema_name }}</td>
 					<td>{{ model?.model_version }}</td>
 					<td>{{ model?.metadata?.processed_at }}</td>
 					<td>{{ model?.metadata?.annotations?.authors?.join(', ') }}</td>

--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -3,7 +3,7 @@
 	<main>
 		<tera-asset
 			v-if="model"
-			:name="model.name"
+			:name="model.header.name"
 			:feature-config="featureConfig"
 			:is-naming-asset="isNaming"
 			:stretch-content="view === ModelView.MODEL"

--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -117,7 +117,7 @@ const optionsMenuItems = ref([
 		label: 'Rename',
 		command() {
 			isRenaming.value = true;
-			newName.value = model.value?.name ?? '';
+			newName.value = model.value?.header.name ?? '';
 		}
 	}
 	// { icon: 'pi pi-clone', label: 'Make a copy', command: initiateModelDuplication }

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -70,7 +70,7 @@
 				</tr>
 				<tr>
 					<td>{{ capitalize(model?.header.schema_name ?? '--') }}</td>
-					<td>{{ model?.model_version ?? '--' }}</td>
+					<td>{{ model?.header.model_version ?? '--' }}</td>
 					<td>{{ model?.metadata?.processed_at ?? '--' }}</td>
 					<td>
 						{{

--- a/packages/client/hmi-client/src/components/models/tera-model.vue
+++ b/packages/client/hmi-client/src/components/models/tera-model.vue
@@ -69,7 +69,7 @@
 					<th>Source</th>
 				</tr>
 				<tr>
-					<td>{{ capitalize(model?.schema_name ?? '--') }}</td>
+					<td>{{ capitalize(model?.header.schema_name ?? '--') }}</td>
 					<td>{{ model?.model_version ?? '--' }}</td>
 					<td>{{ model?.metadata?.processed_at ?? '--' }}</td>
 					<td>

--- a/packages/client/hmi-client/src/components/widgets/tera-tab-group.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-tab-group.vue
@@ -66,9 +66,18 @@ const getTabName = (tab: Tab) => {
 		const asset: any = assets[tab.pageType as string].find(
 			(assetItem: any) => assetItem.id?.toString() === tab.assetId?.toString()
 		);
+
+		// FIXME should unify upstream via a summary endpoint
+		let assetName = null;
+		if (asset?.header && asset?.header?.name) {
+			assetName = asset.header.name;
+		} else {
+			assetName = asset.name;
+		}
+
 		// FIXME: remove this check for title/name once the following github issue has been addressed
 		// https://github.com/DARPA-ASKEM/data-service/issues/299
-		return (tab.pageType === AssetType.Publications ? asset?.title : asset?.name) ?? 'n/a';
+		return (tab.pageType === AssetType.Publications ? asset?.title : assetName) ?? 'n/a';
 	}
 
 	if (tab.pageType === AssetType.Code) return 'New File';

--- a/packages/client/hmi-client/src/components/workflow/tera-model-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-model-node.vue
@@ -1,6 +1,6 @@
 <template>
 	<template v-if="model">
-		<h5>{{ model.name }}</h5>
+		<h5>{{ model.header.name }}</h5>
 		<div class="container">
 			<tera-model-diagram :model="model" :is-editable="false" nodePreview />
 		</div>

--- a/packages/client/hmi-client/src/components/workflow/tera-stratify.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-stratify.vue
@@ -169,13 +169,13 @@
 				Saved as:
 				<Button
 					class=".p-button-link"
-					:label="stratifiedModel?.name"
+					:label="stratifiedModel?.header.name"
 					icon="pi pi-pencil"
 					iconPos="right"
 					text
 					@click="
 						emit('open-asset', {
-							assetName: `${stratifiedModel?.name}`,
+							assetName: `${stratifiedModel?.header.name}`,
 							pageType: AssetType.Models,
 							assetId: stratifiedModel?.id
 						})

--- a/packages/client/hmi-client/src/examples/mira-petri.json
+++ b/packages/client/hmi-client/src/examples/mira-petri.json
@@ -1,9 +1,11 @@
 {
- "name": "Scenario 1 age/diagnosis stratified",
- "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
- "schema_name": "petrinet",
- "description": "Scenario 1 age/diagnosis stratified",
- "model_version": "0.1",
+	"header": {
+		"name": "Scenario 1 age/diagnosis stratified",
+		"schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+		"schema_name": "petrinet",
+		"description": "Scenario 1 age/diagnosis stratified",
+		"model_version": "0.1"
+	},
  "properties": {},
  "model": {
   "states": [

--- a/packages/client/hmi-client/src/examples/sir.json
+++ b/packages/client/hmi-client/src/examples/sir.json
@@ -1,9 +1,11 @@
 {
-  "name": "SIR model",
-  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
-  "schema_name": "petrinet",
-  "description": "SIR model",
-  "model_version": "0.1",
+	"header": {
+		"name": "SIR model",
+		"schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+		"schema_name": "petrinet",
+		"description": "SIR model",
+		"model_version": "0.1"
+	},
   "properties": {},
   "model": {
     "states": [

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -551,13 +551,13 @@ export const updateExistingModelContent = (amr: Model, amrOld: Model): Model => 
 export const cloneModelWithExtendedTypeSystem = (amr: Model) => {
 	const amrCopy = cloneDeep(amr);
 	if (amrCopy.semantics?.typing) {
-		const { name, description, schema, semantics } = amrCopy;
+		const { name, description, schema } = amrCopy.header;
 		const typeSystem = {
 			name,
 			description,
 			schema,
-			model_version: amrCopy.model_version,
-			model: semantics?.typing?.system
+			model_version: amrCopy.header.model_version,
+			model: amrCopy.semantics?.typing?.system
 		};
 		amrCopy.semantics.typing.system = typeSystem;
 	}

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -601,8 +601,6 @@ export const getStratificationType = (amr: Model) => {
 };
 
 export function newAMR(modelName: string) {
-	// @ts-ignore
-	// eslint-disable-next-line
 	const amr: Model = {
 		header: {
 			name: modelName,

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -601,14 +601,18 @@ export const getStratificationType = (amr: Model) => {
 };
 
 export function newAMR(modelName: string) {
+	// @ts-ignore
+	// eslint-disable-next-line
 	const amr: Model = {
+		header: {
+			name: modelName,
+			description: '',
+			schema:
+				'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json',
+			schema_name: 'petrinet',
+			model_version: '0.1'
+		},
 		id: '',
-		name: modelName,
-		description: '',
-		schema:
-			'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json',
-		schema_name: 'petrinet',
-		model_version: '0.1',
 		model: {
 			states: [],
 			transitions: []

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -39,7 +39,13 @@
 			</ul>
 			<div
 				class="description"
-				v-html="highlightSearchTerms((asset as Model | Dataset).description)"
+				v-if="resourceType === ResourceType.MODEL"
+				v-html="highlightSearchTerms((asset as Model).header.description)"
+			/>
+			<div
+				class="description"
+				v-else-if="resourceType === ResourceType.DATASET"
+				v-html="highlightSearchTerms((asset as Dataset).description)"
 			/>
 			<div
 				class="parameters"
@@ -189,10 +195,14 @@ const snippets = computed(() =>
 		: null
 );
 const title = computed(() => {
-	const value =
-		props.resourceType === ResourceType.XDD
-			? (props.asset as Document).title
-			: (props.asset as Model | Dataset).name;
+	let value = '';
+	if (props.resourceType === ResourceType.XDD) {
+		value = (props.asset as Document).title;
+	} else if (props.resourceType === ResourceType.MODEL) {
+		value = (props.asset as Model).header.name;
+	} else if (props.resourceType === ResourceType.DATASET) {
+		value = (props.asset as Dataset).name;
+	}
 	return highlightSearchTerms(value);
 });
 

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -29,7 +29,7 @@
 					</template>
 				</div>
 				<div v-else-if="resourceType === ResourceType.MODEL">
-					{{ (asset as Model).schema_name }}
+					{{ (asset as Model).header.schema_name }}
 				</div>
 			</div>
 			<header class="title" v-html="title" />

--- a/packages/client/hmi-client/src/page/project/components/tera-model-modal.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-model-modal.vue
@@ -55,7 +55,7 @@ const invalidInputStyle = computed(() => (!isValidName.value ? 'p-invalid' : '')
 const existingModelNames = computed(() => {
 	const modelNames: string[] = [];
 	props.project.assets?.models.forEach((item) => {
-		modelNames.push(item.name);
+		modelNames.push(item.header.name);
 	});
 	return modelNames;
 });

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -328,7 +328,13 @@ const assets = computed(() => {
 			const projectAssetType: AssetType = type as AssetType;
 			const typeAssets = projectAssets[projectAssetType]
 				.map((asset) => {
-					const assetName = (asset?.name || asset?.title || asset?.id)?.toString();
+					let assetName = (asset?.name || asset?.title || asset?.id)?.toString();
+
+					// FIXME should unify upstream via a summary endpoint
+					if (asset.header && asset.header.name) {
+						assetName = asset.header.name;
+					}
+
 					const pageType = asset?.type ?? projectAssetType;
 					const assetId = asset?.id ?? '';
 					return { assetName, pageType, assetId };

--- a/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-page.vue
@@ -114,6 +114,10 @@ const assetName = computed<string>(() => {
 	 */
 	if (assets) {
 		const asset: any = assets[props.pageType as string].find((d: any) => d.id === props.assetId);
+
+		// FIXME should unify upstream via a summary endpoint
+		if (asset.header && asset.header.name) return asset.header.name;
+
 		if (asset.name) return asset.name;
 	}
 	if (props.pageType === AssetType.Code) return 'New File';

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -183,7 +183,13 @@ const assets = computed((): IProjectAssetTabs => {
 			const projectAssetType = type as AssetType;
 			const typeAssets = projectAssets[projectAssetType]
 				.map((asset) => {
-					const assetName = (asset?.name || asset?.title || asset?.id)?.toString();
+					let assetName = (asset?.name || asset?.title || asset?.id)?.toString();
+
+					// FIXME should unify upstream via a summary endpoint
+					if (asset.header && asset.header.name) {
+						assetName = asset.header.name;
+					}
+
 					const pageType = asset?.type ?? projectAssetType;
 					const assetId = asset?.id?.toString();
 					return { assetName, pageType, assetId };

--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -226,6 +226,7 @@ const filterAssets = <T extends Model | Dataset>(
 				const assetIDs = matchingResult?.map((mr) => mr.id);
 
 				assetIDs?.forEach((assetId) => {
+					// @ts-ignore
 					const asset = allAssets.find((m) => m.id === assetId);
 					if (asset) finalAssets.push(asset);
 				});

--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -20,7 +20,8 @@ import {
 	XDDFacetsItemResponse,
 	Extraction,
 	Dataset,
-	AssetType
+	AssetType,
+	Model
 } from '@/types/Types';
 import {
 	XDDDictionary,
@@ -30,7 +31,7 @@ import {
 	XDD_RESULT_DEFAULT_PAGE_SIZE
 } from '@/types/XDD';
 import { logger } from '@/utils/logger';
-import { ID, Model, ModelSearchParams, MODEL_FILTER_FIELDS } from '../types/Model';
+import { ID, ModelSearchParams, MODEL_FILTER_FIELDS } from '../types/Model';
 import { getFacets as getConceptFacets } from './concept';
 import * as DatasetService from './dataset';
 import { getAllModelDescriptions } from './model';

--- a/packages/client/hmi-client/src/services/models/stratification-service.ts
+++ b/packages/client/hmi-client/src/services/models/stratification-service.ts
@@ -133,12 +133,14 @@ export function generateAgeStrataModel(stateNames: string[]): Model {
 	};
 	const model: Model = {
 		id: 'age-contact',
-		name: 'Age-contact strata model',
-		description: 'Age-contact strata model',
-		schema:
-			'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
-		schema_name: 'petrinet',
-		model_version: '0.1',
+		header: {
+			name: 'Age-contact strata model',
+			description: 'Age-contact strata model',
+			schema:
+				'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
+			schema_name: 'petrinet',
+			model_version: '0.1'
+		},
 		model: {
 			states,
 			transitions
@@ -263,12 +265,14 @@ export function generateLocationStrataModel(stateNames: string[]): Model {
 	};
 	const model: Model = {
 		id: 'location-travel',
-		name: 'Location-travel strata model',
-		description: 'Location-travel strata model',
-		schema:
-			'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
-		schema_name: 'petrinet',
-		model_version: '0.1',
+		header: {
+			name: 'Location-travel strata model',
+			description: 'Location-travel strata model',
+			schema:
+				'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
+			schema_name: 'petrinet',
+			model_version: '0.1'
+		},
 		model: {
 			states,
 			transitions

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -78,11 +78,27 @@ export interface DocumentAsset {
 
 export interface Model {
     id: string;
+    /**
+     * @deprecated
+     */
     name: string;
+    /**
+     * @deprecated
+     */
     description: string;
+    /**
+     * @deprecated
+     */
     model_version?: string;
+    /**
+     * @deprecated
+     */
     schema: string;
+    /**
+     * @deprecated
+     */
     schema_name?: string;
+    header: ModelHeader;
     model: { [index: string]: any };
     properties?: any;
     semantics?: ModelSemantics;
@@ -312,6 +328,14 @@ export interface Concept {
     type: AssetType;
     status: OntologicalField;
     object_id: string;
+}
+
+export interface ModelHeader {
+    name: string;
+    schema: string;
+    schema_name?: string;
+    description: string;
+    model_version?: string;
 }
 
 export interface ModelSemantics {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -81,11 +81,11 @@ export interface Model {
     /**
      * @deprecated
      */
-    name: string;
+    name?: string;
     /**
      * @deprecated
      */
-    description: string;
+    description?: string;
     /**
      * @deprecated
      */
@@ -93,7 +93,7 @@ export interface Model {
     /**
      * @deprecated
      */
-    schema: string;
+    schema?: string;
     /**
      * @deprecated
      */

--- a/packages/client/hmi-client/src/utils/data-util.ts
+++ b/packages/client/hmi-client/src/utils/data-util.ts
@@ -60,7 +60,7 @@ export const getResourceTypeIcon = (type: string) => {
 
 // TEMP FUNCTIONS
 export function isModel(item: ResultType): item is Model {
-	return (<Model>item).model_version !== undefined;
+	return (<Model>item).header.model_version !== undefined;
 }
 
 export function isDataset(item: ResultType): item is Dataset {

--- a/packages/client/hmi-client/src/utils/facets.ts
+++ b/packages/client/hmi-client/src/utils/facets.ts
@@ -1,11 +1,11 @@
 import { Facets, SearchResults, FacetBucket, ResourceType } from '@/types/common';
 import { ConceptFacets, CONCEPT_FACETS_FIELD } from '@/types/Concept';
+import { Model, Document, XDDFacetsItemResponse, Dataset } from '@/types/Types';
 import {
 	FACET_FIELDS as DATASET_FACET_FIELDS,
 	DISPLAY_NAMES as DATASET_DISPLAY_NAMES
 } from '@/types/Dataset';
 import {
-	Model,
 	FACET_FIELDS as MODEL_FACET_FIELDS,
 	DISPLAY_NAMES as MODEL_DISPLAY_NAMES,
 	ID
@@ -15,7 +15,6 @@ import {
 	FACET_FIELDS as DOCUMENT_FACET_FIELDS,
 	GITHUB_URL
 } from '@/types/XDD';
-import { Document, XDDFacetsItemResponse, Dataset } from '@/types/Types';
 import { groupBy, mergeWith, isArray } from 'lodash';
 
 import { logger } from '@/utils/logger';

--- a/packages/client/hmi-client/tests/unit/model-representation/petrinet/petrinet.spec.ts
+++ b/packages/client/hmi-client/tests/unit/model-representation/petrinet/petrinet.spec.ts
@@ -35,7 +35,7 @@ describe('petrinet general utilities test', () => {
 
 	it('new empty amr', () => {
 		const res = newAMR('test123');
-		expect(res.name).to.eq('test123');
+		expect(res.header.name).to.eq('test123');
 		expect(res).toHaveProperty('model');
 	});
 });

--- a/packages/client/hmi-client/tests/unit/services/stratification-service.spec.ts
+++ b/packages/client/hmi-client/tests/unit/services/stratification-service.spec.ts
@@ -12,12 +12,14 @@ describe('test generate age strata model', () => {
 		const model = generateAgeStrataModel(stateNames);
 		expect(model).toEqual({
 			id: 'age-contact',
-			name: 'Age-contact strata model',
-			description: 'Age-contact strata model',
-			schema:
-				'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
-			schema_name: 'petrinet',
-			model_version: '0.1',
+			header: {
+				name: 'Age-contact strata model',
+				description: 'Age-contact strata model',
+				schema:
+					'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
+				schema_name: 'petrinet',
+				model_version: '0.1'
+			},
 			model: {
 				states: [
 					{
@@ -206,12 +208,14 @@ describe('test generate location strata model', () => {
 		const model = generateLocationStrataModel(stateNames);
 		expect(model).toEqual({
 			id: 'location-travel',
-			name: 'Location-travel strata model',
-			description: 'Location-travel strata model',
-			schema:
-				'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
-			schema_name: 'petrinet',
-			model_version: '0.1',
+			header: {
+				name: 'Location-travel strata model',
+				description: 'Location-travel strata model',
+				schema:
+					'https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json',
+				schema_name: 'petrinet',
+				model_version: '0.1'
+			},
 			model: {
 				states: [
 					{

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -23,21 +23,21 @@ public class Model implements Serializable {
 
 	// To be removed
 	// See: https://github.com/DARPA-ASKEM/Model-Representations/commit/f2c90f16c6c3865f71d1e727e15bc2f0b1f5ec58
-	@deprecated
+	@Deprecated
 	private String name;
 
-	@deprecated
+	@Deprecated
 	@JsonSetter(nulls = Nulls.SKIP)
 	private String description = "";
 
-	@deprecated
+	@Deprecated
 	@TSOptional
 	private String model_version;
 
-	@deprecated
+	@Deprecated
 	private String schema;
 
-	@deprecated
+	@Deprecated
 	@TSOptional
 	private String schema_name;
 	// End

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.models.dataservice;
 
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelHeader;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelSemantics;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import software.uncharted.terarium.hmiserver.annotations.TSOptional;
@@ -20,18 +21,28 @@ import java.util.Map;
 public class Model implements Serializable {
 	private String id;
 
+	// To be removed
+	// See: https://github.com/DARPA-ASKEM/Model-Representations/commit/f2c90f16c6c3865f71d1e727e15bc2f0b1f5ec58
+	@deprecated
 	private String name;
 
+	@deprecated
 	@JsonSetter(nulls = Nulls.SKIP)
 	private String description = "";
 
+	@deprecated
 	@TSOptional
 	private String model_version;
 
+	@deprecated
 	private String schema;
 
+	@deprecated
 	@TSOptional
 	private String schema_name;
+	// End
+
+	private ModelHeader header;
 
 	private Map<String, Object> model;
 

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Model.java
@@ -24,10 +24,12 @@ public class Model implements Serializable {
 	// To be removed
 	// See: https://github.com/DARPA-ASKEM/Model-Representations/commit/f2c90f16c6c3865f71d1e727e15bc2f0b1f5ec58
 	@Deprecated
+	@TSOptional
 	private String name;
 
 	@Deprecated
 	@JsonSetter(nulls = Nulls.SKIP)
+	@TSOptional
 	private String description = "";
 
 	@Deprecated
@@ -35,6 +37,7 @@ public class Model implements Serializable {
 	private String model_version;
 
 	@Deprecated
+	@TSOptional
 	private String schema;
 
 	@Deprecated

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelHeader.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelHeader.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSOptional;
+
+@Data
+@Accessors(chain = true)
+public class ModelHeader {
+	private String name;
+
+	private String schema;
+
+	@TSOptional
+	private String schema_name;
+
+	private String description;
+
+	@TSOptional
+	private String model_version;
+}


### PR DESCRIPTION
### Summary
This address various parts that need to be converted to use `amr.header` format.

Note the tabs/summary portions are rather janky, they need to be re-addressed by having a better unified summary endpoint instead of doing specialized parsing.