### PR TITLE
chore: workflow project resource cleanup

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
@@ -4,22 +4,23 @@
 
 <script setup lang="ts">
 import { WorkflowNode } from '@/types/workflow';
-import { onMounted, ref, watch } from 'vue';
+import { onMounted, ref, computed, watch } from 'vue';
 import { Code } from '@/types/Types';
+import { useProjects } from '@/composables/project';
 import { CodeAssetState } from './code-asset-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CodeAssetState>;
-	codeAssets: Code[];
 }>();
 
 const emit = defineEmits(['select-code-asset']);
 
 const code = ref<Code | null>(null);
+const codeAssets = computed<Code[]>(() => useProjects().activeProject.value?.assets?.code ?? []);
 
 onMounted(async () => {
 	if (props.node.state.codeAssetId) {
-		code.value = props.codeAssets.find(({ id }) => id === props.node.state.codeAssetId) ?? null;
+		code.value = codeAssets.value.find(({ id }) => id === props.node.state.codeAssetId) ?? null;
 	}
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import { WorkflowNode } from '@/types/workflow';
 import { onMounted, ref, computed, watch } from 'vue';
 import { Code } from '@/types/Types';
@@ -13,7 +14,7 @@ const props = defineProps<{
 	node: WorkflowNode<CodeAssetState>;
 }>();
 
-const emit = defineEmits(['select-code-asset']);
+const emit = defineEmits(['update-state']);
 
 const code = ref<Code | null>(null);
 const codeAssets = computed<Code[]>(() => useProjects().activeProject.value?.assets?.code ?? []);
@@ -28,7 +29,9 @@ watch(
 	() => code.value,
 	() => {
 		if (code.value?.id) {
-			emit('select-code-asset', { id: code.value.id });
+			const state = _.cloneDeep(props.node.state);
+			state.codeAssetId = code.value.id;
+			emit('update-state', state);
 		}
 	}
 );

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
@@ -58,7 +58,7 @@ const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
 }>();
 
-const emit = defineEmits(['select-dataset']);
+const emit = defineEmits(['select-dataset', 'append-output-port']);
 
 const datasets = computed<Dataset[]>(
 	() => useProjects().activeProject.value?.assets?.datasets ?? []
@@ -82,7 +82,13 @@ watch(
 			selectedColumns = ref(csvHeaders?.value);
 			// Once a dataset is selected the output is assigned here, if there is already an output do not reassign
 			if (isEmpty(props.node.outputs)) {
-				emit('select-dataset', { id: dataset.value.id, name: dataset.value.name });
+				// emit('select-dataset', { id: dataset.value.id, name: dataset.value.name });
+
+				emit('append-output-port', {
+					type: 'datasetId',
+					label: dataset.value.name,
+					value: [dataset.value.id]
+				});
 			}
 		}
 	}

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
@@ -1,41 +1,43 @@
 <template>
-	<template v-if="dataset">
-		<tera-operator-title>{{ dataset.name }}</tera-operator-title>
-		<section v-if="csvContent">
-			<div class="datatable-toolbar">
-				<span class="datatable-toolbar-item"
-					>{{ `${csvContent[0].length} columns | ${csvContent.length} rows` }}
-				</span>
-				<span class="datatable-toolbar-item">
-					<MultiSelect
-						:modelValue="selectedColumns"
-						:options="csvHeaders"
-						@update:modelValue="onToggle"
-						:maxSelectedLabels="1"
-						placeholder="Select columns"
-					/>
-				</span>
-			</div>
+	<main>
+		<template v-if="dataset">
+			<tera-operator-title>{{ dataset.name }}</tera-operator-title>
+			<section v-if="csvContent">
+				<div class="datatable-toolbar">
+					<span class="datatable-toolbar-item"
+						>{{ `${csvContent[0].length} columns | ${csvContent.length} rows` }}
+					</span>
+					<span class="datatable-toolbar-item">
+						<MultiSelect
+							:modelValue="selectedColumns"
+							:options="csvHeaders"
+							@update:modelValue="onToggle"
+							:maxSelectedLabels="1"
+							placeholder="Select columns"
+						/>
+					</span>
+				</div>
 
-			<DataTable class="p-datatable-xsm" :value="csvContent.slice(1, 6)">
-				<Column
-					v-for="(colName, index) of selectedColumns"
-					:key="index"
-					:field="index.toString()"
-					:header="colName"
-				/>
-			</DataTable>
-			<span>Showing first 5 rows</span>
-		</section>
-	</template>
-	<Dropdown
-		v-else
-		class="w-full p-button-sm p-button-outlined"
-		:options="datasets"
-		option-label="name"
-		v-model="dataset"
-		placeholder="Select a dataset"
-	/>
+				<DataTable class="p-datatable-xsm" :value="csvContent.slice(1, 6)">
+					<Column
+						v-for="(colName, index) of selectedColumns"
+						:key="index"
+						:field="index.toString()"
+						:header="colName"
+					/>
+				</DataTable>
+				<span>Showing first 5 rows</span>
+			</section>
+		</template>
+		<Dropdown
+			v-else
+			class="w-full p-button-sm p-button-outlined"
+			:options="datasets"
+			option-label="name"
+			v-model="dataset"
+			placeholder="Select a dataset"
+		/>
+	</main>
 </template>
 
 <script setup lang="ts">
@@ -49,14 +51,18 @@ import { downloadRawFile, getDataset } from '@/services/dataset';
 import { WorkflowNode } from '@/types/workflow';
 import MultiSelect from 'primevue/multiselect';
 import TeraOperatorTitle from '@/workflow/operator/tera-operator-title.vue';
+import { useProjects } from '@/composables/project';
 import { DatasetOperationState } from './dataset-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
-	datasets: Dataset[];
 }>();
 
 const emit = defineEmits(['select-dataset']);
+
+const datasets = computed<Dataset[]>(
+	() => useProjects().activeProject.value?.assets?.datasets ?? []
+);
 
 const dataset = ref<Dataset | null>(null);
 const rawContent = ref<CsvAsset | null>(null);

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
@@ -58,7 +58,7 @@ const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
 }>();
 
-const emit = defineEmits(['select-dataset', 'append-output-port']);
+const emit = defineEmits(['append-output-port']);
 
 const datasets = computed<Dataset[]>(
 	() => useProjects().activeProject.value?.assets?.datasets ?? []
@@ -80,10 +80,9 @@ watch(
 		if (dataset?.value?.id && dataset?.value?.fileNames && dataset?.value?.fileNames?.length > 0) {
 			rawContent.value = await downloadRawFile(dataset.value.id, dataset.value?.fileNames[0] ?? '');
 			selectedColumns = ref(csvHeaders?.value);
+
 			// Once a dataset is selected the output is assigned here, if there is already an output do not reassign
 			if (isEmpty(props.node.outputs)) {
-				// emit('select-dataset', { id: dataset.value.id, name: dataset.value.name });
-
 				emit('append-output-port', {
 					type: 'datasetId',
 					label: dataset.value.name,

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, computed } from 'vue';
 import { getModel } from '@/services/model';
 import Dropdown from 'primevue/dropdown';
 import { Model } from '@/types/Types';
@@ -43,14 +43,15 @@ import TeraModelEquation from '@/components/model/petrinet/tera-model-equation.v
 import { WorkflowNode } from '@/types/workflow';
 import SelectButton from 'primevue/selectbutton';
 import TeraOperatorTitle from '@/workflow/operator/tera-operator-title.vue';
+import { useProjects } from '@/composables/project';
 import { ModelOperationState } from './model-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
-	models: Model[];
 }>();
 
 const emit = defineEmits(['select-model']);
+const models = computed<Model[]>(() => useProjects().activeProject.value?.assets?.models ?? []);
 
 enum ModelNodeView {
 	Diagram = 'Diagram',

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import { ref, watch, onMounted, computed } from 'vue';
 import { getModel } from '@/services/model';
 import Dropdown from 'primevue/dropdown';
@@ -50,7 +51,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
 }>();
 
-const emit = defineEmits(['select-model']);
+const emit = defineEmits(['update-state']);
 const models = computed<Model[]>(() => useProjects().activeProject.value?.assets?.models ?? []);
 
 enum ModelNodeView {
@@ -65,7 +66,12 @@ const viewOptions = ref([ModelNodeView.Diagram, ModelNodeView.Equation]);
 
 async function getModelById(modelId: string) {
 	model.value = await getModel(modelId);
-	emit('select-model', { id: model.value?.id });
+
+	if (model.value) {
+		const state = _.cloneDeep(props.node.state);
+		state.modelId = model.value?.id;
+		emit('update-state', state);
+	}
 }
 
 watch(
@@ -81,10 +87,10 @@ onMounted(async () => {
 	const state = props.node.state;
 	if (state.modelId) {
 		model.value = await getModel(state.modelId);
-	}
 
-	// Force refresh of configs in the workflow node - August 2023
-	emit('select-model', { id: model.value?.id });
+		// Force refresh of configs in the workflow node - August 2023
+		emit('update-state', _.cloneDeep(state));
+	}
 });
 </script>
 

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -432,25 +432,6 @@ async function updateWorkflowName() {
 	wf.value = await workflowService.getWorkflow(props.assetId);
 }
 
-/*
-async function selectDataset(
-	node: WorkflowNode<DatasetOperationState>,
-	data: { id: string; name: string }
-) {
-	node.state.datasetId = data.id;
-	node.outputs = [
-		{
-			id: uuidv4(),
-			type: 'datasetId',
-			label: data.name,
-			value: [data.id],
-			isOptional: false,
-			status: WorkflowPortStatus.NOT_CONNECTED
-		}
-	];
-	workflowDirty = true;
-}
-*/
 function appendInputPort(
 	node: WorkflowNode<any>,
 	port: { type: string; label?: string; value: any }

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -64,32 +64,27 @@
 			>
 				<template #body>
 					<tera-model-node
-						v-if="node.operationType === WorkflowOperationTypes.MODEL && models"
-						:models="models"
+						v-if="node.operationType === WorkflowOperationTypes.MODEL"
 						:node="node"
 						@select-model="(event) => selectModel(node, event)"
 					/>
 					<tera-dataset-node
-						v-else-if="node.operationType === WorkflowOperationTypes.DATASET && datasets"
-						:datasets="datasets"
+						v-else-if="node.operationType === WorkflowOperationTypes.DATASET"
 						:node="node"
 						@select-dataset="(event) => selectDataset(node, event)"
 					/>
 					<tera-code-asset-node
-						v-else-if="node.operationType === WorkflowOperationTypes.CODE && codeAssets"
-						:code-assets="codeAssets"
+						v-else-if="node.operationType === WorkflowOperationTypes.CODE"
 						:node="node"
 						@select-code-asset="(event) => selectCodeAsset(node, event)"
 					/>
 					<tera-dataset-transformer-node
-						v-else-if="
-							node.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER && datasets
-						"
+						v-else-if="node.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER"
 						:node="node"
 						@append-input-port="(event) => appendInputPort(node, event)"
 					/>
 					<tera-model-transformer-node
-						v-else-if="node.operationType === WorkflowOperationTypes.MODEL_TRANSFORMER && models"
+						v-else-if="node.operationType === WorkflowOperationTypes.MODEL_TRANSFORMER"
 						:node="node"
 						@append-input-port="(event) => appendInputPort(node, event)"
 					/>
@@ -270,11 +265,10 @@ import InputText from 'primevue/inputtext';
 import Menu from 'primevue/menu';
 import * as workflowService from '@/services/workflow';
 import * as d3 from 'd3';
-import { AssetType, Code, Dataset, Model } from '@/types/Types';
+import { AssetType } from '@/types/Types';
 import { useDragEvent } from '@/services/drag-drop';
 import { v4 as uuidv4 } from 'uuid';
 
-import { useProjects } from '@/composables/project';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 
 import { logger } from '@/utils/logger';
@@ -418,13 +412,6 @@ const toggleOptionsMenu = (event) => {
 const isEdgeTargetSim = (edge) =>
 	wf.value.nodes.find((node) => node.id === edge.target)?.operationType ===
 	WorkflowOperationTypes.SIMULATE_JULIA;
-
-const models = computed<Model[]>(() => useProjects().activeProject.value?.assets?.models ?? []);
-const datasets = computed<Dataset[]>(
-	() => useProjects().activeProject.value?.assets?.datasets ?? []
-);
-
-const codeAssets = computed<Code[]>(() => useProjects().activeProject.value?.assets?.code ?? []);
 
 const refreshModelNode = async (node: WorkflowNode<ModelOperationState>) => {
 	// FIXME: Need additional design to work out exactly what to show. June 2023

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -66,17 +66,17 @@
 					<tera-model-node
 						v-if="node.operationType === WorkflowOperationTypes.MODEL"
 						:node="node"
-						@select-model="(event) => selectModel(node, event)"
+						@update-state="(event) => updateWorkflowNodeState(node, event)"
 					/>
 					<tera-dataset-node
 						v-else-if="node.operationType === WorkflowOperationTypes.DATASET"
 						:node="node"
-						@select-dataset="(event) => selectDataset(node, event)"
+						@append-output-port="(event) => appendOutputPort(node, event)"
 					/>
 					<tera-code-asset-node
 						v-else-if="node.operationType === WorkflowOperationTypes.CODE"
 						:node="node"
-						@select-code-asset="(event) => selectCodeAsset(node, event)"
+						@update-state="(event) => updateWorkflowNodeState(node, event)"
 					/>
 					<tera-dataset-transformer-node
 						v-else-if="node.operationType === WorkflowOperationTypes.DATASET_TRANSFORMER"
@@ -287,12 +287,7 @@ import {
 	TeraStratifyMira,
 	TeraStratifyNodeMira
 } from './ops/stratify-mira/mod';
-import {
-	DatasetOperation,
-	TeraDatasetWorkflowWrapper,
-	TeraDatasetNode,
-	DatasetOperationState
-} from './ops/dataset/mod';
+import { DatasetOperation, TeraDatasetWorkflowWrapper, TeraDatasetNode } from './ops/dataset/mod';
 import { FunmanOperation, TeraFunman, TeraFunmanNode } from './ops/funman/mod';
 
 import {
@@ -340,12 +335,7 @@ import {
 	TeraModelTransformerNode
 } from './ops/model-transformer/mod';
 
-import {
-	TeraCodeAssetNode,
-	CodeAssetOperation,
-	CodeAssetState,
-	TeraCodeAssetWrapper
-} from './ops/code-asset/mod';
+import { TeraCodeAssetNode, CodeAssetOperation, TeraCodeAssetWrapper } from './ops/code-asset/mod';
 
 const workflowEventBus = workflowService.workflowEventBus;
 const WORKFLOW_SAVE_INTERVAL = 8000;
@@ -434,15 +424,6 @@ const refreshModelNode = async (node: WorkflowNode<ModelOperationState>) => {
 	});
 };
 
-async function selectModel(node: WorkflowNode<ModelOperationState>, data: { id: string }) {
-	node.state.modelId = data.id;
-	await refreshModelNode(node);
-}
-
-async function selectCodeAsset(node: WorkflowNode<CodeAssetState>, data: { id: string }) {
-	node.state.codeAssetId = data.id;
-}
-
 async function updateWorkflowName() {
 	const workflowClone = cloneDeep(wf.value);
 	workflowClone.name = newWorkflowName.value;
@@ -451,6 +432,7 @@ async function updateWorkflowName() {
 	wf.value = await workflowService.getWorkflow(props.assetId);
 }
 
+/*
 async function selectDataset(
 	node: WorkflowNode<DatasetOperationState>,
 	data: { id: string; name: string }
@@ -468,6 +450,7 @@ async function selectDataset(
 	];
 	workflowDirty = true;
 }
+*/
 function appendInputPort(
 	node: WorkflowNode<any>,
 	port: { type: string; label?: string; value: any }
@@ -516,6 +499,10 @@ function appendOutputPort(
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
 	workflowService.updateNodeState(wf.value, node.id, state);
+
+	if (node.operationType === WorkflowOperationTypes.MODEL) {
+		refreshModelNode(node);
+	}
 	workflowDirty = true;
 }
 


### PR DESCRIPTION
### Summary
This PR continues previous clean ups to have the operations beahviours closer to each so they can be reasoned with at a higher level and not be worried about the inner-workings.

- Cleans up bespoked events, such as `select-code-asset`, `select-dataset` and rolls them under the common messaging scheme (update-state, append-output-port, append-input-port).
- Cleans up special props, project specific resources are derived within the operations rather than outside.

TODO: The registry introduced in previous PR (https://github.com/DARPA-ASKEM/terarium/pull/2300) will be expanded to house the operation-nodes as well


### Testing
No functional changes. Workflow will behave in the same manner as before.