### PR TITLE
feat: dynamic component routing for operation drilldown

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
@@ -10,7 +10,6 @@ import { CodeAssetState } from './code-asset-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CodeAssetState>;
-	droppedCodeAssetId: null | string;
 	codeAssets: Code[];
 }>();
 
@@ -19,8 +18,8 @@ const emit = defineEmits(['select-code-asset']);
 const code = ref<Code | null>(null);
 
 onMounted(async () => {
-	if (props.droppedCodeAssetId) {
-		code.value = props.codeAssets.find(({ id }) => id === props.droppedCodeAssetId) ?? null;
+	if (props.node.state.codeAssetId) {
+		code.value = props.codeAssets.find(({ id }) => id === props.node.state.codeAssetId) ?? null;
 	}
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
@@ -54,7 +54,6 @@ import { DatasetOperationState } from './dataset-operation';
 const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
 	datasets: Dataset[];
-	droppedDatasetId: null | string;
 }>();
 
 const emit = defineEmits(['select-dataset']);
@@ -86,11 +85,6 @@ watch(
 onMounted(async () => {
 	if (props.node.state.datasetId) {
 		dataset.value = await getDataset(props.node.state.datasetId);
-	}
-
-	// If dataset is drag and dropped from resource panel
-	else if (props.droppedDatasetId) {
-		dataset.value = props.datasets.find(({ id }) => id === props.droppedDatasetId) ?? null;
 	}
 });
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -48,7 +48,6 @@ import { ModelOperationState } from './model-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
 	models: Model[];
-	droppedModelId: null | string;
 }>();
 
 const emit = defineEmits(['select-model']);
@@ -82,9 +81,6 @@ onMounted(async () => {
 	if (state.modelId) {
 		model.value = await getModel(state.modelId);
 	}
-
-	// If model is drag and dropped from resource panel
-	else if (props.droppedModelId) await getModelById(props.droppedModelId);
 
 	// Force refresh of configs in the workflow node - August 2023
 	emit('select-model', { id: model.value?.id });

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -120,11 +120,6 @@
 						@append-output-port="(event) => appendOutputPort(node, event)"
 						@update-state="(event) => updateWorkflowNodeState(node, event)"
 					/>
-					<!--
-					<tera-stratify-node-julia
-						v-else-if="node.operationType === WorkflowOperationTypes.STRATIFY_JULIA"
-					/>
-					-->
 					<tera-stratify-node-mira
 						v-else-if="node.operationType === WorkflowOperationTypes.STRATIFY_MIRA"
 					/>
@@ -242,93 +237,13 @@
 			<template #header>
 				<h5>{{ currentActiveNode.displayName }}</h5>
 			</template>
-			<tera-calibrate-julia
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATION_JULIA"
+			<component
+				:is="drilldownRegistry.get(currentActiveNode.operationType)"
 				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-calibrate-ciemss
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATION_CIEMSS"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-
-			<tera-simulate-julia
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_JULIA"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-simulate-ciemss
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_CIEMSS"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-
-			<tera-stratify-mira
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.STRATIFY_MIRA"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-
-			<tera-model-from-code
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL_FROM_CODE"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-
-			<tera-simulate-ensemble-ciemss
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.SIMULATE_ENSEMBLE_CIEMSS"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-calibrate-ensemble-ciemss
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CALIBRATE_ENSEMBLE_CIEMSS"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-
-			<tera-model-workflow-wrapper
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-dataset-workflow-wrapper
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.DATASET"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-code-asset-wrapper
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.CODE"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-dataset-transformer
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-model-transformer
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.MODEL_TRANSFORMER"
-				:node="currentActiveNode"
-				@append-output-port="(event) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event) => updateWorkflowNodeState(currentActiveNode, event)"
-			/>
-			<tera-funman
-				v-if="currentActiveNode.operationType === WorkflowOperationTypes.FUNMAN"
-				:node="currentActiveNode"
-			/>
+				@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
+				@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
+			>
+			</component>
 		</tera-drilldown>
 	</Teleport>
 </template>
@@ -445,6 +360,23 @@ import {
 
 const workflowEventBus = workflowService.workflowEventBus;
 const WORKFLOW_SAVE_INTERVAL = 8000;
+
+// FIXME: check if there is a component typing instead of any
+const drilldownRegistry = new Map<string, any>();
+drilldownRegistry.set(CalibrationOperationJulia.name, TeraCalibrateJulia);
+drilldownRegistry.set(CalibrationOperationCiemss.name, TeraCalibrateCiemss);
+drilldownRegistry.set(SimulateJuliaOperation.name, TeraSimulateJulia);
+drilldownRegistry.set(SimulateCiemssOperation.name, TeraSimulateCiemss);
+drilldownRegistry.set(StratifyMiraOperation.name, TeraStratifyMira);
+drilldownRegistry.set(ModelFromCodeOperation.name, TeraModelFromCode);
+drilldownRegistry.set(SimulateEnsembleCiemssOperation.name, TeraSimulateEnsembleCiemss);
+drilldownRegistry.set(CalibrateEnsembleCiemssOperation.name, TeraCalibrateEnsembleCiemss);
+drilldownRegistry.set(ModelOperation.name, TeraModelWorkflowWrapper);
+drilldownRegistry.set(DatasetOperation.name, TeraDatasetWorkflowWrapper);
+drilldownRegistry.set(CodeAssetOperation.name, TeraCodeAssetWrapper);
+drilldownRegistry.set(DatasetTransformerOperation.name, TeraDatasetTransformer);
+drilldownRegistry.set(ModelTransformerOperation.name, TeraModelTransformer);
+drilldownRegistry.set(FunmanOperation.name, TeraFunman);
 
 // Will probably be used later to save the workflow in the project
 const props = defineProps<{
@@ -679,15 +611,6 @@ const contextMenuItems = ref([
 			workflowDirty = true;
 		}
 	},
-	/*
-	{
-		label: 'Stratify Julia',
-		command: () => {
-			workflowService.addNode(wf.value, StratifyOperation, newNodePosition, { state: null });
-			workflowDirty = true;
-		}
-	},
-	*/
 	{
 		label: 'Create model',
 		disabled: false,

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -66,20 +66,17 @@
 					<tera-model-node
 						v-if="node.operationType === WorkflowOperationTypes.MODEL && models"
 						:models="models"
-						:dropped-model-id="droppedAssetId"
 						:node="node"
 						@select-model="(event) => selectModel(node, event)"
 					/>
 					<tera-dataset-node
 						v-else-if="node.operationType === WorkflowOperationTypes.DATASET && datasets"
 						:datasets="datasets"
-						:dropped-dataset-id="droppedAssetId"
 						:node="node"
 						@select-dataset="(event) => selectDataset(node, event)"
 					/>
 					<tera-code-asset-node
 						v-else-if="node.operationType === WorkflowOperationTypes.CODE && codeAssets"
-						:dropped-code-asset-id="droppedAssetId"
 						:code-assets="codeAssets"
 						:node="node"
 						@select-code-asset="(event) => selectCodeAsset(node, event)"
@@ -292,7 +289,6 @@ import {
 	TeraSimulateCiemss,
 	TeraSimulateNodeCiemss
 } from './ops/simulate-ciemss/mod';
-// import { StratifyOperation, TeraStratifyNodeJulia } from './ops/stratify-julia/mod';
 import {
 	StratifyMiraOperation,
 	TeraStratifyMira,
@@ -394,7 +390,6 @@ const isWorkflowLoading = ref(false);
 
 const currentActiveNode = ref<WorkflowNode<any> | null>(null);
 const newEdge = ref<WorkflowEdge | undefined>();
-const droppedAssetId = ref<string | null>(null);
 const isMouseOverCanvas = ref<boolean>(false);
 const dialogIsOpened = ref(false);
 
@@ -453,13 +448,11 @@ const refreshModelNode = async (node: WorkflowNode<ModelOperationState>) => {
 };
 
 async function selectModel(node: WorkflowNode<ModelOperationState>, data: { id: string }) {
-	droppedAssetId.value = null;
 	node.state.modelId = data.id;
 	await refreshModelNode(node);
 }
 
 async function selectCodeAsset(node: WorkflowNode<CodeAssetState>, data: { id: string }) {
-	droppedAssetId.value = null;
 	node.state.codeAssetId = data.id;
 }
 
@@ -475,7 +468,6 @@ async function selectDataset(
 	node: WorkflowNode<DatasetOperationState>,
 	data: { id: string; name: string }
 ) {
-	droppedAssetId.value = null;
 	node.state.datasetId = data.id;
 	node.outputs = [
 		{
@@ -727,23 +719,25 @@ function onDrop(event) {
 		updateNewNodePosition(event);
 
 		let operation: Operation;
+		let state: any = null;
 
 		switch (assetType) {
 			case AssetType.Models:
 				operation = ModelOperation;
+				state = { modelId: assetId };
 				break;
 			case AssetType.Datasets:
 				operation = DatasetOperation;
+				state = { datasetId: assetId };
 				break;
 			case AssetType.Code:
 				operation = CodeAssetOperation;
+				state = { codeAssetId: assetId };
 				break;
 			default:
 				return;
 		}
-
-		workflowService.addNode(wf.value, operation, newNodePosition);
-		droppedAssetId.value = assetId;
+		workflowService.addNode(wf.value, operation, newNodePosition, { state });
 	}
 }
 


### PR DESCRIPTION
### Summary
Using `<component>` to instantiate the drilldown-components dynamically. This will:
- Keep the size of the template section nearly constant
- Allows for a more plug-and-play style: we can import components at runtime via `await import(path_to_component)` and add them into the registry
- Better enforcement of behaviours across components

Next up are the operation-nodes, they will need to go through some major refactoring, as some of them have the the core-logic embedded in the nodes and need to be shifted to the drilldowns. 

Also: 
- I also cleaned out the Julia stratify from the workflow.
- Cleaned out droppedAssetId hook to set the state, we can directly set the state on node-creation

### Testing
No functional changes, workflow should work as before.