### PR TITLE
fix: redirect to overview page if you removed an asset that's currently opened

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -169,8 +169,11 @@ const activeAccordionTabs = ref(
 const assetItemsMap = computed(() => generateProjectAssetsMap(searchAsset.value));
 
 function removeAsset() {
-	emit('remove-asset', assetToDelete.value);
-	isRemovalModal.value = false;
+	if (assetToDelete.value) {
+		const { assetId, pageType } = assetToDelete.value;
+		emit('remove-asset', { assetId, pageType } as AssetRoute); // Pass as AssetRoute
+		isRemovalModal.value = false;
+	}
 }
 
 function saveAccordionTabsState() {

--- a/packages/client/hmi-client/src/page/project/tera-project.vue
+++ b/packages/client/hmi-client/src/page/project/tera-project.vue
@@ -92,6 +92,7 @@ const pageType = computed(
 	() => (route.params.pageType as ProjectPages | AssetType) ?? ProjectPages.EMPTY
 );
 const assetId = computed(() => (route.params.assetId as string) ?? '');
+const openedAssetRoute = computed(() => ({ pageType: pageType.value, assetId: assetId.value }));
 const assetName = computed<string>(() => {
 	if (pageType.value === ProjectPages.OVERVIEW) return 'Overview';
 
@@ -116,12 +117,7 @@ const assetName = computed<string>(() => {
 });
 
 function openAsset(assetRoute: AssetRoute) {
-	if (
-		!isEqual(assetRoute, {
-			pageType: pageType.value,
-			assetId: assetId.value
-		})
-	) {
+	if (!isEqual(assetRoute, openedAssetRoute.value)) {
 		router.push({
 			name: RouteName.Project,
 			params: assetRoute
@@ -141,8 +137,10 @@ async function removeAsset(assetRoute: AssetRoute) {
 			assetRoute.pageType as AssetType,
 			assetRoute.assetId
 		);
-
 		if (isRemoved) {
+			if (isEqual(assetRoute, openedAssetRoute.value)) {
+				openAsset({ assetId: '', pageType: ProjectPages.OVERVIEW });
+			}
 			logger.info(`${assetRoute.assetId} was removed.`, { showToast: true });
 			return;
 		}


### PR DESCRIPTION
# Description

If you remove an asset that is currently opened it will now redirect to the overview page instead of staying at the deleted asset.

https://github.com/DARPA-ASKEM/terarium/assets/28237258/1c2d0e68-1ac9-4939-b595-fe9b92794b6f


