### PR TITLE
fix: sidepanel scroll persists

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -9,7 +9,7 @@
 	</header>
 	<main>
 		<router-view v-slot="{ Component }">
-			<component class="page" ref="pageRef" :is="Component" :key="route.path" />
+			<component class="page" ref="pageRef" :is="Component" />
 		</router-view>
 	</main>
 	<footer>

--- a/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
@@ -161,6 +161,7 @@ import * as EventService from '@/services/event';
 import { EvaluationScenarioStatus, EventType } from '@/types/Types';
 import API from '@/api/api';
 import { useProjects } from '@/composables/project';
+import { ProjectPages } from '@/types/Project';
 
 defineProps<{
 	active: boolean;
@@ -402,7 +403,11 @@ watch(
 			items.push({
 				label: project.name,
 				icon: 'pi pi-folder',
-				command: () => router.push({ name: RouteName.Project, params: { projectId: project.id } })
+				command: () =>
+					router.push({
+						name: RouteName.Project,
+						params: { projectId: project.id, pageType: ProjectPages.OVERVIEW }
+					})
 			});
 		});
 		navMenuItems.value = [homeItem, explorerItem, ...items];


### PR DESCRIPTION
# Description

* A fix to allow the scroll position in the asset nav sidebar to persist, we now directly go to the overview page when clicking on a nav item.  Removing the key attribute will no longer make the component refresh so it keeps the scroll position

BEFORE:


https://github.com/DARPA-ASKEM/terarium/assets/33158416/bb50851d-e15d-46a4-8759-f381fc196d75



AFTER:

https://github.com/DARPA-ASKEM/terarium/assets/33158416/4f70789e-4335-4a9e-9d9f-376d69fca665




Resolves #(issue)
