### PR TITLE
fix: ensure we login after idle timeouts or on 401s

### DIFF
--- a/packages/client/hmi-client/src/api/api.ts
+++ b/packages/client/hmi-client/src/api/api.ts
@@ -40,6 +40,13 @@ API.interceptors.response.use(
 					toastTitle: `${ToastSummaries.NETWORK_ERROR} (${status})`
 				});
 		}
+		if (status === 401) {
+			// redirect to login
+			const auth = useAuthStore();
+			auth.keycloak?.login({
+				redirectUri: window.location.href
+			});
+		}
 		return null;
 	}
 );


### PR DESCRIPTION
Ensure that we redirect to the login screen on 401's with the redirect URI back to where we currently are.