### PR TITLE
Ciemss calibrate initial UI refactor

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -1,85 +1,97 @@
 <template>
-	<!--Probably rename tera-asset to something even more abstract-->
 	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<section>
-			<tera-asset stretch-content>
-				<template #edit-buttons>
-					<SelectButton
-						:model-value="view"
-						@change="if ($event.value) view = $event.value;"
-						:options="viewOptions"
-						option-value="value"
-					>
-						<template #option="{ option }">
-							<i :class="`${option.icon} p-button-icon-left`" />
-							<span class="p-button-label">{{ option.value }}</span>
-						</template>
-					</SelectButton>
-				</template>
-				<Accordion
-					v-if="view === CalibrationView.Input && modelConfig"
-					:multiple="true"
-					:active-index="[0, 1, 2, 3, 4]"
-				>
-					<AccordionTab :header="modelConfig.configuration.name">
-						<tera-model-diagram :model="modelConfig.configuration" :is-editable="false" />
-					</AccordionTab>
-					<AccordionTab header="Mapping">
-						<DataTable class="mapping-table" :value="mapping">
-							<Column field="modelVariable">
-								<template #header>
-									<span class="column-header">Model variable</span>
-								</template>
-								<template #body="{ data, field }">
-									<!-- Tom TODO: No v-model -->
-									<Dropdown
-										class="w-full"
-										placeholder="Select a variable"
-										v-model="data[field]"
-										:options="modelColumnNames"
-									/>
-								</template>
-							</Column>
-							<Column field="datasetVariable">
-								<template #header>
-									<span class="column-header">Dataset variable</span>
-								</template>
-								<template #body="{ data, field }">
-									<!-- Tom TODO: No v-model -->
-									<Dropdown
-										class="w-full"
-										placeholder="Select a variable"
-										v-model="data[field]"
-										:options="datasetColumnNames"
-									/>
-								</template>
-							</Column>
-						</DataTable>
-						<div>
-							<Button
-								class="p-button-sm p-button-text"
-								icon="pi pi-plus"
-								label="Add mapping"
-								@click="addMapping"
+		<section :tabName="CalibrateTabs.Wizard">
+			<tera-drilldown-section>
+				<div class="form-section">
+					<h4>Mapping</h4>
+					<DataTable class="mapping-table" :value="mapping">
+						<Column field="modelVariable">
+							<template #header>
+								<span class="column-header">Model variable</span>
+							</template>
+							<template #body="{ data, field }">
+								<!-- Tom TODO: No v-model -->
+								<Dropdown
+									class="w-full"
+									placeholder="Select a variable"
+									v-model="data[field]"
+									:options="modelColumnNames"
+								/>
+							</template>
+						</Column>
+						<Column field="datasetVariable">
+							<template #header>
+								<span class="column-header">Dataset variable</span>
+							</template>
+							<template #body="{ data, field }">
+								<!-- Tom TODO: No v-model -->
+								<Dropdown
+									class="w-full"
+									placeholder="Select a variable"
+									v-model="data[field]"
+									:options="datasetColumnNames"
+								/>
+							</template>
+						</Column>
+					</DataTable>
+					<div>
+						<Button
+							class="p-button-sm p-button-text"
+							icon="pi pi-plus"
+							label="Add mapping"
+							@click="addMapping"
+						/>
+					</div>
+				</div>
+				<div class="form-section">
+					<h4>Calibration settings</h4>
+					<div class="input-row">
+						<div class="label-and-input">
+							<label for="num-samples">Number of samples</label>
+							<InputNumber class="p-inputtext-sm" inputId="integeronly" v-model="numSamples" />
+						</div>
+						<div class="label-and-input">
+							<label for="num-iterations">Number of solver iterations</label>
+							<InputNumber class="p-inputtext-sm" inputId="integeronly" v-model="numIterations" />
+						</div>
+						<div class="label-and-input">
+							<label for="method">Solver method</label>
+							<Dropdown
+								class="p-inputtext-sm"
+								:options="ciemssMethodOptions"
+								v-model="method"
+								placeholder="Select"
 							/>
 						</div>
-					</AccordionTab>
-					<AccordionTab v-if="datasetId" :header="currentDatasetFileName">
-						<tera-dataset-datatable preview-mode :raw-content="csvAsset ?? null" />
-					</AccordionTab>
-					<AccordionTab header="Train / Test ratio">
-						<section class="train-test-ratio">
-							<InputNumber v-model="trainTestValue" />
-							<Slider v-model="trainTestValue" />
-						</section>
-					</AccordionTab>
-				</Accordion>
-				<Accordion
-					v-if="view === CalibrationView.Output && modelConfig"
-					:multiple="true"
-					:active-index="[0, 1]"
-				>
-					<AccordionTab header="Variables">
+					</div>
+				</div>
+			</tera-drilldown-section>
+		</section>
+		<section :tabName="CalibrateTabs.Notebook">
+			<h4>Notebook</h4>
+		</section>
+		<template #preview>
+			<tera-drilldown-preview title="Preview">
+				<!-- <div class="form-section">
+					<h4>Calibrated parameters</h4>
+					<table class="p-datatable-table">
+						<thead class="p-datatable-thead">
+							<th>Parameter</th>
+							<th>Value</th>
+						</thead>
+						<tr v-for="(content, key) in parameterResult" :key="key">
+							<td>
+								<p>{{ key }}</p>
+							</td>
+							<td>
+								<p>{{ content }}</p>
+							</td>
+						</tr>
+					</table>
+				</div> -->
+				<div v-if="!showSpinner" class="form-section">
+					<h4>Variables</h4>
+					<section v-if="modelConfig && node.state.chartConfigs.length">
 						<tera-simulate-chart
 							v-for="(cfg, index) of node.state.chartConfigs"
 							:key="index"
@@ -98,77 +110,82 @@
 							label="Add chart"
 							icon="pi pi-plus"
 						></Button>
-					</AccordionTab>
-					<!-- <AccordionTab header="Calibrated parameter values">
-				<table class="p-datatable-table">
-					<thead class="p-datatable-thead">
-						<th>Parameter</th>
-						<th>Value</th>
-					</thead>
-					<tr v-for="(content, key) in parameterResult" :key="key">
-						<td>
-							<p>{{ key }}</p>
-						</td>
-						<td>
-							<p>{{ content }}</p>
-						</td>
-					</tr>
-				</table>
-			</AccordionTab> -->
-				</Accordion>
-				<section v-else-if="!modelConfig" class="emptyState">
-					<img src="@assets/svg/seed.svg" alt="" draggable="false" />
-					<p class="helpMessage">Connect a model configuration and dataset</p>
+					</section>
+					<section v-else-if="!modelConfig" class="emptyState">
+						<img src="@assets/svg/seed.svg" alt="" draggable="false" />
+						<p class="helpMessage">Connect a model configuration and dataset</p>
+					</section>
+				</div>
+				<section v-else>
+					<tera-progress-bar :value="progress.value" :status="progress.status" />
 				</section>
-			</tera-asset>
-		</section>
+			</tera-drilldown-preview>
+		</template>
+		<template #footer>
+			<Button
+				outlined
+				:style="{ marginRight: 'auto' }"
+				label="Run"
+				icon="pi pi-play"
+				@click="runCalibrate"
+				:disabled="disableRunButton"
+			/>
+			<Button label="Close" @click="emit('close')" />
+		</template>
 	</tera-drilldown>
 </template>
 
 <script setup lang="ts">
 import _ from 'lodash';
-import { computed, ref, shallowRef, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue';
 import Button from 'primevue/button';
 import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
 import Column from 'primevue/column';
-import { getRunResult, getRunResultCiemss } from '@/services/models/simulation-service';
-import Accordion from 'primevue/accordion';
-import AccordionTab from 'primevue/accordiontab';
-import TeraAsset from '@/components/asset/tera-asset.vue';
-import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-model-diagram.vue';
-import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
-import { CsvAsset, ModelConfiguration } from '@/types/Types';
-import Slider from 'primevue/slider';
+import {
+	getRunResultCiemss,
+	makeCalibrateJobCiemss,
+	simulationPollAction,
+	querySimulationInProgress
+} from '@/services/models/simulation-service';
+import {
+	CalibrationRequestCiemss,
+	ClientEvent,
+	ClientEventType,
+	CsvAsset,
+	ModelConfiguration
+} from '@/types/Types';
 import InputNumber from 'primevue/inputnumber';
 import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
-import { WorkflowNode } from '@/types/workflow';
+import { ProgressState, WorkflowNode } from '@/types/workflow';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
-import SelectButton from 'primevue/selectbutton';
+import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import { CalibrationOperationStateCiemss, CalibrateMap } from './calibrate-operation';
+import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
+import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
+import { subscribe, unsubscribe } from '@/services/ClientEventService';
+import { Poller, PollerState } from '@/api/api';
+import { getTimespan } from '@/workflow/util';
+import { logger } from '@/utils/logger';
+import {
+	CalibrationOperationCiemss,
+	CalibrationOperationStateCiemss,
+	CalibrateMap
+} from './calibrate-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
 }>();
 const emit = defineEmits(['append-output-port', 'update-state', 'close']);
 
-enum CalibrationView {
-	Input = 'Input',
-	Output = 'Output'
+enum CalibrateTabs {
+	Wizard = 'Wizard',
+	Notebook = 'Notebook'
 }
 
 // Model variables checked in the model configuration will be options in the mapping dropdown
 const modelColumnNames = ref<string[] | undefined>();
-
-const view = ref(CalibrationView.Input);
-const viewOptions = ref([
-	{ value: CalibrationView.Input, icon: 'pi pi-sign-in' },
-	{ value: CalibrationView.Output, icon: 'pi pi-sign-out' }
-]);
-
-const trainTestValue = ref(80);
 
 const datasetColumnNames = ref<string[]>();
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
@@ -179,9 +196,165 @@ const modelConfigId = computed<string | undefined>(() => props.node.inputs[0]?.v
 const datasetId = computed<string | undefined>(() => props.node.inputs[1]?.value?.[0]);
 const currentDatasetFileName = ref<string>();
 const simulationIds = computed<any | undefined>(() => props.node.outputs[0]?.value);
+
 const runResults = ref<RunResults>({});
-const parameterResult = ref<{ [index: string]: any }[]>();
+const completedRunId = ref<string>();
+// const parameterResult = ref<{ [index: string]: any }[]>();
+
+const showSpinner = ref(false);
+const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
+
 const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
+
+// EXTRA section
+const numSamples = ref(100);
+const numIterations = ref(100);
+const method = ref('dopri5');
+const ciemssMethodOptions = ref(['dopri5', 'euler']);
+
+const poller = new Poller();
+
+const disableRunButton = computed(
+	() =>
+		!currentDatasetFileName.value ||
+		!modelConfig.value ||
+		!csvAsset.value ||
+		!modelConfigId.value ||
+		!datasetId.value
+);
+
+onMounted(() => {
+	const runIds = querySimulationInProgress(props.node);
+	if (runIds.length > 0) {
+		getStatus(runIds[0]);
+	}
+});
+
+onUnmounted(() => {
+	poller.stop();
+});
+
+const runCalibrate = async () => {
+	if (
+		!modelConfigId.value ||
+		!datasetId.value ||
+		!currentDatasetFileName.value ||
+		!modelConfig.value
+	)
+		return;
+
+	const formattedMap: { [index: string]: string } = {};
+	// If the user has done any mapping populate formattedMap
+	if (mapping.value[0].datasetVariable !== '') {
+		mapping.value.forEach((ele) => {
+			formattedMap[ele.datasetVariable] = ele.modelVariable;
+		});
+	}
+	// TODO: TS/1225 -> Should not have to rand results
+	const initials = modelConfig.value.configuration.semantics.ode.initials.map((d) => d.target);
+	const rates = modelConfig.value.configuration.semantics.ode.rates.map((d) => d.target);
+	const initialsObj = {};
+	const paramsObj = {};
+
+	initials.forEach((d) => {
+		initialsObj[d] = Math.random() * 100;
+	});
+	rates.forEach((d) => {
+		paramsObj[d] = Math.random() * 0.05;
+	});
+
+	const calibrationRequest: CalibrationRequestCiemss = {
+		modelConfigId: modelConfigId.value,
+		dataset: {
+			id: datasetId.value,
+			filename: currentDatasetFileName.value,
+			mappings: formattedMap
+		},
+		extra: {
+			num_samples: numSamples.value,
+			num_iterations: numIterations.value,
+			method: method.value
+		},
+		timespan: getTimespan(csvAsset.value, mapping.value),
+		engine: 'ciemss'
+	};
+	const response = await makeCalibrateJobCiemss(calibrationRequest);
+
+	if (response?.simulationId) {
+		getStatus(response.simulationId);
+	}
+};
+
+/* const handlingProgress = (message: string) => {
+	const parsedMessage = JSON.parse(message);
+	if (parsedMessage.progress) {
+		progress.value.value = Math.round(parsedMessage.progress * 100);
+	}
+}; */
+
+function getMessageHandler(event: ClientEvent<any>) {
+	const runIds: string[] = querySimulationInProgress(props.node);
+	if (runIds.length === 0) return;
+
+	if (runIds.includes(event.data.id)) {
+		// perform some action here
+		console.log(`Event received for: ${event.data.id}`);
+	}
+}
+
+const getStatus = async (simulationId: string) => {
+	console.log('Getting status');
+	showSpinner.value = true;
+	if (!simulationId) {
+		console.log('No sim id');
+		return;
+	}
+	console.log(`Simulation Id:${simulationId}`);
+	const runIds = [simulationId];
+
+	// open a connection for each run id and handle the messages
+	await subscribe(ClientEventType.SimulationPyciemss, getMessageHandler);
+
+	poller
+		.setInterval(3000)
+		.setThreshold(300)
+		.setPollAction(async () => simulationPollAction(runIds, props.node, progress, emit));
+	console.log('Poller defined');
+	const pollerResults = await poller.start();
+
+	// closing event source connections
+	await unsubscribe(ClientEventType.SimulationPyciemss, getMessageHandler);
+
+	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
+		// throw if there are any failed runs for now
+		showSpinner.value = false;
+		logger.error(`Calibrate: ${simulationId} has failed`, {
+			toastTitle: 'Error - Pyciemss'
+		});
+		throw Error('Failed Runs');
+	}
+	completedRunId.value = simulationId;
+	updateOutputPorts(completedRunId);
+	showSpinner.value = false;
+};
+
+const updateOutputPorts = async (runId) => {
+	const portLabel = props.node.inputs[0].label;
+	const state = _.cloneDeep(props.node.state);
+	state.chartConfigs.push({
+		selectedRun: runId,
+		selectedVariable: []
+	});
+	emit('update-state', state);
+
+	emit('append-output-port', {
+		type: CalibrationOperationCiemss.outputs[0].type,
+		label: `${portLabel} Result`,
+		value: {
+			runId
+		}
+	});
+};
 
 // Tom TODO: Make this generic... its copy paste from node.
 const chartConfigurationChange = (index: number, config: ChartConfig) => {
@@ -250,17 +423,13 @@ watch(
 
 		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
 		runResults.value = output.runResults;
-		parameterResult.value = await getRunResult(simulationIds.value[0].runId, 'visualization.json');
+		// parameterResult.value = await getRunResult(simulationIds.value[0].runId, 'visualization.json');
 	},
 	{ immediate: true }
 );
 </script>
 
 <style scoped>
-.p-accordion {
-	padding-top: 1rem;
-}
-
 .mapping-table:deep(td) {
 	padding: 0rem 0.25rem 0.5rem 0rem !important;
 	border: none !important;
@@ -270,23 +439,6 @@ watch(
 	padding: 0rem 0.25rem 0.5rem 0.25rem !important;
 	border: none !important;
 	width: 50%;
-}
-
-.dropdown-button {
-	width: 156px;
-	height: 25px;
-	border-radius: 6px;
-}
-
-.train-test-ratio {
-	display: flex;
-	gap: 1rem;
-	margin: 0.5rem 0;
-}
-
-.train-test-ratio > .p-slider {
-	margin-top: 1rem;
-	width: 100%;
 }
 
 th {
@@ -316,19 +468,32 @@ th {
 	margin-top: 1rem;
 }
 
-.sim-tspan-container {
-	display: flex;
-	gap: 1em;
-}
-
-.sim-tspan-group {
-	display: flex;
-	flex-direction: column;
-	flex-grow: 1;
-	flex-basis: 0;
-}
-
 img {
 	width: 20%;
+}
+
+.form-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.label-and-input {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.input-row {
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+
+	& > * {
+		flex: 1;
+	}
 }
 </style>

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -1,104 +1,9 @@
 <template>
-	<section v-if="!showSpinner">
-		<Accordion
-			v-if="datasetColumnNames && modelColumnNames"
-			:multiple="true"
-			:active-index="[0, 3]"
-		>
-			<AccordionTab header="Mapping">
-				<DataTable class="p-datatable-xsm" :value="mapping">
-					<Column field="modelVariable">
-						<template #header>
-							<span class="column-header">Model variable</span>
-						</template>
-						<template #body="{ data, field }">
-							<div :class="data[field] ? 'mappingVariable' : 'unmappedVariable'">
-								{{ data[field] ? data[field] : '-' }}
-							</div>
-						</template>
-					</Column>
-					<Column field="datasetVariable">
-						<template #header>
-							<span class="column-header">Dataset variable</span>
-						</template>
-						<template #body="{ data, field }">
-							<div :class="data[field] ? 'mappingVariable' : 'unmappedVariable'">
-								{{ data[field] ? data[field] : 'Not mapped' }}
-							</div>
-						</template>
-					</Column>
-				</DataTable>
-			</AccordionTab>
-			<AccordionTab header="Variables">
-				<tera-simulate-chart
-					v-for="(cfg, index) of node.state.chartConfigs"
-					:key="index"
-					:run-results="runResults"
-					:initial-data="csvAsset"
-					:mapping="mapping"
-					:chartConfig="cfg"
-					has-mean-line
-					@configuration-change="chartConfigurationChange(index, $event)"
-				/>
-				<Button
-					class="add-chart"
-					text
-					:outlined="true"
-					@click="addChart"
-					label="Add chart"
-					icon="pi pi-plus"
-				></Button>
-			</AccordionTab>
-			<AccordionTab header="Calibrated parameter values">
-				<table class="p-datatable-table">
-					<thead class="p-datatable-thead">
-						<th>Parameter</th>
-						<th>Value</th>
-					</thead>
-					<tr v-for="(content, key) in parameterResult" :key="key">
-						<td>
-							<p>{{ key }}</p>
-						</td>
-						<td>
-							<p>{{ content }}</p>
-						</td>
-					</tr>
-				</table>
-			</AccordionTab>
-			<AccordionTab header="Extras">
-				<div class="extras w-full">
-					<div class="flex flex-column gap-2 w-full">
-						<label class="extras-label" for="numSamples">Number of samples</label>
-						<InputNumber id="numSamples" v-model="numSamples"></InputNumber>
-					</div>
-					<div class="flex flex-column gap-2 w-full">
-						<label class="extras-label" for="numIterations">Number of solver iterations</label>
-						<InputNumber id="numIterations" v-model="numIterations"></InputNumber>
-					</div>
-				</div>
-				<div class="flex flex-column gap-2 w-full">
-					<label class="extras-label" for="method">Solver method</label>
-					<Dropdown id="method" :options="ciemssMethodOptions" v-model="method" />
-				</div>
-			</AccordionTab>
-			<!-- <AccordionTab header="Loss"></AccordionTab>
-			<AccordionTab header="Parameters"></AccordionTab>
-			<AccordionTab header="Variables"></AccordionTab> -->
-		</Accordion>
-		<section v-else class="emptyState">
-			<img src="@assets/svg/seed.svg" alt="" draggable="false" />
-			<p class="helpMessage">
-				Connect a model configuration and dataset, then configure in the side panel
-			</p>
-		</section>
-		<Button
-			v-if="modelConfigId && datasetId"
-			class="p-button-sm run-button"
-			label="Run"
-			icon="pi pi-play"
-			@click="runCalibrate"
-			:disabled="disableRunButton"
-		/>
+	<section v-if="!showSpinner" class="emptyState">
+		<img src="@assets/svg/seed.svg" alt="" draggable="false" />
+		<p class="helpMessage">
+			Connect a model configuration and dataset, then configure in the side panel
+		</p>
 	</section>
 	<section v-else>
 		<tera-progress-bar :value="progress.value" :status="progress.status" />
@@ -106,42 +11,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, shallowRef, watch, ref, ComputedRef, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
 import { ProgressState, WorkflowNode } from '@/types/workflow';
-import DataTable from 'primevue/datatable';
-import Button from 'primevue/button';
-import Dropdown from 'primevue/dropdown';
-import Column from 'primevue/column';
-import Accordion from 'primevue/accordion';
-import AccordionTab from 'primevue/accordiontab';
-import InputNumber from 'primevue/inputnumber';
 import {
-	CalibrationRequestCiemss,
-	ClientEvent,
-	ClientEventType,
-	CsvAsset,
-	ModelConfiguration
-} from '@/types/Types';
-import {
-	makeCalibrateJobCiemss,
-	getRunResultCiemss,
 	simulationPollAction,
 	querySimulationInProgress
 } from '@/services/models/simulation-service';
-import { setupModelInput, setupDatasetInput } from '@/services/calibrate-workflow';
-import { ChartConfig, RunResults } from '@/types/SimulateConfig';
-import _ from 'lodash';
 import { Poller, PollerState } from '@/api/api';
-import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
-import { getTimespan } from '@/workflow/util';
 import { logger } from '@/utils/logger';
-import { subscribe, unsubscribe } from '@/services/ClientEventService';
-import {
-	CalibrationOperationCiemss,
-	CalibrationOperationStateCiemss,
-	CalibrateMap
-} from './calibrate-operation';
+import { CalibrationOperationStateCiemss } from './calibrate-operation';
+
+// TODO: FIGURE OUT WHAT TO SHOW IN THIS WORKFLOW NODE WHILE CALIBRATION IS RUNNING FROM THE DRILLDOWN
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
@@ -149,41 +30,10 @@ const props = defineProps<{
 
 const emit = defineEmits(['append-output-port', 'update-state']);
 
-const modelConfigId = computed(() => props.node.inputs[0].value?.[0] as string | undefined);
-const datasetId = computed(() => props.node.inputs[1].value?.[0] as string | undefined);
-const currentDatasetFileName = ref<string>();
-const modelConfig = ref<ModelConfiguration>();
-const completedRunId = ref<string>();
-const parameterResult = ref<{ [index: string]: any }>();
-
-const datasetColumnNames = ref<string[]>();
-const modelColumnNames = ref<string[] | undefined>();
-const runResults = ref<RunResults>({});
-const simulationIds: ComputedRef<any | undefined> = computed(
-	<any | undefined>(() => props.node.outputs[0]?.value)
-);
-
-const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
-const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const showSpinner = ref(false);
 const progress = ref({ status: ProgressState.RETRIEVING, value: 0 });
 
-// EXTRA section
-const numSamples = ref(100);
-const numIterations = ref(100);
-const method = ref('dopri5');
-const ciemssMethodOptions = ref(['dopri5', 'euler']);
-
 const poller = new Poller();
-
-const disableRunButton = computed(
-	() =>
-		!currentDatasetFileName.value ||
-		!modelConfig.value ||
-		!csvAsset.value ||
-		!modelConfigId.value ||
-		!datasetId.value
-);
 
 onMounted(() => {
 	const runIds = querySimulationInProgress(props.node);
@@ -196,74 +46,6 @@ onUnmounted(() => {
 	poller.stop();
 });
 
-const runCalibrate = async () => {
-	if (
-		!modelConfigId.value ||
-		!datasetId.value ||
-		!currentDatasetFileName.value ||
-		!modelConfig.value
-	)
-		return;
-
-	const formattedMap: { [index: string]: string } = {};
-	// If the user has done any mapping populate formattedMap
-	if (mapping.value[0].datasetVariable !== '') {
-		mapping.value.forEach((ele) => {
-			formattedMap[ele.datasetVariable] = ele.modelVariable;
-		});
-	}
-	// TODO: TS/1225 -> Should not have to rand results
-	const initials = modelConfig.value.configuration.semantics.ode.initials.map((d) => d.target);
-	const rates = modelConfig.value.configuration.semantics.ode.rates.map((d) => d.target);
-	const initialsObj = {};
-	const paramsObj = {};
-
-	initials.forEach((d) => {
-		initialsObj[d] = Math.random() * 100;
-	});
-	rates.forEach((d) => {
-		paramsObj[d] = Math.random() * 0.05;
-	});
-
-	const calibrationRequest: CalibrationRequestCiemss = {
-		modelConfigId: modelConfigId.value,
-		dataset: {
-			id: datasetId.value,
-			filename: currentDatasetFileName.value,
-			mappings: formattedMap
-		},
-		extra: {
-			num_samples: numSamples.value,
-			num_iterations: numIterations.value,
-			method: method.value
-		},
-		timespan: getTimespan(csvAsset.value, mapping.value),
-		engine: 'ciemss'
-	};
-	const response = await makeCalibrateJobCiemss(calibrationRequest);
-
-	if (response?.simulationId) {
-		getStatus(response.simulationId);
-	}
-};
-
-/* const handlingProgress = (message: string) => {
-	const parsedMessage = JSON.parse(message);
-	if (parsedMessage.progress) {
-		progress.value.value = Math.round(parsedMessage.progress * 100);
-	}
-}; */
-
-function getMessageHandler(event: ClientEvent<any>) {
-	const runIds: string[] = querySimulationInProgress(props.node);
-	if (runIds.length === 0) return;
-
-	if (runIds.includes(event.data.id)) {
-		// perform some action here
-		console.log(`Event received for: ${event.data.id}`);
-	}
-}
-
 const getStatus = async (simulationId: string) => {
 	console.log('Getting status');
 	showSpinner.value = true;
@@ -274,18 +56,12 @@ const getStatus = async (simulationId: string) => {
 	console.log(`Simulation Id:${simulationId}`);
 	const runIds = [simulationId];
 
-	// open a connection for each run id and handle the messages
-	await subscribe(ClientEventType.SimulationPyciemss, getMessageHandler);
-
 	poller
 		.setInterval(3000)
 		.setThreshold(300)
 		.setPollAction(async () => simulationPollAction(runIds, props.node, progress, emit));
 	console.log('Poller defined');
 	const pollerResults = await poller.start();
-
-	// closing event source connections
-	await unsubscribe(ClientEventType.SimulationPyciemss, getMessageHandler);
 
 	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
 		// throw if there are any failed runs for now
@@ -295,86 +71,9 @@ const getStatus = async (simulationId: string) => {
 		});
 		throw Error('Failed Runs');
 	}
-	completedRunId.value = simulationId;
-	updateOutputPorts(completedRunId);
+
 	showSpinner.value = false;
 };
-
-const updateOutputPorts = async (runId) => {
-	const portLabel = props.node.inputs[0].label;
-	const state = _.cloneDeep(props.node.state);
-	state.chartConfigs.push({
-		selectedRun: runId,
-		selectedVariable: []
-	});
-	emit('update-state', state);
-
-	emit('append-output-port', {
-		type: CalibrationOperationCiemss.outputs[0].type,
-		label: `${portLabel} Result`,
-		value: {
-			runId
-		}
-	});
-};
-
-// Tom TODO: Make this generic, its copy paste from drilldown
-const chartConfigurationChange = (index: number, config: ChartConfig) => {
-	const state = _.cloneDeep(props.node.state);
-	state.chartConfigs[index] = config;
-
-	emit('update-state', state);
-};
-
-const addChart = () => {
-	const state = _.cloneDeep(props.node.state);
-	state.chartConfigs.push(_.last(state.chartConfigs) as ChartConfig);
-
-	emit('update-state', state);
-};
-
-// Set up model config + dropdown names
-// Note: Same as calibrate side panel
-watch(
-	() => modelConfigId.value,
-	async () => {
-		const { modelConfiguration, modelColumnNameOptions } = await setupModelInput(
-			modelConfigId.value
-		);
-		modelConfig.value = modelConfiguration;
-		modelColumnNames.value = modelColumnNameOptions;
-	},
-	{ immediate: true }
-);
-
-// Set up csv + dropdown names
-// Note: Same as calibrate side panel
-watch(
-	() => datasetId.value,
-	async () => {
-		const { filename, csv } = await setupDatasetInput(datasetId.value);
-		currentDatasetFileName.value = filename;
-		csvAsset.value = csv;
-		datasetColumnNames.value = csv?.headers;
-	},
-	{ immediate: true }
-);
-
-// Fetch simulation run results whenever output changes
-watch(
-	() => simulationIds.value,
-	async () => {
-		if (!simulationIds.value) return;
-		// const resultCsv = await getRunResult(simulationIds.value[0].runId, 'simulation.csv');
-		// const csvData = csvParse(resultCsv);
-		// runResults.value[simulationIds.value[0].runId] = csvData as any;
-		// parameterResult.value = await getRunResult(simulationIds.value[0].runId, 'parameters.json');
-
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
-		runResults.value = output.runResults;
-	},
-	{ immediate: true }
-);
 </script>
 
 <style scoped>
@@ -394,43 +93,5 @@ watch(
 }
 img {
 	width: 20%;
-}
-
-th {
-	text-align: left;
-}
-.column-header {
-	color: var(--text-color-primary);
-	font-size: var(--font-caption);
-	font-weight: var(--font-semibold);
-}
-.mappingVariable {
-	font-size: var(--font-caption);
-}
-.unmappedVariable {
-	font-size: var(--font-caption);
-	color: var(--text-color-subdued);
-}
-.extras {
-	display: flex;
-	flex-direction: row;
-	gap: 1rem;
-	margin-bottom: 1rem;
-}
-
-.extras-label {
-	font-size: var(--font-caption);
-}
-#numSamples:deep(.p-inputnumber-input),
-#numIterations:deep(.p-inputnumber-input),
-#method:deep(.p-dropdown-label) {
-	width: 100%;
-	padding: 0.75rem;
-}
-.run-button {
-	margin-top: 1rem;
-	margin-bottom: 0.5rem;
-	width: 5rem;
-	float: right;
 }
 </style>


### PR DESCRIPTION
This code strips out the code from `tera-calibrate-node-ciemss.vue` and puts it in `tera-calibrate-ciemss.vue`.
This isn't the final version of the workflow node or the drilldown.

Open questions/concerns that need to be fixed in the future/separate PR:
- What should the workflow node show after a calibrate was started from the drilldown and a user exited out of the drilldown?
- What should happen while a calibrate is running but a user has exited out of the drilldown?
  - to further clarify on this point, because the the drilldown component gets unmounted when it's closed, we stop querying the message queue, so in that time the simulation could finish running but we may not have all the intermediate results? (TODO: still need to verify the exact details of what happens in this scenario)
