### PR TITLE
increase size limit to allieviate search issues

### DIFF
--- a/packages/client/hmi-client/src/services/data.ts
+++ b/packages/client/hmi-client/src/services/data.ts
@@ -205,8 +205,10 @@ const filterAssets = <T extends Model | Dataset>(
 
 		AssetFilterAttributes.forEach((attribute) => {
 			finalAssets = allAssets.filter((d) => {
-				if (d[attribute as keyof T])
-					return (d[attribute as keyof T] as string).toLowerCase().includes(term.toLowerCase());
+				const searchTarget = resourceType === ResourceType.MODEL ? (d as Model).header : d;
+
+				if (searchTarget[attribute])
+					return (searchTarget[attribute] as string).toLowerCase().includes(term.toLowerCase());
 				return '';
 			});
 		});

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/DatasetResource.java
@@ -59,7 +59,7 @@ public class DatasetResource implements SnakeCaseResource {
 	@GET
 	@Tag(name = "Get all datasets via TDS proxy")
 	public List<Dataset> getDatasets(
-		@DefaultValue("500") @QueryParam("page_size") final Integer pageSize,
+		@DefaultValue("1000") @QueryParam("page_size") final Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") final Integer page
 	) {
 		return datasetProxy.getDatasets(pageSize, page);

--- a/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ModelResource.java
+++ b/packages/services/hmi-server/src/main/java/software/uncharted/terarium/hmiserver/resources/dataservice/ModelResource.java
@@ -61,7 +61,7 @@ public class ModelResource {
 	@GET
 	@Path("/descriptions")
 	public Response getDescriptions(
-		@DefaultValue("100") @QueryParam("page_size") final Integer pageSize,
+		@DefaultValue("1000") @QueryParam("page_size") final Integer pageSize,
 		@DefaultValue("0") @QueryParam("page") final Integer page
 	) {
 		return proxy.getDescriptions(pageSize, page);


### PR DESCRIPTION
### Summary
- Increase page size limit so the client search can work, previously this was bringing back 100 models when we have over 400 models.
- Fix AMR header structure change for model search

<img width="941" alt="image" src="https://github.com/DARPA-ASKEM/Terarium/assets/1220927/605fb6f7-b0f7-4009-b13c-71713cd61d2e">


### Testing
Data-explore model search "works" in that it doesn't always return blank when you have a search term, e.g. "SIR".

