### PR TITLE
chore: factor out event-emitter, add unit tests

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -1,5 +1,6 @@
 import API from '@/api/api';
 import _ from 'lodash';
+import { EventEmitter } from '@/utils/emitter';
 import {
 	Operation,
 	Position,
@@ -206,53 +207,7 @@ export const getWorkflow = async (id: string) => {
 /// /////////////////////////////////////////////////////////////////////////////
 // Events bus for workflow
 /// /////////////////////////////////////////////////////////////////////////////
-type EventCallback = (args: any) => void;
-type EventName = string | symbol;
-class EventEmitter {
-	listeners: Map<EventName, Set<EventCallback>> = new Map();
-
-	on(eventName: EventName, fn: EventCallback): void {
-		if (!this.listeners.has(eventName)) {
-			this.listeners.set(eventName, new Set());
-		}
-		this.listeners.get(eventName)?.add(fn);
-	}
-
-	once(eventName: EventName, fn: EventCallback): void {
-		if (!this.listeners.has(eventName)) {
-			this.listeners.set(eventName, new Set());
-		}
-
-		const onceWrapper = (args: any) => {
-			fn(args);
-			this.off(eventName, onceWrapper);
-		};
-		this.listeners.get(eventName)?.add(onceWrapper);
-	}
-
-	off(eventName: EventName, fn: EventCallback): void {
-		const set = this.listeners.get(eventName);
-		if (set) {
-			set.delete(fn);
-		}
-	}
-
-	removeAllEvents(eventName: EventName): void {
-		if (this.listeners.has(eventName)) {
-			this.listeners.delete(eventName);
-		}
-	}
-
-	emit(eventName: EventName, args?: any): boolean {
-		const fns = this.listeners.get(eventName);
-		if (!fns) return false;
-
-		fns.forEach((f) => {
-			f(args);
-		});
-		return true;
-	}
-
+class WorkflowEventEmitter extends EventEmitter {
 	emitNodeStateChange(payload: { workflowId: string; nodeId: string; state: any }) {
 		this.emit('node-state-change', payload);
 	}
@@ -262,4 +217,4 @@ class EventEmitter {
 	}
 }
 
-export const workflowEventBus = new EventEmitter();
+export const workflowEventBus = new WorkflowEventEmitter();

--- a/packages/client/hmi-client/src/utils/emitter.ts
+++ b/packages/client/hmi-client/src/utils/emitter.ts
@@ -1,0 +1,69 @@
+export type EventCallback = (args: any) => void;
+export type EventName = string | symbol;
+
+/**
+ * A simple event emitter with arbitary payload
+ *
+ * Usage:
+ *
+ *   const bus = new EventEmitter();
+ *   bus.on('ping', (n) => { console.log(`pong ${n}`); })
+ *
+ *   for (let i = 0; i < 3; i++) {
+ *     bus.emit('ping', i);
+ *   }
+ *
+ * */
+export class EventEmitter {
+	listeners: Map<EventName, Set<EventCallback>> = new Map();
+
+	on(eventName: EventName, fn: EventCallback): void {
+		if (!this.listeners.has(eventName)) {
+			this.listeners.set(eventName, new Set());
+		}
+		this.listeners.get(eventName)?.add(fn);
+	}
+
+	once(eventName: EventName, fn: EventCallback): void {
+		if (!this.listeners.has(eventName)) {
+			this.listeners.set(eventName, new Set());
+		}
+
+		const onceWrapper = (args: any) => {
+			fn(args);
+			this.off(eventName, onceWrapper);
+		};
+		this.listeners.get(eventName)?.add(onceWrapper);
+	}
+
+	off(eventName: EventName, fn: EventCallback): void {
+		const set = this.listeners.get(eventName);
+		if (set) {
+			set.delete(fn);
+		}
+	}
+
+	removeAllEvents(eventName: EventName): void {
+		if (this.listeners.has(eventName)) {
+			this.listeners.delete(eventName);
+		}
+	}
+
+	emit(eventName: EventName, args?: any): boolean {
+		const fns = this.listeners.get(eventName);
+		if (!fns) return false;
+
+		fns.forEach((f) => {
+			f(args);
+		});
+		return true;
+	}
+
+	emitNodeStateChange(payload: { workflowId: string; nodeId: string; state: any }) {
+		this.emit('node-state-change', payload);
+	}
+
+	emitNodeRefresh(payload: { workflowId: string; nodeId: string }) {
+		this.emit('node-refresh', payload);
+	}
+}

--- a/packages/client/hmi-client/tests/unit/utils/emitter.spec.ts
+++ b/packages/client/hmi-client/tests/unit/utils/emitter.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { EventEmitter } from '@/utils/emitter';
+
+describe('event emitter', () => {
+	it('general emit', () => {
+		const bus = new EventEmitter();
+		let counter = 0;
+		const callback = (n: number) => {
+			counter += n;
+		};
+
+		bus.on('ping', callback);
+		for (let i = 1; i <= 4; i++) {
+			bus.emit('ping', i);
+		}
+		expect(counter).to.eq(10);
+	});
+
+	it('once emit', () => {
+		const bus = new EventEmitter();
+		let counter = 0;
+		const callback = (n: number) => {
+			counter += n;
+		};
+
+		bus.once('ping', callback);
+		for (let i = 1; i <= 4; i++) {
+			bus.emit('ping', i);
+		}
+		expect(counter).to.eq(1);
+	});
+
+	it('off emit', () => {
+		const bus = new EventEmitter();
+		let counter = 0;
+		const callback = (n: number) => {
+			counter += n;
+		};
+
+		bus.on('ping', callback);
+		for (let i = 1; i <= 4; i++) {
+			bus.emit('ping', i);
+			if (i === 3) {
+				bus.off('ping', callback);
+			}
+		}
+		expect(counter).to.eq(6);
+	});
+});


### PR DESCRIPTION
### Summary
Factor out the event-emitter into its own class and added a few unit tests. 

Aside from better separation of concerns,  we may also want to consider using an event-emitter to wrap a better closure around events we send to the beaker_kernel: because requests and responses are asynchronous, it isn't entirely obvious which response match to which request.  With an event-bus like mechanism, we may be able to do something like this:

```
sendKernelRequest( createStratifyRequest( ... ) )
  .on('stratification-response', updateCodeCallback)
  .on('model-preview', updateModelCallback);
```


### Testing
Run `yarn workspace hmi-client run test`