### PR TITLE
Drilldown layout, behaviour, and preview

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
@@ -6,9 +6,9 @@
 				<Dropdown
 					v-if="options"
 					class="output-dropdown"
-					v-model="selectedValue"
+					:model-value="output"
 					:options="options"
-					@update:model-value="emit('change-output')"
+					@update:model-value="emit('update:output', $event)"
 				></Dropdown>
 			</header>
 			<main :style="{ height: mainHeight }">
@@ -26,43 +26,25 @@
 </template>
 
 <script setup lang="ts">
-import { isEmpty } from 'lodash';
 import Button from 'primevue/button';
 import Dropdown from 'primevue/dropdown';
-import { nextTick, onMounted, onUpdated, ref, watch } from 'vue';
+import { onUpdated, ref } from 'vue';
 
-const props = defineProps<{
+defineProps<{
 	options?: string[]; // subject to change based on how we want to pass in output data
-	// selectedOutput: string
-	value?: string;
+	output?: string;
 	canSaveAsset?: boolean;
 }>();
 
-const emit = defineEmits(['cancel', 'apply-changes', 'save-asset', 'change-output']);
-
-const selectedValue = ref<string>();
+const emit = defineEmits(['cancel', 'apply-changes', 'save-asset', 'update:output']);
 
 const mainHeight = ref();
 const header = ref();
 
-onMounted(() => {
-	if (!isEmpty(props.options)) {
-		selectedValue.value = props.options?.[0];
-	}
-});
-
 onUpdated(async () => {
-	await nextTick();
 	const headerHeight = header.value?.offsetHeight;
 	mainHeight.value = `calc(100% - ${headerHeight}px)`;
 });
-
-watch(
-	() => props.value,
-	() => {
-		selectedValue.value = props.value;
-	}
-);
 </script>
 
 <style scoped>
@@ -77,7 +59,7 @@ watch(
 	background-color: var(--surface-50);
 	flex-grow: 1;
 	padding: 1rem;
-	border-radius: 6px;
+	border-radius: var(--border-radius-medium);
 	box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.25) inset;
 	overflow: hidden;
 }
@@ -104,10 +86,10 @@ header {
 
 .output-dropdown:deep(.p-inputtext) {
 	padding: 0.75rem 1rem;
-	font-size: 14px;
+	font-size: var(--font-body-small);
 }
 
 .output-dropdown:deep(.pi) {
-	font-size: 14px;
+	font-size: var(--font-body-small);
 }
 </style>

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
@@ -16,11 +16,15 @@
 			</main>
 		</div>
 		<footer>
-			<Button v-if="canSaveAsset" outlined label="Save Model" @click="emit('save-asset')"></Button>
-			<div class="right-aligned-buttons">
-				<Button outlined label="Cancel" @click="emit('cancel')"></Button>
-				<Button label="Apply Changes and Close" @click="emit('apply-changes')"></Button>
-			</div>
+			<Button
+				v-if="canSaveAsset"
+				outlined
+				label="Save Model"
+				@click="emit('save-asset')"
+				class="save-asset-button"
+			></Button>
+			<Button outlined label="Cancel" @click="emit('cancel')"></Button>
+			<Button label="Apply Changes and Close" @click="emit('apply-changes')"></Button>
 		</footer>
 	</div>
 </template>
@@ -66,11 +70,11 @@ onUpdated(async () => {
 
 footer {
 	display: flex;
-}
-.right-aligned-buttons {
-	margin-left: auto;
-	display: flex;
+	justify-content: flex-end;
 	gap: 0.5rem;
+}
+.save-asset-button {
+	margin-right: auto;
 }
 
 header {

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="preview">
 		<div class="content-container">
-			<header ref="header">
+			<header>
 				<h5>Preview</h5>
 				<Dropdown
 					v-if="options"
@@ -11,7 +11,7 @@
 					@update:model-value="emit('update:output', $event)"
 				></Dropdown>
 			</header>
-			<main :style="{ height: mainHeight }">
+			<main>
 				<slot />
 			</main>
 		</div>
@@ -32,7 +32,6 @@
 <script setup lang="ts">
 import Button from 'primevue/button';
 import Dropdown from 'primevue/dropdown';
-import { onUpdated, ref } from 'vue';
 
 defineProps<{
 	options?: string[]; // subject to change based on how we want to pass in output data
@@ -41,14 +40,6 @@ defineProps<{
 }>();
 
 const emit = defineEmits(['cancel', 'apply-changes', 'save-asset', 'update:output']);
-
-const mainHeight = ref();
-const header = ref();
-
-onUpdated(async () => {
-	const headerHeight = header.value?.offsetHeight;
-	mainHeight.value = `calc(100% - ${headerHeight}px)`;
-});
 </script>
 
 <style scoped>
@@ -60,6 +51,8 @@ onUpdated(async () => {
 	gap: 0.5rem;
 }
 .content-container {
+	display: flex;
+	flex-direction: column;
 	background-color: var(--surface-50);
 	flex-grow: 1;
 	padding: 1rem;
@@ -86,6 +79,7 @@ header {
 
 .content-container > main {
 	overflow-y: auto;
+	flex-grow: 1;
 }
 
 .output-dropdown:deep(.p-inputtext) {

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -99,5 +99,6 @@ main {
 :deep(.drilldown-panel) {
 	display: grid;
 	grid-auto-flow: column;
+	height: 100%;
 }
 </style>

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -11,12 +11,12 @@
 			>
 			<main>
 				<section
-					v-for="(view, index) in views"
+					v-for="(tab, index) in tabs"
 					class="slot-container"
 					:class="{ 'hide-slot': hideSlot(index) }"
 					:key="index"
 				>
-					<slot :name="view" />
+					<component :is="tab" class="drilldown-panel" />
 				</section>
 			</main>
 		</section>
@@ -36,7 +36,17 @@ const props = defineProps<{
 const emit = defineEmits(['on-close-clicked']);
 const slots = useSlots();
 
-const views = computed(() => Object.keys(slots));
+/**
+ * This will retrieve and filer all top level components in the default slot if they have the tabName prop.
+ */
+const tabs = computed(() => {
+	if (slots.default?.()) {
+		return slots.default().filter((vnode) => vnode.props?.tabName);
+	}
+	return [];
+});
+
+const views = computed(() => tabs.value.map((vnode) => vnode.props?.tabName));
 
 const selectedViewIndex = ref<number>(0);
 
@@ -84,5 +94,10 @@ main {
 }
 .hide-slot {
 	display: none;
+}
+
+:deep(.drilldown-panel) {
+	display: grid;
+	grid-auto-flow: column;
 }
 </style>

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -100,5 +100,7 @@ main {
 	display: grid;
 	grid-auto-flow: column;
 	height: 100%;
+	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+	padding: 1rem 1.5rem;
 }
 </style>

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -37,7 +37,7 @@ const emit = defineEmits(['on-close-clicked']);
 const slots = useSlots();
 
 /**
- * This will retrieve and filer all top level components in the default slot if they have the tabName prop.
+ * This will retrieve and filter all top level components in the default slot if they have the tabName prop.
  */
 const tabs = computed(() => {
 	if (slots.default?.()) {

--- a/packages/client/hmi-client/src/components/drilldown/tera-ops-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-ops-preview.vue
@@ -1,0 +1,113 @@
+<template>
+	<div class="preview">
+		<div class="content-container">
+			<header ref="header">
+				<h5>Preview</h5>
+				<Dropdown
+					v-if="options"
+					class="output-dropdown"
+					v-model="selectedValue"
+					:options="options"
+					@update:model-value="emit('change-output')"
+				></Dropdown>
+			</header>
+			<main :style="{ height: mainHeight }">
+				<slot />
+			</main>
+		</div>
+		<footer>
+			<Button v-if="canSaveAsset" outlined label="Save Model" @click="emit('save-asset')"></Button>
+			<div class="right-aligned-buttons">
+				<Button outlined label="Cancel" @click="emit('cancel')"></Button>
+				<Button label="Apply Changes and Close" @click="emit('apply-changes')"></Button>
+			</div>
+		</footer>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { isEmpty } from 'lodash';
+import Button from 'primevue/button';
+import Dropdown from 'primevue/dropdown';
+import { nextTick, onMounted, onUpdated, ref, watch } from 'vue';
+
+const props = defineProps<{
+	options?: string[]; // subject to change based on how we want to pass in output data
+	// selectedOutput: string
+	value?: string;
+	canSaveAsset?: boolean;
+}>();
+
+const emit = defineEmits(['cancel', 'apply-changes', 'save-asset', 'change-output']);
+
+const selectedValue = ref<string>();
+
+const mainHeight = ref();
+const header = ref();
+
+onMounted(() => {
+	if (!isEmpty(props.options)) {
+		selectedValue.value = props.options?.[0];
+	}
+});
+
+onUpdated(async () => {
+	await nextTick();
+	const headerHeight = header.value?.offsetHeight;
+	mainHeight.value = `calc(100% - ${headerHeight}px)`;
+});
+
+watch(
+	() => props.value,
+	() => {
+		selectedValue.value = props.value;
+	}
+);
+</script>
+
+<style scoped>
+.preview {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	gap: 0.5rem;
+}
+.content-container {
+	background-color: var(--surface-50);
+	flex-grow: 1;
+	padding: 1rem;
+	border-radius: 6px;
+	box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.25) inset;
+	overflow: hidden;
+}
+
+footer {
+	display: flex;
+}
+.right-aligned-buttons {
+	margin-left: auto;
+	display: flex;
+	gap: 0.5rem;
+}
+
+header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-bottom: 0.5rem;
+}
+
+.content-container > main {
+	overflow-y: auto;
+}
+
+.output-dropdown:deep(.p-inputtext) {
+	padding: 0.75rem 1rem;
+	font-size: 14px;
+}
+
+.output-dropdown:deep(.pi) {
+	font-size: 14px;
+}
+</style>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -234,12 +234,18 @@
 			:tooltip="'A brief description of the operator.'"
 		>
 			<component
+				tabName="Wizard"
 				:is="drilldownRegistry.get(currentActiveNode.operationType)"
 				:node="currentActiveNode"
 				@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
 				@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 			>
 			</component>
+
+			<div tabName="Notebook">
+				<section>section 1</section>
+				<section>section 2</section>
+			</div>
 		</tera-drilldown>
 	</Teleport>
 </template>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -233,14 +233,15 @@
 			:title="currentActiveNode.displayName"
 			:tooltip="'A brief description of the operator.'"
 		>
-			<component
-				tabName="Wizard"
-				:is="drilldownRegistry.get(currentActiveNode.operationType)"
-				:node="currentActiveNode"
-				@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
-				@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
-			>
-			</component>
+			<div tabName="Wizard">
+				<component
+					:is="drilldownRegistry.get(currentActiveNode.operationType)"
+					:node="currentActiveNode"
+					@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
+					@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
+				>
+				</component>
+			</div>
 
 			<div tabName="Notebook">
 				<section>section 1</section>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -233,7 +233,7 @@
 			:title="currentActiveNode.displayName"
 			:tooltip="'A brief description of the operator.'"
 		>
-			<div tabName="Wizard">
+			<section tabName="Wizard">
 				<component
 					:is="drilldownRegistry.get(currentActiveNode.operationType)"
 					:node="currentActiveNode"
@@ -241,12 +241,7 @@
 					@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 				>
 				</component>
-			</div>
-
-			<div tabName="Notebook">
-				<section>section 1</section>
-				<section>section 2</section>
-			</div>
+			</section>
 		</tera-drilldown>
 	</Teleport>
 </template>


### PR DESCRIPTION
# Description

* Layout & behaviour for tera-drilldown
* Preview section for tera-drilldown


This idea for this ticket is to create a generalized format for the `tera-drilldown `component
### Defining Tabs
We can add as many tabs as we want by adding the `tabName` prop to a top level element under `tera-drilldown` 
In this example we have added three tabs to the drilldown called ("Tab 1", "Tab 2", "Tab 3")
```
<tera-drilldown>
    <div tabName="Tab 1"></div>
    <section tabName="Tab 2"></section>
    <section tabName="Tab 3"></section>
</tera-drilldown>
```

### Defining Tab columns
Taking this further inside each tab, every top level component will be shown in its own evenly-space columns:

In this example. Tab 1 would be split into 3 evenly spaced columns, Tab 2 into 2 evenly spaced columns, and Tab 3 in one column which takes up the entire drilldown.
```
<tera-drilldown>
    <div tabName="Tab 1">
        <section> section 1<section>
        <section> section 2<section>
        <section> section 3<section>
    </div>
    <section tabName="Tab 2">
        <section> section 1<section>
        <section> section 2<section>
    </section>
    <section tabName="Tab 3">
        <section> section 1<section>
    </section>
</tera-drilldown>
```

### Video
Here's an example video:

https://github.com/DARPA-ASKEM/terarium/assets/33158416/88f8ee9e-9f91-495f-95d7-9913bfae99e8



sample code from the video.
```
<tera-drilldown
	v-if="dialogIsOpened && currentActiveNode"
	@on-close-clicked="dialogIsOpened = false"
	:title="currentActiveNode.displayName"
	:tooltip="'A brief description of the operator.'"
>
	
	<section tabName="Wizard">
		<component
			:is="drilldownRegistry.get(currentActiveNode.operationType)"
			:node="currentActiveNode"
			@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
			@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
		>
		</component>
		<tera-drilldown-preview :options="outputs" v-model="selectedOutput">
                       <p> Lorem Ipsum ... </p>
		</tera-drilldown-preview>
	</section>

	<section tabName="Notebook">
		<section>section 1</section>
		<section>section 2</section>
		<section>section 3</section>
		<section>section 4</section>
	</section>
</tera-drilldown>

```


### Preview
There has also been a generic preview section added which is a common component that is shared with some drilldowns called `tera-drilldown-preview`

This models the selected output and the developer has the ability to add their own template within the component.  

For example
```
<tera-drilldown-preview>
    <p>Outputs</p>
    <Accordion>
       <Accordion-Tab />
       <Accordion-Tab />
       <Accordion-Tab />
    </Accordion>
</tera-drilldown-preview>
```


Resolves #(issue)
