### PR TITLE
chore: code asset styling tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/code/tera-code.vue
+++ b/packages/client/hmi-client/src/components/code/tera-code.vue
@@ -696,7 +696,8 @@ h4 {
 
 .code-asset-editor {
 	width: 100%;
-	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
 }
 
 .code-asset-editor-header {

--- a/packages/client/hmi-client/src/components/code/tera-directory.vue
+++ b/packages/client/hmi-client/src/components/code/tera-directory.vue
@@ -105,6 +105,11 @@ watch(
 .tree-container {
 	min-width: 10rem;
 	max-width: 20rem;
-	overflow-y: auto;
+}
+
+.tree-container:deep(.p-tree) {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 }
 </style>


### PR DESCRIPTION
# Description

* just some small tweaks so that the filter header on the directory and the header for the code container are fixed to the top

https://github.com/DARPA-ASKEM/terarium/assets/33158416/4c2f969d-7ff7-4d7b-b664-6fce9a4162ef

