### PR TITLE
Fix: Data-transform-node 

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer-node.vue
@@ -33,8 +33,8 @@ const model = ref<Model | null>(null);
 
 const fetchModel = async () => {
 	// FIXME: The state now holds a modelConfigIds - so this may have to be updated to support that
-	if (!props.node?.state?.modelId) return;
-	model.value = await getModel(props.node?.state?.modelId);
+	if (!props.node.inputs[0].value?.[0]) return;
+	model.value = await getModel(props.node.inputs[0].value[0]);
 };
 
 onMounted(async () => {


### PR DESCRIPTION
The data-transform-node was relying on a state that is not being updated to pull a model.
This resulted in the node never having a model and not being able to access the drill down (due to the if)

This change is to rely on the node's input instead of the state that is not being updated:
<img width="236" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/7dc12f7c-a528-4437-9b15-14a511c166a8">

