### PR TITLE
fix: avoid passing empty project id to `getAssets`

### DIFF
--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -25,11 +25,9 @@ export function useProjects() {
 	 * @param {string} projectId Id of the project to set as the active project.
 	 * @returns {Promise<IProject | null>} Active project.
 	 */
-	async function get(projectId?: IProject['id']): Promise<IProject | null> {
+	async function get(projectId: IProject['id'] = activeProjectId.value): Promise<IProject | null> {
 		if (projectId) {
 			activeProject.value = await ProjectService.get(projectId, true);
-		} else {
-			activeProject.value = await ProjectService.get(activeProjectId.value, true);
 		}
 		return activeProject.value;
 	}


### PR DESCRIPTION
# Description

Avoids 404 error on home page when projects are fetched. Error was caused by passing an empty project id to `getAssets`
