### PR TITLE
feat: provisionally working branch duplication interaction

### DIFF
--- a/packages/client/hmi-client/src/components/operator/tera-operator-header.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-header.vue
@@ -17,7 +17,12 @@ import { OperatorStatus } from '@/types/workflow';
 import Button from 'primevue/button';
 import Menu from 'primevue/menu';
 
-const emit = defineEmits(['remove-operator', 'bring-to-front', 'open-in-new-window']);
+const emit = defineEmits([
+	'remove-operator',
+	'bring-to-front',
+	'open-in-new-window',
+	'duplicate-branch'
+]);
 
 const props = defineProps({
 	name: {
@@ -46,7 +51,7 @@ const toggleMenu = (event) => {
 };
 
 const options = ref([
-	{ icon: 'pi pi-clone', label: 'Duplicate', command: () => emit('bring-to-front') },
+	{ icon: 'pi pi-clone', label: 'Duplicate', command: () => emit('duplicate-branch') },
 	{
 		icon: 'pi pi-external-link',
 		label: 'Open in new window',

--- a/packages/client/hmi-client/src/components/operator/tera-operator.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator.vue
@@ -14,6 +14,7 @@
 			:interaction-status="interactionStatus"
 			@open-in-new-window="openInNewWindow"
 			@remove-operator="emit('remove-operator', props.node.id)"
+			@duplicate-branch="emit('duplicate-branch')"
 			@bring-to-front="bringToFront"
 		/>
 		<tera-operator-inputs
@@ -63,7 +64,8 @@ const emit = defineEmits([
 	'port-mouseleave',
 	'remove-operator',
 	'remove-edges',
-	'resize'
+	'resize',
+	'duplicate-branch'
 ]);
 
 enum PortDirection {

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -437,14 +437,18 @@ export const branchWorkflow = (wf: Workflow, nodeId: string) => {
 			registry.set(port.id, uuidv4());
 		});
 	});
+	copyEdges.forEach((edge) => {
+		registry.set(edge.id, uuidv4());
+	});
 
 	copyEdges.forEach((edge) => {
 		// Don't replace upstream edge sources, they are still valid
 		if (upstreamEdges.map((e) => e.source).includes(edge.source) === false) {
 			edge.source = registry.get(edge.source as string);
+			edge.sourcePortId = registry.get(edge.sourcePortId as string);
 		}
+		edge.id = registry.get(edge.id) as string;
 		edge.target = registry.get(edge.target as string);
-		edge.sourcePortId = registry.get(edge.sourcePortId as string);
 		edge.targetPortId = registry.get(edge.targetPortId as string);
 	});
 	copyNodes.forEach((node) => {
@@ -455,6 +459,9 @@ export const branchWorkflow = (wf: Workflow, nodeId: string) => {
 		node.outputs.forEach((port) => {
 			port.id = registry.get(port.id) as string;
 		});
+		if (node.active) {
+			node.active = registry.get(node.active);
+		}
 	});
 
 	// 5. Reposition new nodes so they don't exaclty overlap
@@ -462,10 +469,12 @@ export const branchWorkflow = (wf: Workflow, nodeId: string) => {
 	copyNodes.forEach((n) => {
 		n.y += offset;
 	});
-	copyEdges.forEach((e) => {
-		if (!e.points || e.points.length < 2) return;
-		e.points[0].y += offset;
-		e.points[e.points.length - 1].y += offset;
+	copyEdges.forEach((edge) => {
+		if (!edge.points || edge.points.length < 2) return;
+		if (upstreamEdges.map((e) => e.source).includes(edge.source) === false) {
+			edge.points[0].y += offset;
+		}
+		edge.points[edge.points.length - 1].y += offset;
 	});
 
 	// 6. Finally put everything back into the workflow

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -77,6 +77,7 @@
 					@port-mouseover="onPortMouseover"
 					@port-mouseleave="onPortMouseleave"
 					@remove-operator="(event) => removeNode(event)"
+					@duplicate-branch="duplicateBranch(node.id)"
 					@remove-edges="removeEdges"
 				>
 					<template #body>
@@ -358,6 +359,10 @@ const openDrilldown = (node: WorkflowNode<any>) => {
 
 const removeNode = (event) => {
 	workflowService.removeNode(wf.value, event);
+};
+
+const duplicateBranch = (id: string) => {
+	workflowService.branchWorkflow(wf.value, id);
 };
 
 const addOperatorToWorkflow: Function =


### PR DESCRIPTION
### Summary
Hook up the branch-duplication feature, effectively this just calls the `workflowService.branchWorkflow(...)` function.

Also fixed a few bugs as there were a few places where the identifier-reassignment were missed - e.g. node.active field.

Duplicate option:

<img width="661" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/1358c0d2-258d-4ee5-b0ac-fc8d1ed53664">

After example, the duplicated branch is slightly shifted down.

<img width="931" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/601097b9-2983-41c2-8e85-a5189d079f3f">




### Testing
Using the "duplicate" option on any operator will duplicate itself, and all downstream operator(s).
