### PR TITLE
fix: return type for acset-to-latex

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/TransformController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/TransformController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import software.uncharted.terarium.hmiserver.models.modelservice.PetriNet;
@@ -26,12 +27,12 @@ public class TransformController {
 	ModelServiceProxy modelServiceProxy;
 
 	@PostMapping("/mathml-to-acset")
-	public ResponseEntity<JsonNode> mathML2ACSet(List<String> list) {
+	public ResponseEntity<JsonNode> mathML2ACSet(@RequestBody List<String> list) {
 		return skemaProxy.convertMathML2ACSet(list);
 	}
 
-	@PostMapping("/acset-to-latex")
-	public ResponseEntity<JsonNode> acet2Latex(PetriNet content) {
+	@PostMapping(value = "/acset-to-latex", produces = {"text/plain", "application/*"})
+	public ResponseEntity<String> acet2Latex(@RequestBody PetriNet content) {
 		return modelServiceProxy.petrinetToLatex(content);
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/modelservice/ModelServiceProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/modelservice/ModelServiceProxy.java
@@ -10,8 +10,8 @@ import software.uncharted.terarium.hmiserver.models.modelservice.StratifyRequest
 
 @FeignClient(name = "model-service", url = "${terarium.dataservice.url}", path = "/model-service")
 public interface ModelServiceProxy {
-	@PostMapping("/petri-to-latex")
-	ResponseEntity<JsonNode> petrinetToLatex(
+	@PostMapping(value = "/petri-to-latex", produces = {"text/plain", "application/*"})
+	ResponseEntity<String> petrinetToLatex(
 		@RequestBody PetriNet content
 	);
 


### PR DESCRIPTION
# Summary
Fix return type, should be string and not JsonNode