### PR TITLE
fix: project name nav

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -386,7 +386,7 @@ async function updateDatasetName() {
 		datasetClone.name = newDatasetName.value;
 		await updateDataset(datasetClone);
 		dataset.value = await getDataset(props.assetId);
-		useProjects().get();
+		useProjects().refresh();
 		isRenamingDataset.value = false;
 	}
 }

--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -140,7 +140,7 @@ async function updateModelContent(updatedModel: Model) {
 	await updateModel(updatedModel);
 	setTimeout(async () => {
 		await getModelWithConfigurations(); // elastic search might still not update in time
-		useProjects().get();
+		useProjects().refresh();
 	}, 800);
 }
 

--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -26,7 +26,17 @@ export function useProjects() {
 	 * @param {string} projectId Id of the project to set as the active project.
 	 * @returns {Promise<IProject | null>} Active project.
 	 */
-	async function get(projectId: IProject['id'] = activeProjectId.value): Promise<IProject | null> {
+	async function get(projectId: IProject['id']): Promise<IProject | null> {
+		if (projectId) {
+			activeProject.value = await ProjectService.get(projectId, true);
+		} else {
+			activeProject.value = null;
+		}
+		return activeProject.value;
+	}
+
+	async function refresh(): Promise<IProject | null> {
+		const projectId: IProject['id'] = activeProjectId.value;
 		if (projectId) {
 			activeProject.value = await ProjectService.get(projectId, true);
 		}
@@ -217,6 +227,7 @@ export function useProjects() {
 		create,
 		update,
 		remove,
+		refresh,
 		getPublicationAssets,
 		getPermissions,
 		setPermissions,

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -400,10 +400,10 @@ const watchCompletedRunList = async () => {
 };
 
 async function saveDatasetToProject() {
-	const { activeProject, get } = useProjects();
+	const { activeProject, refresh } = useProjects();
 	if (activeProject.value?.id) {
 		if (await saveDataset(activeProject.value.id, completedRunId.value, saveAsName.value)) {
-			get();
+			refresh();
 		}
 		showSaveInput.value = false;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -212,10 +212,10 @@ const handleSelectedRunChange = () => {
 };
 
 async function saveDatasetToProject() {
-	const { activeProject, get } = useProjects();
+	const { activeProject, refresh } = useProjects();
 	if (activeProject.value?.id) {
 		if (await saveDataset(activeProject.value.id, selectedRun.value.runId, saveAsName.value)) {
-			get();
+			refresh();
 		}
 		showSaveInput.value = false;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -379,10 +379,10 @@ const addChart = () => {
 };
 
 async function saveDatasetToProject() {
-	const { activeProject, get } = useProjects();
+	const { activeProject, refresh } = useProjects();
 	if (activeProject.value?.id) {
 		if (await saveDataset(activeProject.value.id, completedRunId.value, saveAsName.value)) {
-			get();
+			refresh();
 		}
 		showSaveInput.value = false;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -190,10 +190,10 @@ const handleSelectedRunChange = () => {
 };
 
 async function saveDatasetToProject() {
-	const { activeProject, get } = useProjects();
+	const { activeProject, refresh } = useProjects();
 	if (activeProject.value?.id) {
 		if (await saveDataset(activeProject.value.id, selectedRun.value.runId, saveAsName.value)) {
-			get();
+			refresh();
 		}
 		showSaveInput.value = false;
 	}


### PR DESCRIPTION
# Description

* Fix a bug where the project name is showing in the top left when navigating from a project to the home or explorer page.
* needed to set the active project as null when we navigate to these pages
* separate get and refresh function for a project in the useProjects composable.


https://github.com/DARPA-ASKEM/terarium/assets/33158416/5947f677-9c31-4167-9dee-7a113a6c78a7

