### PR TITLE
task: fix funman traj manip

### DIFF
--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -51,6 +51,7 @@ export const processFunman = (result: any) => {
 	// List of states and parameters
 	const states = result.model.petrinet.model.states.map((s) => s.id);
 	const params = result.model.petrinet.semantics.ode.parameters.map((p) => p.id);
+	const timesteps = result.request.structure_parameters.at(0).schedules.at(0).timepoints;
 
 	// "dataframes"
 	const points = [['id', 'label', 'box_id', ...params]];
@@ -105,15 +106,6 @@ export const processFunman = (result: any) => {
 						return obj;
 					}, {});
 
-				const timesteps = [
-					...new Set(
-						Object.keys(filteredVals).map((key) => {
-							const splitKey = key.split('_');
-							return +splitKey[splitKey.length - 1]; // timestep
-						})
-					)
-				].sort((a, b) => a - b);
-
 				timesteps.forEach((t) => {
 					const traj: any = {
 						boxId,
@@ -121,9 +113,12 @@ export const processFunman = (result: any) => {
 						timestep: t
 					};
 					states.forEach((s) => {
-						traj[s] = filteredVals[`${s}_${t}`];
+						if (filteredVals[`${s}_${t}`] !== undefined) {
+							// Only push values that exist in this box
+							traj[s] = filteredVals[`${s}_${t}`];
+							trajs.push(traj);
+						}
 					});
-					trajs.push(traj);
 				});
 			}); // foreach point
 		} // box.points

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -115,7 +115,7 @@ export const processFunman = (result: any) => {
 					};
 					states.forEach((s) => {
 						// Only push states that have a timestep key pair
-						if (Object.keys(filteredVals).includes(`${s}_${t}`)) {
+						if (Object.prototype.hasOwnProperty.call(filteredVals, `${s}_${t}`)) {
 							traj[s] = filteredVals[`${s}_${t}`];
 						} else {
 							pushFlag = false;

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -107,18 +107,23 @@ export const processFunman = (result: any) => {
 					}, {});
 
 				timesteps.forEach((t) => {
+					let pushFlag = true;
 					const traj: any = {
 						boxId,
 						pointId: point.id,
 						timestep: t
 					};
 					states.forEach((s) => {
-						if (filteredVals[`${s}_${t}`] !== undefined) {
-							// Only push values that exist in this box
+						// Only push states that have a timestep key pair
+						if (Object.keys(filteredVals).includes(`${s}_${t}`)) {
 							traj[s] = filteredVals[`${s}_${t}`];
-							trajs.push(traj);
+						} else {
+							pushFlag = false;
 						}
 					});
+					if (pushFlag) {
+						trajs.push(traj);
+					}
 				});
 			}); // foreach point
 		} // box.points


### PR DESCRIPTION
Funman traj was pushing a lot of incorrect timesteps due to ugly string manip to get timesteps
Change how we are getting these trajs
<img width="525" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/a4a7601a-87fd-4499-92ad-e613c128d565">

<img width="372" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/89dd2461-de03-40a9-8859-a1b39be90942">

