### PR TITLE
checking file extensions. some file types not rec

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-upload-resources-modal.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-upload-resources-modal.vue
@@ -85,16 +85,16 @@ const importedFiles = ref<File[]>([]);
 
 async function processFiles(files: File[], csvDescription: string) {
 	return files.map(async (file) => {
-		switch (file.type) {
-			case AcceptedTypes.CSV:
+		switch (file.name.split('.').pop()) {
+			case AcceptedExtensions.CSV:
 				return processDataset(file, csvDescription);
-			case AcceptedTypes.PDF:
-			case AcceptedTypes.TXT:
-			case AcceptedTypes.MD:
+			case AcceptedExtensions.PDF:
+			case AcceptedExtensions.TXT:
+			case AcceptedExtensions.MD:
 				return processDocument(file);
-			case AcceptedTypes.PY:
-			case AcceptedTypes.R:
-			case AcceptedTypes.JL:
+			case AcceptedExtensions.PY:
+			case AcceptedExtensions.R:
+			case AcceptedExtensions.JL:
 				return processCode(file);
 			default:
 				return { id: '', assetType: '' };
@@ -107,7 +107,6 @@ async function processFiles(files: File[], csvDescription: string) {
  * @param file
  */
 async function processCode(file: File) {
-	// This is pdf, txt, md files
 	const newCode = await uploadCodeToProject(file, progress);
 	return { id: newCode?.id ?? '', assetType: AssetType.Code };
 }


### PR DESCRIPTION
# Description
**It should be noted, that this does not solve the problem of viewing these assets. That is being done under a different issue and different branch.**


Some file types are not recognized.
For example .md files and .java files being read  as a `HTMLInputElement.files` has no `types`

Rather than checking this types field which is unreliable lets check the extension on the filename allowing us to actually handle these scenarios

<img width="236" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/6bee7554-2387-42ea-8f69-da672ab08324">
