### PR TITLE
Funman drilldown boundary chart

### DIFF
--- a/packages/client/hmi-client/src/components/funman/tera-funman-boundary-chart.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-boundary-chart.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
 	param1: string;
 	param2: string;
 	timestep: number;
+	selectedBoxId: string;
 	options?: RenderOptions;
 }>();
 
@@ -30,12 +31,13 @@ onMounted(async () => {
 		props.param1,
 		props.param2,
 		props.timestep,
+		props.selectedBoxId,
 		renderOptions
 	);
 });
 
 watch(
-	() => [props.param1, props.param2],
+	() => [props.param1, props.param2, props.selectedBoxId],
 	async () => {
 		renderFunmanBoundaryChart(
 			boundaryRef.value as HTMLElement,
@@ -43,6 +45,7 @@ watch(
 			props.param1,
 			props.param2,
 			props.timestep,
+			props.selectedBoxId,
 			renderOptions
 		);
 	}

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -11,7 +11,31 @@
 	</p>
 
 	<!-- TODO: add boxes modal per row https://github.com/DARPA-ASKEM/terarium/issues/1924 -->
-	<div class="variables-table">
+	<div class="variables-table" v-if="selectedParam2">
+		<!-- Larger version of boundary chart: TODO -->
+		<section class="boundary-drilldown">
+			<div class="boundary-drilldown-header">
+				{{ selectedParam }} : {{ selectedParam2 }} pairwise drilldown
+				<Button
+					class="close-mask"
+					icon="pi pi-times"
+					text
+					rounded
+					aria-label="Close"
+					@click="selectedParam2 = ''"
+				/>
+			</div>
+			<TeraFunmanBoundaryChart
+				:processed-data="processedData as FunmanProcessedData"
+				:param1="selectedParam"
+				:param2="selectedParam2"
+				:options="{ width: 475, height: 280 }"
+				:timestep="timestep"
+			/>
+		</section>
+	</div>
+
+	<div class="variables-table" v-if="selectedParam2 === ''">
 		<div class="variables-header">
 			<header
 				v-for="(title, index) in ['select', 'Parameter', 'Lower bound', 'Upper bound', '']"
@@ -46,17 +70,6 @@
 				/>
 			</div>
 		</div>
-
-		<!-- Larger version of boundary chart: TODO -->
-		<div v-if="selectedParam2">
-			<TeraFunmanBoundaryChart
-				:processed-data="processedData as FunmanProcessedData"
-				:param1="selectedParam"
-				:param2="selectedParam2"
-				:options="{ width: 350, height: 250 }"
-				:timestep="timestep"
-			/>
-		</div>
 	</div>
 </template>
 
@@ -70,6 +83,7 @@ import {
 } from '@/services/models/funman-service';
 import Dropdown from 'primevue/dropdown';
 import RadioButton from 'primevue/radiobutton';
+import Button from 'primevue/button';
 import InputNumber from 'primevue/inputnumber';
 import TeraFunmanBoundaryChart from './tera-funman-boundary-chart.vue';
 
@@ -127,8 +141,8 @@ const initalizeParameters = async () => {
 };
 
 const renderGraph = async () => {
-	const width = 800;
-	const height = 250;
+	const width = 650;
+	const height = 225;
 	renderFumanTrajectories(
 		trajRef.value as HTMLElement,
 		processedData.value as FunmanProcessedData,
@@ -209,5 +223,18 @@ watch(
 .variables-header {
 	display: grid;
 	grid-template-columns: repeat(6, 1fr) 0.5fr;
+}
+
+.boundary-drilldown {
+	border: 1px solid var(--00-neutral-300, #c3ccd6);
+	padding: 5px;
+}
+
+.boundary-drilldown-header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	font-size: var(--font-body-medium);
 }
 </style>

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -23,7 +23,7 @@
 					@click="selectedParam2 = ''"
 				/>
 			</div>
-			<TeraFunmanBoundaryChart
+			<tera-funman-boundary-chart
 				:processed-data="processedData as FunmanProcessedData"
 				:param1="selectedParam"
 				:param2="selectedParam2"
@@ -60,7 +60,7 @@
 					class="p-inputtext-sm"
 					v-model="bound.ub"
 				/>
-				<TeraFunmanBoundaryChart
+				<tera-funman-boundary-chart
 					:processed-data="processedData as FunmanProcessedData"
 					:param1="selectedParam"
 					:param2="parameter"

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -6,7 +6,7 @@
 	<div ref="trajRef"></div>
 
 	<h4>Configuration parameters <i class="pi pi-info-circle" /></h4>
-	<p class="secondary-text">
+	<p class="secondary-text" v-if="selectedParam2 === ''">
 		Adjust parameter ranges to only include values in the green region or less.
 	</p>
 
@@ -141,8 +141,8 @@ const initalizeParameters = async () => {
 };
 
 const renderGraph = async () => {
-	const width = 650;
-	const height = 225;
+	const width = 600;
+	const height = 200;
 	renderFumanTrajectories(
 		trajRef.value as HTMLElement,
 		processedData.value as FunmanProcessedData,

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -29,6 +29,7 @@
 				:param2="selectedParam2"
 				:options="drilldownChartOptions"
 				:timestep="timestep"
+				:selectedBoxId="selectedBoxId"
 			/>
 		</section>
 	</div>
@@ -112,10 +113,9 @@ const selectedBoxId = ref('');
 const selectedBox = ref<any>({});
 
 const drilldownChartOptions = ref<RenderOptions>({
-	width: 475,
-	height: 280,
+	width: 550,
+	height: 275,
 	click: (d: any) => {
-		console.log('selected', d.id);
 		selectedBoxId.value = d.id;
 	}
 });
@@ -148,8 +148,8 @@ const initalizeParameters = async () => {
 };
 
 const renderGraph = async (boxId: string) => {
-	const width = 600;
-	const height = 200;
+	const width = 580;
+	const height = 180;
 	renderFumanTrajectories(
 		trajRef.value as HTMLElement,
 		processedData.value as FunmanProcessedData,

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -120,9 +120,11 @@ const initalizeParameters = async () => {
 	processedData.value = processFunman(funmanResult);
 	parameterOptions.value = [];
 
-	funmanResult.model.petrinet.semantics.ode.parameters.map((ele) =>
-		parameterOptions.value.push(ele.id)
-	);
+	const initialVars = funmanResult.model.petrinet.semantics?.ode.initials.map((d) => d.expression);
+
+	funmanResult.model.petrinet.semantics.ode.parameters
+		.filter((ele) => !initialVars.includes(ele.id))
+		.map((ele) => parameterOptions.value.push(ele.id));
 	selectedParam.value = parameterOptions.value[0];
 	timestepOptions.value = funmanResult.request.structure_parameters[0].schedules[0].timepoints;
 	timestep.value = timestepOptions.value[1];

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -289,6 +289,11 @@ export const renderFunmanBoundaryChart = (
 ) => {
 	const { width, height } = options;
 
+	let margin = 30;
+	if (height < 100 || width < 100) {
+		margin = 0;
+	}
+
 	const trueBoxes = getBoxes(processedData, param1, param2, timestep, 'true');
 	const falseBoxes = getBoxes(processedData, param1, param2, timestep, 'false');
 	const { minX, maxX, minY, maxY } = getBoxesDomain([...trueBoxes, ...falseBoxes]);
@@ -300,12 +305,12 @@ export const renderFunmanBoundaryChart = (
 	const xScale = d3
 		.scaleLinear()
 		.domain([minX, maxX]) // input domain
-		.range([0, width]); // output range
+		.range([margin, width - margin]); // output range
 
 	const yScale = d3
 		.scaleLinear()
 		.domain([minY, maxY]) // input domain (inverted)
-		.range([height, 0]); // output range (inverted)
+		.range([height - margin, margin]); // output range (inverted)
 
 	g.selectAll('.true-box')
 		.data(trueBoxes)
@@ -332,6 +337,14 @@ export const renderFunmanBoundaryChart = (
 	// Don't render text into tight spaces
 	if (height < 100 || width < 100) return;
 
+	g.append('rect')
+		.attr('x', margin)
+		.attr('y', margin)
+		.attr('width', width - 2 * margin)
+		.attr('height', height - 2 * margin)
+		.attr('stroke', '#888')
+		.attr('fill', 'transparent');
+
 	g.selectAll('text')
 		.data([...trueBoxes, ...falseBoxes])
 		.enter()
@@ -341,4 +354,40 @@ export const renderFunmanBoundaryChart = (
 		.style('stroke', 'none')
 		.style('fill', '#333')
 		.text((d) => d.id);
+
+	const xaxisH = height - margin + 13;
+
+	// xaxis-label
+	g.append('text')
+		.attr('x', 0.5 * width)
+		.attr('y', xaxisH)
+		.text(param1);
+
+	// yaxis-label
+	g.append('g')
+		.attr('transform', `translate(15, ${0.5 * height})`)
+		.append('text')
+		.style('text-anchor', 'middle')
+		.style('transform', 'rotate(270deg)')
+		.text(param2);
+
+	g.append('text').attr('x', margin).attr('y', xaxisH).style('font-size', '12').text(minX);
+	g.append('text')
+		.attr('x', width - margin)
+		.attr('y', xaxisH)
+		.style('font-size', '12')
+		.text(maxX);
+
+	g.append('text')
+		.attr('x', margin - 2)
+		.attr('y', xaxisH - 12)
+		.style('text-anchor', 'end')
+		.style('font-size', '12')
+		.text(minY);
+	g.append('text')
+		.attr('x', margin - 2)
+		.attr('y', margin)
+		.style('text-anchor', 'end')
+		.style('font-size', '12')
+		.text(maxY);
 };

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -378,10 +378,6 @@ export const renderFunmanBoundaryChart = (
 		.attr('width', (d) => xScale(d.x2) - xScale(d.x1))
 		.attr('height', (d) => yScale(d.y1) - yScale(d.y2))
 		.attr('stroke', '#888')
-		.style('stroke-width', (d) => {
-			if (selectedBoxId !== '' && selectedBoxId === d.id) return 2.0;
-			return 1.0;
-		})
 		.attr('fill-opacity', 0.5)
 		.on('click', (_evt: PointerEvent, d: any) => {
 			// Invoke callback
@@ -389,6 +385,27 @@ export const renderFunmanBoundaryChart = (
 				options.click(d);
 			}
 		});
+
+	if (selectedBoxId !== '') {
+		const boundBox = [...trueBoxes, ...falseBoxes].find((box) => box.id === selectedBoxId);
+		if (!boundBox) return;
+
+		g.selectAll('.select-marker')
+			.data([
+				[boundBox.x1, boundBox.y1],
+				[boundBox.x2, boundBox.y1],
+				[boundBox.x2, boundBox.y2],
+				[boundBox.x1, boundBox.y2]
+			])
+			.enter()
+			.append('circle')
+			.classed('select-marker', true)
+			.attr('cx', (d) => xScale(d[0]))
+			.attr('cy', (d) => yScale(d[1]))
+			.attr('r', 4)
+			.style('stroke', '#888')
+			.style('fill', '#bbb');
+	}
 
 	if (options.click) {
 		g.selectAll<any, FunmanBoundingBox>('rect').style('cursor', 'pointer');

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -383,7 +383,15 @@ const initialize = async () => {
 const setModelOptions = async () => {
 	if (!model.value) return;
 
+	const initialVars = model.value.semantics?.ode.initials?.map((d) => d.expression);
 	const modelColumnNameOptions: string[] = model.value.model.states.map((state: any) => state.id);
+
+	// FIXME: filter out initial values
+	model.value.semantics?.ode.parameters?.forEach((param) => {
+		if (initialVars?.includes(param.id)) return;
+		modelColumnNameOptions.push(param.id);
+	});
+
 	// observables are not currently supported
 	// if (modelConfiguration.value.configuration.semantics?.ode?.observables) {
 	// 	modelConfiguration.value.configuration.semantics.ode.observables.forEach((o) => {

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -292,7 +292,7 @@ const getStatus = async (runId: string) => {
 
 	poller
 		.setInterval(3000)
-		.setThreshold(50)
+		.setThreshold(100)
 		.setPollAction(async () => {
 			const response = await getQueries(runId);
 			if (response.done && response.done === true) {
@@ -386,7 +386,6 @@ const setModelOptions = async () => {
 	const initialVars = model.value.semantics?.ode.initials?.map((d) => d.expression);
 	const modelColumnNameOptions: string[] = model.value.model.states.map((state: any) => state.id);
 
-	// FIXME: filter out initial values
 	model.value.semantics?.ode.parameters?.forEach((param) => {
 		if (initialVars?.includes(param.id)) return;
 		modelColumnNameOptions.push(param.id);


### PR DESCRIPTION
### Summary
Continue to add to Funman features

- Add in drilldown for the boundary chart, and interactions to select a specific box
- Add in a (temporary) solution with Funman exits and zero-fills the remainder timestamps, we need to remove the zeros
- Add in parameters to constraint groups, and conversely filter out initial state-values
- Small stylistic tweaks

<img width="1481" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/5f2bc1a4-31dd-4dec-9665-0f376a29357e">

