### PR TITLE
Provisional regnet stockflow support

### DIFF
--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -88,5 +88,9 @@ export async function addNewModelToProject(modelName: string): Promise<string | 
 
 // A helper function to check if a model is empty.
 export function isModelEmpty(model: Model) {
-	return isEmpty(model.model?.states) && isEmpty(model.model?.transitions);
+	if (model.header.schema_name === 'petrinet') {
+		return isEmpty(model.model?.states) && isEmpty(model.model?.transitions);
+	}
+	// TODO: support different frameworks' version of empty
+	return false;
 }

--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -118,7 +118,7 @@ export async function getRunResultCiemss(runId: string, filename = 'result.csv')
 			const keySuffix = keyArr.pop();
 			const keyName = keyArr.join('_');
 
-			if (keySuffix === 'param') {
+			if (keySuffix === 'param' || keySuffix === 'state') {
 				outputRowRunResults[keyName] = inputRow[key];
 				if (!runConfigs[keyName]) {
 					runConfigs[keyName] = [];


### PR DESCRIPTION
### Summary
Provisional support for running stock-and-flow and regnet model frameworks through the simulate operation. Technically this can be merged without impacting any existing functions, to to actually run RegNet and StockFlow it depends on the CIEMSS refactor. 

RegNet and StockFlow simulate can be tested with this branch from CIEMSS here:
https://github.com/DARPA-ASKEM/pyciemss-service/pull/50

<img width="897" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/1068716a-036e-4da0-a4ba-fcfb6a09a9b2">