### PR TITLE
treat keycloak as canonical source

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/permissions/UsersController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/permissions/UsersController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
+import software.uncharted.terarium.hmiserver.models.authority.RoleType;
 import software.uncharted.terarium.hmiserver.models.permissions.PermissionUser;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.utils.rebac.ReBACService;
@@ -42,14 +43,14 @@ public class UsersController {
 		}
 
 		try {
-			if (roleName.equals(Roles.ADMIN)) {
+			if (roleName.equals(RoleType.ADMIN.name().toLowerCase())) {
 				RebacGroup adminGroup = new RebacGroup(ReBACService.ASKEM_ADMIN_GROUP_ID, reBACService);
 				RebacUser who = new RebacUser(userId, reBACService);
 				adminGroup.removePermissionRelationships(who, Schema.Relationship.ADMIN.toString());
 				RebacGroup publicGroup = new RebacGroup(ReBACService.PUBLIC_GROUP_ID, reBACService);
 				publicGroup.removePermissionRelationships(who, Schema.Relationship.ADMIN.toString());
 			}
-			if (roleName.equals(Roles.USER)) {
+			if (roleName.equals(RoleType.USER.name().toLowerCase())) {
 				RebacGroup publicGroup = new RebacGroup(ReBACService.PUBLIC_GROUP_ID, reBACService);
 				RebacUser who = new RebacUser(userId, reBACService);
 				publicGroup.removePermissionRelationships(who, Schema.Relationship.MEMBER.toString());
@@ -71,14 +72,14 @@ public class UsersController {
 		}
 
 		try {
-			if (roleName.equals(Roles.ADMIN)) {
+			if (roleName.equals(RoleType.ADMIN.name().toLowerCase())) {
 				RebacGroup adminGroup = new RebacGroup(ReBACService.ASKEM_ADMIN_GROUP_ID, reBACService);
 				RebacUser who = new RebacUser(userId, reBACService);
 				adminGroup.setPermissionRelationships(who, Schema.Relationship.ADMIN.toString());
 				RebacGroup publicGroup = new RebacGroup(ReBACService.PUBLIC_GROUP_ID, reBACService);
 				publicGroup.setPermissionRelationships(who, Schema.Relationship.ADMIN.toString());
 			}
-			if (roleName.equals(Roles.USER)) {
+			if (roleName.equals(RoleType.USER.name().toLowerCase())) {
 				RebacGroup publicGroup = new RebacGroup(ReBACService.PUBLIC_GROUP_ID, reBACService);
 				RebacUser who = new RebacUser(userId, reBACService);
 				publicGroup.setPermissionRelationships(who, Schema.Relationship.MEMBER.toString());

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/security/KeycloakJwtAuthenticationConverter.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/security/KeycloakJwtAuthenticationConverter.java
@@ -55,10 +55,7 @@ public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, Abstra
 		// Merge with existing roles (or create the new user if this is first login
 		final String userId = jwt.getClaimAsString(StandardClaimNames.SUB);
 		User databaseUser = userService.getById(userId);
-		User jwtUser = adminClientService.getUserFromJwt(jwt);
-		if (databaseUser == null) {
-			databaseUser = initializeUser(jwt, realmRoles);
-		}
+		User jwtUser = initializeUser(jwt, realmRoles);
 		if (User.isDirty(databaseUser, jwtUser)) {
 			databaseUser = userService.save(jwtUser.merge(databaseUser));
 		}
@@ -66,10 +63,6 @@ public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, Abstra
 		return roleService.getAuthorities(databaseUser.getRoles()).stream()
 			.map(SimpleGrantedAuthority::new)
 			.collect(Collectors.toSet());
-//
-//		return realmRoles.stream()
-//			.map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-//			.collect(Collectors.toSet());
 	}
 
 	@Transactional

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/DataInitializationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/DataInitializationService.java
@@ -4,15 +4,9 @@ import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import software.uncharted.terarium.hmiserver.models.authority.AuthorityLevel;
-import software.uncharted.terarium.hmiserver.models.authority.AuthorityType;
-import software.uncharted.terarium.hmiserver.models.authority.KeycloakRole;
-import software.uncharted.terarium.hmiserver.models.authority.RoleType;
+import software.uncharted.terarium.hmiserver.models.authority.*;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -35,16 +29,37 @@ public class DataInitializationService {
 	}
 
 	private void initializeRoles() {
-		if (roleService.count() == 0L) {
-			roleService.createRole(RoleType.ADMIN, Map.of(
-				AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE),
-				AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE)
-			));
+		List<RoleType> roleTypesMissing = new ArrayList<>();
+		for (RoleType roleType : RoleType.values()) {
+			List<Role> res = roleService.getAllByTypes(new HashSet<>(Arrays.asList(roleType.name())));
+			if (res.isEmpty()) {
+				roleTypesMissing.add(roleType);
+			}
+		}
 
-			roleService.createRole(RoleType.USER, Map.of(
-				AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ),
-				AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.UPDATE)
-			));
+		for (RoleType roleType : roleTypesMissing) {
+			switch (roleType) {
+				case ADMIN -> roleService.createRole(RoleType.ADMIN, Map.of(
+					AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE),
+					AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE)
+				));
+				case USER -> roleService.createRole(RoleType.USER, Map.of(
+					AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ),
+					AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.UPDATE)
+				));
+				case GROUP -> roleService.createRole(RoleType.GROUP, Map.of(
+					AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ),
+					AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.UPDATE)
+				));
+				case TEST -> roleService.createRole(RoleType.TEST, Map.of(
+					AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ),
+					AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE)
+				));
+				case SERVICE -> roleService.createRole(RoleType.SERVICE, Map.of(
+					AuthorityType.GRANT_AUTHORITY, List.of(AuthorityLevel.READ),
+					AuthorityType.USERS, List.of(AuthorityLevel.READ, AuthorityLevel.CREATE, AuthorityLevel.UPDATE, AuthorityLevel.DELETE)
+				));
+			}
 		}
 	}
 


### PR DESCRIPTION
Keycloak is the canonical source of Users and Roles.  The extra overhead of duplicating this in an additional Postgres is curious, but the fact that Keycloak is not treated as the canonical source is troubling.