### PR TITLE
feat(hmi-server): add endpoint to see if name already exists

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetController.java
@@ -1,0 +1,104 @@
+package software.uncharted.terarium.hmiserver.controller.dataservice;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.ProjectAsset;
+import software.uncharted.terarium.hmiserver.security.Roles;
+import software.uncharted.terarium.hmiserver.service.CurrentUserService;
+import software.uncharted.terarium.hmiserver.service.data.*;
+import software.uncharted.terarium.hmiserver.utils.rebac.ReBACService;
+import software.uncharted.terarium.hmiserver.utils.rebac.askem.RebacProject;
+import software.uncharted.terarium.hmiserver.utils.rebac.askem.RebacUser;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequestMapping("/assets")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Tags(@Tag(name = "Assets", description = "Asset related operations"))
+public class AssetController {
+
+	final ProjectService projectService;
+	final ProjectAssetService projectAssetService;
+	final ReBACService reBACService;
+	final CurrentUserService currentUserService;
+
+
+	/**
+	 * Check if an asset name is available for a given asset type. If a ProjectId is given the search will be
+	 * limited to just that project. Otherwise, the entire asset type will be searched. If the asset name is available,
+	 * a 204 No Content response is returned. If the asset name is not available, a 409 Conflict response is returned.
+	 * @param assetType Asset type to check
+	 * @param assetName Asset name to check
+	 * @param projectId Project ID to limit the search to (optional)
+	 * @return 204 No Content if the asset name is available, 409 Conflict if the asset name is not available
+	 */
+	@GetMapping("/asset-name-available/{asset-type}/{asset-name}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Check if an asset name is available for a given asset type. If a ProjectId is given the search will be limited to just that project. Otherwise, the entire asset type will be searched.")
+	@ApiResponses( value = {
+		@ApiResponse(responseCode = "204", description = "Asset name is available"),
+		@ApiResponse(responseCode = "409", description = "Asset name is not available"),
+		@ApiResponse(responseCode = "404", description = "Project id provided, but project not found"),
+		@ApiResponse(responseCode = "403", description = "User does not have permission to access this project"),
+		@ApiResponse(responseCode = "500", description = "Unable to verify project permissions")
+	})
+	public ResponseEntity<Void> verifyAssetNameAvailability(
+		@PathVariable("asset-type") AssetType assetType,
+		@PathVariable("asset-name") String assetName,
+		@RequestParam(name="project-id", required = false) UUID projectId) {
+
+		if(projectId == null) {
+
+			final Optional<ProjectAsset> asset = projectAssetService.getProjectAssetByNameAndType(assetName, assetType);
+			if (asset.isPresent()) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT, "Asset name is not available");
+			} else {
+				return ResponseEntity.noContent().build();
+			}
+
+		} else {
+			final RebacUser rebacUser = new RebacUser(currentUserService.get().getId(), reBACService);
+			final RebacProject rebacProject = new RebacProject(projectId, reBACService);
+			try {
+					if (rebacUser.canRead(rebacProject)) {
+							final Optional<Project> project = projectService.getProject(projectId);
+							if (project.isPresent()) {
+									final Optional<ProjectAsset> asset = projectAssetService.getProjectAssetByNameAndTypeAndProjectId(projectId, assetName, assetType);
+									if (asset.isPresent()) {
+											throw new ResponseStatusException(HttpStatus.CONFLICT, "Asset name is not available in this project");
+									} else {
+											return ResponseEntity.noContent().build();
+									}
+							} else {
+									throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found");
+							}
+					} else {
+							throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User does not have permission to access this project");
+					}
+			} catch (ResponseStatusException e){
+				throw e; // Like any responsible fisher, we're going to catch and release!
+			} catch (Exception e) {
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to verify project permissions");
+			}
+    }
+
+	}
+
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/AssetType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/AssetType.java
@@ -7,34 +7,13 @@ import java.util.Arrays;
 
 @TSModel
 public enum AssetType {
-	DATASET("dataset"),
-	MODEL_CONFIGURATION("model_configuration"),
-	MODEL("model"),
-	PUBLICATION("publication"),
-	SIMULATION("simulation"),
-	WORKFLOW("workflow"),
-	ARTIFACT("artifact"),
-	CODE("code"),
-	DOCUMENT("document");
-
-
-	public final String type;
-
-
-	AssetType(final String type) {
-		this.type = type.toLowerCase();
-	}
-
-	@Override
-	public String toString() {
-		return type;
-	}
-
-	@JsonCreator
-	public static AssetType fromString(final String type) {
-		return Arrays.stream(AssetType.values())
-			.filter(t -> t.type.equalsIgnoreCase(type))
-			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("Unknown resource type: " + type));
-	}
+	DATASET,
+	MODEL_CONFIGURATION,
+	MODEL,
+	PUBLICATION,
+	SIMULATION,
+	WORKFLOW,
+	ARTIFACT,
+	CODE,
+	DOCUMENT
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/repository/data/ProjectAssetRepository.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/repository/data/ProjectAssetRepository.java
@@ -21,4 +21,8 @@ public interface ProjectAssetRepository extends PSCrudRepository<ProjectAsset, U
 	ProjectAsset findByProjectIdAndAssetIdAndAssetType(@NotNull UUID projectId, @NotNull UUID assetId,
 			@NotNull AssetType type);
 
+	ProjectAsset findByAssetNameAndAssetTypeAndDeletedOnIsNull(@NotNull String assetName, @NotNull AssetType type);
+
+	ProjectAsset findByProjectIdAndAssetNameAndAssetTypeAndDeletedOnIsNull(@NotNull UUID projectId, @NotNull String assetName, @NotNull AssetType type);
+
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
@@ -156,4 +156,12 @@ public class ProjectAssetService {
 		return Optional.of(projectAssetRepository.save(asset));
 	}
 
+	public Optional<ProjectAsset> getProjectAssetByNameAndType(final String assetName, final AssetType assetType) {
+		return Optional.ofNullable(projectAssetRepository.findByAssetNameAndAssetTypeAndDeletedOnIsNull(assetName, assetType));
+	}
+
+	public Optional<ProjectAsset> getProjectAssetByNameAndTypeAndProjectId(final UUID projectId, final String assetName, final AssetType assetType) {
+		return Optional.ofNullable(projectAssetRepository.findByProjectIdAndAssetNameAndAssetTypeAndDeletedOnIsNull(projectId, assetName, assetType));
+	}
+
 }

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetControllerTests.java
@@ -1,0 +1,167 @@
+package software.uncharted.terarium.hmiserver.controller.dataservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
+import software.uncharted.terarium.hmiserver.configuration.MockUser;
+import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
+import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.ProjectAsset;
+import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
+import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
+import software.uncharted.terarium.hmiserver.service.data.ProjectService;
+
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+public class AssetControllerTests extends TerariumApplicationTests {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private ProjectService projectService;
+
+	@Autowired
+	private ProjectAssetService projectAssetService;
+
+	@Autowired
+	private DocumentAssetService documentAssetService;
+
+	private static final String TEST_ASSET_NAME_1 = "test-asset-name-1";
+	private static final String TEST_ASSET_NAME_2 = "test-asset-name-2";
+	private static final String TEST_ASSET_NAME_UNUSED = "test-asset-name-unused";
+
+	Project project;
+
+	Project project2;
+
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testErrorConditions() throws Exception {
+
+		// Test that we get a 404 if we provide a project id that doesn't exist
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_UNUSED + "?project-id=" + UUID.randomUUID())
+				.with(csrf()))
+			.andExpect(status().isNotFound());
+
+	}
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testItCanVerifyAssetNameAvailabilityGenerally() throws Exception {
+
+		// Test that we get a 204 if the asset name is available
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_UNUSED)
+				.with(csrf()))
+			.andExpect(status().isNoContent());
+
+		// Test that we get a 409 if the asset name is not available
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_1)
+				.with(csrf()))
+			.andExpect(status().isConflict());
+
+		// Test that we get a 409 if the asset name is not available
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_2)
+				.with(csrf()))
+			.andExpect(status().isConflict());
+
+		// Test that we get a 204 if the asset name is available because of different asset type
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.CODE.name() + "/" + TEST_ASSET_NAME_1)
+				.with(csrf()))
+			.andExpect(status().isNoContent());
+
+	}
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testItCanVerifyAssetNameAvailabilityInProjects() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_UNUSED + "?project-id=" + project.getId())
+				.with(csrf()))
+			.andExpect(status().isNoContent());
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_1 + "?project-id=" + project.getId())
+				.with(csrf()))
+			.andExpect(status().isConflict());
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_2 + "?project-id=" + project.getId())
+				.with(csrf()))
+			.andExpect(status().isNoContent());
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.CODE.name() + "/" + TEST_ASSET_NAME_1 + "?project-id=" + project.getId())
+				.with(csrf()))
+			.andExpect(status().isNoContent());
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.get("/assets/asset-name-available/" + AssetType.DOCUMENT.name() + "/" + TEST_ASSET_NAME_2 + "?project-id=" + project2.getId())
+				.with(csrf()))
+			.andExpect(status().isConflict());
+	}
+
+	/**
+	 * Helper method to set up a scenario where we have two projects each with one document asset.
+	 * @throws Exception
+	 */
+	@BeforeEach
+	public void setUpScenario() throws Exception{
+		project = projectService.createProject(new Project()
+			.setName("test-proj-1"));
+
+		final DocumentAsset documentAsset = documentAssetService.createDocumentAsset(new DocumentAsset()
+			.setName(TEST_ASSET_NAME_1)
+			.setDescription("my description"));
+
+		final ProjectAsset projectAsset = new ProjectAsset()
+			.setAssetId(documentAsset.getId())
+			.setAssetName(documentAsset.getName())
+			.setAssetType(AssetType.DOCUMENT);
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.post("/projects/" + project.getId() + "/assets/" + AssetType.DOCUMENT.name() + "/"
+					+ documentAsset.getId())
+				.with(csrf())
+				.contentType("application/json")
+				.content(objectMapper.writeValueAsString(projectAsset)))
+			.andExpect(status().isCreated());
+
+		project2 = projectService.createProject(new Project()
+			.setName("test-proj-2"));
+
+		final DocumentAsset documentAsset2 = documentAssetService.createDocumentAsset(new DocumentAsset()
+			.setName(TEST_ASSET_NAME_2)
+			.setDescription("my description"));
+
+		final ProjectAsset projectAsset2 = new ProjectAsset()
+			.setAssetId(documentAsset.getId())
+			.setAssetName(documentAsset.getName())
+			.setAssetType(AssetType.DOCUMENT);
+
+		mockMvc.perform(MockMvcRequestBuilders
+				.post("/projects/" + project2.getId() + "/assets/" + AssetType.DOCUMENT.name() + "/"
+					+ documentAsset2.getId())
+				.with(csrf())
+				.contentType("application/json")
+				.content(objectMapper.writeValueAsString(projectAsset2)))
+			.andExpect(status().isCreated());
+	}
+
+}


### PR DESCRIPTION
Adding a new endpoint to the server to check if an asset already exists with that name. This can optionally be done within the scope of a specific project or across all entries of that asset type.  In addition, blowing away old unused `toString()` functionality inside of AssetType as it was a nightmare to work with and unused.

**NOTE**
This is being merged into the new dataservice branch as it makes use of new database calls, and will be a part of `main` once that branch is merged in.


Resolves #2465 
