### PR TITLE
feat: model config operator

### DIFF
--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -15,7 +15,8 @@ export enum WorkflowOperationTypes {
 	MODEL_TRANSFORMER = 'ModelTransformer',
 	MODEL_FROM_CODE = 'ModelFromCode',
 	FUNMAN = 'Funman',
-	CODE = 'Code'
+	CODE = 'Code',
+	MODEL_CONFIG = 'ModelConfiguraiton'
 }
 
 export enum OperatorStatus {

--- a/packages/client/hmi-client/src/workflow/ops/model-config/mod.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/mod.ts
@@ -1,2 +1,7 @@
-export * from './model-config-operation';
-export { default as node } from './tera-model-config-node.vue';
+import { ModelConfigOperation as operation } from './model-config-operation';
+import node from './tera-model-config-node.vue';
+import drilldown from './tera-model-config.vue';
+
+const name = operation.name;
+
+export { name, operation, node, drilldown };

--- a/packages/client/hmi-client/src/workflow/ops/model-config/mod.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/mod.ts
@@ -1,0 +1,2 @@
+export * from './model-config-operation';
+export { default as node } from './tera-model-config-node.vue';

--- a/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
@@ -1,0 +1,24 @@
+import { Operation } from '@/types/workflow';
+
+export const name = 'ModelConfigOperation';
+
+export interface ModelConfigOperationState {
+	modelId: string | null;
+}
+
+export const ModelConfigOperation: Operation = {
+	name,
+	displayName: 'Model Configuration',
+	description: 'Create model configurations.',
+	isRunnable: true,
+	inputs: [{ type: 'modelId' }],
+	outputs: [{ type: 'modelConfigId' }],
+	action: async () => ({}),
+
+	initState: () => {
+		const init: ModelConfigOperationState = {
+			modelId: null
+		};
+		return init;
+	}
+};

--- a/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
@@ -1,4 +1,4 @@
-import { Operation } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes } from '@/types/workflow';
 
 export const name = 'ModelConfigOperation';
 
@@ -7,7 +7,7 @@ export interface ModelConfigOperationState {
 }
 
 export const ModelConfigOperation: Operation = {
-	name,
+	name: WorkflowOperationTypes.MODEL_CONFIG,
 	displayName: 'Model Configuration',
 	description: 'Create model configurations.',
 	isRunnable: true,

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,0 +1,5 @@
+<template>
+	<div>TODO</div>
+</template>
+
+<script setup lang="ts"></script>

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,5 +1,4 @@
 <template>
-	<!-- stub testing -->
 	<ul>
 		<li v-for="config of modelConfigs" :key="config.id">
 			{{ config.name }}
@@ -35,7 +34,6 @@ const refresh = async (modelId: string) => {
 watch(
 	() => [props.node.inputs[0].value],
 	async () => {
-		console.log('hello');
 		if (props.node.inputs[0].value) {
 			const modelId = props.node.inputs[0].value[0];
 			await refresh(modelId);

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,5 +1,45 @@
 <template>
-	<div>TODO</div>
+	<!-- stub testing -->
+	<ul>
+		<li v-for="config of modelConfigs" :key="config.id">
+			{{ config.name }}
+		</li>
+	</ul>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { watch, ref } from 'vue';
+import { WorkflowNode } from '@/types/workflow';
+import { ModelConfiguration } from '@/types/Types';
+import { getModelConfigurations } from '@/services/model';
+import { ModelConfigOperationState } from './model-config-operation';
+
+const props = defineProps<{
+	node: WorkflowNode<ModelConfigOperationState>;
+}>();
+const emit = defineEmits(['append-output-port']);
+
+const modelConfigs = ref<ModelConfiguration[]>([]);
+
+const refresh = async (modelId: string) => {
+	modelConfigs.value = await getModelConfigurations(modelId);
+	modelConfigs.value.forEach((config) => {
+		emit('append-output-port', {
+			type: 'modelConfigId',
+			label: config.name,
+			value: [config.id]
+		});
+	});
+};
+
+watch(
+	() => [props.node.inputs[0].value],
+	async () => {
+		console.log('hello');
+		if (props.node.inputs[0].value) {
+			const modelId = props.node.inputs[0].value[0];
+			await refresh(modelId);
+		}
+	}
+);
+</script>

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -1,22 +1,18 @@
 <template>
-	<main></main>
+	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+		<section>TODO</section>
+	</tera-drilldown>
 </template>
 
 <script setup lang="ts">
-/*
 import { WorkflowNode } from '@/types/workflow';
+import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import { ModelConfigOperationState } from './model-config-operation';
 
-const props = defineProps<{
+defineProps<{
 	node: WorkflowNode<ModelConfigOperationState>;
 }>();
-*/
+const emit = defineEmits(['close']);
 </script>
 
-<style scoped>
-main {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-</style>
+<style scoped></style>

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -1,0 +1,22 @@
+<template>
+	<main></main>
+</template>
+
+<script setup lang="ts">
+/*
+import { WorkflowNode } from '@/types/workflow';
+import { ModelConfigOperationState } from './model-config-operation';
+
+const props = defineProps<{
+	node: WorkflowNode<ModelConfigOperationState>;
+}>();
+*/
+</script>
+
+<style scoped>
+main {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+</style>

--- a/packages/client/hmi-client/src/workflow/ops/model/model-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model/model-operation.ts
@@ -11,8 +11,8 @@ export const ModelOperation: Operation = {
 	description: 'Select a model and configure its initial and parameter values.',
 	isRunnable: true,
 	inputs: [],
-	outputs: [{ type: 'modelConfigId' }],
-	action: async (modelConfigId: string) => [{ type: 'modelConfigId', value: modelConfigId }],
+	outputs: [{ type: 'modelId' }],
+	action: async () => ({}),
 
 	initState: () => {
 		const init: ModelOperationState = {

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -51,7 +51,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
 }>();
 
-const emit = defineEmits(['update-state']);
+const emit = defineEmits(['update-state', 'append-output-port']);
 const models = computed<Model[]>(() => useProjects().activeProject.value?.assets?.models ?? []);
 
 enum ModelNodeView {
@@ -71,6 +71,11 @@ async function getModelById(modelId: string) {
 		const state = _.cloneDeep(props.node.state);
 		state.modelId = model.value?.id;
 		emit('update-state', state);
+		emit('append-output-port', {
+			type: 'modelId',
+			label: model.value.header.name,
+			value: [model.value.id]
+		});
 	}
 }
 
@@ -87,9 +92,6 @@ onMounted(async () => {
 	const state = props.node.state;
 	if (state.modelId) {
 		model.value = await getModel(state.modelId);
-
-		// Force refresh of configs in the workflow node - August 2023
-		emit('update-state', _.cloneDeep(state));
 	}
 });
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-workflow-wrapper.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-workflow-wrapper.vue
@@ -15,7 +15,7 @@
 
 import { WorkflowNode } from '@/types/workflow';
 import TeraModel from '@/components/model/tera-model.vue';
-import { workflowEventBus } from '@/services/workflow';
+// import { workflowEventBus } from '@/services/workflow';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import { ModelOperationState } from './model-operation';
 
@@ -27,9 +27,9 @@ const emit = defineEmits(['close']);
 
 // Send refresh event onto the eventBus
 const refreshModelNode = () => {
-	workflowEventBus.emitNodeRefresh({
-		workflowId: props.node.workflowId,
-		nodeId: props.node.id
-	});
+	// workflowEventBus.emitNodeRefresh({
+	// 	workflowId: props.node.workflowId,
+	// 	nodeId: props.node.id
+	// });
 };
 </script>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -418,10 +418,6 @@ function appendOutputPort(
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
 	workflowService.updateNodeState(wf.value, node.id, state);
-
-	// if (node.operationType === WorkflowOperationTypes.MODEL) {
-	// 	refreshModelNode(node);
-	// }
 	workflowDirty = true;
 }
 

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -269,6 +269,9 @@ import {
 
 import { TeraCodeAssetNode, CodeAssetOperation, TeraCodeAssetWrapper } from './ops/code-asset/mod';
 
+// New import style for operators
+import * as ModelConfigOp from './ops/model-config/mod';
+
 const workflowEventBus = workflowService.workflowEventBus;
 const WORKFLOW_SAVE_INTERVAL = 8000;
 
@@ -295,6 +298,8 @@ registry.set(CodeAssetOperation.name, TeraCodeAssetNode, TeraCodeAssetWrapper);
 registry.set(DatasetTransformerOperation.name, TeraDatasetTransformerNode, TeraDatasetTransformer);
 registry.set(ModelTransformerOperation.name, TeraModelTransformerNode, TeraModelTransformer);
 registry.set(FunmanOperation.name, TeraFunmanNode, TeraFunman);
+
+registry.set(ModelConfigOp.name, ModelConfigOp.node, ModelConfigOp.drilldown);
 
 // Will probably be used later to save the workflow in the project
 const props = defineProps<{
@@ -420,9 +425,9 @@ function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
 	workflowService.updateNodeState(wf.value, node.id, state);
 
-	if (node.operationType === WorkflowOperationTypes.MODEL) {
-		refreshModelNode(node);
-	}
+	// if (node.operationType === WorkflowOperationTypes.MODEL) {
+	// 	refreshModelNode(node);
+	// }
 	workflowDirty = true;
 }
 
@@ -456,6 +461,13 @@ const contextMenuItems = ref([
 		label: 'Model',
 		command: () => {
 			workflowService.addNode(wf.value, ModelOperation, newNodePosition);
+			workflowDirty = true;
+		}
+	},
+	{
+		label: 'Model Configuration',
+		command: () => {
+			workflowService.addNode(wf.value, ModelConfigOp.operation, newNodePosition);
 			workflowDirty = true;
 		}
 	},


### PR DESCRIPTION
### Summary
Just the plumbings for the model-configuration operator. 

We still need to
- Implement config operator-node
- Implement config operator-drilldown 
- Amend model operator-drilldown

Note I introduced a new import syntax/semantic to try to make things a bit more readable in tera-workflow component (e.g. cleaner import). Let me know if this sits well with everyone.

```
import { ModelConfigOperation as operation } from './model-config-operation';
import node from './tera-model-config-node.vue';
import drilldown from './tera-model-config.vue';

const name = operation.name;

export { name, operation, node, drilldown };
```