### PR TITLE
fix double simulations get doubly created

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -394,7 +394,9 @@ watch(() => completedRunId.value, watchCompletedRunId, { immediate: true });
 watch(
 	() => selectedRunId.value,
 	() => {
-		lazyLoadSimulationData(selectedRunId.value);
+		if (selectedRunId.value) {
+			lazyLoadSimulationData(selectedRunId.value);
+		}
 	},
 	{ immediate: true }
 );

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
@@ -112,7 +112,11 @@ public class SimulationRequestController implements SnakeCaseController {
 		sim.setEngine(SimulationEngine.SCIML);
 
 		try {
-			return ResponseEntity.ok(simulationService.createSimulation(sim));
+			final Optional<Simulation> updated = simulationService.updateSimulation(sim);
+			if (updated.isEmpty()) {
+				return ResponseEntity.notFound().build();
+			}
+			return ResponseEntity.ok(updated.get());
 		} catch (final Exception e) {
 			final String error = "Failed to create simulation";
 			log.error(error, e);
@@ -154,7 +158,11 @@ public class SimulationRequestController implements SnakeCaseController {
 		sim.setEngine(SimulationEngine.CIEMSS);
 
 		try {
-			return ResponseEntity.ok(simulationService.createSimulation(sim));
+			final Optional<Simulation> updated = simulationService.updateSimulation(sim);
+			if (updated.isEmpty()) {
+				return ResponseEntity.notFound().build();
+			}
+			return ResponseEntity.ok(updated.get());
 		} catch (final Exception e) {
 			final String error = "Failed to create simulation";
 			log.error(error, e);


### PR DESCRIPTION
### Summary
Fix double creating problem with forecast calls. Simulate is created by the external services into hmi-server, so hmi-server does not need to create a copy of it.