### PR TITLE
fix: stop the warning message spam coming from model from code node 

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code-node.vue
@@ -1,6 +1,8 @@
 <template>
-	<main>model from code node</main>
-	<tera-operator-image-carousel :images="images" />
+	<main>
+		model from code node
+		<tera-operator-image-carousel :images="images" />
+	</main>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
# Description

The model from code node wasn't wrapped properly which threw a bunch of warnings.
