### PR TITLE
Task: Adding FUNMAN basic APIs into hmiserver.

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -350,6 +350,34 @@ export interface ExtractionResponseResult {
     job_result: any;
 }
 
+export interface FunmanPostQueriesRequest {
+    query: any;
+    parameters: any[];
+    config: FunmanConfig;
+    structureParameters: any[];
+}
+
+export interface FunmanConfig {
+    tolerance: number;
+    queueTimeout: number;
+    numberOfProcesses: number;
+    waitTimeout: number;
+    waitActionTimeout: number;
+    solver: string;
+    numSteps: number;
+    stepSize: number;
+    numInitialBoxes: number;
+    saveSmtlib: boolean;
+    drealPrecision: number;
+    drealLogLevel: string;
+    constraintNoise: number;
+    initialStateTolerance: number;
+    drealMcts: boolean;
+    substituteSubformulas: boolean;
+    useCompartmentalConstraints: boolean;
+    normalize: boolean;
+}
+
 export interface DKG {
     curie: string;
     name: string;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/funman/FunmanController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/funman/FunmanController.java
@@ -1,0 +1,38 @@
+package software.uncharted.terarium.hmiserver.controller.funman;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import software.uncharted.terarium.hmiserver.proxies.funman.FunmanProxy;
+import software.uncharted.terarium.hmiserver.models.funman.FunmanPostQueriesRequest;
+
+@RestController
+@RequestMapping("/funman/queries")
+public class FunmanController {
+
+    @Autowired
+    private FunmanProxy funmanProxy;
+
+    @GetMapping("/{query_id}/halt")
+    public ResponseEntity<JsonNode> halt(@PathVariable String query_id) {
+        ResponseEntity<JsonNode> response = funmanProxy.halt(query_id);
+
+        return ResponseEntity.ok(response.getBody());
+    }
+
+    @GetMapping("/{query_id}")
+    public ResponseEntity<JsonNode> getQueries(@PathVariable String query_id) {
+        ResponseEntity<JsonNode> response = funmanProxy.getQueries(query_id);
+
+        return ResponseEntity.ok(response.getBody());
+    }
+
+    @PostMapping
+    public ResponseEntity<JsonNode> postQueries(@RequestBody FunmanPostQueriesRequest requestBody) {
+        ResponseEntity<JsonNode> response = funmanProxy.postQueries(requestBody);
+
+        return ResponseEntity.ok(response.getBody());
+    }
+} 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/funman/FunmanPostQueriesRequest.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/funman/FunmanPostQueriesRequest.java
@@ -1,0 +1,20 @@
+package software.uncharted.terarium.hmiserver.models.funman;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.models.funman.parts.FunmanConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class FunmanPostQueriesRequest {
+    private JsonNode query;
+    private List<JsonNode> parameters;
+    private FunmanConfig config;
+    private List<JsonNode> structureParameters;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/funman/parts/FunmanConfig.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/funman/parts/FunmanConfig.java
@@ -1,0 +1,29 @@
+package software.uncharted.terarium.hmiserver.models.funman.parts;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class FunmanConfig {
+	private Double tolerance;
+	private Integer queueTimeout;
+	private Integer numberOfProcesses;
+	private Integer waitTimeout;
+	private Double waitActionTimeout;
+	private String solver;
+	private Integer numSteps;
+	private Integer stepSize;
+	private Integer numInitialBoxes;
+	private Boolean saveSmtlib;
+	private Double drealPrecision;
+	private String drealLogLevel;
+	private Double constraintNoise;
+	private Double initialStateTolerance;
+	private Boolean drealMcts;
+	private Boolean substituteSubformulas;
+	private Boolean useCompartmentalConstraints;
+	private Boolean normalize;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/funman/FunmanProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/funman/FunmanProxy.java
@@ -1,0 +1,24 @@
+package software.uncharted.terarium.hmiserver.proxies.funman;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import software.uncharted.terarium.hmiserver.models.funman.FunmanPostQueriesRequest;
+import software.uncharted.terarium.hmiserver.proxies.funman.FunmanProxy;
+
+@FeignClient(name = "funman-api", url = "${funman-service.url}", path="/queries")
+public interface FunmanProxy {
+
+    @GetMapping("/{query_id}/halt")
+    ResponseEntity<JsonNode> halt(@PathVariable("query_id") String queryId);
+   
+    @GetMapping("/{query_id}")
+    ResponseEntity<JsonNode> getQueries(@PathVariable("query_id") String queryId);
+
+    @PostMapping
+    ResponseEntity<JsonNode> postQueries(@RequestBody FunmanPostQueriesRequest requestBody);
+}

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -67,6 +67,7 @@ skema-unified.url=https://api.askem.lum.ai
 terarium.dataservice.url=https://data-service.staging.terarium.ai
 xdd-dev-service.url=https://xdddev.chtc.io
 xdd-prod-service.url=https://xdd.wisc.edu
+funman-service.url=http://funman.staging.terarium.ai/api
 simulation-service.url=https://sciml-service.staging.terarium.ai
 ciemss-service.url=https://pyciemss.staging.terarium.ai
 


### PR DESCRIPTION
- Replacement for the other 1889 PR this aims to simplify by not trying to keep up with the "fluid" responses and just use jsonnode

- Changing config -> parts and using base folder for request type to follow convention

- Keeping other PR available rather than overwriting is as im currently having trouble connecting to and testing Funman. Safety is handy