### PR TITLE
fix: recognize page type when an asset is highlighted on the sidebar

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -54,7 +54,10 @@
 				<Button
 					v-for="assetItem in assetItems"
 					:key="assetItem.assetId"
-					:active="assetItem.assetId === openedAssetRoute.assetId"
+					:active="
+						assetItem.assetId === openedAssetRoute.assetId &&
+						assetItem.pageType === openedAssetRoute.pageType
+					"
 					:title="assetItem.assetName"
 					class="asset-button"
 					plain


### PR DESCRIPTION
# Description

This can happen when assets of different types share the same id:
![image](https://github.com/DARPA-ASKEM/terarium/assets/28237258/fcfab647-a2aa-43d3-8972-10f8442eb93f)

I had to check for `pageType` so now the proper one will be highlighted
