### PR TITLE
SSE and mq improvements

### DIFF
--- a/packages/client/hmi-client/src/services/ClientEventService.ts
+++ b/packages/client/hmi-client/src/services/ClientEventService.ts
@@ -20,6 +20,11 @@ let lastHeartbeat = new Date().valueOf();
 let backoffMs = 1000;
 
 /**
+ * Whether we are currently reconnecting to the SSE endpoint
+ */
+let reconnecting = false;
+
+/**
  * An error that can be retried
  */
 class RetriableError extends Error {}
@@ -82,10 +87,14 @@ export async function init(): Promise<void> {
  * and reconnects if not
  */
 setInterval(async () => {
-	const config = await getConfiguration();
-	const heartbeatIntervalMillis = config?.sseHeartbeatIntervalMillis ?? 10000;
-	if (new Date().valueOf() - lastHeartbeat > heartbeatIntervalMillis) {
-		await init();
+	if (!reconnecting) {
+		const config = await getConfiguration();
+		const heartbeatIntervalMillis = config?.sseHeartbeatIntervalMillis ?? 10000;
+		if (new Date().valueOf() - lastHeartbeat > heartbeatIntervalMillis) {
+			reconnecting = true;
+			await init();
+			reconnecting = false;
+		}
 	}
 }, 1000);
 

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -931,6 +931,9 @@ export enum AuthorityType {
 export enum RoleType {
     Admin = "ADMIN",
     User = "USER",
+    Group = "GROUP",
+    Test = "TEST",
+    Service = "SERVICE",
     Special = "SPECIAL",
 }
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/Config.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/Config.java
@@ -45,7 +45,7 @@ public class Config {
 	/**
 	 * If queues should be declared durable.  IF running Rabbit inside docker, this should be false
 	 */
-	Boolean durableQueues = true;
+	Boolean durableQueues = false;
 
 	@Data
 	@Accessors(chain = true)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -27,10 +27,10 @@ import software.uncharted.terarium.hmiserver.models.User;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
@@ -44,7 +44,8 @@ public class ClientEventService{
   private static final String CLIENT_USER_EVENT_QUEUE = "clientUserEventQueue";
   private static final String CLIENT_ALL_USERS_EVENT_QUEUE = "clientAllUsersEventQueue";
 
-  final Map<String, SseEmitter> userIdToEmitter = new HashMap<>();
+  final Map<String, SseEmitter> userIdToEmitter = new ConcurrentHashMap<>();
+
   Queue allUsersQueue;
   Queue userQueue;
 
@@ -118,7 +119,6 @@ public class ClientEventService{
    */
   @RabbitListener(
           queues = {CLIENT_ALL_USERS_EVENT_QUEUE},
-          exclusive = true,
           concurrency = "1")
   void onSendToAllUsersEvent(final Message message, final Channel channel) {
     final JsonNode messageJson = decodeMessage(message);
@@ -152,7 +152,6 @@ public class ClientEventService{
    */
   @RabbitListener(
           queues = {CLIENT_USER_EVENT_QUEUE},
-          exclusive = true,
           concurrency = "1")
   void onSendToUserEvent(final Message message, final Channel channel) throws IOException {
     final JsonNode messageJson = decodeMessage(message);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
@@ -1,6 +1,5 @@
 package software.uncharted.terarium.hmiserver.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.Channel;
@@ -12,7 +11,6 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import software.uncharted.terarium.hmiserver.configuration.Config;
 import software.uncharted.terarium.hmiserver.models.ClientEvent;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
@@ -21,99 +19,100 @@ import software.uncharted.terarium.hmiserver.models.simulationservice.ScimlStatu
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class SimulationEventService {
 
+    private final ObjectMapper mapper;
+    private final ClientEventService clientEventService;
+    private final Config config;
+    private final RabbitAdmin rabbitAdmin;
 
-	private final ObjectMapper mapper;
-  private final ClientEventService clientEventService;
-  private final Config config;
-  private final RabbitAdmin rabbitAdmin;
+    private final Map<String, Set<String>> simulationIdToUserIds = new ConcurrentHashMap<>();
 
-	private final Map<String, Set<String>> simulationIdToUserIds = new HashMap<>();
-
-  private final static String SCIML_QUEUE = "sciml-queue";
-  private final static String PYCIEMSS_QUEUE = "simulation-status";
-
-
-  Queue scimlQueue;
-  Queue pyciemssQueue;
+    private final static String SCIML_QUEUE = "sciml-queue";
+    private final static String PYCIEMSS_QUEUE = "simulation-status";
 
 
-  @PostConstruct
-  void init() {
-    scimlQueue = new Queue(SCIML_QUEUE, config.getDurableQueues());
-    rabbitAdmin.declareQueue(scimlQueue);
-
-    pyciemssQueue = new Queue(PYCIEMSS_QUEUE, config.getDurableQueues());
-    rabbitAdmin.declareQueue(pyciemssQueue);
-
-  }
-	public void subscribe(List<String> simulationIds, User user){
-		for(String simulationId : simulationIds) {
-			if(!simulationIdToUserIds.containsKey(simulationId)) {
-				simulationIdToUserIds.put(simulationId, new HashSet<>());
-			}
-			simulationIdToUserIds.get(simulationId).add(user.getId());
-		}
-
-	}
-
-	public void unsubscribe(List<String> simulationIds, User user){
-		for(String simulationId : simulationIds)
-			simulationIdToUserIds.get(simulationId).remove(user.getId());
-	}
+    Queue scimlQueue;
+    Queue pyciemssQueue;
 
 
-  /**
-   * Lisens for messages to send to a user and if we have the SSE connection, send it
-   * @param message       the message to send
-   * @param channel       the channel to send the message on
-   * @throws IOException  if there was an error sending the message
-   */
-  @RabbitListener(
-    queues = {SCIML_QUEUE},
-    exclusive = true,
-    concurrency = "1")
-  private void onScimlSendToUserEvent(final Message message, final Channel channel) throws IOException {
+    @PostConstruct
+    void init() {
+        scimlQueue = new Queue(SCIML_QUEUE, config.getDurableQueues());
+        rabbitAdmin.declareQueue(scimlQueue);
 
-		final ScimlStatusUpdate update = decodeMessage(message, ScimlStatusUpdate.class);
-		ClientEvent<ScimlStatusUpdate> status = ClientEvent.<ScimlStatusUpdate>builder().type(ClientEventType.SIMULATION_SCIML).data(update).build();
+        pyciemssQueue = new Queue(PYCIEMSS_QUEUE, config.getDurableQueues());
+        rabbitAdmin.declareQueue(pyciemssQueue);
 
-		simulationIdToUserIds.get(update.getId()).forEach(userId -> {
-			clientEventService.sendToUser(status, userId);
-		});
+    }
 
-  }
+    public void subscribe(List<String> simulationIds, User user) {
+        for (String simulationId : simulationIds) {
+            if (!simulationIdToUserIds.containsKey(simulationId)) {
+                simulationIdToUserIds.put(simulationId, new HashSet<>());
+            }
+            simulationIdToUserIds.get(simulationId).add(user.getId());
+        }
 
-  /**
-   * Lisens for messages to send to a user and if we have the SSE connection, send it
-   * @param message       the message to send
-   * @param channel       the channel to send the message on
-   * @throws IOException  if there was an error sending the message
-   */
-  @RabbitListener(
-          queues = {PYCIEMSS_QUEUE},
-          exclusive = true,
-          concurrency = "1")
-  private void onPyciemssSendToUserEvent(final Message message, final Channel channel) throws IOException {
-    //SimulationIntermediateResultsCiemss
-		final JsonNode messageJson = decodeMessage(message, JsonNode.class);
-		ClientEvent<Object> status = ClientEvent.builder().type(ClientEventType.SIMULATION_PYCIEMSS).data(messageJson).build();
-		clientEventService.sendToAllUsers(status);
-  }
+    }
 
-	private <T>T decodeMessage(final Message message, Class<T> clazz) {
+    public void unsubscribe(List<String> simulationIds, User user) {
+        for (String simulationId : simulationIds)
+            simulationIdToUserIds.get(simulationId).remove(user.getId());
+    }
 
-			try {
-					return mapper.readValue(message.getBody(), clazz);
-			} catch (IOException e) {
-					log.error("Error decoding message", e);
-					return null;
-			}
-	}
+
+    /**
+     * Lisens for messages to send to a user and if we have the SSE connection, send it
+     *
+     * @param message the message to send
+     * @param channel the channel to send the message on
+     * @throws IOException if there was an error sending the message
+     */
+    @RabbitListener(
+            queues = {SCIML_QUEUE},
+            concurrency = "1")
+    private void onScimlSendToUserEvent(final Message message, final Channel channel) throws IOException {
+
+        final ScimlStatusUpdate update = decodeMessage(message, ScimlStatusUpdate.class);
+        ClientEvent<ScimlStatusUpdate> status = ClientEvent.<ScimlStatusUpdate>builder().type(ClientEventType.SIMULATION_SCIML).data(update).build();
+
+        simulationIdToUserIds.get(update.getId()).forEach(userId -> {
+            clientEventService.sendToUser(status, userId);
+        });
+
+    }
+
+    /**
+     * Lisens for messages to send to a user and if we have the SSE connection, send it
+     *
+     * @param message the message to send
+     * @param channel the channel to send the message on
+     * @throws IOException if there was an error sending the message
+     */
+    @RabbitListener(
+            queues = {PYCIEMSS_QUEUE},
+            concurrency = "1")
+    private void onPyciemssSendToUserEvent(final Message message, final Channel channel) throws IOException {
+        //SimulationIntermediateResultsCiemss
+        final JsonNode messageJson = decodeMessage(message, JsonNode.class);
+        ClientEvent<Object> status = ClientEvent.builder().type(ClientEventType.SIMULATION_PYCIEMSS).data(messageJson).build();
+        clientEventService.sendToAllUsers(status);
+    }
+
+    private <T> T decodeMessage(final Message message, Class<T> clazz) {
+
+        try {
+            return mapper.readValue(message.getBody(), clazz);
+        } catch (IOException e) {
+            log.error("Error decoding message", e);
+            return null;
+        }
+    }
 
 }

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -53,8 +53,6 @@ spring.jackson.default-property-inclusion=NON_NULL
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
 logging.level.org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver=ERROR
-logging.level.org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer=ERROR
-logging.level.org.springframework.amqp.rabbit.connection.CachingConnectionFactory=ERROR
 
 ########################################################################################################################
 # Microservice configurations


### PR DESCRIPTION
* Removing the silencing of some errors. these errors mean something!
* Reverting change to ClientEventService.ts which resulted in `init()` being spammed every second
* Queues should not be exclusive. This will require us to blow away queues on rabbitmq after this merge
* Queues are not durable.
* Maps of connections and users should be concurrent safe.

# Description

* Include a summary of the changes and the related issue. 
* Include relevant motivation and context.

Resolves #(issue)
