### PR TITLE
task: spinner for documents

### DIFF
--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -1,5 +1,5 @@
 <template>
-	<main @scroll="updateScrollPosition">
+	<main v-if="!isLoading" @scroll="updateScrollPosition">
 		<slot name="nav" />
 		<header v-if="shrinkHeader || showStickyHeader" class="shrinked">
 			<h4 v-html="name" />
@@ -66,6 +66,7 @@
 			<slot name="default" />
 		</section>
 	</main>
+	<section v-else><tera-progress-spinner :font-size="2" /></section>
 </template>
 
 <script setup lang="ts">
@@ -75,6 +76,7 @@ import Button from 'primevue/button';
 import { FeatureConfig } from '@/types/common';
 import { ProjectPages } from '@/types/Project';
 import { AssetType } from '@/types/Types';
+import teraProgressSpinner from '../widgets/tera-progress-spinner.vue';
 
 const props = defineProps({
 	name: {
@@ -105,7 +107,8 @@ const props = defineProps({
 	isNamingAsset: Boolean,
 	hideIntro: Boolean,
 	showStickyHeader: Boolean,
-	stretchContent: Boolean
+	stretchContent: Boolean,
+	isLoading: Boolean
 });
 
 const emit = defineEmits(['close-preview']);

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -6,6 +6,7 @@
 		:is-naming-asset="isRenamingDataset"
 		:stretch-content="view === DatasetView.DATA"
 		@close-preview="emit('close-preview')"
+		:is-loading="isDatasetLoading"
 	>
 		<template #name-input>
 			<InputText
@@ -338,6 +339,7 @@ const newDatasetName = ref('');
 const isRenamingDataset = ref(false);
 const rawContent: Ref<CsvAsset | null> = ref(null);
 const jupyterCsv: Ref<CsvAsset | null> = ref(null);
+const isDatasetLoading = ref(false);
 
 function formatName(name: string) {
 	return (name.charAt(0).toUpperCase() + name.slice(1)).replace('_', ' ');
@@ -479,7 +481,9 @@ watch(
 	async () => {
 		isRenamingDataset.value = false;
 		if (props.assetId !== '') {
-			fetchDataset();
+			isDatasetLoading.value = true;
+			await fetchDataset();
+			isDatasetLoading.value = false;
 		} else {
 			dataset.value = null;
 			rawContent.value = null;

--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -1,7 +1,7 @@
 <!-- This template is a copy of tera-external-publication with some elements stripped out.  TODO: merge the concept of external publication and document asset -->
 <template>
 	<tera-asset
-		v-if="doc && !documentLoading"
+		v-if="doc"
 		:feature-config="featureConfig"
 		:name="highlightSearchTerms(doc.name)"
 		:overline="highlightSearchTerms(doc.source)"
@@ -9,6 +9,7 @@
 		:hide-intro="view === DocumentView.PDF"
 		:stretch-content="view === DocumentView.PDF"
 		:show-sticky-header="view === DocumentView.PDF"
+		:is-loading="documentLoading"
 	>
 		<template #edit-buttons>
 			<SelectButton
@@ -112,9 +113,6 @@
 		/>
 		<tera-text-editor v-else-if="view === DocumentView.TXT" :initial-text="docText" />
 	</tera-asset>
-	<section v-else class="flex justify-content-center">
-		<tera-progress-spinner :font-size="2" />
-	</section>
 </template>
 
 <script setup lang="ts">
@@ -136,7 +134,6 @@ import Image from 'primevue/image';
 import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
 import SelectButton from 'primevue/selectbutton';
 import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
-import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import TeraTextEditor from './tera-text-editor.vue';
 
 enum DocumentView {

--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -6,6 +6,7 @@
 		:is-naming-asset="isNaming"
 		:stretch-content="view === ModelView.MODEL"
 		@close-preview="emit('close-preview')"
+		:is-loading="isModelLoading"
 	>
 		<template #name-input>
 			<InputText
@@ -108,6 +109,7 @@ const model = ref<Model | null>(null);
 const modelConfigurations = ref<ModelConfiguration[]>([]);
 const newName = ref('New Model');
 const isRenaming = ref(false);
+const isModelLoading = ref(false);
 
 const view = ref(ModelView.DESCRIPTION);
 const viewOptions = ref([
@@ -217,7 +219,11 @@ watch(
 		// Reset view of model page
 		isRenaming.value = false;
 		view.value = ModelView.DESCRIPTION;
-		if (!isEmpty(props.assetId)) await getModelWithConfigurations();
+		if (!isEmpty(props.assetId)) {
+			isModelLoading.value = true;
+			await getModelWithConfigurations();
+			isModelLoading.value = false;
+		}
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/components/widgets/tera-progress-spinner.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-progress-spinner.vue
@@ -1,0 +1,14 @@
+<template>
+	<i class="pi pi-spin pi-spinner" :style="{ fontSize: fontSize + 'rem' }"></i>
+</template>
+
+<script setup lang="ts">
+defineProps({
+	fontSize: {
+		type: Number,
+		default: 1
+	}
+});
+</script>
+
+<style scoped></style>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -1,6 +1,7 @@
 <template>
 	<!-- add 'debug-mode' to debug this -->
 	<tera-infinite-canvas
+		v-if="!isWorkflowLoading"
 		@click="onCanvasClick()"
 		@contextmenu="toggleContextMenu"
 		@save-transform="saveTransform"
@@ -211,6 +212,7 @@
 			/>
 		</template>
 	</tera-infinite-canvas>
+	<section v-else><tera-progress-spinner :font-size="2" /></section>
 </template>
 
 <script setup lang="ts">
@@ -243,6 +245,7 @@ import { useDragEvent } from '@/services/drag-drop';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useProjects } from '@/composables/project';
+import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { ModelOperation, TeraModelNode, ModelOperationState } from './ops/model/mod';
 import { SimulateCiemssOperation, TeraSimulateNodeCiemss } from './ops/simulate-ciemss/mod';
 import { StratifyOperation, TeraStratifyNodeJulia } from './ops/stratify-julia/mod';
@@ -284,6 +287,8 @@ let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
 let saveTimer: any = null;
 let workflowDirty: boolean = false;
+
+const isWorkflowLoading = ref(false);
 
 const currentActiveNode = ref<WorkflowNode<any> | null>();
 
@@ -803,7 +808,9 @@ watch(
 		}
 		const workflowId = props.assetId;
 		if (!workflowId) return;
+		isWorkflowLoading.value = true;
 		wf.value = await workflowService.getWorkflow(workflowId);
+		isWorkflowLoading.value = false;
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
# Description

* Adding a spinner when navigating to a document, this endpoint does take a while to show - so giving a sense of progress here.
* I figure it wouldn't hurt to add a simple spinner component here and we can define its size.
* Added a snippet of text for the scenario when pdf-extractions haven't completed.  This can probably be refactored when we work on [this](https://github.com/DARPA-ASKEM/terarium/issues/2069) and can listen to these async job properly


https://github.com/DARPA-ASKEM/terarium/assets/33158416/3d58f563-3b74-46eb-9fb9-cb050789a265


