### PR TITLE
style: sidepanel footer css

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-slider.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider.vue
@@ -67,13 +67,13 @@ const sidePanelTabStyle = computed(
 }
 
 .slider.left.closed .slider-tab,
-.slider.left.open .slider-content {
-	border-right: 1px solid var(--surface-border-light);
+.slider.left.open {
+	outline: 1px solid var(--surface-border-light);
 }
 
 .slider.right.closed .slider-tab,
 .slider.right.open {
-	border-left: 1px solid var(--surface-border-light);
+	outline: 1px solid var(--surface-border-light);
 }
 
 .slider-content-container {

--- a/packages/client/hmi-client/src/components/widgets/tera-slider.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider.vue
@@ -66,13 +66,7 @@ const sidePanelTabStyle = computed(
 	transition: all 0.2s ease-out;
 }
 
-.slider.left.closed .slider-tab,
-.slider.left.open {
-	outline: 1px solid var(--surface-border-light);
-}
-
-.slider.right.closed .slider-tab,
-.slider.right.open {
+.slider {
 	outline: 1px solid var(--surface-border-light);
 }
 

--- a/packages/client/hmi-client/src/components/widgets/tera-slider.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider.vue
@@ -72,7 +72,7 @@ const sidePanelTabStyle = computed(
 }
 
 .slider.right.closed .slider-tab,
-.slider.right.open .slider-content {
+.slider.right.open {
 	border-left: 1px solid var(--surface-border-light);
 }
 
@@ -110,6 +110,7 @@ footer:empty {
 footer {
 	position: relative;
 	border-top: 1px solid var(--surface-border-light);
+	box-shadow: 0px -4px 8px -7px #b8b8b8;
 	background-color: var(--surface-section);
 	height: 5rem;
 	width: 100%;


### PR DESCRIPTION
# Description

Proper border in side panel footer. Also using outline rule for panels is a lot more simpler - takes care of open and closed states.

Box shadow rule was determined by tera-asset headers box shadow.

![image](https://github.com/DARPA-ASKEM/terarium/assets/28237258/7f16467c-8bd5-48d1-b9ad-ee433cd7da26)
