### PR TITLE
fix: fluent interface kernel session

### DIFF
--- a/packages/client/hmi-client/src/services/jupyter.ts
+++ b/packages/client/hmi-client/src/services/jupyter.ts
@@ -293,7 +293,7 @@ export class KernelSessionManager {
 			sessionKernel.sendJupyterMessage(contextMessage);
 			return kernelMessage;
 		}
-		return null;
+		throw new Error(`Unable to send message ${msgType}: ${messageBody}`);
 	}
 
 	disposeMessage(msgId: string) {

--- a/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
@@ -208,16 +208,16 @@ const runCodeModelCoupling = () => {
 
 	kernelManager
 		.sendMessage('execute_request', messageContent)
-		?.register('execute_input', (data) => {
+		.register('execute_input', (data) => {
 			console.log('execute_input', data.content);
 		})
-		?.register('stream', (data) => {
+		.register('stream', (data) => {
 			console.log('stream', data.content);
 		})
-		?.register('error', (data) => {
+		.register('error', (data) => {
 			console.log('error', data.content.evalue);
 		})
-		?.register('decapodes_preview', (data) => {
+		.register('decapodes_preview', (data) => {
 			console.log('decapodes_preview', data.content);
 			modelCouplingResult.value = data.content['application/json'];
 		});

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -111,7 +111,7 @@ const runFromCodeWrapper = () => {
 	if (!code) return;
 
 	// Reset model
-	kernelManager.sendMessage('reset_request', {})?.register('reset_response', () => {
+	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		runFromCode();
 	});
 };
@@ -119,9 +119,6 @@ const runFromCodeWrapper = () => {
 const runFromCode = () => {
 	const code = editor?.getValue();
 	if (!code) return;
-
-	// reset model
-	kernelManager.sendMessage('reset_request', {});
 
 	const messageContent = {
 		silent: false,
@@ -134,30 +131,28 @@ const runFromCode = () => {
 
 	let executedCode = '';
 
-	kernelManager.sendMessage('reset_request', {})?.register('reset_response', () => {
-		kernelManager
-			.sendMessage('execute_request', messageContent)
-			?.register('execute_input', (data) => {
-				executedCode = data.content.code;
-			})
-			?.register('stream', (data) => {
-				console.log('stream', data);
-			})
-			?.register('error', (data) => {
-				logger.error(`${data.content.ename}: ${data.content.evalue}`);
-				console.log('error', data.content);
-			})
-			?.register('model_preview', (data) => {
-				console.log('!!', data.content);
-				if (!data.content) return;
+	kernelManager
+		.sendMessage('execute_request', messageContent)
+		.register('execute_input', (data) => {
+			executedCode = data.content.code;
+		})
+		.register('stream', (data) => {
+			console.log('stream', data);
+		})
+		.register('error', (data) => {
+			logger.error(`${data.content.ename}: ${data.content.evalue}`);
+			console.log('error', data.content);
+		})
+		.register('model_preview', (data) => {
+			console.log('!!', data.content);
+			if (!data.content) return;
 
-				handleModelPreview(data);
+			handleModelPreview(data);
 
-				if (executedCode) {
-					saveCodeToState(executedCode, true);
-				}
-			});
-	});
+			if (executedCode) {
+				saveCodeToState(executedCode, true);
+			}
+		});
 };
 
 const resetModel = () => {
@@ -165,8 +160,8 @@ const resetModel = () => {
 
 	kernelManager
 		.sendMessage('reset_request', {})
-		?.register('reset_response', handleResetResponse)
-		?.register('model_preview', handleModelPreview);
+		.register('reset_response', handleResetResponse)
+		.register('model_preview', handleModelPreview);
 };
 
 const handleResetResponse = (data: any) => {

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -144,7 +144,6 @@ const runFromCode = () => {
 			console.log('error', data.content);
 		})
 		.register('model_preview', (data) => {
-			console.log('!!', data.content);
 			if (!data.content) return;
 
 			handleModelPreview(data);

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -301,8 +301,8 @@ async function handleCode() {
 
 		kernelManager
 			.sendMessage('compile_expr_request', messageContent)
-			?.register('compile_expr_response', handleCompileExprResponse)
-			?.register('decapodes_preview', handleDecapodesPreview);
+			.register('compile_expr_response', handleCompileExprResponse)
+			.register('decapodes_preview', handleDecapodesPreview);
 	}
 }
 

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -139,8 +139,8 @@ const resetModel = () => {
 
 	kernelManager
 		.sendMessage('reset_request', {})
-		?.register('reset_response', handleResetResponse)
-		?.register('model_preview', handleModelPreview);
+		.register('reset_response', handleResetResponse)
+		.register('model_preview', handleModelPreview);
 };
 
 const handleResetResponse = (data: any) => {
@@ -169,11 +169,11 @@ const stratifyRequest = () => {
 		}
 	};
 
-	kernelManager.sendMessage('reset_request', {})?.register('reset_response', () => {
+	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		kernelManager
 			.sendMessage('stratify_request', messageContent)
-			?.register('stratify_response', handleStratifyResponse)
-			?.register('model_preview', handleModelPreview);
+			.register('stratify_response', handleStratifyResponse)
+			.register('model_preview', handleModelPreview);
 	});
 };
 
@@ -277,19 +277,19 @@ const runCodeStratify = () => {
 
 	let executedCode = '';
 
-	kernelManager.sendMessage('reset_request', {})?.register('reset_response', () => {
+	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		kernelManager
 			.sendMessage('execute_request', messageContent)
-			?.register('execute_input', (data) => {
+			.register('execute_input', (data) => {
 				executedCode = data.content.code;
 			})
-			?.register('stream', (data) => {
+			.register('stream', (data) => {
 				console.log('stream', data);
 			})
-			?.register('error', (data) => {
+			.register('error', (data) => {
 				logger.error(`${data.content.ename}: ${data.content.evalue}`);
 			})
-			?.register('model_preview', (data) => {
+			.register('model_preview', (data) => {
 				// TODO: https://github.com/DARPA-ASKEM/terarium/issues/2305
 				// currently no matter what kind of code is run we always get a `model_preview` response.
 				// We may want to compare the response model with the existing model to see if the response model


### PR DESCRIPTION
### Summary
This PR handles two things:
- Instead of returning null if kernel-session-manager's sendMessage fails, throw an error. This makes the fluent interface a bit less gnarly to read. Instead of `sendMessage(...)?.register`, now it is just `sendMessage(...).register`

- I noticed we send a lot of extra, unneeded messages (e.g. reset) for model-edit, this cleans them up


### Testing
No functional changes, can test with one or more operators that leverages the kernel session manager. 

For model-edit: 
- pipe in a model to model-edit operator, 
- in the notebook we can override with an empty mira-model-template
```
# Define an empty model as basis
model = TemplateModel(
	templates = [],
	parameters = {},
	initials = {},
    observables = {},
	time = Time(name = "t", units = None),
	annotations = Annotations(name = "PetriNet model created by a user"))
```


For code-to-mode:
- create a code-to-model operator
- select julia, select deapodes
- run the following code
```
  C::Form0{X}
  dC::Form1{X}

  dC == d₀{X}(C)
```