### PR TITLE
fix: reroute funman-url to match orchestration

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/funman/FunmanProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/funman/FunmanProxy.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import software.uncharted.terarium.hmiserver.models.funman.FunmanPostQueriesRequest;
 
-@FeignClient(name = "funman-api", url = "${funman-service.url}", path="/queries")
+@FeignClient(name = "funman-api", url = "${funman-service.url}", path="/api/queries")
 public interface FunmanProxy {
 
     @GetMapping("/{queryId}/halt")
     ResponseEntity<JsonNode> halt(@PathVariable("queryId") String queryId);
-   
+
     @GetMapping("/{queryId}")
     ResponseEntity<JsonNode> getQueries(@PathVariable("queryId") String queryId);
 

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -68,7 +68,7 @@ skema-unified.url=https://api.askem.lum.ai
 terarium.dataservice.url=https://data-service.staging.terarium.ai
 xdd-dev-service.url=https://xdddev.chtc.io
 xdd-prod-service.url=https://xdd.wisc.edu
-funman-service.url=http://funman.staging.terarium.ai/api
+funman-service.url=http://funman.staging.terarium.ai
 simulation-service.url=https://sciml-service.staging.terarium.ai
 ciemss-service.url=https://pyciemss.staging.terarium.ai
 


### PR DESCRIPTION
### Summary
Modify the URL to match how the param/var are passed in in orchestration configs.


@dgauldie @dvince2 This need to be ported to the migration branch.