### PR TITLE
Inital proof of concept

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/TerariumApplication.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/TerariumApplication.java
@@ -1,10 +1,20 @@
 package software.uncharted.terarium.hmiserver;
 
+import org.apache.catalina.connector.Connector;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.TomcatServletWebServerFactoryCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @SpringBootApplication
 @EnableFeignClients
@@ -13,5 +23,51 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class TerariumApplication {
 	public static void main(final String[] args) {
 		SpringApplication.run(TerariumApplication.class, args);
+	}
+
+	@Value("${server.port:3000}")
+	private String serverPort;
+
+	@Value("${server.trustedPort:3001}")
+	private String trustedPort;
+
+	@Bean
+	public WebServerFactoryCustomizer servletContainer() {
+		Connector[] additionalConnectors = this.additionalConnector();
+
+		ServerProperties serverProperties = new ServerProperties();
+		return new TomcatMultiConnectorServletWebServerFactoryCustomizer(serverProperties, additionalConnectors);
+	}
+
+	private Connector[] additionalConnector() {
+		Set<String> defaultPorts = new HashSet<>();
+		defaultPorts.add(serverPort);
+
+		if (!defaultPorts.contains(trustedPort)) {
+			Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+			connector.setScheme("http");
+			connector.setPort(Integer.valueOf(trustedPort));
+			return new Connector[]{connector};
+		} else {
+			return new Connector[]{};
+		}
+	}
+
+	private class TomcatMultiConnectorServletWebServerFactoryCustomizer extends TomcatServletWebServerFactoryCustomizer {
+		private final Connector[] additionalConnectors;
+
+		TomcatMultiConnectorServletWebServerFactoryCustomizer(ServerProperties serverProperties, Connector[] additionalConnectors) {
+			super(serverProperties);
+			this.additionalConnectors = additionalConnectors;
+		}
+
+		@Override
+		public void customize(TomcatServletWebServerFactory factory) {
+			super.customize(factory);
+
+			if (additionalConnectors != null && additionalConnectors.length > 0) {
+				factory.addAdditionalTomcatConnectors(additionalConnectors);
+			}
+		}
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TerariumWebConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TerariumWebConfiguration.java
@@ -2,9 +2,13 @@ package software.uncharted.terarium.hmiserver.configuration;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import software.uncharted.terarium.hmiserver.controller.internal.InternalController;
 import software.uncharted.terarium.hmiserver.interceptors.OrderedHandlerInterceptor;
 
 import java.util.Comparator;
@@ -16,10 +20,18 @@ import java.util.List;
 public class TerariumWebConfiguration implements WebMvcConfigurer {
 	private final List<OrderedHandlerInterceptor> interceptorList;
 
+	@Value("${server.trustedPort:3001}")
+	private String trustedPort;
+
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		interceptorList.stream()
 			.sorted(Comparator.comparingInt(OrderedHandlerInterceptor::getOrder))
 			.forEach(registry::addInterceptor);
+	}
+
+	@Bean
+	public FilterRegistrationBean<TrustedEndpointsFilter> trustedEndpointsFilter() {
+		return new FilterRegistrationBean<>(new TrustedEndpointsFilter(trustedPort, InternalController.PATH));
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TrustedEndpointsFilter.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/TrustedEndpointsFilter.java
@@ -1,0 +1,48 @@
+package software.uncharted.terarium.hmiserver.configuration;
+
+import jakarta.servlet.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
+import org.springframework.security.web.util.OnCommittedResponseWrapper;
+
+import java.io.IOException;
+
+@Slf4j
+public class TrustedEndpointsFilter implements Filter {
+
+	static private int trustedPortNum;
+	static private String trustedPathPrefix;
+
+	TrustedEndpointsFilter(String trustedPort, String trustedPathPrefix) {
+		if (trustedPort != null && trustedPathPrefix != null && !"null".equals(trustedPathPrefix)) {
+			trustedPortNum = Integer.valueOf(trustedPort);
+			this.trustedPathPrefix = trustedPathPrefix;
+		}
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+		if (trustedPortNum != 0) {
+
+			if (isRequestForTrustedEndpoint(servletRequest) && servletRequest.getLocalPort() != trustedPortNum) {
+				log.warn("denying request for trusted endpoint on untrusted port");
+				((OnCommittedResponseWrapper) servletResponse).setStatus(403);
+				servletResponse.getOutputStream().close();
+				return;
+			}
+
+			if (!isRequestForTrustedEndpoint(servletRequest) && servletRequest.getLocalPort() == trustedPortNum) {
+				log.warn("denying request for untrusted endpoint on trusted port");
+				((OnCommittedResponseWrapper) servletResponse).setStatus(403);
+				servletResponse.getOutputStream().close();
+				return;
+			}
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	private boolean isRequestForTrustedEndpoint(ServletRequest servletRequest) {
+		return ((SecurityContextHolderAwareRequestWrapper) servletRequest).getRequestURI().startsWith(trustedPathPrefix);
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/internal/InternalController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/internal/InternalController.java
@@ -1,0 +1,47 @@
+package software.uncharted.terarium.hmiserver.controller.internal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import software.uncharted.terarium.hmiserver.models.data.project.Project;
+import software.uncharted.terarium.hmiserver.service.data.ProjectService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequestMapping("/internal")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@Tags(@Tag(name = "Internal", description = "Insecure internal access"))
+public class InternalController {
+	public static final String PATH = "/internal";
+
+	final ProjectService projectService;
+
+	@Operation(summary = "Gets a project by ID")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Project found.", content = {
+			@Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Project.class)) }),
+		@ApiResponse(responseCode = "500", description = "Error finding project", content = @Content),
+		@ApiResponse(responseCode = "404", description = "Project not found", content = @Content) })
+	@GetMapping("/projects/{id}")
+	public ResponseEntity<Project> getProject(
+		@PathVariable("id") final UUID id) {
+		final Optional<Project> project = projectService.getProject(id);
+		if (project.isPresent()) {
+			return ResponseEntity.ok(project.get());
+		}
+		return ResponseEntity.notFound().build();
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/security/SecurityConfig.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/security/SecurityConfig.java
@@ -3,7 +3,6 @@ package software.uncharted.terarium.hmiserver.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,7 +11,9 @@ import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import software.uncharted.terarium.hmiserver.configuration.Config;
+import software.uncharted.terarium.hmiserver.controller.internal.InternalController;
 
 @Configuration
 @EnableWebSecurity
@@ -50,6 +51,7 @@ public class SecurityConfig {
 			}
 				authorize
 				.requestMatchers(config.getUnauthenticatedUrlPatterns().toArray(new String[0])).permitAll()
+				.requestMatchers(new AntPathRequestMatcher(InternalController.PATH+ "/**")).permitAll()
 				.anyRequest().authenticated();
 		});
 		http.oauth2ResourceServer(configurer -> configurer.jwt(jwtConfigurer -> jwtConfigurer.jwtAuthenticationConverter(authenticationConverter)));

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -64,6 +64,7 @@ terarium.clientConfig.sseHeartbeatIntervalMillis=5000
 # Server configuration
 ########################################################################################################################
 server.port=3000
+server.trustedPort=3001
 server.http2.enabled=true
 spring.jackson.default-property-inclusion=NON_NULL
 # This value needs to be mirrored in default.conf in the nginx container


### PR DESCRIPTION
Stands up the `hmi-server` listening on two ports (by default `3000` (secure) and `3001` (insecure))

Adds `InternalController` that serves requests to URL that start with `/internal/`

Adds functionality to allow only calls on `3001` to route to `/internal/`

Calls to `/internal/` from `3000` will fail (with 403)
Calls to not `/internal/` from `3001` will fail (with 403)

To test: `curl -v localhost:3001/internal/projects/<project-id> | jq`