### PR TITLE
start consolidating events

### DIFF
--- a/packages/client/hmi-client/src/utils/emitter.ts
+++ b/packages/client/hmi-client/src/utils/emitter.ts
@@ -58,12 +58,4 @@ export class EventEmitter {
 		});
 		return true;
 	}
-
-	emitNodeStateChange(payload: { workflowId: string; nodeId: string; state: any }) {
-		this.emit('node-state-change', payload);
-	}
-
-	emitNodeRefresh(payload: { workflowId: string; nodeId: string }) {
-		this.emit('node-refresh', payload);
-	}
 }

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -140,7 +140,6 @@ import InputNumber from 'primevue/inputnumber';
 import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import SelectButton from 'primevue/selectbutton';
 import { CalibrationOperationStateCiemss, CalibrateMap } from './calibrate-operation';
@@ -148,6 +147,7 @@ import { CalibrationOperationStateCiemss, CalibrateMap } from './calibrate-opera
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 enum CalibrationView {
 	Input = 'Input',
@@ -183,22 +183,14 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push(_.last(state.chartConfigs) as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // Used from button to add new entry to the mapping object
@@ -212,11 +204,7 @@ function addMapping() {
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = mapping.value;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 }
 // Set up model config + dropdown names
 // Note: Same as calibrate-node

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -130,7 +130,6 @@ import {
 } from '@/services/models/simulation-service';
 import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
-import { workflowEventBus } from '@/services/workflow';
 import _ from 'lodash';
 import { Poller, PollerState } from '@/api/api';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
@@ -317,22 +316,14 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push(_.last(state.chartConfigs) as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // Set up model config + dropdown names

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -203,7 +203,6 @@ import { ref, shallowRef, computed, watch } from 'vue';
 import { getRunResultCiemss } from '@/services/models/simulation-service';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import Button from 'primevue/button';
 import AccordionTab from 'primevue/accordiontab';
 import Accordion from 'primevue/accordion';
@@ -228,6 +227,7 @@ const dataLabelPlugin = [ChartDataLabels];
 const props = defineProps<{
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 enum CalibrateView {
 	Input = 'Input',
@@ -283,11 +283,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const calculateWeights = () => {
@@ -315,11 +311,7 @@ function addMapping() {
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = ensembleConfigs.value;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 }
 
 const setBarChartData = () => {
@@ -384,11 +376,7 @@ const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push({ selectedVariable: [], selectedRun: '' } as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // assume only one run for now
@@ -458,11 +446,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.mapping = ensembleConfigs.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	},
 	{ immediate: true }
 );
@@ -473,11 +457,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.extra = extra.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -48,7 +48,6 @@ import { ref, shallowRef, watch, computed, ComputedRef, onMounted, onUnmounted }
 // import { getRunResult } from '@/services/models/simulation-service';
 import { ProgressState, WorkflowNode, OperatorStatus } from '@/types/workflow';
 // import { getModelConfigurationById } from '@/services/model-configurations';
-import { workflowEventBus } from '@/services/workflow';
 import { CsvAsset, EnsembleCalibrationCiemssRequest, EnsembleModelConfigs } from '@/types/Types';
 import {
 	makeEnsembleCiemssCalibration,
@@ -171,11 +170,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // TODO: This is repeated every single node that uses a chart. Hope to refactor if the state manip allows for it easily
@@ -183,11 +178,7 @@ const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push({ selectedRun: '', selectedVariable: [] } as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // Set up csv + dropdown names
@@ -220,11 +211,7 @@ watch(
 			const state = _.cloneDeep(props.node.state);
 			state.modelConfigIds = modelConfigIds.value;
 			state.mapping = mapping;
-			workflowEventBus.emitNodeStateChange({
-				workflowId: props.node.workflowId,
-				nodeId: props.node.id,
-				state
-			});
+			emit('update-state', state);
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -147,7 +147,6 @@ import InputNumber from 'primevue/inputnumber';
 import { setupModelInput, setupDatasetInput, renderLossGraph } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults, RunType } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import SelectButton from 'primevue/selectbutton';
 import { getRunResultJulia } from '@/services/models/simulation-service';
@@ -157,6 +156,7 @@ import { CalibrationOperationStateJulia, CalibrateMap } from './calibrate-operat
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateJulia>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 enum CalibrationView {
 	Input = 'Input',
@@ -206,11 +206,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.calibrateConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 onMounted(() => {
@@ -228,11 +224,7 @@ const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.calibrateConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // Used from button to add new entry to the mapping object
@@ -246,11 +238,7 @@ function addMapping() {
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = mapping.value;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 }
 // Set up model config + dropdown names
 // Note: Same as calibrate-node
@@ -288,11 +276,7 @@ const handleSelectedRunChange = () => {
 		state.calibrateConfigs.runConfigs[runId].active = runId === selectedRun.value.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 watch(() => selectedRun.value, handleSelectedRunChange, { immediate: true });
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
@@ -198,7 +198,6 @@ import {
 import { setupModelInput, setupDatasetInput, renderLossGraph } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults, RunType } from '@/types/SimulateConfig';
 import { csvParse } from 'd3';
-import { workflowEventBus } from '@/services/workflow';
 import _ from 'lodash';
 import InputNumber from 'primevue/inputnumber';
 import InputText from 'primevue/inputtext';
@@ -440,11 +439,7 @@ const watchCompletedRunList = async (runIdList: string[]) => {
 		active: true,
 		loss: lossValues
 	};
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 
 	// clear out intermediate values for next run
 	lossValues = [];
@@ -465,22 +460,14 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.calibrateConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.calibrateConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // Set up model config + dropdown names
@@ -522,11 +509,7 @@ const handleSelectedRunChange = () => {
 		state.calibrateConfigs.runConfigs[runId].active = runId === selectedRun.value.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 watch(() => selectedRun.value, handleSelectedRunChange, { immediate: true });
 

--- a/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
@@ -18,7 +18,6 @@
 import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import TeraDatasetJupyterPanel from '@/components/dataset/tera-dataset-jupyter-panel.vue';
 import { computed, onMounted, ref } from 'vue';
-import { workflowEventBus } from '@/services/workflow';
 import { createNotebookSession, getNotebookSessionById } from '@/services/notebook-session';
 import { NotebookSession } from '@/types/Types';
 import { cloneDeep } from 'lodash';
@@ -28,6 +27,8 @@ import { DatasetTransformerState } from './dataset-transformer-operation';
 const props = defineProps<{
 	node: WorkflowNode<DatasetTransformerState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
+
 const showKernels = ref(<boolean>false);
 const showChatThoughts = ref(<boolean>false);
 const assetIds = computed(() =>
@@ -55,20 +56,19 @@ onMounted(async () => {
 		if (notebookSessionId) {
 			// update the node state with the notebook session id
 			state.notebookSessionId = notebookSessionId;
-			workflowEventBus.emit('update-state', {
-				node: props.node,
-				state
-			});
+			emit('update-state', state);
 		}
 	}
 
 	notebookSession.value = await getNotebookSessionById(notebookSessionId!);
 });
 
-const addOutputPort = (data) => {
-	workflowEventBus.emit('append-output-port', {
-		node: props.node,
-		port: { id: data.id, label: data.name, type: 'datasetId', value: data.id }
+const addOutputPort = (data: any) => {
+	emit('append-output-port', {
+		id: data.id,
+		label: data.name,
+		type: 'datasetId',
+		value: data.id
 	});
 };
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
@@ -19,7 +19,6 @@
 import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import TeraModelJupyterPanel from '@/components/model/tera-model-jupyter-panel.vue';
 import { computed, onMounted, ref } from 'vue';
-import { workflowEventBus } from '@/services/workflow';
 import { createNotebookSession, getNotebookSessionById } from '@/services/notebook-session';
 import { v4 as uuidv4 } from 'uuid';
 import { NotebookSession } from '@/types/Types';
@@ -31,6 +30,8 @@ import { ModelTransformerState } from './model-transformer-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelTransformerState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
+
 const modelConfigurationId = computed(() => {
 	// for now we are only using 1 model configuration for the llm at a time, this can be expanded in the future
 	const modelConfirgurationList = props.node?.inputs
@@ -59,10 +60,7 @@ onMounted(async () => {
 		if (notebookSessionId) {
 			// update the node state with the notebook session id
 			state.notebookSessionId = notebookSessionId;
-			workflowEventBus.emit('update-state', {
-				node: props.node,
-				state
-			});
+			emit('update-state', state);
 		}
 	}
 	notebookSession.value = await getNotebookSessionById(notebookSessionId!);
@@ -78,7 +76,7 @@ const addOutputPort = async (data) => {
 	const state = cloneDeep(props.node.state);
 	state.modelId = model?.id;
 	// update node state with the model id
-	workflowEventBus.emit('update-state', { node: props.node, state });
+	emit('update-state', state);
 
 	// set default configuration
 	await addDefaultConfiguration(model);
@@ -87,14 +85,11 @@ const addOutputPort = async (data) => {
 	setTimeout(async () => {
 		const configurationList = await getModelConfigurations(model.id);
 		configurationList.forEach((configuration) => {
-			workflowEventBus.emit('append-output-port', {
-				node: props.node,
-				port: {
-					id: uuidv4(),
-					label: configuration.name,
-					type: 'modelConfigId',
-					value: [configuration.id]
-				}
+			emit('append-output-port', {
+				id: uuidv4(),
+				label: configuration.name,
+				type: 'modelConfigId',
+				value: [configuration.id]
 			});
 		});
 	}, 800);

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -171,7 +171,6 @@ import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-mo
 import TeraModelConfigurations from '@/components/model/petrinet/tera-model-configurations.vue';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import { saveDataset, createCsvAssetFromRunResults } from '@/services/dataset';
 import InputText from 'primevue/inputtext';
 import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
@@ -182,6 +181,7 @@ import { SimulateCiemssOperationState } from './simulate-ciemss-operation';
 const props = defineProps<{
 	node: WorkflowNode<SimulateCiemssOperationState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 const hasValidDatasetName = computed<boolean>(() => saveAsName.value !== '');
 
@@ -218,11 +218,7 @@ const configurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const handleSelectedRunChange = () => {
@@ -236,22 +232,14 @@ const handleSelectedRunChange = () => {
 		state.simConfigs.runConfigs[runId].active = runId === selectedRun.value?.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 async function saveDatasetToProject() {
@@ -302,11 +290,7 @@ watch(
 	(n) => {
 		const state = _.cloneDeep(props.node.state);
 		state.numSamples = n;
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	}
 );
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -65,7 +65,6 @@ import {
 import InputNumber from 'primevue/inputnumber';
 import { ProgressState, WorkflowNode } from '@/types/workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
-import { workflowEventBus } from '@/services/workflow';
 import { Poller, PollerState } from '@/api/api';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
@@ -192,11 +191,7 @@ const watchCompletedRunList = async (runIdList: string[]) => {
 		};
 	}
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 
 	emit('append-output-port', {
 		type: SimulateCiemssOperation.outputs[0].type,
@@ -217,11 +212,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.numSamples = numSamples.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	}
 );
 
@@ -231,11 +222,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.method = method.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	}
 );
 
@@ -243,11 +230,7 @@ const configurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const lazyLoadRunResults = async (runId: string) => {
@@ -268,22 +251,14 @@ const handleSelectedRunChange = () => {
 		state.simConfigs.runConfigs[runId].active = runId === selectedRun.value?.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 </script>
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -199,7 +199,6 @@ import { ref, computed, watch } from 'vue';
 import { getRunResultCiemss } from '@/services/models/simulation-service';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import Button from 'primevue/button';
 import AccordionTab from 'primevue/accordiontab';
 import Accordion from 'primevue/accordion';
@@ -221,6 +220,7 @@ const dataLabelPlugin = [ChartDataLabels];
 const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 enum SimulateView {
 	Input = 'Input',
@@ -270,11 +270,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const calculateWeights = () => {
@@ -302,11 +298,7 @@ function addMapping() {
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = ensembleConfigs.value;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 }
 
 const setBarChartData = () => {
@@ -371,11 +363,7 @@ const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push({ selectedVariable: [], selectedRun: '' } as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 async function saveDatasetToProject() {
@@ -434,11 +422,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.mapping = ensembleConfigs.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	},
 	{ immediate: true }
 );
@@ -449,11 +433,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.timeSpan = timeSpan.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	},
 	{ immediate: true }
 );
@@ -464,11 +444,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.numSamples = numSamples.value;
 
-		workflowEventBus.emitNodeStateChange({
-			workflowId: props.node.workflowId,
-			nodeId: props.node.id,
-			state
-		});
+		emit('update-state', state);
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -47,7 +47,6 @@ import { ref, watch, computed, ComputedRef, onMounted, onUnmounted } from 'vue';
 // import { getRunResult } from '@/services/models/simulation-service';
 import { ProgressState, WorkflowNode, OperatorStatus } from '@/types/workflow';
 // import { getModelConfigurationById } from '@/services/model-configurations';
-import { workflowEventBus } from '@/services/workflow';
 import { EnsembleSimulationCiemssRequest, TimeSpan, EnsembleModelConfigs } from '@/types/Types';
 import {
 	makeEnsembleCiemssSimulation,
@@ -115,11 +114,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 // TODO: This is repeated every single node that uses a chart. Hope to refactor if the state manip allows for it easily
@@ -127,11 +122,7 @@ const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push({ selectedRun: '', selectedVariable: [] } as ChartConfig);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const getStatus = async (simulationId: string) => {
@@ -185,11 +176,7 @@ watch(
 			const state = _.cloneDeep(props.node.state);
 			state.modelConfigIds = modelConfigIds.value;
 			state.mapping = mapping;
-			workflowEventBus.emitNodeStateChange({
-				workflowId: props.node.workflowId,
-				nodeId: props.node.id,
-				state
-			});
+			emit('update-state', state);
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -142,7 +142,6 @@ import { getModel } from '@/services/model';
 import { saveDataset, createCsvAssetFromRunResults } from '@/services/dataset';
 import { csvParse } from 'd3';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import InputText from 'primevue/inputtext';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
@@ -153,6 +152,7 @@ import { SimulateJuliaOperationState } from './simulate-julia-operation';
 const props = defineProps<{
 	node: WorkflowNode<SimulateJuliaOperationState>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 const timespan = ref<TimeSpan>(props.node.state.currentTimespan);
 
@@ -187,11 +187,7 @@ const configurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const handleSelectedRunChange = () => {
@@ -205,22 +201,14 @@ const handleSelectedRunChange = () => {
 		state.simConfigs.runConfigs[runId].active = runId === selectedRun.value?.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 async function saveDatasetToProject() {

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -47,7 +47,6 @@ import { ProgressState, WorkflowNode } from '@/types/workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 
 import { getModelConfigurationById } from '@/services/model-configurations';
-import { workflowEventBus } from '@/services/workflow';
 import { Poller, PollerState } from '@/api/api';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
@@ -176,11 +175,7 @@ const watchCompletedRunList = async (runIdList: string[]) => {
 			timeSpan: sim.executionPayload.timespan
 		};
 	}
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 
 	emit('append-output-port', {
 		type: SimulateJuliaOperation.outputs[0].type,
@@ -198,11 +193,7 @@ const configurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs[index] = config.selectedVariable;
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 watch(
@@ -248,22 +239,14 @@ const handleSelectedRunChange = () => {
 		state.simConfigs.runConfigs[runId].active = runId === selectedRun.value?.runId;
 	});
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const addChart = () => {
 	const state = _.cloneDeep(props.node.state);
 	state.simConfigs.chartConfigs.push([]);
 
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 </script>
 

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -78,7 +78,6 @@ import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-mo
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { getModel, createModel } from '@/services/model';
 import { WorkflowNode } from '@/types/workflow';
-import { workflowEventBus } from '@/services/workflow';
 import { useProjects } from '@/composables/project';
 import { logger } from '@/utils/logger';
 
@@ -90,6 +89,7 @@ import { StratifyOperationStateMira } from './stratify-mira-operation';
 const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
+const emit = defineEmits(['append-output-port', 'update-state']);
 
 enum StratifyTabs {
 	wizard,
@@ -105,46 +105,16 @@ const modelNodeOptions = ref<string[]>([]);
 const teraModelDiagramRef = ref();
 const newModelName = ref('');
 
-// TODO: Limit to single strata for now - DC, Nov 2023
-// const addGroupForm = () => {
-// 	const state = _.cloneDeep(props.node.state);
-// 	const newGroup: StratifyGroup = {
-// 		borderColour: '#00c387',
-// 		name: '',
-// 		selectedVariables: [],
-// 		groupLabels: '',
-// 		cartesianProduct: true,
-// 		isPending: true
-// 	};
-// 	state.strataGroups.push(newGroup);
-//
-// 	workflowEventBus.emitNodeStateChange({
-// 		workflowId: props.node.workflowId,
-// 		nodeId: props.node.id,
-// 		state
-// 	});
-// };
-
 const deleteStratifyGroupForm = (data: any) => {
 	const state = _.cloneDeep(props.node.state);
 	state.strataGroups.splice(data.index, 1);
-
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const updateStratifyGroupForm = (data: any) => {
 	const state = _.cloneDeep(props.node.state);
 	state.strataGroups[data.index] = data.updatedConfig;
-
-	workflowEventBus.emitNodeStateChange({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id,
-		state
-	});
+	emit('update-state', state);
 };
 
 const stratifyModel = () => {

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -460,7 +460,7 @@ let workflowDirty: boolean = false;
 
 const isWorkflowLoading = ref(false);
 
-const currentActiveNode = ref<WorkflowNode<any> | null>();
+const currentActiveNode = ref<WorkflowNode<any> | null>(null);
 
 workflowEventBus.on('clearActiveNode', () => {
 	currentActiveNode.value = null;

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -294,6 +294,8 @@
 			<tera-dataset-transformer
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-model-transformer
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL_TRANSFORMER"
@@ -434,10 +436,10 @@ let workflowDirty: boolean = false;
 
 const isWorkflowLoading = ref(false);
 
-const currentActiveNode = ref<WorkflowNode<any> | null>();
+const currentActiveNode = ref<WorkflowNode<any>>();
 
 workflowEventBus.on('clearActiveNode', () => {
-	currentActiveNode.value = null;
+	currentActiveNode.value = undefined;
 });
 
 const newEdge = ref<WorkflowEdge | undefined>();
@@ -584,7 +586,6 @@ function updateWorkflowNodeState(node: WorkflowNode<any>, state: any) {
 const drilldown = (event: WorkflowNode<any>) => {
 	currentActiveNode.value = event;
 	dialogIsOpened.value = true;
-	// workflowEventBus.emit('drilldown', event);
 };
 
 workflowEventBus.on('node-state-change', (payload: any) => {
@@ -609,15 +610,15 @@ workflowEventBus.on('node-refresh', (payload: { workflowId: string; nodeId: stri
 	}
 });
 
-workflowEventBus.on(
-	'add-node',
-	(payload: { id: string; operation: Operation; position: Position; state: any }) => {
-		workflowService.addNode(wf.value, payload.operation, payload.position, {
-			state: payload.state
-		});
-		workflowDirty = true;
-	}
-);
+// workflowEventBus.on(
+// 	'add-node',
+// 	(payload: { id: string; operation: Operation; position: Position; state: any }) => {
+// 		workflowService.addNode(wf.value, payload.operation, payload.position, {
+// 			state: payload.state
+// 		});
+// 		workflowDirty = true;
+// 	}
+// );
 
 workflowEventBus.on(
 	'append-output-port',

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -461,11 +461,6 @@ let workflowDirty: boolean = false;
 const isWorkflowLoading = ref(false);
 
 const currentActiveNode = ref<WorkflowNode<any> | null>(null);
-
-workflowEventBus.on('clearActiveNode', () => {
-	currentActiveNode.value = null;
-});
-
 const newEdge = ref<WorkflowEdge | undefined>();
 const droppedAssetId = ref<string | null>(null);
 const isMouseOverCanvas = ref<boolean>(false);

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -245,51 +245,73 @@
 			<tera-calibrate-julia
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATION_JULIA"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-calibrate-ciemss
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATION_CIEMSS"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 
 			<tera-simulate-julia
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_JULIA"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-simulate-ciemss
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_CIEMSS"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 
 			<tera-stratify-mira
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.STRATIFY_MIRA"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 
 			<tera-model-from-code
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL_FROM_CODE"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 
 			<tera-simulate-ensemble-ciemss
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_ENSEMBLE_CIEMSS"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-calibrate-ensemble-ciemss
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATE_ENSEMBLE_CIEMSS"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 
 			<tera-model-workflow-wrapper
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-dataset-workflow-wrapper
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.DATASET"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-code-asset-wrapper
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CODE"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-dataset-transformer
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER"
@@ -300,6 +322,8 @@
 			<tera-model-transformer
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL_TRANSFORMER"
 				:node="currentActiveNode"
+				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
 			/>
 			<tera-funman
 				v-if="currentActiveNode.operationType === WorkflowOperationTypes.FUNMAN"
@@ -436,10 +460,10 @@ let workflowDirty: boolean = false;
 
 const isWorkflowLoading = ref(false);
 
-const currentActiveNode = ref<WorkflowNode<any>>();
+const currentActiveNode = ref<WorkflowNode<any> | null>();
 
 workflowEventBus.on('clearActiveNode', () => {
-	currentActiveNode.value = undefined;
+	currentActiveNode.value = null;
 });
 
 const newEdge = ref<WorkflowEdge | undefined>();
@@ -550,9 +574,11 @@ function appendInputPort(
 }
 
 function appendOutputPort(
-	node: WorkflowNode<any>,
+	node: WorkflowNode<any> | null,
 	port: { type: string; label?: string; value: any }
 ) {
+	if (!node) return;
+
 	node.outputs.push({
 		id: uuidv4(),
 		type: port.type,
@@ -578,7 +604,8 @@ function appendOutputPort(
 	workflowDirty = true;
 }
 
-function updateWorkflowNodeState(node: WorkflowNode<any>, state: any) {
+function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
+	if (!node) return;
 	workflowService.updateNodeState(wf.value, node.id, state);
 	workflowDirty = true;
 }
@@ -588,10 +615,13 @@ const drilldown = (event: WorkflowNode<any>) => {
 	dialogIsOpened.value = true;
 };
 
-workflowEventBus.on('node-state-change', (payload: any) => {
+workflowEventBus.on('node-state-change', (/* payload: any */) => {
+	throw new Error('node-state-change event is no longer available');
+	/*
 	if (wf.value?.id !== payload.workflowId) return;
 	workflowService.updateNodeState(wf.value, payload.nodeId, payload.state);
 	workflowDirty = true;
+	*/
 });
 
 workflowEventBus.on('node-refresh', (payload: { workflowId: string; nodeId: string }) => {

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -615,15 +615,6 @@ const drilldown = (event: WorkflowNode<any>) => {
 	dialogIsOpened.value = true;
 };
 
-workflowEventBus.on('node-state-change', (/* payload: any */) => {
-	throw new Error('node-state-change event is no longer available');
-	/*
-	if (wf.value?.id !== payload.workflowId) return;
-	workflowService.updateNodeState(wf.value, payload.nodeId, payload.state);
-	workflowDirty = true;
-	*/
-});
-
 workflowEventBus.on('node-refresh', (payload: { workflowId: string; nodeId: string }) => {
 	if (wf.value?.id !== payload.workflowId) return;
 	const node = wf.value.nodes.find((n) => n.id === payload.nodeId);
@@ -640,37 +631,17 @@ workflowEventBus.on('node-refresh', (payload: { workflowId: string; nodeId: stri
 	}
 });
 
-// workflowEventBus.on(
-// 	'add-node',
-// 	(payload: { id: string; operation: Operation; position: Position; state: any }) => {
-// 		workflowService.addNode(wf.value, payload.operation, payload.position, {
-// 			state: payload.state
-// 		});
-// 		workflowDirty = true;
-// 	}
-// );
+// TODO: Remove
+workflowEventBus.on('node-state-change', (/* payload: any */) => {
+	throw new Error('bus event no longer available');
+});
 
-workflowEventBus.on(
-	'append-output-port',
-	(payload: {
-		node: WorkflowNode<any>;
-		port: { id: string; type: string; label: string; value: string };
-	}) => {
-		const foundNode = wf.value.nodes.find((node) => node.id === payload.node.id);
-		if (foundNode) {
-			if (payload.port.type === 'datasetId') {
-				foundNode.state.datasetId = payload.port.value;
-			}
-			appendOutputPort(foundNode, payload.port);
-		}
-	}
-);
+workflowEventBus.on('append-output-port', () => {
+	throw new Error('bus event no longer available');
+});
 
-workflowEventBus.on('update-state', (payload: { node: WorkflowNode<any>; state }) => {
-	const foundNode = wf.value.nodes.find((node) => node.id === payload.node.id);
-	if (foundNode) {
-		updateWorkflowNodeState(foundNode, payload.state);
-	}
+workflowEventBus.on('update-state', () => {
+	throw new Error('bus event no longer available');
 });
 
 const removeNode = (event) => {


### PR DESCRIPTION
### Summary
Mostly consolidate how events are passed - right now we have a mix of using event-emitters for bubbling up events, and using an event-bus for broadcasting across the Vue-app. This is a legacy architecture when some components were co-located and some where not.

Here we consolidate as much as we can, favouring using the vue-emit rather than the event-bus.
They are kind of the same thing with respect to the designs we have at this stage, but the idea is to pick a single method to make the logic and implementation easier to follow, less error-prone, and to indicate a more de-facto way of handling things rather than having mixed modalities. 

TODO: Once this has been achieved we can then further refactor and significantly simplify the vue-templates, and also make things more systematic to add new operators.


### Testing
Things should work as before except for Julia-stratify, which is slated to be decommissioned. 