### PR TITLE
feat: operator actions

### DIFF
--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -35,6 +35,13 @@ export enum OperatorStatus {
 	DISABLED = 'disabled'
 }
 
+export interface OperatorActionButton {
+	label: string;
+	action: any;
+	icon: string;
+	isPrimary: boolean;
+}
+
 export enum WorkflowPortStatus {
 	CONNECTED = 'connected',
 	NOT_CONNECTED = 'not connected'

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -37,9 +37,9 @@ export enum OperatorStatus {
 
 export interface OperatorActionButton {
 	label: string;
-	action: any;
 	icon: string;
 	isPrimary: boolean;
+	action: Function;
 }
 
 export enum WorkflowPortStatus {

--- a/packages/client/hmi-client/src/workflow/operator/tera-operator-actions.vue
+++ b/packages/client/hmi-client/src/workflow/operator/tera-operator-actions.vue
@@ -1,13 +1,15 @@
 <template>
-	<Button
-		v-for="({ label, action, isPrimary, icon }, index) in actionButtons"
-		:key="index"
-		:label="label"
-		:icon="icon"
-		:severity="!isPrimary ? 'secondary' : undefined"
-		:outlined="!isPrimary"
-		@click="action()"
-	/>
+	<section>
+		<Button
+			v-for="({ label, action, isPrimary, icon }, index) in actionButtons"
+			:key="index"
+			:label="label"
+			:icon="icon"
+			:severity="!isPrimary ? 'secondary' : undefined"
+			:outlined="!isPrimary"
+			@click="action()"
+		/>
+	</section>
 </template>
 
 <script setup lang="ts">

--- a/packages/client/hmi-client/src/workflow/operator/tera-operator-actions.vue
+++ b/packages/client/hmi-client/src/workflow/operator/tera-operator-actions.vue
@@ -1,0 +1,24 @@
+<template>
+	<Button
+		v-for="({ label, action, isPrimary, icon }, index) in actionButtons"
+		:key="index"
+		:label="label"
+		:icon="icon"
+		:severity="!isPrimary ? 'secondary' : undefined"
+		:outlined="!isPrimary"
+		@click="action()"
+	/>
+</template>
+
+<script setup lang="ts">
+import { PropType } from 'vue';
+import { OperatorActionButton } from '@/types/workflow';
+import Button from 'primevue/button';
+
+defineProps({
+	actionButtons: {
+		type: Array as PropType<OperatorActionButton[]>,
+		default: () => []
+	}
+});
+</script>

--- a/packages/client/hmi-client/src/workflow/tera-operator.vue
+++ b/packages/client/hmi-client/src/workflow/tera-operator.vue
@@ -14,9 +14,8 @@
 			@port-selected="(input: WorkflowPort, direction: WorkflowDirection) => emit('port-selected', input, direction)"
 			@remove-edges="(portId: string) => emit('remove-edges', portId)"
 		/>
-		<section>
+		<section class="content">
 			<slot name="body" />
-			<Button label="Open Drilldown" @click="openDrilldown" severity="secondary" outlined />
 			<tera-operator-actions :action-buttons="actionButtons" />
 		</section>
 		<tera-operator-outputs
@@ -38,7 +37,6 @@ import {
 	OperatorActionButton
 } from '@/types/workflow';
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
-import Button from 'primevue/button';
 import floatingWindow from '@/utils/floating-window';
 import router from '@/router';
 import { RouteName } from '@/router/routes';
@@ -63,9 +61,14 @@ const emit = defineEmits([
 	'drilldown'
 ]);
 
-const actionButtons = computed<OperatorActionButton[]>(() => [
-	{ label: 'Open drilldown', isPrimary: false, icon: '', action: openDrilldown() }
-]);
+const actionButtons: OperatorActionButton[] = [
+	{
+		label: 'Open drilldown',
+		icon: '',
+		isPrimary: false,
+		action: () => emit('drilldown', props.node)
+	}
+];
 
 const nodeStyle = computed(() => ({
 	minWidth: `${props.node.width}px`,
@@ -115,10 +118,6 @@ onMounted(() => {
 	document.addEventListener('mousemove', drag);
 	operator.value.addEventListener('mouseup', stopDrag);
 });
-
-function openDrilldown() {
-	emit('drilldown', props.node);
-}
 
 function bringToFront() {
 	// TODO: bring to front
@@ -170,20 +169,24 @@ main:hover {
 	z-index: 2;
 }
 
-section {
+main > .content {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-evenly;
 	margin: 0 0.5rem;
+	gap: 0.5rem;
+}
+
+.content:deep(> *),
+ul {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin: 0.5rem 0;
 }
 
 /* Inputs/outputs */
 ul {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-evenly;
-	margin: 0.5rem 0;
-	gap: 0.5rem;
 	list-style: none;
 	font-size: var(--font-caption);
 	color: var(--text-color-secondary);

--- a/packages/client/hmi-client/src/workflow/tera-operator.vue
+++ b/packages/client/hmi-client/src/workflow/tera-operator.vue
@@ -17,6 +17,7 @@
 		<section>
 			<slot name="body" />
 			<Button label="Open Drilldown" @click="openDrilldown" severity="secondary" outlined />
+			<tera-operator-actions :action-buttons="actionButtons" />
 		</section>
 		<ul class="outputs">
 			<li
@@ -42,7 +43,8 @@ import {
 	WorkflowNode,
 	WorkflowPortStatus,
 	WorkflowDirection,
-	WorkflowPort
+	WorkflowPort,
+	OperatorActionButton
 } from '@/types/workflow';
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import Button from 'primevue/button';
@@ -51,6 +53,7 @@ import router from '@/router';
 import { RouteName } from '@/router/routes';
 import TeraOperatorHeader from './operator/tera-operator-header.vue';
 import TeraOperatorInputs from './operator/tera-operator-inputs.vue';
+import TeraOperatorActions from './operator/tera-operator-actions.vue';
 
 const props = defineProps<{
 	node: WorkflowNode<any>;
@@ -66,6 +69,10 @@ const emit = defineEmits([
 	'remove-operator',
 	'remove-edge',
 	'drilldown'
+]);
+
+const actionButtons = computed<OperatorActionButton[]>(() => [
+	{ label: 'Open drilldown', isPrimary: false, icon: '', action: openDrilldown() }
 ]);
 
 const nodeStyle = computed(() => ({


### PR DESCRIPTION
# Description

- Created `tera-operator-actions.vue` which holds all operator buttons
- Open drilldown button is now the only button
- Passing functions of the different operators into `tera-operator-actions.vue` requires rethinking the structure of them

