### PR TITLE
chore: cleanup drag in tera-operator

### DIFF
--- a/packages/client/hmi-client/src/workflow/tera-operator.vue
+++ b/packages/client/hmi-client/src/workflow/tera-operator.vue
@@ -60,8 +60,6 @@ enum PortDirection {
 
 const props = defineProps<{
 	node: WorkflowNode<any>;
-	canDrag: boolean;
-	isActive: boolean;
 }>();
 
 const emit = defineEmits([
@@ -103,10 +101,6 @@ const drag = (evt: MouseEvent) => {
 
 	tempX = evt.x;
 	tempY = evt.y;
-
-	if (!props.canDrag) {
-		stopDrag();
-	}
 };
 
 const stopDrag = (/* evt: MouseEvent */) => {

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -5,8 +5,8 @@
 		@click="onCanvasClick()"
 		@contextmenu="toggleContextMenu"
 		@save-transform="saveTransform"
-		@mouseleave="isMouseOverCanvas = false"
-		@mouseenter="isMouseOverCanvas = true"
+		@mouseleave="setMouseOverCanvas(false)"
+		@mouseenter="setMouseOverCanvas(true)"
 		@focus="() => {}"
 		@blur="() => {}"
 		@drop="onDrop"
@@ -297,7 +297,7 @@ const newNodePosition = { x: 0, y: 0 };
 let canvasTransform = { x: 0, y: 0, k: 1 };
 let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
-const isMouseOverCanvas: boolean = false;
+let isMouseOverCanvas: boolean = false;
 let saveTimer: any = null;
 let workflowDirty: boolean = false;
 
@@ -324,6 +324,10 @@ const optionsMenuItems = ref([
 		}
 	}
 ]);
+
+const setMouseOverCanvas = (val: boolean) => {
+	isMouseOverCanvas = val;
+};
 
 const toggleOptionsMenu = (event) => {
 	optionsMenu.value.toggle(event);

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -59,8 +59,6 @@
 				@remove-operator="(event) => removeNode(event)"
 				@remove-edges="removeEdges"
 				@drilldown="(event) => drilldown(event)"
-				:canDrag="isMouseOverCanvas"
-				:isActive="currentActiveNode?.id === node.id"
 			>
 				<template #body>
 					<component
@@ -736,6 +734,7 @@ function updateEdgePositions(node: WorkflowNode<any>, { x, y }) {
 }
 
 const updatePosition = (node: WorkflowNode<any>, { x, y }) => {
+	if (!isMouseOverCanvas.value) return;
 	node.x += x / canvasTransform.k;
 	node.y += y / canvasTransform.k;
 	updateEdgePositions(node, { x, y });

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -297,6 +297,7 @@ const newNodePosition = { x: 0, y: 0 };
 let canvasTransform = { x: 0, y: 0, k: 1 };
 let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
+const isMouseOverCanvas: boolean = false;
 let saveTimer: any = null;
 let workflowDirty: boolean = false;
 
@@ -304,7 +305,6 @@ const isWorkflowLoading = ref(false);
 
 const currentActiveNode = ref<WorkflowNode<any> | null>(null);
 const newEdge = ref<WorkflowEdge | undefined>();
-const isMouseOverCanvas = ref<boolean>(false);
 const dialogIsOpened = ref(false);
 
 const wf = ref<Workflow>(workflowService.emptyWorkflow());
@@ -734,7 +734,7 @@ function updateEdgePositions(node: WorkflowNode<any>, { x, y }) {
 }
 
 const updatePosition = (node: WorkflowNode<any>, { x, y }) => {
-	if (!isMouseOverCanvas.value) return;
+	if (!isMouseOverCanvas) return;
 	node.x += x / canvasTransform.k;
 	node.y += y / canvasTransform.k;
 	updateEdgePositions(node, { x, y });


### PR DESCRIPTION
### Summary
For some odd reason, `canDrag` prop is causing unnecessary refreshes within the operator components (embedded tera-simulate-charts are refreshing when moving-in  and moving-out of the canvas). 

While the refreshing problem is still under investigation, upon closer look we can remove and simplify the canDrag logic; and also removed unused props while I am in the area.


### Testing
No functional changess, can drag operator nodes as normal.