### PR TITLE
Update application.properties

### DIFF
--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -47,6 +47,7 @@ terarium.unauthenticated-url-patterns[1]=/actuator/health
 ########################################################################################################################
 management.health.rabbit.enabled=false
 server.port=3000
+server.http2.enabled=true
 spring.jackson.default-property-inclusion=NON_NULL
 # This value needs to be mirrored in default.conf in the nginx container
 spring.servlet.multipart.max-file-size=100MB


### PR DESCRIPTION
# Description

* `hmi-server` now [use HTTP-2](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.server.server.http2.enabled)
* Resolves #2026
