### PR TITLE
fix(hmi): 500 error on new models

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -89,6 +89,7 @@ export const petriToLatex = async (petri: PetriNet): Promise<string | null> => {
 		if (resp && resp.status === 200 && resp.data && typeof resp.data === 'string') {
 			return resp.data;
 		}
+		if (resp && resp.status === 204) return null;
 
 		logger.error('[Model Service] petriToLatex: Server did not provide a correct response', {
 			showToast: false,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/TransformController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/TransformController.java
@@ -37,6 +37,11 @@ public class TransformController {
 	@PostMapping(value = "/acset-to-latex", produces = {"text/plain", "application/*"})
 	@Secured(Roles.USER)
 	public ResponseEntity<String> acset2Latex(@RequestBody final PetriNet content) {
+
+		if(content.getS().isEmpty() && content.getT().isEmpty() && content.getI().isEmpty() && content.getO().isEmpty()) {
+			return ResponseEntity.noContent().build();
+		}
+
 		final ResponseEntity<String> res = modelServiceProxy.petrinetToLatex(content);
 
 		// since the model-service returns headers that are duplicated in the hmi-server response,


### PR DESCRIPTION
When a new model is created, there is a `watch` call to `/ascet-to-latex` which results in a 500 error because the model is empty.  Arguably this call shouldn't be happening at all in the empty state, but, we should at least handle the empty case better. Thats whats happening here - we short circuit the request and return a 204.