### PR TITLE
fix(hmi-server): Increase max upload size for files

### DIFF
--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -49,6 +49,8 @@ terarium.unauthenticated-url-patterns[2]=/configuration/ga
 management.health.rabbit.enabled=false
 server.port=3000
 spring.jackson.default-property-inclusion=NON_NULL
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=100MB
 
 ########################################################################################################################
 # Microservice configurations


### PR DESCRIPTION
# Description
* Increased the maximum size upload to 100MB
* Resolves #1995

