### PR TITLE
[fix: hmi-server] Add safety code to sciml message reading

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TerariumEnvPostProcessor.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TerariumEnvPostProcessor.java
@@ -9,6 +9,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.UUID;
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class TerariumEnvPostProcessor implements EnvironmentPostProcessor {
@@ -23,13 +24,17 @@ public class TerariumEnvPostProcessor implements EnvironmentPostProcessor {
 
     public String getQueueSuffix() {
 
-        String hostName = "";
+        String hostName = UUID.randomUUID().toString();
         try {
             InetAddress inetAddress = InetAddress.getLocalHost();
+						if(inetAddress.getHostName().equalsIgnoreCase("staging") || inetAddress.getHostName().equalsIgnoreCase("production")){
+							System.err.println("Hostname is staging or production, using random queue name. This may have unintended consequences");
+							return hostName;
+						}
             hostName = inetAddress.getHostName();
         } catch (UnknownHostException e) {
             //This happens before our logger is initialized. Need to use System.out
-            System.out.println("UnknownHostException: " + e.getMessage());
+            System.err.println("UnknownHostException: " + e.getMessage());
         }
         return hostName;
     }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/ClientEventType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/ClientEventType.java
@@ -3,6 +3,6 @@ package software.uncharted.terarium.hmiserver.models;
 public enum ClientEventType {
 	HEARTBEAT,
 	NOTIFICATION,
-  	SIMULATION_SCIML,
+	SIMULATION_SCIML,
 	SIMULATION_PYCIEMSS
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -186,6 +186,14 @@ public class ClientEventService{
     }
   }
 
+	/**
+	 * Decodes a message into the given class. If there is an issue parsing to this class we will attempt to just
+	 * parse it as a JsonNode and log the error. If that fails we will log the error and hope for the best
+	 * @param message the message to decode
+	 * @param clazz  the class to decode the message to
+	 * @return 		 the decoded message or null if there was an error
+	 * @param <T>
+	 */
 	public static <T> T decodeMessage(final Message message, Class<T> clazz) {
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -133,7 +133,7 @@ public class ClientEventService{
           queues = "${terarium.client-all-user-event-queue}${terarium.queue.suffix:${terarium.userqueue.suffix}}",
           concurrency = "1")
   void onSendToAllUsersEvent(final Message message, final Channel channel) {
-    final JsonNode messageJson = decodeMessage(message);
+    final JsonNode messageJson = decodeMessage(message, JsonNode.class);
     if (messageJson == null) {
       return;
     }
@@ -166,7 +166,7 @@ public class ClientEventService{
           queues = {"${terarium.client-user-event-queue}${terarium.queue.suffix:${terarium.userqueue.suffix}}"},
           concurrency = "1")
   void onSendToUserEvent(final Message message, final Channel channel) throws IOException {
-    final JsonNode messageJson = decodeMessage(message);
+    final JsonNode messageJson = decodeMessage(message, JsonNode.class);
     if (messageJson == null) {
       return;
     }
@@ -186,19 +186,24 @@ public class ClientEventService{
     }
   }
 
-  /**
-   * Decodes a message into a JsonNode
-   * @param message the message to decode
-   * @return        the decoded message, null if there was an error
-   */
-  private JsonNode decodeMessage(final Message message) {
-    try {
-      return mapper.readValue(message.getBody(), JsonNode.class);
-    } catch (IOException e) {
-      log.error("Error decoding message", e);
-      return null;
-    }
-  }
+	public static <T> T decodeMessage(final Message message, Class<T> clazz) {
+
+		ObjectMapper mapper = new ObjectMapper();
+
+		try {
+			return mapper.readValue(message.getBody(), clazz);
+		} catch (Exception e) {
+			try {
+				JsonNode jsonMessage =  mapper.readValue(message.getBody(), JsonNode.class);
+				log.error("Unable to parse message as {}. Message: {}", clazz.getName(), jsonMessage.toPrettyString());
+				return null;
+			} catch (Exception e1) {
+				log.error("Error decoding message as either {} or {}. Raw message is: {}", clazz.getName(), JsonNode.class.getName(), message.getBody());
+				log.error("",e1);
+				return null;
+			}
+		}
+	}
 
   /**
    * Heartbeat to ensure that the clients are subscribed to the SSE service. If the client does

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -91,4 +91,6 @@ spring.rabbitmq.username=${terarium.mq-username}
 spring.rabbitmq.password=${terarium.mq-password}
 terarium.client-user-event-queue=clientUserEventQueue_
 terarium.client-all-user-event-queue=clientAllUsersEventQueue_
+terarium.sciml-queue=scimlQueue_
+terarium.simulation-status=simulation-status_
 


### PR DESCRIPTION
This is some back end legwork.
* Adding safety to message parsing
* Better error message for problems parsing
* Sciml and pyciemss now use individual queues
* Some safety code in case someone's hostname is staging or production. This isn't an exhaustive safety plan but enough to stop an accident ;)
* Note that this will break sciml messages from coming in in the current form as the sciml service is hard coded against a specific queue name. However since thats all broken anyway, its not a big loss ;)
@Jami159 you'll need to hard code your queue name locally though until part two of this is in


Resolves #2239 
