### PR TITLE
Broken test cases

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
@@ -144,7 +144,6 @@ public class ProjectAssetService {
 		}
 		asset.setAssetType(assetType);
 		asset.setAssetId(assetId);
-		asset.setProject(project);
 		asset.setCreatedOn(Timestamp.from(Instant.now()));
 
 		return Optional.of(projectAssetRepository.save(asset));


### PR DESCRIPTION
Because of the underlying data structure, we apparently don't need to set this project field on asset because setting asset field on project takes care of this for us. More specifically, we *can't* set this field because an unsupported operation exception is thrown!

