### PR TITLE
fix: rewire operations to use modelId instead of modelConfigurationId

### DIFF
--- a/packages/client/hmi-client/src/components/model/tera-model-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model-jupyter-panel.vue
@@ -129,7 +129,7 @@ const confirm = useConfirm();
 
 const props = defineProps<{
 	model: Model | null;
-	modelConfigurationId: string;
+	modelId: string;
 	showKernels: boolean;
 	showChatThoughts: boolean;
 	notebookSession?: NotebookSession;
@@ -183,7 +183,7 @@ jupyterSession.kernelChanged.connect((_context, kernelInfo) => {
 	if (kernel?.name === 'beaker') {
 		setKernelContext(kernel as IKernelConnection, {
 			context: 'mira_model',
-			context_info: { id: props.modelConfigurationId, type: 'model_config' }
+			context_info: { id: props.modelId, type: 'model' }
 		});
 	}
 });
@@ -255,7 +255,7 @@ const saveAsNewModel = async () => {
 		session: session?.name || '',
 		channel: 'shell',
 		content: {
-			parent_dataset_id: String(props.modelConfigurationId),
+			parent_dataset_id: String(props.modelId),
 			name: modelName
 		},
 		msgType: 'save_amr_request',

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/model-transformer-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/model-transformer-operation.ts
@@ -11,7 +11,7 @@ export const ModelTransformerOperation: Operation = {
 	description: 'Select a model',
 	displayName: 'Model Transformer',
 	isRunnable: true,
-	inputs: [{ type: 'modelConfigId', label: 'Model Configuration' }],
+	inputs: [{ type: 'modelId', label: 'Model' }],
 	outputs: [],
 	action: () => {},
 

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
@@ -3,7 +3,7 @@
 		<div class="background">
 			<Suspense>
 				<tera-model-jupyter-panel
-					:model-configuration-id="modelConfigurationId"
+					:model-id="modelId"
 					:model="null"
 					:show-kernels="false"
 					:show-chat-thoughts="false"
@@ -25,7 +25,7 @@ import { createNotebookSession, getNotebookSessionById } from '@/services/notebo
 import { v4 as uuidv4 } from 'uuid';
 import { NotebookSession } from '@/types/Types';
 import { cloneDeep } from 'lodash';
-import { getModel, getModelConfigurations } from '@/services/model';
+import { getModel } from '@/services/model';
 import { addDefaultConfiguration } from '@/services/model-configurations';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import { ModelTransformerState } from './model-transformer-operation';
@@ -35,7 +35,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits(['append-output-port', 'update-state', 'close']);
 
-const modelConfigurationId = computed(() => {
+const modelId = computed(() => {
 	// for now we are only using 1 model configuration for the llm at a time, this can be expanded in the future
 	const modelConfirgurationList = props.node?.inputs
 		.filter((inputNode) => inputNode.status === WorkflowPortStatus.CONNECTED && inputNode.value)
@@ -84,18 +84,12 @@ const addOutputPort = async (data) => {
 	// set default configuration
 	await addDefaultConfiguration(model);
 
-	// setting timeout...elastic search might not update default config in time
-	setTimeout(async () => {
-		const configurationList = await getModelConfigurations(model.id);
-		configurationList.forEach((configuration) => {
-			emit('append-output-port', {
-				id: uuidv4(),
-				label: configuration.name,
-				type: 'modelConfigId',
-				value: [configuration.id]
-			});
-		});
-	}, 800);
+	emit('append-output-port', {
+		id: uuidv4(),
+		label: model.header.name,
+		type: 'modelId',
+		value: [model.id]
+	});
 };
 </script>
 

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -31,7 +31,7 @@ export const StratifyMiraOperation: Operation = {
 	name: WorkflowOperationTypes.STRATIFY_MIRA,
 	displayName: 'Stratify MIRA',
 	description: 'Stratify a model',
-	inputs: [{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: false }],
+	inputs: [{ type: 'modelId', label: 'Model', acceptMultiple: false }],
 	outputs: [{ type: 'model' }],
 	isRunnable: false,
 	action: () => {},


### PR DESCRIPTION
### Summary
This PR aims to resolve some of the logical discrepancies between model and model-configuration. 

For example, to change the model structure we are passing the operators the model-configuration, but in the operators we are using the model-configurations to get their respective models anyway. 

Impacted operators:
- model-transform
- mira-stratification


### Testing
Can make connections from model to the operators specified above.  Note because of stability issues the operators may not be running properly.