### PR TITLE
fix: allow decimal input

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-editor.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-editor.vue
@@ -90,6 +90,7 @@
 							class="p-inputtext-sm"
 							inputId="numericInput"
 							mode="decimal"
+							:minFractionDigits="4"
 							v-model="paramValue"
 							@update:model-value="updateParameter(paramValue)"
 						/>


### PR DESCRIPTION
### Summary
Model config editor did not allow fractional numbers


### Test
Being able to enter fraction in model-config-editor