### PR TITLE
fix(hmi-server): Increase max upload size for files

### DIFF
--- a/packages/client/hmi-client/docker/default.conf
+++ b/packages/client/hmi-client/docker/default.conf
@@ -1,6 +1,8 @@
 server {
   listen 80;
   server_name  _;
+  # max file size. Should be kept in sync with the value in application.properties
+  client_max_body_size 100M;
 
   # redirect server error pages to the static page /50x.html
   error_page   500 502 503 504  /50x.html;

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -49,6 +49,7 @@ terarium.unauthenticated-url-patterns[2]=/configuration/ga
 management.health.rabbit.enabled=false
 server.port=3000
 spring.jackson.default-property-inclusion=NON_NULL
+# This value needs to be mirrored in default.conf in the nginx container
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
 


### PR DESCRIPTION
* Increase the limit in our nginx instance to 100mb as well.

Resolves #1995 
