### PR TITLE
stub for additional ciemss operators - on hold for ciemss migration

### DIFF
--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -12,7 +12,8 @@ export enum WorkflowOperationTypes {
 	SIMULATE_ENSEMBLE_CIEMSS = 'SimulateEnsembleCiemms',
 	CALIBRATE_ENSEMBLE_CIEMSS = 'CalibrateEnsembleCiemms',
 	DATASET_TRANSFORMER = 'DatasetTransformer',
-	MODEL_TRANSFORMER = 'ModelTransformer'
+	MODEL_TRANSFORMER = 'ModelTransformer',
+	OPTIMIZE_CIEMSS = 'OptimizeCiemss'
 }
 
 export enum WorkflowStatus {

--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -1,0 +1,23 @@
+import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+
+export interface OptimizeCiemssOperationState {}
+
+export const SimulateCiemssOperation: Operation = {
+	name: WorkflowOperationTypes.OPTIMIZE_CIEMSS,
+	displayName: 'Optimization',
+	description: 'Optimize model under scenario',
+	inputs: [{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: false }],
+	outputs: [],
+	isRunnable: true,
+
+	initState: () => {
+		const init: OptimizeCiemssOperationState = {};
+		return init;
+	},
+
+	// TODO: Figure out mapping
+	// Calls API, returns results.
+	action: async (): Promise<void> => {
+		console.log('test');
+	}
+};


### PR DESCRIPTION
### Summary
Place holder for splitting CiEMSS compounded operations into atomic operations.



Reference
```
### Calibrate-Simulate
- Calibrate
  - input: model-config, dataset
  - state: mappings, extra configs
  - output; joint posterior distribution blob, sample of joint-distribution?
  - notes:
    - probably need to do some post processing

- Simulate
  - input:
    - model-configuration
    - joint posterior blob + model-configuration
  - state: start/end, solver ... etc
  - output:
    - simulate output


### Ensemble-hodge-star
@Nelson to check


### Calibrate-Optimize-Simulate
Exist in pyciemss, not hooked up in Terarium

- Calibrate (Sample joint distribution, call sampling function)
- Optimize (@Nelson to check if this can take in distribution blob)
- Simulate


### Optimize-Simulate
Exist in pyciemss, not hooked up in Terarium
- Optimize
 - input: model-config + goal + extra stuff??
 - state: ???
 - output: parameter values, risk values and other metrics
 - notes:
   - probably need to do some post processing to turn params into model-config
   - does it have intermediate result?? what is the value of the target at step n

- Simulate
 - ref: #simulate
```