### PR TITLE
fix: no longer remove state on error

### DIFF
--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -268,7 +268,8 @@ export async function simulationPollAction(
 
 	// there are unhandled states - we will return an error and remove all simulation Ids
 	if (unhandledStateSimulationIds.length > 0) {
-		const newState = deleteSimulationInProgress(node, simulationIds);
+		const newState = cloneDeep(node.state);
+		deleteSimulationInProgress(newState, simulationIds);
 		if (!isEqual(node.state, newState)) {
 			emitFn('update-state', newState);
 		}


### PR DESCRIPTION
# Description
This is a bit of a bandaid fix. I think we should discuss how to better guardrail `WorkflowNode.state`
Maybe its type `CalibrationOperationStateCiemss | CalibrateEnsembleCiemssOperationState | ... | null`

Im not sure

![image](https://github.com/DARPA-ASKEM/terarium/assets/17088680/e90f91a7-2368-497e-9e53-6fb33d0ff63f)