### PR TITLE
fix: call type for artifacts

### DIFF
--- a/packages/client/hmi-client/src/services/artifact.ts
+++ b/packages/client/hmi-client/src/services/artifact.ts
@@ -82,7 +82,7 @@ async function uploadArtifactToProject(
  * @param artifact the artifact to create
  */
 async function createNewArtifact(artifact: Artifact): Promise<Artifact | null> {
-	const response = await API.put('/artifacts', artifact);
+	const response = await API.post('/artifacts', artifact);
 	if (!response || response.status >= 400) return null;
 	return response.data;
 }


### PR DESCRIPTION
# Description
Previously failing to create an artifact due to a client side typo