### PR TITLE
refactor: generate context menu from specification

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -255,27 +255,36 @@ export const workflowEventBus = new WorkflowEventEmitter();
 /// /////////////////////////////////////////////////////////////////////////////
 interface OperatorImport {
 	name: string;
+	operation: Operation;
 	node: Component;
 	drilldown: Component;
 }
 export class WorkflowRegistry {
+	operationMap: Map<string, Operation>;
+
 	nodeMap: Map<string, Component>;
 
 	drilldownMap: Map<string, Component>;
 
 	constructor() {
+		this.operationMap = new Map();
 		this.nodeMap = new Map();
 		this.drilldownMap = new Map();
 	}
 
-	set(name: string, node: Component, drilldown: Component) {
+	set(name: string, operation: Operation, node: Component, drilldown: Component) {
+		this.operationMap.set(name, operation);
 		this.nodeMap.set(name, node);
 		this.drilldownMap.set(name, drilldown);
 	}
 
 	// shortcut
 	registerOp(op: OperatorImport) {
-		this.set(op.name, op.node, op.drilldown);
+		this.set(op.name, op.operation, op.node, op.drilldown);
+	}
+
+	getOperation(name: string) {
+		return this.operationMap.get(name);
 	}
 
 	getNode(name: string) {

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -302,166 +302,40 @@ const removeNode = (event) => {
 	workflowService.removeNode(wf.value, event);
 };
 
-const contextMenuItems = ref([
-	{
-		label: 'Model',
+const largeNode = { width: 420, height: 220 };
+const operationContextMenuList = [
+	{ name: ModelOp.name },
+	{ name: ModelConfigOp.name },
+	{ name: DatasetOp.name },
+	{ name: DatasetTransformerOp.name },
+	{ name: ModelTransformerOp.name },
+	{ name: StratifyMiraOp.name },
+	{ name: CodeAssetOp.name },
+	{ name: ModelFromCodeOp.name },
+	{ name: FunmanOp.name },
+	{ name: ModelOptimizeOp.name },
+	{ name: SimulateJuliaOp.name, options: { size: largeNode } },
+	{ name: CalibrateJuliaOp.name, options: { size: largeNode } },
+	{ name: SimulateCiemssOp.name, options: { size: largeNode } },
+	{ name: CalibrateCiemssOp.name, options: { size: largeNode } },
+	{ name: SimulateEnsembleCiemssOp.name, options: { size: largeNode } },
+	{ name: CalibrateEnsembleCiemssOp.name, options: { size: largeNode } }
+];
+
+const contextMenuItems = ref<any[]>([]);
+operationContextMenuList.forEach((item) => {
+	const op = registry.getOperation(item.name);
+	if (!op) return;
+
+	contextMenuItems.value.push({
+		label: op.displayName,
 		command: () => {
-			workflowService.addNode(wf.value, ModelOp.operation, newNodePosition);
+			workflowService.addNode(wf.value, op, newNodePosition, item.options);
 			workflowDirty = true;
 		}
-	},
-	{
-		label: 'Model Configuration',
-		command: () => {
-			workflowService.addNode(wf.value, ModelConfigOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Dataset',
-		command: () => {
-			workflowService.addNode(wf.value, DatasetOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Dataset Transformer',
-		command: () => {
-			workflowService.addNode(wf.value, DatasetTransformerOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Model Transformer',
-		command: () => {
-			workflowService.addNode(wf.value, ModelTransformerOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Stratify Mira',
-		command: () => {
-			workflowService.addNode(wf.value, StratifyMiraOp.operation, newNodePosition, { state: null });
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Code asset',
-		command: () => {
-			workflowService.addNode(wf.value, CodeAssetOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Model from code',
-		disabled: false,
-		command: () => {
-			workflowService.addNode(wf.value, ModelFromCodeOp.operation, newNodePosition);
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Validate model configuration',
-		command: () => {
-			workflowService.addNode(wf.value, FunmanOp.operation, newNodePosition, { state: null });
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'Optimize model',
-		command: () => {
-			workflowService.addNode(wf.value, ModelOptimizeOp.operation, newNodePosition, {
-				state: null
-			});
-			workflowDirty = true;
-		}
-	},
-	{
-		label: 'DETERMINISTIC',
-		items: [
-			{
-				label: 'Simulate',
-				command: () => {
-					workflowService.addNode(wf.value, SimulateJuliaOp.operation, newNodePosition, {
-						size: {
-							width: 420,
-							height: 220
-						}
-					});
-					workflowDirty = true;
-				}
-			},
-			{
-				label: 'Simulate ensemble',
-				disabled: true,
-				command: () => {}
-			},
-			{
-				label: 'Calibrate',
-				command: () => {
-					workflowService.addNode(wf.value, CalibrateJuliaOp.operation, newNodePosition);
-					workflowDirty = true;
-				}
-			}
-		]
-	},
-	{
-		label: 'PROBABILISTIC',
-		items: [
-			{
-				label: 'Simulate',
-				command: () => {
-					workflowService.addNode(wf.value, SimulateCiemssOp.operation, newNodePosition, {
-						size: {
-							width: 420,
-							height: 220
-						}
-					});
-					workflowDirty = true;
-				}
-			},
-			{
-				label: 'Calibrate & Simulate',
-				disabled: false,
-				command: () => {
-					workflowService.addNode(wf.value, CalibrateCiemssOp.operation, newNodePosition, {
-						size: {
-							width: 420,
-							height: 220
-						}
-					});
-					workflowDirty = true;
-				}
-			},
-			{
-				label: 'Simulate ensemble',
-				disabled: false,
-				command: () => {
-					workflowService.addNode(wf.value, SimulateEnsembleCiemssOp.operation, newNodePosition, {
-						size: {
-							width: 420,
-							height: 220
-						}
-					});
-					workflowDirty = true;
-				}
-			},
-			{
-				label: 'Calibrate ensemble',
-				disabled: false,
-				command: () => {
-					workflowService.addNode(wf.value, CalibrateEnsembleCiemssOp.operation, newNodePosition, {
-						size: {
-							width: 420,
-							height: 220
-						}
-					});
-					workflowDirty = true;
-				}
-			}
-		]
-	}
-]);
+	});
+});
+
 const addComponentMenu = ref();
 const showAddComponentMenu = (event) => addComponentMenu.value.toggle(event);
 


### PR DESCRIPTION
### Summary
Generate context menu from specification rather than manually spec'ing them out, this reduces replicated code and also unifies the displayed names of operators across different application context. 

Note the number of menu items are growing, and we will need to revisit the designs, however it is considered to be out-of-scope here in this PR.


### Test
Some naming may have changes (e.g. capitalization) due to using standard `operator.displayName`, but otherwise no functional changes. Workflow behaves in the same manner as before.