### PR TITLE
chore: clean vite-local

### DIFF
--- a/packages/client/hmi-client/vite.config.local.ts
+++ b/packages/client/hmi-client/vite.config.local.ts
@@ -12,17 +12,6 @@ config.server.proxy = {
 		target: `http://${localhost}:3000`,
 		rewrite: (path_str) => path_str.replace(/^\/api/, ''),
 		changeOrigin: true
-	},
-	'^/beaker_ws': {
-		target: `ws://${localhost}:3050`,
-		rewrite: (path_str) => path_str.replace(/^\/beaker_ws/, ''),
-		changeOrigin: true,
-		ws: true
-	},
-	'^/beaker': {
-		target: `http://${localhost}:3050`,
-		rewrite: (path_str) => path_str.replace(/^\/beaker/, ''),
-		changeOrigin: true
 	}
 };
 

--- a/packages/client/hmi-client/vite.config.ts
+++ b/packages/client/hmi-client/vite.config.ts
@@ -47,12 +47,6 @@ export default defineConfig({
 				target: 'https://server.staging.terarium.ai',
 				rewrite: (path_str) => path_str.replace(/^\/api/, ''),
 				changeOrigin: true
-			},
-			'^/beaker/(.*)': {
-				target: 'http://beaker.staging.terarium.ai'
-			},
-			'^/beaker_ws/(.*)': {
-				target: 'http://beaker.staging.terarium.ai'
 			}
 		}
 	},


### PR DESCRIPTION
### Summary
The `TGPTController` is responsible for returning the connection information for beaker - e.g. the websocket address, jupyter-token ... etc. Currently instead of returning these information, the server returns the client address with dummy-routes, and then the client routes again based on the running configuration. This creates a weird circular double-proxy situation where the client needs to know the server and the server needs to know the client.

- client asks server how to connect to beaker
- server returns dummy client routes
- client connects through these routes
- the routes are intercepted by the client and rerouted to actual beaker host

This can be simplified by just getting the client to connect directly, so
- client asks server how to connect to beaker
- client connects through these routes
