### PR TITLE
fix: edge relink skipping candidate edges

### DIFF
--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -619,7 +619,7 @@ const threshold2 = 5.0 * 5.0;
  */
 function relinkEdges(node: WorkflowNode<any> | null) {
 	const nodes = node ? [node] : wf.value.nodes;
-	const edges = wf.value.edges;
+	const allEdges = wf.value.edges;
 
 	// Note id can start with numerals, so we need [id=...]
 	const getPortElement = (id: string) =>
@@ -635,35 +635,41 @@ function relinkEdges(node: WorkflowNode<any> | null) {
 
 	for (let i = 0; i < nodes.length; i++) {
 		const n = nodes[i];
+		const nodePosition: Position = { x: n.x, y: n.y };
 
 		// The input ports connects to the edge's target
 		const inputs = n.inputs;
 		inputs.forEach((port) => {
-			const edge = edges.find((e) => e.targetPortId === port.id);
-			if (!edge) return;
-			const portElem = getPortElement(edge.targetPortId as string);
-			const nodePosition: Position = { x: n.x, y: n.y };
-			const totalOffsetY = portElem.offsetTop + portElem.offsetHeight / 2;
-			const portPos = {
-				x: nodePosition.x,
-				y: nodePosition.y + totalOffsetY
-			};
-			relink(edge.points[1], portPos);
+			const edges = allEdges.filter((e) => e.targetPortId === port.id);
+			if (!edges || edges.length === 0) return;
+
+			edges.forEach((edge) => {
+				const portElem = getPortElement(edge.targetPortId as string);
+				const totalOffsetY = portElem.offsetTop + portElem.offsetHeight / 2;
+
+				const portPos = {
+					x: nodePosition.x,
+					y: nodePosition.y + totalOffsetY
+				};
+				relink(edge.points[1], portPos);
+			});
 		});
 
 		// The output ports connects to the edge's source
 		const outputs = n.outputs;
 		outputs.forEach((port) => {
-			const edge = edges.find((e) => e.sourcePortId === port.id);
-			if (!edge) return;
-			const portElem = getPortElement(edge.sourcePortId as string);
-			const nodePosition: Position = { x: n.x, y: n.y };
-			const totalOffsetY = portElem.offsetTop + portElem.offsetHeight / 2;
-			const portPos = {
-				x: nodePosition.x + n.width + portElem.offsetWidth * 0.5,
-				y: nodePosition.y + totalOffsetY
-			};
-			relink(edge.points[0], portPos);
+			const edges = allEdges.filter((e) => e.sourcePortId === port.id);
+			if (!edges || edges.length === 0) return;
+
+			edges.forEach((edge) => {
+				const portElem = getPortElement(edge.sourcePortId as string);
+				const totalOffsetY = portElem.offsetTop + portElem.offsetHeight / 2;
+				const portPos = {
+					x: nodePosition.x + n.width + portElem.offsetWidth * 0.5,
+					y: nodePosition.y + totalOffsetY
+				};
+				relink(edge.points[0], portPos);
+			});
 		});
 	}
 }


### PR DESCRIPTION
### Summary
The current relinking scheme has a bug, that for a given port, it finds the "first" bad edge and fixes its position, it should find "all" bad edges and relink all of them.


### Testing
You can test this scenario if you directly change the edge attributes in the workflow document in ElasticSearch, as the instances I found have been fixed already via testing.
