### PR TITLE
Add notebook functionality to Mira Stratify

### DIFF
--- a/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
@@ -2,11 +2,7 @@
 	<div class="strata-group" :style="`border-left: 9px solid ${props.config.borderColour}`">
 		<div class="sub-header">
 			<label for="strata-name">Cartesian product</label>
-			<InputSwitch
-				@change="emit('update-self', { index: props.index, updatedConfig: updatedConfig })"
-				v-model="cartesianProduct"
-			/>
-			<i class="trash-button pi pi-trash" @click="emit('delete-self', { index: props.index })" />
+			<InputSwitch @change="emit('update-self', updatedConfig)" v-model="cartesianProduct" />
 		</div>
 		<div class="first-row">
 			<div class="age-group">
@@ -14,7 +10,7 @@
 				<InputText
 					v-model="strataName"
 					placeholder="Age group"
-					@focusout="emit('update-self', { index: props.index, updatedConfig: updatedConfig })"
+					@focusout="emit('update-self', updatedConfig)"
 				/>
 			</div>
 			<div class="select-variables">
@@ -24,9 +20,7 @@
 					:options="props.modelNodeOptions"
 					placeholder="Model states"
 					display="chip"
-					@update:model-value="
-						emit('update-self', { index: props.index, updatedConfig: updatedConfig })
-					"
+					@update:model-value="emit('update-self', updatedConfig)"
 				></MultiSelect>
 			</div>
 		</div>
@@ -38,14 +32,14 @@
 			<InputText
 				v-model="labels"
 				placeholder="Young, Old"
-				@focusout="emit('update-self', { index: props.index, updatedConfig: updatedConfig })"
+				@focusout="emit('update-self', updatedConfig)"
 			/>
 		</div>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import InputText from 'primevue/inputtext';
 import MultiSelect from 'primevue/multiselect';
 import InputSwitch from 'primevue/inputswitch';
@@ -54,10 +48,9 @@ import { StratifyGroup } from '@/workflow/ops/stratify-mira/stratify-mira-operat
 const props = defineProps<{
 	modelNodeOptions: string[];
 	config: StratifyGroup;
-	index: number;
 }>();
 
-const emit = defineEmits(['delete-self', 'update-self']);
+const emit = defineEmits(['update-self']);
 
 const strataName = ref(props.config.name);
 const selectedVariables = ref<string[]>(props.config.selectedVariables);
@@ -71,6 +64,16 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	groupLabels: labels.value,
 	cartesianProduct: cartesianProduct.value
 }));
+
+watch(
+	() => props.config,
+	() => {
+		strataName.value = props.config.name;
+		selectedVariables.value = props.config.selectedVariables;
+		labels.value = props.config.groupLabels;
+		cartesianProduct.value = props.config.cartesianProduct;
+	}
+);
 </script>
 
 <style scoped>
@@ -113,9 +116,5 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 
 .subdued-text {
 	color: var(--text-color-subdued);
-}
-
-.trash-button {
-	cursor: pointer;
 }
 </style>

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -14,10 +14,18 @@ export interface StratifyCode {
 }
 
 export interface StratifyOperationStateMira {
-	strataGroups: StratifyGroup[];
+	strataGroup: StratifyGroup;
 	strataCodeHistory: StratifyCode[];
 	hasCodeBeenRun: boolean;
 }
+
+export const blankStratifyGroup: StratifyGroup = {
+	borderColour: '#c300a6',
+	name: '',
+	selectedVariables: [],
+	groupLabels: '',
+	cartesianProduct: true
+};
 
 export const StratifyMiraOperation: Operation = {
 	name: WorkflowOperationTypes.STRATIFY_MIRA,
@@ -29,15 +37,7 @@ export const StratifyMiraOperation: Operation = {
 	action: () => {},
 	initState: () => {
 		const init: StratifyOperationStateMira = {
-			strataGroups: [
-				{
-					borderColour: '#c300a6',
-					name: '',
-					selectedVariables: [],
-					groupLabels: '',
-					cartesianProduct: true
-				}
-			],
+			strataGroup: blankStratifyGroup,
 			strataCodeHistory: [],
 			hasCodeBeenRun: false
 		};

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -16,6 +16,7 @@ export interface StratifyCode {
 export interface StratifyOperationStateMira {
 	strataGroups: StratifyGroup[];
 	strataCodeHistory: StratifyCode[];
+	hasCodeBeenRun: boolean;
 }
 
 export const StratifyMiraOperation: Operation = {
@@ -37,7 +38,8 @@ export const StratifyMiraOperation: Operation = {
 					cartesianProduct: true
 				}
 			],
-			strataCodeHistory: []
+			strataCodeHistory: [],
+			hasCodeBeenRun: false
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -169,11 +169,11 @@ const stratifyRequest = () => {
 };
 
 const handleStratifyResponse = (data: any) => {
-	const code = data.content.executed_code;
-	codeText.value = code;
+	const executedCode = data.content.executed_code;
+	codeText.value = executedCode;
 
 	const state = _.cloneDeep(props.node.state);
-	state.strataCodeHistory.push({ code, timestamp: Date.now() });
+	state.strataCodeHistory.push({ code: executedCode, timestamp: Date.now() });
 	emit('update-state', state);
 };
 
@@ -262,7 +262,7 @@ const saveNewModel = async (modelName: string) => {
 	}, 800);
 };
 
-const initialize = async (editorInstance) => {
+const initialize = (editorInstance) => {
 	editor.value = editorInstance;
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -113,8 +113,8 @@ enum StratifyTabs {
 }
 
 interface SaveOptions {
-	addToProject: boolean;
-	appendOutputPort: boolean;
+	addToProject?: boolean;
+	appendOutputPort?: boolean;
 }
 
 const kernelManager = new KernelSessionManager();


### PR DESCRIPTION
This PR adds the ability to stratify a model via the drilldown using the wizard or the notebook.
- if model is stratified via the wizard, then the executed code is reflected in the notebook
- if model is stratified via the notebook, then it is not reflected in the wizard -> there is a warning box stating this
- if models are stratified either via wizard or notebook, then a new output port is added to the stratify node
- if models are explicitly saved, then they are added to the project

Demo video: https://capture.dropbox.com/SBfR4JKnqO5xBEV0

Resolves #2279
