### PR TITLE
fix(hmi-server): Fixing datetime format for Simulation

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
@@ -112,6 +112,7 @@ public class SimulationController {
 	@Operation(summary = "Update a simulation by ID")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Simulation updated.", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Simulation.class))),
+			@ApiResponse(responseCode = "404", description = "Simulation not found", content = @Content),
 			@ApiResponse(responseCode = "500", description = "There was an issue updating the simulation", content = @Content)
 	})
 	public ResponseEntity<Simulation> updateSimulation(@PathVariable("id") final UUID id,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/simulation/Simulation.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/simulation/Simulation.java
@@ -6,6 +6,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -71,11 +72,13 @@ public class Simulation implements Serializable {
 	@JsonAlias("start_time")
 	@TSOptional
 	@Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
+	@JsonFormat(pattern="yyyy-MM-dd HH:mm:ss.SSS")
 	private Timestamp startTime;
 
 	@JsonAlias("completed_time")
 	@TSOptional
 	@Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
+	@JsonFormat(pattern="yyyy-MM-dd HH:mm:ss.SSS")
 	private Timestamp completedTime;
 
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
The services return a datetime object with a slightly different format. Adding support for this format in parsing. Also updating docs to explain a 404 from `PUT simulations/{id}`

