### PR TITLE
docs: update readme, add vscode project files.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,13 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
-		"Vue.volar"
+		"vue.volar",
+		"vscjava.vscode-java-pack",
+		"editorconfig.editorconfig",
+		"vscjava.vscode-gradle"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+	"unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             "mainClass": "software.uncharted.terarium.hmiserver.TerariumApplication",
             "projectName": "server",
             "args": [
-              "--spring.profiles.active=default,secrets,local"
+                "--spring.profiles.active=default,secrets,local"
             ]
         }
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.gradle.buildServer.enabled": "off"
+}

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ There should now be a `application-secrets.properties` file in the `packages/ser
 <summary><b>Debugging the Server in VSCode</b></summary>
 
 1) Ensure you have the `Extension Pack for Java` extension pack installed.
-2) Ensure the following configuration is in the `.vscode/launch.json` directory:
+2) If you have the `Gradle for Java` extension installed, disable the gradle build server: [it causes problems with building and live reload](https://github.com/redhat-developer/vscode-java/issues/2338).
+3) Ensure the following configuration is in the `.vscode/launch.json` directory:
 
 ```json
 {

--- a/hmiServerDev.sh
+++ b/hmiServerDev.sh
@@ -44,14 +44,14 @@ function deploy_remote() {
 function deploy_local() {
   echo "Deploying containers for development against local services"
   cat containers/common.env containers/secrets.env > containers/.env
-  docker compose --env-file containers/.env --file containers/docker-compose-remote.yml pull
+  docker compose --env-file containers/.env --file containers/docker-compose-local.yml pull
   docker compose --env-file containers/.env --file containers/docker-compose-local.yml up --detach --wait
 }
 
 function deploy_full() {
   echo "Locally run all containers"
   cat containers/common.env containers/secrets.env > containers/.env
-  docker compose --env-file containers/.env --file containers/docker-compose-remote.yml pull
+  docker compose --env-file containers/.env --file containers/docker-compose-full.yml pull
   docker compose --env-file containers/.env --file containers/docker-compose-full.yml up --detach --wait
 }
 


### PR DESCRIPTION
This adds the recommended extensions to properly run the project in VSCode, as well as disabling the gradle extensions build server which causes lots of headaches with the debugger.

Fix issue in hmiServerDev.sh pulling the wrong containers depending on the deployment arg.