### PR TITLE
Fix: acc closed, diagram changed, acc opened, no change

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-editor.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-editor.vue
@@ -1,5 +1,5 @@
 <template>
-	<Accordion multiple :active-index="[0, 1, 2, 3]">
+	<Accordion multiple :active-index="[0, 1, 2, 3]" v-bind:lazy="true">
 		<AccordionTab header="Model diagram">
 			<tera-model-diagram
 				ref="teraModelDiagramRef"


### PR DESCRIPTION
# Description
When the model diagram was closed and the model was changed via equations it would re-render the graph. The issue is the graphElement had height and width of 0 due to the acc being closed.
When reopened it would not re-render and the model changes were not displayed (specifically going from nothing to a model)

This tag means this section will only render when opened 


https://github.com/DARPA-ASKEM/terarium/assets/17088680/14359448-3693-42b3-9284-23949183cb64





