### PR TITLE
fix: do not change route if name/path exists

### DIFF
--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -64,7 +64,9 @@ keycloak
 			app.mount('body');
 			logger.info('Application Mounted', { showToast: false, silent: true });
 
-			router.push(RoutePath.Home);
+			if (!router.currentRoute.value.name) {
+				router.push(RoutePath.Home);
+			}
 
 			// Token Refresh
 			setInterval(async () => {


### PR DESCRIPTION
### Summary
This address a problem where refresh a page that is not the home-page results in a redirection back home.


### Testing
- Login
- Goto any project page
- Refresh the page, should remain in the same project page with login/credentials intact

