### PR TITLE
Fix decimal input not working for model config drilldown

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-editor.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-editor.vue
@@ -90,6 +90,7 @@
 							class="p-inputtext-sm"
 							inputId="numericInput"
 							mode="decimal"
+							:min-fraction-digits="1"
 							v-model="paramValue"
 							@update:model-value="updateParameter(paramValue)"
 						/>


### PR DESCRIPTION
Decimal input wasn't working for what seems to be a known issue with primevue InputNumber: https://github.com/primefaces/primevue/issues/1881

Resolves #2493 
