### PR TITLE
1993 feat limit xdd extraction previews for performance

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -98,13 +98,22 @@
 				</template>
 				<div class="asset-nav-arrows">
 					<span class="asset-pages" v-if="!isEmpty(extractions)">
-						<i class="pi pi-arrow-left" @click.stop="previewMovement(-1)"></i>
-						<span class="asset-count">
-							{{ chosenExtractionFilter }}
-							<span class="asset-count-text">{{ relatedAssetPage + 1 }}</span> of
-							<span class="asset-count-text">{{ extractions.length }}</span>
+						<span v-if="totalExtractions > 1" class="asset-count">
+							<template v-for="(_, index) in extractions.length" :key="_">
+								<i
+									:class="
+										index === relatedAssetPage
+											? 'asset-count-selected-text'
+											: 'asset-count-selected'
+									"
+									@click.stop="previewMovement(index)"
+									>{{ index + 1 }}</i
+								>
+							</template>
+							<span v-if="totalExtractions > 5" class="asset-count-text">
+								(+{{ totalExtractions }})</span
+							>
 						</span>
-						<i class="pi pi-arrow-right" @click.stop="previewMovement(1)"></i>
 					</span>
 				</div>
 			</figure>
@@ -188,6 +197,16 @@ const extractions: ComputedRef<UrlExtraction[] & Extraction[]> = computed(() => 
 	return [];
 });
 
+const totalExtractions: ComputedRef<number> = computed(() => {
+	if ((props.asset as Document).knownEntitiesCounts) {
+		return (
+			(props.asset as Document).knownEntitiesCounts.askemObjectCount +
+			(props.asset as Document).knownEntitiesCounts.urlExtractionCount
+		);
+	}
+	return 0;
+});
+
 const relatedAsset = computed(() => extractions.value[relatedAssetPage.value]);
 const snippets = computed(() =>
 	(props.asset as Document).highlight
@@ -215,11 +234,10 @@ watch(
 );
 
 function previewMovement(movement: number) {
-	const newPage = relatedAssetPage.value + movement;
+	const newPage = movement;
 	if (newPage > -1 && newPage < extractions.value.length) {
 		relatedAssetPage.value = newPage;
 	}
-	// console.log(relatedAsset.value);
 }
 
 function updateExtractionFilter(extractionType: XDDExtractionType) {
@@ -376,6 +394,11 @@ function endDrag() {
 
 .asset-nav-arrows .asset-count-text {
 	color: var(--text-color-subdued);
+}
+
+.asset-count-selected-text {
+	font-weight: 1000;
+	color: var(--text-color-primary);
 }
 
 .title,

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -234,9 +234,8 @@ watch(
 );
 
 function previewMovement(movement: number) {
-	const newPage = movement;
-	if (newPage > -1 && newPage < extractions.value.length) {
-		relatedAssetPage.value = newPage;
+	if (movement > -1 && movement < extractions.value.length) {
+		relatedAssetPage.value = movement;
 	}
 }
 

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -449,6 +449,7 @@ export interface Document {
     relatedDocuments: Document[];
     relatedExtractions: Extraction[];
     knownEntities: KnownEntities;
+    knownEntitiesCounts: KnownEntitiesCounts;
     citationList: { [index: string]: string }[];
     citedBy: { [index: string]: any }[];
 }
@@ -568,6 +569,11 @@ export interface KnownEntities {
     urlExtractions: XDDUrlExtraction[];
     askemObjects: Extraction[];
     summaries: string[];
+}
+
+export interface KnownEntitiesCounts {
+    askemObjectCount: number;
+    urlExtractionCount: number;
 }
 
 export interface OdeSemantics {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/XDDDocumentController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/XDDDocumentController.java
@@ -48,7 +48,8 @@ public class XDDDocumentController {
 		@RequestParam(required = false, name = "match") String match,
 		@RequestParam(required = false, name = "known_entities") String known_entities,
 		@RequestParam(required = false, name = "github_url") String github_url,
-		@RequestParam(required = false, name = "similar_to") String similar_to
+		@RequestParam(required = false, name = "similar_to") String similar_to,
+		@RequestParam(required = false, name = "entity_limit", defaultValue = "5") String entity_limit
 	) {
 
 		// only go ahead with the query if at least one param is present
@@ -84,7 +85,7 @@ public class XDDDocumentController {
 
 				XDDResponse<DocumentsResponseOK> doc = proxy.getDocuments(apiKey,
 					docid, doi, title, term, dataset, include_score, include_highlights, inclusive, full_results, max, per_page, dict, facets,
-					min_published, max_published, pubname, publisher, additional_fields, match, known_entities, github_url, similar_to);
+					min_published, max_published, pubname, publisher, additional_fields, match, known_entities, github_url, similar_to, entity_limit);
 
 				if (doc.getErrorMessage() != null) {
 					return ResponseEntity.internalServerError().build();

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/Document.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/Document.java
@@ -63,6 +63,9 @@ public class Document implements Serializable {
 	@JsonAlias("known_entities")
 	private KnownEntities knownEntities;
 
+	@JsonAlias("known_entities_counts")
+	private KnownEntitiesCounts knownEntitiesCounts;
+
 	@JsonAlias("citation_list")
 	private List<Map<String, String>> citationList;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/KnownEntitiesCounts.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/KnownEntitiesCounts.java
@@ -1,0 +1,18 @@
+package software.uncharted.terarium.hmiserver.models.documentservice;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class KnownEntitiesCounts {
+
+    @JsonAlias("askem_object")
+    private Integer askemObjectCount;
+
+    @JsonAlias("url_extractions")
+    private Integer urlExtractionCount;
+
+
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/documentservice/DocumentProxy.java
@@ -35,7 +35,8 @@ public interface DocumentProxy {
 		@RequestParam(required = false, name = "match") String match,
 		@RequestParam(required = false, name = "known_entities") String known_entities,
 		@RequestParam(required = false, name = "github_url") String github_url,
-		@RequestParam(required = false, name = "similar_to") String similar_to
+		@RequestParam(required = false, name = "similar_to") String similar_to,
+		@RequestParam(required = false, name = "entity_limit", defaultValue = "5") String entity_limit
 	);
 
 	@GetMapping("/sets")


### PR DESCRIPTION
# Description

* Leveraging new xDD api to limit returned extractions
* Thumbnails are now limited to 5 with total extractions displayed in brackets
* Extractions in document are not affected.
* New Test

Resolves #1993
