### PR TITLE
feat: maintain open closed resource tabs using localstorage

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -108,7 +108,12 @@
 					<Column selection-mode="multiple" headerStyle="width: 3rem" />
 					<Column field="assetName" header="Name" sortable style="width: 75%">
 						<template #body="slotProps">
-							<div class="asset-button" @click="openResource(slotProps.data)">
+							<div
+								class="asset-button"
+								@click="
+									openAsset({ pageType: slotProps.data.pageType, assetId: slotProps.data.assetId })
+								"
+							>
 								<tera-asset-icon :assetType="slotProps.data.pageType" />
 								<span class="p-button-label">{{ slotProps.data.assetName }}</span>
 							</div>
@@ -132,7 +137,13 @@
 								plain
 								text
 								rounded
-								@click.stop="(e) => showRowActions(e, slotProps.data)"
+								@click.stop="
+									(e) =>
+										showAssetActions(e, {
+											pageType: slotProps.data.pageType,
+											assetId: slotProps.data.assetId
+										})
+								"
 							/>
 							<Menu ref="rowActionMenu" :model="rowActionMenuItems" :popup="true" />
 						</template>
@@ -173,6 +184,7 @@ import { AssetType } from '@/types/Types';
 import { useRouter } from 'vue-router';
 import { RouteName } from '@/router/routes';
 import { useProjects } from '@/composables/project';
+import { AssetRoute } from '@/types/common';
 import TeraAssetIcon from '@/components/widgets/tera-asset-icon.vue';
 import TeraUploadResourcesModal from './tera-upload-resources-modal.vue';
 
@@ -183,7 +195,7 @@ const inputElement = ref<HTMLInputElement | null>(null);
 const newProjectName = ref<string>('');
 const selectedResources = ref();
 
-const openedRow = ref(null);
+const assetRouteToOpen = ref<AssetRoute | null>(null);
 
 const searchTable = ref('');
 const showMultiSelect = ref<boolean>(false);
@@ -207,8 +219,8 @@ async function editProject() {
 	inputElement.value?.$el.focus();
 }
 
-async function openResource(data) {
-	router.push({ name: RouteName.Project, params: data });
+function openAsset(assetRoute: AssetRoute) {
+	router.push({ name: RouteName.Project, params: assetRoute });
 }
 
 async function updateProjectName() {
@@ -251,16 +263,18 @@ function setRowHover() {
 /* Row Action Menu */
 const rowActionMenu = ref();
 const rowActionMenuItems = ref([
-	{ label: 'Open', command: () => openResource(openedRow.value) }
-
+	{
+		label: 'Open',
+		command: () => assetRouteToOpen.value && openAsset(assetRouteToOpen.value)
+	}
 	// TODO add the follow commands
 	// { label: 'Rename' },
 	// { label: 'Make a copy' },
 	// { label: 'Delete' },
 	// { label: 'Download' }
 ]);
-const showRowActions = (event, data) => {
-	openedRow.value = data;
+const showAssetActions = (event, assetRoute: AssetRoute) => {
+	assetRouteToOpen.value = assetRoute;
 	rowActionMenu.value.toggle(event);
 };
 

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -43,7 +43,19 @@
 				<span class="p-button-label">Overview</span>
 			</span>
 		</Button>
-		<Accordion v-if="!isEmpty(assetItemsMap)" :multiple="true" :active-index="[0, 1, 2, 3, 4, 5]">
+		<Accordion
+			v-if="!isEmpty(assetItemsMap)"
+			:multiple="true"
+			:active-index="Array.from(activeAccordionTabs)"
+			@tab-open="
+				activeAccordionTabs.add($event.index);
+				saveAccordionTabsState();
+			"
+			@tab-close="
+				activeAccordionTabs.delete($event.index);
+				saveAccordionTabsState();
+			"
+		>
 			<AccordionTab v-for="[type, assetItems] in assetItemsMap" :key="type">
 				<template #header>
 					<template v-if="type === AssetType.Publications">External Publications</template>
@@ -150,12 +162,21 @@ const isRemovalModal = ref(false);
 const draggedAsset = ref<AssetRoute | null>(null);
 const assetToDelete = ref<AssetItem | null>(null);
 const searchAsset = ref<string>('');
+const activeAccordionTabs = ref(
+	new Set(
+		localStorage.getItem('activeResourceBarTabs')?.split(',').map(Number) ?? [0, 1, 2, 3, 4, 5, 6]
+	)
+);
 
 const assetItemsMap = computed(() => generateProjectAssetsMap(searchAsset.value));
 
 function removeAsset() {
 	emit('remove-asset', assetToDelete.value);
 	isRemovalModal.value = false;
+}
+
+function saveAccordionTabsState() {
+	localStorage.setItem('activeResourceBarTabs', Array.from(activeAccordionTabs.value).join());
 }
 
 const { setDragData, deleteDragData } = useDragEvent();


### PR DESCRIPTION
# Description

Maintain open and closed resource tabs with localstorage. I investigated other methods but they didn't work. 
Also fixed how the overview page opens assets - extra unused params were being passed before.

https://github.com/DARPA-ASKEM/terarium/assets/28237258/2362dce2-7dde-477c-b79c-2be8c22902b8

