### PR TITLE
fix: fix equations to amr

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-configurations.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-configurations.vue
@@ -274,21 +274,14 @@ const baseModel = computed<any>(() => {
 });
 const headerStates = computed<any[]>(() =>
 	stratifiedModelType.value
-		? baseModel.value.states.map(({ name }) => name)
-		: configurations.value[0]?.semantics?.ode.initials?.map(({ target }) =>
-				getInitialTargetStateNames(target)
-		  ) ?? []
+		? baseModel.value.states.map(({ id }) => id)
+		: configurations.value[0]?.semantics?.ode.initials?.map(({ target }) => target) ?? []
 );
-
-function getInitialTargetStateNames(target: string) {
-	return configurations.value[0]?.model.states.find(({ id }) => id === target)?.name ?? target;
-}
-
 const headerTransitions = computed<any[]>(() =>
 	stratifiedModelType.value
 		? // ? baseModel.value.transitions.map(({ id }) => id)
 		  [...getUnstratifiedParameters(props.model).keys()]
-		: configurations.value[0]?.semantics?.ode.parameters?.map(({ name }) => name) ?? []
+		: configurations.value[0]?.semantics?.ode.parameters?.map(({ id }) => id) ?? []
 );
 const headerStatesAndTransitions = computed(() => [
 	...headerStates.value,

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-configurations.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-configurations.vue
@@ -274,14 +274,21 @@ const baseModel = computed<any>(() => {
 });
 const headerStates = computed<any[]>(() =>
 	stratifiedModelType.value
-		? baseModel.value.states.map(({ id }) => id)
-		: configurations.value[0]?.semantics?.ode.initials?.map(({ target }) => target) ?? []
+		? baseModel.value.states.map(({ name }) => name)
+		: configurations.value[0]?.semantics?.ode.initials?.map(({ target }) =>
+				getInitialTargetStateNames(target)
+		  ) ?? []
 );
+
+function getInitialTargetStateNames(target: string) {
+	return configurations.value[0]?.model.states.find(({ id }) => id === target)?.name ?? target;
+}
+
 const headerTransitions = computed<any[]>(() =>
 	stratifiedModelType.value
 		? // ? baseModel.value.transitions.map(({ id }) => id)
 		  [...getUnstratifiedParameters(props.model).keys()]
-		: configurations.value[0]?.semantics?.ode.parameters?.map(({ id }) => id) ?? []
+		: configurations.value[0]?.semantics?.ode.parameters?.map(({ name }) => name) ?? []
 );
 const headerStatesAndTransitions = computed(() => [
 	...headerStates.value,

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -312,10 +312,12 @@
 						]"
 					>
 						<template v-if="isSectionEditable === `transition-${index}`">
-							<td>{{ transition.id }}</td>
+							<!-- Use of split is a hack to get a transition name since we don't have a name field for transitions for models created from equations -->
+							<td>{{ transition.id.split('-')[0] }}</td>
 							<td>{{ transition.name }}</td>
-							<td>{{ transition.input }}</td>
-							<td>{{ transition.output }}</td>
+							<!-- // Use of split is a hack to display state name instead of id -->
+							<td>{{ transition.input.split('-')[0] }}</td>
+							<td>{{ transition.output.split('-')[0] }}</td>
 							<td>
 								<katex-element
 									v-if="transition.expression"
@@ -334,10 +336,12 @@
 							</td>
 						</template>
 						<template v-else>
-							<td>{{ transition.id }}</td>
+							<!-- Use of split is a hack to get a transition name since we don't have a name field for transitions for models created from equations -->
+							<td>{{ transition.id.split('-')[0] }}</td>
 							<td>{{ transition.name }}</td>
-							<td>{{ transition.input }}</td>
-							<td>{{ transition.output }}</td>
+							<!-- // Use of split is a hack to display state name instead of id -->
+							<td>{{ transition.input.split('-')[0] }}</td>
+							<td>{{ transition.output.split('-')[0] }}</td>
 							<td>
 								<katex-element
 									v-if="transition.expression"

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -160,7 +160,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.style('paint-order', 'stroke')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
-			.html((d) => d.id);
+			.html((d) => d.label);
 
 		// transitions expression text
 		transitions
@@ -219,7 +219,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.style('paint-order', 'stroke')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
-			.text((d) => d.id);
+			.text((d) => d.label);
 	}
 
 	renderEdges(selection: D3SelectionIEdge<EdgeData>) {

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -39,7 +39,8 @@ export const convertAMRToACSet = (amr: Model) => {
 	const petrinetModel = amr.model as PetriNetModel;
 
 	petrinetModel.states.forEach((s) => {
-		result.S.push({ sname: s.id });
+		// Use of split is a hack to display state name instead of id
+		result.S.push({ sname: s.id.split('-')[0] });
 	});
 
 	petrinetModel.transitions.forEach((t) => {
@@ -49,7 +50,8 @@ export const convertAMRToACSet = (amr: Model) => {
 	petrinetModel.transitions.forEach((transition) => {
 		transition.input.forEach((input) => {
 			result.I.push({
-				is: result.S.findIndex((s) => s.sname === input) + 1,
+				// Use of split is a hack to display state name instead of id
+				is: result.S.findIndex((s) => s.sname === input.split('-')[0]) + 1,
 				it: result.T.findIndex((t) => t.tname === transition.id) + 1
 			});
 		});
@@ -58,7 +60,8 @@ export const convertAMRToACSet = (amr: Model) => {
 	petrinetModel.transitions.forEach((transition) => {
 		transition.output.forEach((output) => {
 			result.O.push({
-				os: result.S.findIndex((s) => s.sname === output) + 1,
+				// Use of split is a hack to display state name instead of id
+				os: result.S.findIndex((s) => s.sname === output.split('-')[0]) + 1,
 				ot: result.T.findIndex((t) => t.tname === transition.id) + 1
 			});
 		});
@@ -120,7 +123,8 @@ export const convertToIGraph = (amr: Model) => {
 		const strataType = typeMap?.[1] ?? '';
 		result.nodes.push({
 			id: transition.id,
-			label: transition.id,
+			// Use of split is a hack to get a transition name since we don't have a name field for transitions for models created from equations
+			label: transition.id.split('-')[0],
 			type: 'transition',
 			x: 0,
 			y: 0,


### PR DESCRIPTION
# Description

* As per [this slack thread](https://askemgroup.slack.com/archives/C03THCGK2DU/p1697563475264709), state and transition ids not be interpreted as indicating semantic interpretations
* Transition names are not outputted as a result of equation-to-amr 
* **This is a hack** as a proper fix will require more time - will probably have unintended consequences

Resolves #2032
