### PR TITLE
fix: shows if non unpaywall paper is not found

### DIFF
--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -160,6 +160,7 @@ const view = ref(DocumentView.EXTRACTIONS);
 const extractionsOption = { value: DocumentView.EXTRACTIONS, icon: 'pi pi-list' };
 const pdfOption = { value: DocumentView.PDF, icon: 'pi pi-file-pdf' };
 const txtOption = { value: DocumentView.TXT, icon: 'pi pi-file' };
+const notFoundOption = { value: DocumentView.NOT_FOUND, icon: 'pi pi-file', disabled: true };
 
 const viewOptions = computed(() => {
 	const options: { value: DocumentView; icon: string; disabled?: boolean }[] = [extractionsOption];
@@ -170,7 +171,7 @@ const viewOptions = computed(() => {
 			options.push(txtOption);
 		}
 	} else {
-		options.push({ value: DocumentView.NOT_FOUND, icon: 'pi pi-file', disabled: true });
+		options.push(notFoundOption);
 	}
 	return options;
 });

--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -17,11 +17,14 @@
 				@change="if ($event.value) view = $event.value;"
 				:options="viewOptions"
 				option-value="value"
+				option-disabled="disabled"
 			>
 				<template #option="{ option }">
 					<i
 						:class="`${
-							!pdfLink && option.value !== DocumentView.EXTRACTIONS
+							!pdfLink &&
+							option.value !== DocumentView.EXTRACTIONS &&
+							option.value !== DocumentView.NOT_FOUND
 								? 'pi pi-spin pi-spinner'
 								: option.icon
 						} p-button-icon-left`"
@@ -139,7 +142,8 @@ import TeraTextEditor from './tera-text-editor.vue';
 enum DocumentView {
 	EXTRACTIONS = 'Extractions',
 	PDF = 'PDF',
-	TXT = 'Text'
+	TXT = 'Text',
+	NOT_FOUND = 'Not found'
 }
 
 const props = defineProps<{
@@ -152,15 +156,25 @@ const props = defineProps<{
 const doc = ref<DocumentAsset | null>(null);
 const pdfLink = ref<string | null>(null);
 const view = ref(DocumentView.EXTRACTIONS);
-const viewOptions = computed(() => {
-	if (doc.value?.fileNames?.at(0)?.endsWith('.pdf')) {
-		return [extractionsOption, pdfOption];
-	}
-	return [extractionsOption, txtOption];
-});
+
 const extractionsOption = { value: DocumentView.EXTRACTIONS, icon: 'pi pi-list' };
 const pdfOption = { value: DocumentView.PDF, icon: 'pi pi-file-pdf' };
 const txtOption = { value: DocumentView.TXT, icon: 'pi pi-file' };
+
+const viewOptions = computed(() => {
+	const options: { value: DocumentView; icon: string; disabled?: boolean }[] = [extractionsOption];
+	if (!isEmpty(doc.value?.fileNames)) {
+		if (doc.value?.fileNames?.at(0)?.endsWith('.pdf')) {
+			options.push(pdfOption);
+		} else {
+			options.push(txtOption);
+		}
+	} else {
+		options.push({ value: DocumentView.NOT_FOUND, icon: 'pi pi-file', disabled: true });
+	}
+	return options;
+});
+
 const docText = ref<string>('');
 
 const documentLoading = ref(false);


### PR DESCRIPTION
# Description

Non paywall papers stop spinning

Showing the github link and other lacking attributes in the project view is a part of a bigger problem that should be handled in its own PR. 

When a document is added to a project is gets processed through the function `createDocumentFromXDD`. This adds the document into the project in a different format than what is seen in the Data Explorer. It turns a `Document` into a `DocumentAsset`. `DocumentAsset` doesn't have a property for github urls and it isn't clear where it and other properties would belong.

https://github.com/DARPA-ASKEM/terarium/assets/28237258/3ee3379c-f22c-45f8-bcb3-014daef7485c


