### PR TITLE
fix: sse reconnecting too often

### DIFF
--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -14,7 +14,6 @@ import { EventType } from '@/types/Types';
 import * as EventService from '@/services/event';
 import API from '@/api/api';
 import useAuthStore from '@/stores/auth';
-import { init } from '@/services/ClientEventService';
 import router from '@/router';
 import '@node_modules/katex/dist/katex.min.css';
 import App from '@/App.vue';
@@ -54,9 +53,6 @@ logger.info('Authenticated');
 setInterval(async () => {
 	await window.keycloak.updateToken(70);
 }, 6000);
-
-// init sse
-init();
 
 // Set the hash value of the window.location to null
 // This is to prevent the Keycloak from redirecting to the hash value

--- a/packages/client/hmi-client/src/services/ClientEventService.ts
+++ b/packages/client/hmi-client/src/services/ClientEventService.ts
@@ -20,11 +20,6 @@ let lastHeartbeat = new Date().valueOf();
 let backoffMs = 1000;
 
 /**
- * Whether we are currently reconnecting to the SSE endpoint
- */
-let reconnecting = false;
-
-/**
  * An error that can be retried
  */
 class RetriableError extends Error {}
@@ -87,14 +82,10 @@ export async function init(): Promise<void> {
  * and reconnects if not
  */
 setInterval(async () => {
-	if (!reconnecting) {
-		const config = await getConfiguration();
-		const heartbeatIntervalMillis = config?.sseHeartbeatIntervalMillis ?? 10000;
-		if (new Date().valueOf() - lastHeartbeat > heartbeatIntervalMillis) {
-			reconnecting = true;
-			await init();
-			reconnecting = false;
-		}
+	const config = await getConfiguration();
+	const heartbeatIntervalMillis = config?.sseHeartbeatIntervalMillis ?? 10000;
+	if (new Date().valueOf() - lastHeartbeat > heartbeatIntervalMillis) {
+		await init();
 	}
 }, 1000);
 

--- a/packages/client/hmi-client/src/services/ClientEventService.ts
+++ b/packages/client/hmi-client/src/services/ClientEventService.ts
@@ -68,7 +68,9 @@ export async function init(): Promise<void> {
 			// If we get a retriable error, double the backoff time up to a maximum of 60 seconds
 			if (error instanceof RetriableError) {
 				backoffMs *= 2;
-				return Math.min(backoffMs, 60000);
+				const retriesTime = Math.min(backoffMs, 60000);
+				console.log(`Retrying SSE connection in ${retriesTime}ms`);
+				return retriesTime;
 			}
 			throw error; // fatal
 		},

--- a/packages/client/hmi-client/src/services/ClientEventService.ts
+++ b/packages/client/hmi-client/src/services/ClientEventService.ts
@@ -52,11 +52,12 @@ export async function init(): Promise<void> {
 		},
 		async onopen(response: Response) {
 			if (response.status === 401) {
-				// redirect to login
+				// redirect to the login page
 				authStore.keycloak?.login({
 					redirectUri: window.location.href
 				});
-			} else if (response.status === 500) {
+			} else if (response.status >= 500) {
+				console.log('SSE connection error');
 				throw new RetriableError('Internal server error');
 			} else {
 				// Reset the backoff time as we've made a connection successfully


### PR DESCRIPTION
# Description

* For some reasons the `hmi-server` might answer a 503 to the `hmi-client` to the `/api/client-event` endpoint.
* I updated the error status code test to include all `5XX`.
* I added a couple of console.log to explain the issue with the retry times.
* I removed the `init()` call in `main.ts` as the *reconnecting* heartbeat does it anyway, which might produce some conflict.
