### PR TITLE
fix: catch general document error if there's an error processing equation images

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
@@ -118,8 +118,8 @@ public class DocumentController implements SnakeCaseController {
 					// Add the equations into the metadata
 					asset.getMetadata().put("equation", equation);
 				}
-			} catch (IOException e) {
-				log.error("Unable to extract S3 url for assets", e);
+			} catch (Exception e) {
+				log.error("Unable to extract S3 url for assets or extract equations", e);
 			}
 		});
 


### PR DESCRIPTION
# Description

* Added catch all exceptions rather than just IOExceptions.  This will make it so that errors in extracting images aren't blocking errors
* see this [thread](https://unchartedsoftware.slack.com/archives/C049E6PA16V/p1698332262399659), there seems to be an error in in staging only.  image -> equations will need to be addressed, but this is a fix so that it is non blocking