### PR TITLE
fix: explorer nav dropdown

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -152,7 +152,7 @@ watch(
 		if (projectId && !!projectId) {
 			fetchProject(projectId as IProject['id']);
 		} else {
-			project.value = null;
+			resourcesStore.setActiveProject(null);
 		}
 
 		// Refetch the list of all projects


### PR DESCRIPTION
# Description

* fix so that the project name  in the top left dropdown when navigating to the explorer
* a small sneaky fix here, since the active project is stored in the resource store we need to set the active project to null using the mutation rather than directly setting the project to null

BEFORE:

https://github.com/DARPA-ASKEM/Terarium/assets/33158416/ab0ca340-ed2d-45b6-8a80-c140d264a2a1


AFTER:


https://github.com/DARPA-ASKEM/Terarium/assets/33158416/3721b91d-2808-467d-aa91-9c370bd39ae6


Resolves #(issue)
https://github.com/DARPA-ASKEM/Terarium/issues/1674