### PR TITLE
fix: project rename

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -307,10 +307,6 @@ public class ProjectController {
 		@PathVariable("project_id") final String id,
 		@RequestBody final Project project
 	) {
-		System.out.println("\n\n");
-		System.out.println(id);
-		System.out.println(project);
-		System.out.println("\n\n");
 		try {
 			if (new RebacUser(currentUserService.getToken().getSubject(), reBACService).canWrite(new RebacProject(id, reBACService))) {
 				return ResponseEntity.ok(proxy.updateProject(id, project).getBody());

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -278,7 +278,6 @@ public class ProjectController {
 	public ResponseEntity<JsonNode> createProject(
 		@RequestBody final Project project
 	) throws JsonProcessingException {
-
 		ResponseEntity<JsonNode> res = proxy.createProject(project);
 		if (res != null) {
 
@@ -303,11 +302,15 @@ public class ProjectController {
 		}
 	}
 
-	@PutMapping("/{id}")
+	@PutMapping("/{project_id}")
 	public ResponseEntity<JsonNode> updateProject(
-		@PathVariable("id") final String id,
-		final Project project
+		@PathVariable("project_id") final String id,
+		@RequestBody final Project project
 	) {
+		System.out.println("\n\n");
+		System.out.println(id);
+		System.out.println(project);
+		System.out.println("\n\n");
 		try {
 			if (new RebacUser(currentUserService.getToken().getSubject(), reBACService).canWrite(new RebacProject(id, reBACService))) {
 				return ResponseEntity.ok(proxy.updateProject(id, project).getBody());

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/Project.java
@@ -56,14 +56,4 @@ public class Project implements Serializable {
 
 	@TSOptional
 	private String userPermission;
-
-	@Override
-	public String toString() {
-		return "Project: { id: " + this.projectID +
-			" name: " + this.name +
-			" description: " + this.description +
-			" Assets: " + this.assets +
-			" Related Documents: " + this.relatedDocuments +
-			" }";
-	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProjectProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/dataservice/ProjectProxy.java
@@ -31,9 +31,9 @@ public interface ProjectProxy {
 	);
 
 
-	@PutMapping("/{id}")
+	@PutMapping("/{project_id}")
 	ResponseEntity<JsonNode> updateProject(
-		@PathVariable("id") String id,
+		@PathVariable("project_id") String id,
 		@RequestBody Project project
 	);
 


### PR DESCRIPTION
# Description

Projects can now be renamed. The `@Override` in `Project.java` was the culprit - it was reformatting the request body. I don't know what that override could have been used for but it doesn't seem like it's used anywhere now.

https://github.com/DARPA-ASKEM/terarium/assets/28237258/bfd61441-07f9-4328-ae2c-1fbb4535b39f


