### PR TITLE
fix: ensure keycloak-js and vue-router do not interfere with eachother

### DIFF
--- a/packages/client/hmi-client/index.html
+++ b/packages/client/hmi-client/index.html
@@ -10,11 +10,11 @@
 	<script>
 		import Keycloak from 'keycloak-js';
 		window.keycloak = new Keycloak('/api/configuration/keycloak');
-		const kc_options = {
+		const keycloak_options = {
 			onLoad: "login-required",
 			checkLoginIframe: false,
 		};
-		window.kc_init = keycloak.init(kc_options);
+		window.keycloak_init = keycloak.init(keycloak_options);
 	</script>
 	<script src="https://documentservices.adobe.com/view-sdk/viewer.js" async></script>
 	<script type="module" src="/src/main.ts"></script>

--- a/packages/client/hmi-client/index.html
+++ b/packages/client/hmi-client/index.html
@@ -6,6 +6,15 @@
 	<link rel="icon" type="image/png" href="/src/assets/images/terarium-icon.png" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Terarium</title>
+	<script src="https://cdn.jsdelivr.net/npm/keycloak-js@22.0.3/dist/keycloak.min.js"></script>
+	<script>
+		window.keycloak = new Keycloak('/api/configuration/keycloak');
+		const kc_options = {
+			onLoad: "login-required",
+			checkLoginIframe: false,
+		};
+		window.kc_init = keycloak.init(kc_options);
+	</script>
 	<script src="https://documentservices.adobe.com/view-sdk/viewer.js" async></script>
 	<script type="module" src="/src/main.ts"></script>
 </head>

--- a/packages/client/hmi-client/index.html
+++ b/packages/client/hmi-client/index.html
@@ -8,6 +8,7 @@
 	<title>Terarium</title>
 	<script src="https://cdn.jsdelivr.net/npm/keycloak-js@22.0.3/dist/keycloak.min.js"></script>
 	<script>
+		import Keycloak from 'keycloak-js';
 		window.keycloak = new Keycloak('/api/configuration/keycloak');
 		const kc_options = {
 			onLoad: "login-required",

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -24,13 +24,13 @@ import Keycloak from 'keycloak-js';
 // Extend the window object to include the Keycloak object
 declare global {
 	interface Window {
-		kc_init: boolean;
+		keycloak_init: Promise<boolean>;
 		keycloak: Keycloak;
 	}
 }
 
 try {
-	await window.kc_init;
+	await window.keycloak_init;
 } catch (e) {
 	console.error(e);
 	logger.error('Authentication Failed, reloading a the page');

--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -19,6 +19,15 @@ import '@node_modules/katex/dist/katex.min.css';
 import App from '@/App.vue';
 import { useProjects } from '@/composables/project';
 import '@/assets/css/style.scss';
+import Keycloak from 'keycloak-js';
+
+// Extend the window object to include the Keycloak object
+declare global {
+	interface Window {
+		kc_init: boolean;
+		keycloak: Keycloak;
+	}
+}
 
 try {
 	await window.kc_init;
@@ -35,7 +44,7 @@ app.use(createPinia());
 
 // Set up the Keycloak authentication
 const authStore = useAuthStore();
-authStore.setKeycloak(window?.keycloak);
+authStore.setKeycloak(window.keycloak);
 
 // Initialize user
 await authStore.init();


### PR DESCRIPTION
There is a race condition in vue-router that can cause it to leave keycloak hash state laying around.  A proposed solution
(https://github.com/keycloak/keycloak/issues/14742#issuecomment-1312547429) suggests moving the keycloak initialization into a `<script>` element.  This works and, as an added bonus, seems to really improve the performance of the application.
