### PR TITLE
fix(hmi-server): Use correct gradle for startup script

### DIFF
--- a/hmiServerDev.sh
+++ b/hmiServerDev.sh
@@ -31,7 +31,7 @@ function deploy_containers() {
 function start_server() {
 	echo "Starting local server"
 	cd ${SERVER_DIR} || exit
-	gradle bootRun --args='--spring.profiles.active=default,secrets'
+	./gradlew bootRun --args='--spring.profiles.active=default,secrets'
 	cd - || exit
 }
 


### PR DESCRIPTION
* Point start script to gradle wrapper instead of system gradle.

Resolves #1984
