### PR TITLE
Funman ui and ux tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/funman/tera-constraint-group-form.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-constraint-group-form.vue
@@ -48,7 +48,6 @@
 				<label>Start time</label>
 				<InputNumber
 					class="p-inputtext-sm"
-					inputId="integeronly"
 					v-model="startTime"
 					@update:model-value="
 						emit('update-self', { index: props.index, updatedConfig: updatedConfig })
@@ -59,7 +58,6 @@
 				<label>End time</label>
 				<InputNumber
 					class="p-inputtext-sm"
-					inputId="integeronly"
 					v-model="endTime"
 					@update:model-value="
 						emit('update-self', { index: props.index, updatedConfig: updatedConfig })
@@ -70,7 +68,6 @@
 				<label>Lower bound</label>
 				<InputNumber
 					class="p-inputtext-sm"
-					inputId="integeronly"
 					mode="decimal"
 					:min-fraction-digits="3"
 					:max-fraction-digits="3"
@@ -84,7 +81,6 @@
 				<label>Upper bound</label>
 				<InputNumber
 					class="p-inputtext-sm"
-					inputId="integeronly"
 					mode="decimal"
 					:min-fraction-digits="3"
 					:max-fraction-digits="3"

--- a/packages/client/hmi-client/src/components/funman/tera-constraint-group-form.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-constraint-group-form.vue
@@ -4,13 +4,13 @@
 			<i class="trash-button pi pi-trash" @click="emit('delete-self', { index: props.index })" />
 		</div>
 		<div class="button-row">
-			<label for="constraint-name">Name of constraint</label>
+			<label>Name of constraint</label>
 			<InputText
 				v-model="constraintName"
 				placeholder="Add constraint name"
 				@focusout="emit('update-self', { index: props.index, updatedConfig: updatedConfig })"
 			/>
-			<label for="target">Target</label>
+			<label>Target</label>
 			<MultiSelect
 				v-model="variables"
 				:options="props.modelNodeOptions"
@@ -20,7 +20,9 @@
 					emit('update-self', { index: props.index, updatedConfig: updatedConfig })
 				"
 			></MultiSelect>
+			<!--
 			<label for="weights">Weights</label>
+			-->
 			<div v-for="(variable, index) of variables" :key="index">
 				<div class="button-row">
 					<label v-if="weights">
@@ -43,7 +45,7 @@
 		</div>
 		<div class="section-row">
 			<div class="button-row">
-				<label for="start">Start time</label>
+				<label>Start time</label>
 				<InputNumber
 					class="p-inputtext-sm"
 					inputId="integeronly"
@@ -54,7 +56,7 @@
 				/>
 			</div>
 			<div class="button-row">
-				<label for="end">End time</label>
+				<label>End time</label>
 				<InputNumber
 					class="p-inputtext-sm"
 					inputId="integeronly"
@@ -65,7 +67,7 @@
 				/>
 			</div>
 			<div class="button-row">
-				<label for="lower">Lower bound</label>
+				<label>Lower bound</label>
 				<InputNumber
 					class="p-inputtext-sm"
 					inputId="integeronly"
@@ -79,7 +81,7 @@
 				/>
 			</div>
 			<div class="button-row">
-				<label for="upper">Upper bound</label>
+				<label>Upper bound</label>
 				<InputNumber
 					class="p-inputtext-sm"
 					inputId="integeronly"
@@ -133,8 +135,10 @@ const updatedConfig = computed<ConstraintGroup>(
 
 watch(
 	() => variables.value,
-	async () => {
-		weights.value = Array<number>(props.config.variables.length).fill(1);
+	() => {
+		if (!weights.value || weights.value.length === 0) {
+			weights.value = Array<number>(props.config.variables.length).fill(1);
+		}
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -44,10 +44,17 @@
 			</header>
 		</div>
 
-		<div v-for="(bound, parameter) in lastTrueBox?.bounds" :key="parameter">
+		<div v-for="(bound, parameter) in lastTrueBox?.bounds" :key="parameter + Date.now()">
 			<div class="variables-row" v-if="parameterOptions.includes(parameter)">
 				<RadioButton v-model="selectedParam" :value="parameter" />
 				<div>{{ parameter }}</div>
+				<div>
+					{{ selectedBoxId === '' ? bound.lb.toFixed(4) : selectedBox[parameter][0].toFixed(4) }}
+				</div>
+				<div>
+					{{ selectedBoxId === '' ? bound.ub.toFixed(4) : selectedBox[parameter][1].toFixed(4) }}
+				</div>
+				<!--
 				<InputNumber
 					mode="decimal"
 					:min-fraction-digits="1"
@@ -60,6 +67,7 @@
 					class="p-inputtext-sm"
 					v-model="bound.ub"
 				/>
+				-->
 				<tera-funman-boundary-chart
 					:processed-data="processedData as FunmanProcessedData"
 					:param1="selectedParam"
@@ -68,10 +76,12 @@
 					:selectedBoxId="selectedBoxId"
 					@click="selectedParam2 = parameter"
 				/>
+				<!--
 				&nbsp;
 				<div v-if="selectedBox[parameter]">
 					{{ selectedBox[parameter][0].toFixed(4) }}:{{ selectedBox[parameter][1].toFixed(4) }}
 				</div>
+				-->
 			</div>
 		</div>
 	</div>
@@ -88,7 +98,7 @@ import {
 import Dropdown from 'primevue/dropdown';
 import RadioButton from 'primevue/radiobutton';
 import Button from 'primevue/button';
-import InputNumber from 'primevue/inputnumber';
+// import InputNumber from 'primevue/inputnumber';
 import type { FunmanBox, RenderOptions } from '@/services/models/funman-service';
 import TeraFunmanBoundaryChart from './tera-funman-boundary-chart.vue';
 
@@ -116,7 +126,11 @@ const drilldownChartOptions = ref<RenderOptions>({
 	width: 550,
 	height: 275,
 	click: (d: any) => {
-		selectedBoxId.value = d.id;
+		if (d.id === selectedBoxId.value) {
+			selectedBoxId.value = '';
+		} else {
+			selectedBoxId.value = d.id;
+		}
 	}
 });
 

--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -122,6 +122,8 @@ const processedData = ref<FunmanProcessedData>();
 const selectedBoxId = ref('');
 const selectedBox = ref<any>({});
 
+let inputConstraints: any[] = [];
+
 const drilldownChartOptions = ref<RenderOptions>({
 	width: 550,
 	height: 275,
@@ -136,6 +138,7 @@ const drilldownChartOptions = ref<RenderOptions>({
 
 const initalizeParameters = async () => {
 	const funmanResult = await getQueries(props.funModelId);
+	inputConstraints = funmanResult.request.constraints;
 	processedData.value = processFunman(funmanResult);
 	parameterOptions.value = [];
 
@@ -170,6 +173,7 @@ const renderGraph = async (boxId: string) => {
 		selectedTrajState.value,
 		boxId,
 		{
+			constraints: inputConstraints,
 			width,
 			height
 		}

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -330,7 +330,7 @@ export const renderFumanTrajectories = (
 			.attr('height', (d) =>
 				Math.abs(yScale(d.interval?.ub as number) - yScale(d.interval?.lb as number))
 			)
-			.style('fill', '#f80')
+			.style('fill', 'teal')
 			.style('fill-opacity', 0.3);
 	}
 

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -337,7 +337,7 @@ export const renderFunmanBoundaryChart = (
 
 	let margin = 30;
 	if (height < 100 || width < 100) {
-		margin = 0;
+		margin = 5;
 	}
 
 	const trueBoxes = getBoxes(processedData, param1, param2, timestep, 'true');

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -27,6 +27,8 @@ export interface FunmanProcessedData {
 export interface RenderOptions {
 	width: number;
 	height: number;
+
+	constraints?: any[];
 	click?: Function;
 }
 
@@ -304,6 +306,33 @@ export const renderFumanTrajectories = (
 				.style('fill', '#888');
 		}
 	});
+
+	// Render constraints
+	// Since this is variable-vs-time, we can't display constraints that involve more
+	// than one variable, and just the selected variable
+	if (options.constraints && options.constraints.length > 0) {
+		const singleVariableConstraints = options.constraints
+			.filter((d) => d.variable)
+			.filter((d) => d.variable === state);
+
+		svg
+			.selectAll('.constraint-box')
+			.data(singleVariableConstraints)
+			.enter()
+			.append('rect')
+			.classed('constraint-box', true)
+			.attr('x', (d) => xScale(d.timepoints?.lb as number))
+			.attr('y', (d) => yScale(d.interval?.ub as number))
+			.attr('width', (d) => {
+				const w = xScale(d.timepoints?.ub as number) - xScale(d.timepoints?.lb as number);
+				return w;
+			})
+			.attr('height', (d) =>
+				Math.abs(yScale(d.interval?.ub as number) - yScale(d.interval?.lb as number))
+			)
+			.style('fill', '#f80')
+			.style('fill-opacity', 0.3);
+	}
 
 	return svg;
 };

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -13,21 +13,20 @@
 					<div class="section-row timespan">
 						<div class="button-column">
 							<label>Start time</label>
-							<InputNumber inputId="integeronly" v-model="knobs.currentTimespan.start" />
+							<InputNumber v-model="knobs.currentTimespan.start" />
 						</div>
 						<div class="button-column">
 							<label>End time</label>
-							<InputNumber inputId="integeronly" v-model="knobs.currentTimespan.end" />
+							<InputNumber v-model="knobs.currentTimespan.end" />
 						</div>
 						<div class="button-column">
 							<label>Number of steps</label>
-							<InputNumber inputId="integeronly" v-model="knobs.numberOfSteps" />
+							<InputNumber v-model="knobs.numberOfSteps" />
 						</div>
 					</div>
 					<InputText
 						:disabled="true"
 						class="p-inputtext-sm timespan-list"
-						inputId="integeronly"
 						v-model="requestStepListString"
 					/>
 					<p v-if="!showAdditionalOptions" @click="toggleAdditonalOptions" class="green-text">

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -202,12 +202,13 @@ const requestConstraints = computed(
 					timepoints: ele.timepoints
 				};
 			}
+
 			return {
 				// Linear Constraint
 				name: ele.name,
 				variables: ele.variables,
 				weights: ele.weights,
-				interval: ele.interval,
+				additive_bounds: ele.interval,
 				timepoints: ele.timepoints
 			};
 		})


### PR DESCRIPTION
### Summary
This fix various issues with Funman, the main one being be able to run constraint on a linear combination of state-variables (note parameters may not work properly because they seem to require a different data structure).

Also fixes a few interaction issues, and clean up HTML warnings from using the same "id" over and over.

- Fix reactivity bug where the boundary-charts do not change when changing output
- Fix selectedBox cannot be unselected
- Fix weights initializer always go back to 1.0
- Fix linear combination request (use additive_bounds instead of interval)
- Fix HTML warnings
- Add bounding box on trajectory chart (single variable constraint)


<img width="1484" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/d78b7c4c-56e2-47e4-8461-d39fe9765786">

