### PR TITLE
chore: funman hardening part 2

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
@@ -20,8 +20,8 @@ export interface FunmanOperationState {
 	currentTimespan: TimeSpan;
 	numSteps: number;
 	tolerance: number;
-	constraintGroups?: ConstraintGroup[];
-	requestParameters?: RequestParameter[];
+	constraintGroups: ConstraintGroup[];
+	requestParameters: RequestParameter[];
 }
 
 export const FunmanOperation: Operation = {
@@ -37,7 +37,8 @@ export const FunmanOperation: Operation = {
 			currentTimespan: { start: 0, end: 100 },
 			numSteps: 10,
 			tolerance: 0.89,
-			constraintGroups: []
+			constraintGroups: [],
+			requestParameters: []
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
@@ -10,11 +10,18 @@ export interface ConstraintGroup {
 	interval?: FunmanInterval;
 }
 
+export interface RequestParameter {
+	name: string;
+	interval?: FunmanInterval;
+	label: string;
+}
+
 export interface FunmanOperationState {
 	currentTimespan: TimeSpan;
 	numSteps: number;
 	tolerance: number;
 	constraintGroups?: ConstraintGroup[];
+	requestParameters?: RequestParameter[];
 }
 
 export const FunmanOperation: Operation = {

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -190,7 +190,8 @@ const requestConstraints = computed(
 			};
 		})
 );
-const requestParameters = ref();
+
+const requestParameters = ref<any[]>([]);
 const model = ref<Model | null>();
 const modelConfiguration = ref<ModelConfiguration>();
 const modelNodeOptions = ref<string[]>([]); // Used for form's multiselect.
@@ -315,9 +316,6 @@ const addConstraintForm = () => {
 		timepoints: { lb: 0, ub: 100 },
 		variables: []
 	};
-	if (!state.constraintGroups) {
-		state.constraintGroups = [];
-	}
 	state.constraintGroups.push(newGroup);
 
 	emit('update-state', state);
@@ -325,9 +323,6 @@ const addConstraintForm = () => {
 
 const deleteConstraintGroupForm = (data) => {
 	const state = _.cloneDeep(props.node.state);
-	if (!state.constraintGroups) {
-		return;
-	}
 	state.constraintGroups.splice(data.index, 1);
 
 	emit('update-state', state);
@@ -335,9 +330,6 @@ const deleteConstraintGroupForm = (data) => {
 
 const updateConstraintGroupForm = (data) => {
 	const state = _.cloneDeep(props.node.state);
-	if (!state.constraintGroups) {
-		return;
-	}
 	state.constraintGroups[data.index] = data.updatedConfig;
 
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -379,7 +379,7 @@ const setModelOptions = async () => {
 	// }
 	modelNodeOptions.value = modelColumnNameOptions;
 
-	const state = props.node.state;
+	const state = _.cloneDeep(props.node.state);
 	knobs.value.numberOfSteps = state.numSteps;
 	knobs.value.currentTimespan = _.cloneDeep(state.currentTimespan);
 	knobs.value.tolerance = state.tolerance;
@@ -393,10 +393,14 @@ const setModelOptions = async () => {
 	} else {
 		toast.error('', 'Provided model has no parameters');
 	}
+
+	state.requestParameters = _.cloneDeep(requestParameters.value);
+	emit('update-state', state);
 };
 
 const setRequestParameters = (modelParameters: ModelParameter[]) => {
-	if (props.node.state.requestParameters) {
+	const previous = props.node.state.requestParameters;
+	if (previous && previous.length > 0) {
 		requestParameters.value = _.cloneDeep(props.node.state.requestParameters);
 		return;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -176,11 +176,6 @@ const knobs = ref<BasicKnobs>({
 	numberOfSteps: 0
 });
 
-// const tolerance = ref(props.node.state.tolerance);
-// const startTime = ref(props.node.state.currentTimespan.start);
-// const endTime = ref(props.node.state.currentTimespan.end);
-// const numberOfSteps = ref(props.node.state.numSteps);
-
 const requestStepList = computed(() => getStepList());
 const requestStepListString = computed(() => requestStepList.value.join()); // Just used to display. dont like this but need to be quick
 
@@ -287,7 +282,7 @@ const getStatus = async (runId: string) => {
 
 	poller
 		.setInterval(3000)
-		.setThreshold(300)
+		.setThreshold(50)
 		.setPollAction(async () => {
 			const response = await getQueries(runId);
 			if (response.done && response.done === true) {
@@ -304,8 +299,8 @@ const getStatus = async (runId: string) => {
 	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
 		// throw if there are any failed runs for now
 		showSpinner.value = false;
-		console.error(`Simulate: ${runId} has failed`);
-		throw Error('Failed Runs');
+		console.error(`Funman: ${runId} has failed`);
+		throw Error('Failed Funman validation');
 	}
 	showSpinner.value = false;
 	addOutputPorts(runId);
@@ -458,6 +453,7 @@ watch(
 		if (props.node.active) {
 			activeOutput.value = props.node.outputs.find((d) => d.id === props.node.active) as any;
 			selectedOutputId.value = props.node.active;
+			setModelOptions();
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -136,7 +136,6 @@ import TeraFunmanOutput from '@/components/funman/tera-funman-output.vue';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { getModel } from '@/services/model';
 import { useToastService } from '@/services/toast';
-import { v4 as uuidv4 } from 'uuid';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
@@ -284,15 +283,14 @@ const getStatus = async (runId: string) => {
 
 const updateOutputPorts = async (runId: string) => {
 	const portLabel = props.node.inputs[0].label;
-	const portId = uuidv4();
 	emit('append-output-port', {
-		id: portId,
-		label: `${portLabel} Result ${props.node.outputs.length + 1}}`,
+		label: `${portLabel} Result ${props.node.outputs.length + 1}`,
 		type: FunmanOperation.outputs[0].type,
 		value: runId,
 		state: _.cloneDeep(props.node.state)
 	});
 	if (props.node.outputs.length === 1) {
+		const portId = props.node.outputs[0].id;
 		emit('select-output', portId);
 	}
 };

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -90,7 +90,7 @@
 		</div>
 
 		<template #preview>
-			<tera-drilldown-preview title="Validation results">
+			<tera-drilldown-preview title="Validation results" :options="props.node.outputs">
 				<tera-funman-output v-if="outputId" :fun-model-id="outputId" />
 				<div v-else>
 					<img src="@assets/svg/plants.svg" alt="" draggable="false" />
@@ -379,7 +379,6 @@ watch(
 );
 
 onUnmounted(() => {
-	console.log('unmounted.........');
 	poller.stop();
 });
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -92,10 +92,12 @@
 		<template #preview>
 			<tera-drilldown-preview
 				title="Validation results"
+				v-model:output="selectedOutputId"
 				@update:output="onUpdateOutput"
-				:options="props.node.outputs"
+				:options="outputs"
+				is-selectable
 			>
-				<tera-funman-output v-if="activeOutput" :fun-model-id="activeOutput.value[0]" />
+				<tera-funman-output v-if="activeOutput" :fun-model-id="activeOutput.value?.[0]" />
 				<div v-else>
 					<img src="@assets/svg/plants.svg" alt="" draggable="false" />
 					<h4>No Output</h4>
@@ -191,6 +193,18 @@ const requestParameters = ref();
 const model = ref<Model | null>();
 const modelConfiguration = ref<ModelConfiguration>();
 const modelNodeOptions = ref<string[]>([]); // Used for form's multiselect.
+const selectedOutputId = ref<string>();
+const outputs = computed(() => {
+	if (!_.isEmpty(props.node.outputs)) {
+		return [
+			{
+				label: 'Select outputs to display in operator',
+				items: props.node.outputs
+			}
+		];
+	}
+	return [];
+});
 
 // const outputId = computed(() => {
 // 	// FIXME: temporary test
@@ -198,7 +212,7 @@ const modelNodeOptions = ref<string[]>([]); // Used for form's multiselect.
 // 	if (props.node.outputs[last]?.value) return String(props.node.outputs[last].value);
 // 	return undefined;
 // });
-const activeOutput = ref<WorkflowOutput<any> | null>(null);
+const activeOutput = ref<WorkflowOutput<FunmanOperationState> | null>(null);
 
 const poller = new Poller();
 
@@ -398,7 +412,8 @@ watch(
 	() => {
 		// Update selected output
 		if (props.node.active) {
-			activeOutput.value = props.node.outputs.find((d) => d.id === props.node.active);
+			activeOutput.value = props.node.outputs.find((d) => d.id === props.node.active) as any;
+			selectedOutputId.value = props.node.active;
 		}
 	},
 	{ immediate: true }


### PR DESCRIPTION
### Summary
Bring Funman closer to existing operator paradigm and the design specification.

- Adding in the output dropdown/switcher
- UI tweak to make selecting "interested variables" more usable using a multi-select
- Fix state saving and restoration bugs, add requestParameters into saved state spec
- Harden some of the state typing; remove extraneous checks
- Consolidate usage between model-configuration and model - we don't really need to fetch model
- Misc cleanups

There is a bit of a change in terms of how states are handles, rather than proxying state directly, state values are copied into separate refs, and are initialized in the setModelOptions function. This is to facilitate switching between different output-ports, as well it makes it a little easier to write changes back into the actual state-object on the node.


### Testing
Should be able to run several funman valudations with different configuration values, these should be available in the output dropdown. When switching between different output previews the state should reflect that of the selected output.