### PR TITLE
style: simplify overview page - make banner fit in the actual header

### DIFF
--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -14,7 +14,7 @@
 			</aside>
 		</header>
 		<template v-if="!hideIntro">
-			<header id="asset-top" ref="headerRef">
+			<header id="asset-top" :class="isOverview && 'overview-banner'" ref="headerRef">
 				<section>
 					<!-- put the buttons above the title if there is an overline -->
 					<div v-if="overline" class="vertically-center">
@@ -46,8 +46,9 @@
 					<div class="header-buttons">
 						<slot name="bottom-header-buttons" />
 					</div>
+					<slot name="overview-summary" />
 				</section>
-				<aside class="spread-out">
+				<aside v-if="!isOverview" class="spread-out">
 					<Button
 						v-if="featureConfig.isPreview"
 						icon="pi pi-times"
@@ -94,6 +95,7 @@ const props = defineProps({
 		default: { isPreview: false } as FeatureConfig
 	},
 	// Booleans default to false if not specified
+	isOverview: Boolean,
 	isNamingAsset: Boolean,
 	hideIntro: Boolean,
 	showStickyHeader: Boolean,
@@ -208,6 +210,16 @@ header aside {
 
 header.shrinked aside {
 	align-self: center;
+}
+header.overview-banner section {
+	width: 100%;
+	max-width: 100%;
+}
+
+.overview-banner {
+	background: url('@/assets/svg/terarium-icon-transparent.svg') no-repeat right 20% center,
+		linear-gradient(45deg, #8bd4af1a, #d5e8e5 100%) no-repeat;
+	background-size: 25%, 100%;
 }
 
 .nudge-down {

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -52,7 +52,7 @@
 					</div>
 					<slot name="overview-summary" />
 				</section>
-				<aside v-if="pageType === ProjectPages.OVERVIEW" class="spread-out">
+				<aside v-if="pageType !== ProjectPages.OVERVIEW" class="spread-out">
 					<Button
 						v-if="featureConfig.isPreview"
 						icon="pi pi-times"

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -16,7 +16,7 @@
 		<template v-if="!hideIntro">
 			<header
 				id="asset-top"
-				:class="pageType === ProjectPages.OVERVIEW && 'overview-banner'"
+				:class="{ 'overview-banner': pageType === ProjectPages.OVERVIEW }"
 				ref="headerRef"
 			>
 				<section>

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -14,7 +14,11 @@
 			</aside>
 		</header>
 		<template v-if="!hideIntro">
-			<header id="asset-top" :class="isOverview && 'overview-banner'" ref="headerRef">
+			<header
+				id="asset-top"
+				:class="pageType === ProjectPages.OVERVIEW && 'overview-banner'"
+				ref="headerRef"
+			>
 				<section>
 					<!-- put the buttons above the title if there is an overline -->
 					<div v-if="overline" class="vertically-center">
@@ -48,7 +52,7 @@
 					</div>
 					<slot name="overview-summary" />
 				</section>
-				<aside v-if="!isOverview" class="spread-out">
+				<aside v-if="pageType === ProjectPages.OVERVIEW" class="spread-out">
 					<Button
 						v-if="featureConfig.isPreview"
 						icon="pi pi-times"
@@ -66,8 +70,11 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, PropType } from 'vue';
+import { useRoute } from 'vue-router';
 import Button from 'primevue/button';
 import { FeatureConfig } from '@/types/common';
+import { ProjectPages } from '@/types/Project';
+import { AssetType } from '@/types/Types';
 
 const props = defineProps({
 	name: {
@@ -95,7 +102,6 @@ const props = defineProps({
 		default: { isPreview: false } as FeatureConfig
 	},
 	// Booleans default to false if not specified
-	isOverview: Boolean,
 	isNamingAsset: Boolean,
 	hideIntro: Boolean,
 	showStickyHeader: Boolean,
@@ -115,6 +121,8 @@ const shrinkHeader = computed(() => {
 		!props.isNamingAsset // Don't appear while creating an asset eg. a model
 	);
 });
+
+const pageType = useRoute().params.pageType as ProjectPages | AssetType;
 
 // Scroll margin for anchors are adjusted depending on the header (inserted in css)
 const scrollMarginTopStyle = computed(() => (shrinkHeader.value ? '3.5rem' : '0.5rem'));

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -374,7 +374,6 @@ p,
 	display: flex;
 	justify-content: space-evenly;
 	padding: 1rem;
-	width: 100%;
 	background: rgba(255, 255, 255, 0.5);
 	border-radius: var(--border-radius);
 	backdrop-filter: blur(5px);

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -6,7 +6,6 @@
 		:publisher="`Last updated ${DateUtils.formatLong(
 			useProjects().activeProject.value?.timestamp
 		)}`"
-		is-overview
 	>
 		<template #name-input>
 			<InputText

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -1,98 +1,87 @@
 <template>
-	<main>
-		<tera-asset
-			:name="useProjects().activeProject.value?.name"
-			:authors="useProjects().activeProject.value?.username"
-			:is-naming-asset="isRenamingProject"
-			:publisher="`Last updated ${DateUtils.formatLong(
-				useProjects().activeProject.value?.timestamp
-			)}`"
-			class="overview-banner"
-		>
-			<template #name-input>
-				<InputText
-					v-if="isRenamingProject"
-					v-model="newProjectName"
-					ref="inputElement"
-					@keyup.enter="updateProjectName"
-				/>
-			</template>
-			<template #edit-buttons>
-				<Button
-					icon="pi pi-ellipsis-v"
-					class="p-button-icon-only p-button-text p-button-rounded"
-					@click="showProjectMenu"
-				/>
-				<Menu ref="projectMenu" :model="projectMenuItems" :popup="true" />
-			</template>
-			<section>
-				<section class="summary">
-					<!-- This div is so that child elements will automatically collapse margins -->
-					<div>
-						<!-- Description & Contributors -->
-						<section class="description">
-							<p>
-								{{ useProjects().activeProject.value?.description }}
-							</p>
-						</section>
-					</div>
-				</section>
-				<!-- Project summary KPIs -->
-				<section class="summary-KPI-bar">
-					<div
-						class="summary-KPI"
-						v-for="(assets, type) of useProjects().activeProject.value?.assets"
-						:key="type"
-					>
-						<span class="summary-KPI-number">{{ assets.length ?? 0 }}</span>
-						<span class="summary-KPI-label">{{ capitalize(type) }}</span>
-					</div>
-				</section>
+	<tera-asset
+		:name="useProjects().activeProject.value?.name"
+		:authors="useProjects().activeProject.value?.username"
+		:is-naming-asset="isRenamingProject"
+		:publisher="`Last updated ${DateUtils.formatLong(
+			useProjects().activeProject.value?.timestamp
+		)}`"
+		is-overview
+	>
+		<template #name-input>
+			<InputText
+				v-if="isRenamingProject"
+				v-model="newProjectName"
+				ref="inputElement"
+				@keyup.enter="updateProjectName"
+			/>
+		</template>
+		<template #edit-buttons>
+			<Button
+				icon="pi pi-ellipsis-v"
+				class="p-button-icon-only p-button-text p-button-rounded"
+				@click="showProjectMenu"
+			/>
+			<Menu ref="projectMenu" :model="projectMenuItems" :popup="true" />
+		</template>
+		<template #overview-summary>
+			<!-- Description & Contributors -->
+			<p>
+				{{ useProjects().activeProject.value?.description }}
+			</p>
+			<!-- Project summary KPIs -->
+			<section class="summary-KPI-bar">
+				<div
+					class="summary-KPI"
+					v-for="(assets, type) of useProjects().activeProject.value?.assets"
+					:key="type"
+				>
+					<span class="summary-KPI-number">{{ assets.length ?? 0 }}</span>
+					<span class="summary-KPI-label">{{ capitalize(type) }}</span>
+				</div>
 			</section>
-		</tera-asset>
+		</template>
 		<section class="content-container">
 			<h5>Quick links</h5>
 			<!-- Quick link buttons go here -->
-			<section>
-				<div class="quick-links">
-					<Button
-						label="Upload resources"
-						size="large"
-						icon="pi pi-cloud-upload"
-						class="p-button p-button-secondary quick-link-button"
-						@click="isUploadResourcesModalVisible = true"
+			<section class="quick-links">
+				<Button
+					label="Upload resources"
+					size="large"
+					icon="pi pi-cloud-upload"
+					class="p-button p-button-secondary quick-link-button"
+					@click="isUploadResourcesModalVisible = true"
+				/>
+				<Button
+					label="New model"
+					size="large"
+					icon="pi pi-share-alt"
+					class="p-button p-button-secondary quick-link-button"
+					@click="emit('open-new-asset', AssetType.Models)"
+				/>
+				<Button
+					size="large"
+					class="p-button p-button-secondary quick-link-button"
+					@click="emit('open-new-asset', AssetType.Workflows)"
+				>
+					<vue-feather
+						class="p-button-icon-left"
+						type="git-merge"
+						size="1.25rem"
+						stroke="rgb(16, 24, 40)"
 					/>
-					<Button
-						label="New model"
-						size="large"
-						icon="pi pi-share-alt"
-						class="p-button p-button-secondary quick-link-button"
-						@click="emit('open-new-asset', AssetType.Models)"
-					/>
-					<Button
-						size="large"
-						class="p-button p-button-secondary quick-link-button"
-						@click="emit('open-new-asset', AssetType.Workflows)"
-					>
-						<vue-feather
-							class="p-button-icon-left"
-							type="git-merge"
-							size="1.25rem"
-							stroke="rgb(16, 24, 40)"
-						/>
-						<span class="p-button-label">New workflow</span>
-					</Button>
-					<Button size="large" class="p-button p-button-secondary quick-link-button">
-						<compare-models-icon class="icon" />
-						<span class="p-button-label">Compare models</span>
-					</Button>
-					<Button
-						label="New simulation"
-						size="large"
-						icon="pi pi-play"
-						class="p-button p-button-secondary quick-link-button"
-					/>
-				</div>
+					<span class="p-button-label">New workflow</span>
+				</Button>
+				<Button size="large" class="p-button p-button-secondary quick-link-button">
+					<compare-models-icon class="icon" />
+					<span class="p-button-label">Compare models</span>
+				</Button>
+				<Button
+					label="New simulation"
+					size="large"
+					icon="pi pi-play"
+					class="p-button p-button-secondary quick-link-button"
+				/>
 			</section>
 			<!-- Resources list table goes here -->
 			<section class="resource-list">
@@ -168,19 +157,17 @@
 					</template>
 				</DataTable>
 			</section>
-			<section class="drag-n-drop">
-				<tera-upload-resources-modal
-					:visible="isUploadResourcesModalVisible"
-					@close="isUploadResourcesModalVisible = false"
-				/>
-			</section>
+			<tera-upload-resources-modal
+				:visible="isUploadResourcesModalVisible"
+				@close="isUploadResourcesModalVisible = false"
+			/>
 		</section>
 		<tera-multi-select-modal
 			:is-visible="showMultiSelect"
 			:selected-resources="selectedResources"
 			:buttons="multiSelectButtons"
-		></tera-multi-select-modal>
-	</main>
+		/>
+	</tera-asset>
 </template>
 
 <script setup lang="ts">
@@ -364,13 +351,6 @@ a {
 	text-decoration: underline;
 }
 
-.overview-banner {
-	background: url('@/assets/svg/terarium-icon-transparent.svg') no-repeat right 20% center,
-		linear-gradient(45deg, #8bd4af1a, #d5e8e5 100%) no-repeat;
-	background-size: 25%, 100%;
-	height: auto;
-}
-
 .content-container {
 	overflow-y: auto;
 	padding: 1rem;
@@ -379,22 +359,22 @@ a {
 	flex-direction: column;
 }
 
-.description {
-	margin: 1rem;
-}
-
 .contributors {
 	flex-direction: row;
 	align-items: center;
 	gap: 0.75rem;
 }
 
+p,
+.summary-KPI-bar {
+	color: var(--text-color-primary);
+}
+
 .summary-KPI-bar {
 	display: flex;
-	flex-direction: row;
 	justify-content: space-evenly;
-	margin: 1rem;
 	padding: 1rem;
+	width: 100%;
 	background: rgba(255, 255, 255, 0.5);
 	border-radius: var(--border-radius);
 	backdrop-filter: blur(5px);


### PR DESCRIPTION
# Description

Note the background fills the bottom with white. Before the banner background was used as the main background. The banner background is moved to the header of `tera-asset.vue` when Overview is chosen.

![image](https://github.com/DARPA-ASKEM/terarium/assets/28237258/1b1b3ddc-3e61-46ac-ad77-6dbf958d5e8d)