### PR TITLE
fix model_configurations post request param type

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
@@ -28,9 +28,8 @@ public class ModelConfigurationController implements SnakeCaseController {
 		return ResponseEntity.ok(proxy.getAssets(pageSize, page).getBody());
 	}
 
-	//TODO why isnt the param here a ModelConfiguration?
 	@PostMapping
-	public ResponseEntity<JsonNode> createModelConfiguration(Object config) {
+	public ResponseEntity<JsonNode> createModelConfiguration(@RequestBody ModelConfiguration config) {
 		return ResponseEntity.ok(proxy.createAsset(convertObjectToSnakeCaseJsonNode(config)).getBody());
 	}
 


### PR DESCRIPTION
Was getting the following error when making a post request to `http://localhost:8080/api/model_configurations`:
```
{
    "timestamp": "2023-10-04T18:34:02.816+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "trace": "java.lang.IllegalArgumentException: No serializer found for class java.lang.Object and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)...",
    "message": "No serializer found for class java.lang.Object and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)",
    "path": "/model_configurations"
}
```

Specifying the param type fixed it for me.
