### PR TITLE
Cache user fetching

### DIFF
--- a/containers/docker-compose-local-lean.yml
+++ b/containers/docker-compose-local-lean.yml
@@ -1,0 +1,6 @@
+---
+version: '3.8'
+
+include:
+  - scripts/docker-compose-base.yml
+  - scripts/docker-compose-common.yml

--- a/hmiServerDev.sh
+++ b/hmiServerDev.sh
@@ -227,7 +227,8 @@ case ${COMMAND} in
 
       start
         ENVIRONMENT
-          remote | local | full (default: remote)  Indicate which environment to develop against
+          remote | local | full | ll (default: remote)  Indicate which environment to develop against
+              (ll: local_lean to run local with the absolute minimal support to run hmiServer for development)
 
         run (default: null) Indicate whether to run the server after starting the containers
 

--- a/hmiServerDev.sh
+++ b/hmiServerDev.sh
@@ -131,9 +131,21 @@ COMMAND=${COMMAND:-"help"}
 ENVIRONMENT=${ENVIRONMENT:-"remote"}
 SERVER=${SERVER:-"false"}
 
-echo "COMMAND: $COMMAND"
-echo "ENVIRONMENT: $ENVIRONMENT"
-echo "SERVER: $SERVER"
+VALID_ENVIRONMENTS=("remote" "local" "full")
+ENVIRONMENT_IS_VALID=0
+for env in ${VALID_ENVIRONMENTS}; do
+  if [ "${env}" = "${ENVIRONMENT}" ]; then
+    ENVIRONMENT_IS_VALID=1
+  fi
+done
+if [ ${ENVIRONMENT_IS_VALID} -eq 0 ]; then
+  echo "Illegal ENVIRONMENT \"${ENVIRONMENT}\""
+  COMMAND="help"
+else
+  echo "COMMAND: $COMMAND"
+  echo "ENVIRONMENT: $ENVIRONMENT"
+  echo "SERVER: $SERVER"
+fi
 
 case ${COMMAND} in
   start)
@@ -147,10 +159,6 @@ case ${COMMAND} in
         ;;
       full)
         deploy_full
-        ;;
-      *)
-        echo "Illegal ENVIRONMENT"
-        break
         ;;
     esac
     if [ ${SERVER} == "run" ]; then
@@ -173,10 +181,6 @@ case ${COMMAND} in
         ;;
       full)
         stop_full
-        ;;
-      *)
-        echo "Illegal ENVIRONMENT"
-        break
         ;;
     esac
     delete_secrets

--- a/hmiServerDev.sh
+++ b/hmiServerDev.sh
@@ -55,6 +55,12 @@ function deploy_full() {
   docker compose --env-file containers/.env --file containers/docker-compose-full.yml up --detach --wait
 }
 
+function deploy_local_lean() {
+  echo "Deploying containers for development against local services"
+  cat containers/common.env containers/secrets.env > containers/.env
+  docker compose --env-file containers/.env --file containers/docker-compose-local-lean.yml up --detach --wait
+}
+
 function stop_remote() {
   echo "stopping local containers used for remote dev"
   cat containers/common.env containers/secrets.env > containers/.env
@@ -71,6 +77,12 @@ function stop_full() {
   echo "Stopping all containers"
   cat containers/common.env containers/secrets.env > containers/.env
   docker compose --env-file containers/.env --file containers/docker-compose-full.yml down
+}
+
+function stop_local_lean() {
+  echo "Stopping local dev containers"
+  cat containers/common.env containers/secrets.env > containers/.env
+  docker compose --env-file containers/.env --file containers/docker-compose-local-lean.yml down
 }
 
 function start_remote() {
@@ -131,13 +143,16 @@ COMMAND=${COMMAND:-"help"}
 ENVIRONMENT=${ENVIRONMENT:-"remote"}
 SERVER=${SERVER:-"false"}
 
-VALID_ENVIRONMENTS=("remote" "local" "full")
+VALID_ENVIRONMENTS=("remote" "local" "full" "ll")
 ENVIRONMENT_IS_VALID=0
-for env in ${VALID_ENVIRONMENTS}; do
+for env in ${VALID_ENVIRONMENTS[@]}; do
+  echo "checking $ENVIRONMENT against $env"
   if [ "${env}" = "${ENVIRONMENT}" ]; then
+    echo "setting ENVIRONMENT_IS_VALID to 1"
     ENVIRONMENT_IS_VALID=1
   fi
 done
+echo "value of ENVIRONMENT_IS_VALID is ${ENVIRONMENT_IS_VALID}"
 if [ ${ENVIRONMENT_IS_VALID} -eq 0 ]; then
   echo "Illegal ENVIRONMENT \"${ENVIRONMENT}\""
   COMMAND="help"
@@ -160,6 +175,9 @@ case ${COMMAND} in
       full)
         deploy_full
         ;;
+      ll)
+        deploy_local_lean
+        ;;
     esac
     if [ ${SERVER} == "run" ]; then
       if [ ${ENVIRONMENT} == "remote" ]; then
@@ -181,6 +199,9 @@ case ${COMMAND} in
         ;;
       full)
         stop_full
+        ;;
+      ll)
+        stop_local_lean
         ;;
     esac
     delete_secrets

--- a/packages/server/build.gradle
+++ b/packages/server/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     testImplementation 'org.springframework.amqp:spring-rabbit-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.mockito:mockito-core:5.3.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
 }
 
 tasks.named('test') {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/CacheConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/CacheConfiguration.java
@@ -4,11 +4,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableCaching
@@ -18,6 +24,14 @@ import org.springframework.context.annotation.Configuration;
 })
 @Slf4j
 public class CacheConfiguration implements CachingConfigurer {
+
+	@Bean
+	public CacheManager cacheManager() {
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		Cache booksCache = new ConcurrentMapCache("users");
+		cacheManager.setCaches(Arrays.asList(booksCache));
+		return cacheManager;
+	}
 
 	/**
 	 * Overrides the default key generating for spring caching.  This ensures that the fully qualified classname (with the

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/UserService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/UserService.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import software.uncharted.terarium.hmiserver.models.User;
 import software.uncharted.terarium.hmiserver.repository.UserRepository;
@@ -14,7 +15,7 @@ import java.time.Instant;
 public class UserService {
 
 	private final UserRepository userRepository;
-
+	@Cacheable(value="users", key="#id", unless="#result == null")
 	public User getById(final String id) {
 		final User user = userRepository.findById(id).orElse(null);
 		if (user == null) {
@@ -23,6 +24,7 @@ public class UserService {
 		return user;
 	}
 
+	@Cacheable(value="users", key="#user.id")
 	public User createUser(final User user) {
 		final long now = Instant.now().toEpochMilli();
 		user.setCreatedAtMs(now);
@@ -30,6 +32,7 @@ public class UserService {
 		return save(user);
 	}
 
+	@Cacheable(value="users", key="#user.id")
 	public User save(final User user) {
 		return userRepository.save(user);
 	}

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/UserServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/UserServiceTests.java
@@ -1,0 +1,98 @@
+package software.uncharted.terarium.hmiserver.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithUserDetails;
+import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
+import software.uncharted.terarium.hmiserver.configuration.MockUser;
+import software.uncharted.terarium.hmiserver.models.User;
+import software.uncharted.terarium.hmiserver.repository.UserRepository;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTests extends TerariumApplicationTests {
+	@Autowired
+	UserService userService;
+	@MockBean
+	UserRepository mockRepository;
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testItCachesUsers() {
+		final String targetId = MockUser.ADAM;
+		final User mockUser = new User()
+			.setId(MockUser.ADAM)
+			.setGivenName("Emperor")
+			.setFamilyName("Adam")
+			.setEmail("adam@test.io");
+
+		// Tell the repository function to return the mocked user
+		Mockito.when(mockRepository.findById(targetId)).thenReturn(Optional.ofNullable(mockUser));
+
+		// Call the user service twice
+		userService.getById(targetId);
+		userService.getById(targetId);
+
+		// Verify that the database was only accessed once as the result should be cached
+		Mockito.verify(mockRepository, Mockito.atMostOnce()).findById(targetId);
+	}
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testItCreatesAndCachesUsers() {
+		final String targetId = MockUser.ADAM;
+		final User mockUser = new User()
+			.setId(MockUser.ADAM)
+			.setGivenName("Emperor")
+			.setFamilyName("Adam")
+			.setEmail("adam@test.io");
+
+		// Tell the repository function to return the mocked user
+		Mockito.when(mockRepository.findById(targetId)).thenReturn(Optional.ofNullable(mockUser));
+
+		// Create user
+		userService.createUser(mockUser);
+
+		// Call the user service twice
+		userService.getById(targetId);
+		userService.getById(targetId);
+
+
+		// Verify that the database was only accessed once as the result should be cached
+		Mockito.verify(mockRepository, Mockito.atMostOnce()).findById(targetId);
+	}
+
+	@Test
+	@WithUserDetails(MockUser.ADAM)
+	public void testItCreatesAndUpdateAndCachesUsers() {
+		final String targetId = MockUser.ADAM;
+		final User mockUser = new User()
+			.setId(MockUser.ADAM)
+			.setGivenName("Emperor")
+			.setFamilyName("Adam")
+			.setEmail("adam@test.io");
+
+		// Tell the repository function to return the mocked user
+		Mockito.when(mockRepository.findById(targetId)).thenReturn(Optional.ofNullable(mockUser));
+
+		// Create user
+		userService.createUser(mockUser);
+
+		// Update user
+		mockUser.setGivenName("King");
+		userService.save(mockUser);
+
+		// Call the user service twice
+		userService.getById(targetId);
+		userService.getById(targetId);
+
+
+		// Verify that the database was only accessed once as the result should be cached
+		Mockito.verify(mockRepository, Mockito.atMostOnce()).findById(targetId);
+	}
+}


### PR DESCRIPTION
# Description

Adds caches to user table in a hope to reduce request load to PostGres as this is processed for every request to the server and will almost never change

To see caching hits/missed in the logs add the following to application.properties:

`logging.level.org.springframework.cache=TRACE`

Resolves #(issue)

if the incorrect ENVIRONMENT is supplied to `hmiServerDev.sh` then the script errors as `break` is called inappropriately, this corrects that.  Also adds a lean local variant for when one's docker disk is too small for normal local