### PR TITLE
feat: call amr to template and add flat view

### DIFF
--- a/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
@@ -388,7 +388,7 @@ watch(
 				x: 100,
 				y: 100
 			};
-			console.log(flattenedModel);
+
 			modelTemplatingService.addCard(flattenedTemplates.value, flattenedModel);
 
 			// Initialize beaker kernel

--- a/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
@@ -144,12 +144,8 @@ let canvasTransform = { x: 0, y: 0, k: 1 };
 let isMouseOverPort = false;
 let junctionIdForNewEdge: string | null = null;
 
-const decomposedTemplates = ref<ModelTemplates>(
-	modelTemplatingService.initializeModelTemplates(props.model)
-);
-const flattenedTemplates = ref<ModelTemplates>(
-	modelTemplatingService.initializeModelTemplates(props.model)
-);
+const decomposedTemplates = ref<ModelTemplates>(modelTemplatingService.initializeModelTemplates());
+const flattenedTemplates = ref<ModelTemplates>(modelTemplatingService.initializeModelTemplates());
 const modelFormatOptions = ref([EditorFormat.Decomposed, EditorFormat.Flattened]);
 const currentModelFormat = ref(EditorFormat.Decomposed);
 

--- a/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
@@ -43,8 +43,8 @@
 					<!-- TODO: There will be a Diagram/Equation toggle here. There may be plans to make a component for this specific
 						toggle though since in some designs it is used outside of tera-model-diagram and others are inside -->
 					<SelectButton
-						:model-value="modelFormat"
-						@change="if ($event.value) modelFormat = $event.value;"
+						:model-value="currentModelFormat"
+						@change="if ($event.value) currentModelFormat = $event.value;"
 						:options="modelFormatOptions"
 					/>
 				</section>
@@ -131,9 +131,9 @@ const props = defineProps<{
 	model?: Model;
 }>();
 
-enum EditorView {
-	Template = 'Template',
-	Flat = 'Flat'
+enum EditorFormat {
+	Decomposed = 'Decomposed',
+	Flattened = 'Flattened'
 }
 
 const kernelManager = new KernelSessionManager();
@@ -150,11 +150,11 @@ const modelTemplateEditor = ref<ModelTemplateEditor>(
 const flatModelTemplateEditor = ref<ModelTemplateEditor>(
 	modelTemplatingService.initializeModelTemplateEditor(props.model)
 );
-const modelFormatOptions = ref([EditorView.Template, EditorView.Flat]);
-const modelFormat = ref(EditorView.Template);
+const modelFormatOptions = ref([EditorFormat.Decomposed, EditorFormat.Flattened]);
+const currentModelFormat = ref(EditorFormat.Decomposed);
 
 const currentEditor = computed(() =>
-	modelFormat.value === EditorView.Template
+	currentModelFormat.value === EditorFormat.Decomposed
 		? modelTemplateEditor.value
 		: flatModelTemplateEditor.value
 );

--- a/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
@@ -40,8 +40,8 @@
 			<template #foreground>
 				<!--FIXME: This container holding the toggles overlaps the top of the canvas so the drag area is slightly cutoff-->
 				<section class="view-toggles">
-					<!-- TODO: There will be a Diagram/Equation toggle here. There may be plans to make a component for this 
-						toggle specifically though since in some designs it is used outside of tera-model-diagram and others are inside -->
+					<!-- TODO: There will be a Diagram/Equation toggle here. There may be plans to make a component for this specific
+						toggle though since in some designs it is used outside of tera-model-diagram and others are inside -->
 					<SelectButton
 						:model-value="modelFormat"
 						@change="if ($event.value) modelFormat = $event.value;"

--- a/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template-editor.vue
@@ -402,7 +402,6 @@ onUnmounted(() => {
 .toolbar {
 	height: 100%;
 	display: flex;
-	overflow: scroll;
 }
 
 aside {

--- a/packages/client/hmi-client/src/components/model-template/tera-model-template.vue
+++ b/packages/client/hmi-client/src/components/model-template/tera-model-template.vue
@@ -81,7 +81,7 @@ const cardWidth = computed(() => cardRef.value?.clientWidth ?? 0);
 const card = computed<ModelTemplateCard>(
 	() =>
 		props.model.metadata.templateCard ?? {
-			id: -1,
+			id: '',
 			name: props.model.header.name,
 			x: 0,
 			y: 0

--- a/packages/client/hmi-client/src/services/model-templating.ts
+++ b/packages/client/hmi-client/src/services/model-templating.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Position } from '@/types/common';
-import type { ModelTemplateEditor } from '@/types/model-templating';
+import type { Model } from '@/types/Types';
+import type { ModelTemplateCard, ModelTemplateEditor } from '@/types/model-templating';
 import naturalConversion from './model-templates/natural-conversion.json';
 import naturalProduction from './model-templates/natural-production.json';
 import naturalDegredation from './model-templates/natural-degradation.json';
@@ -8,6 +9,18 @@ import controlledConversion from './model-templates/controlled-conversion.json';
 import controlledProduction from './model-templates/controlled-production.json';
 import controlledDegredation from './model-templates/controlled-degradation.json';
 import observable from './model-templates/observable.json';
+// import { KernelSessionManager } from '@/services/jupyter';
+
+// const context = {
+// 	context: 'mira_model',
+// 	language: 'python3',
+// 	context_info: {
+// 		id: '8f1b00a3-00bd-47b1-925a-3e1227a0af9a'
+// 	}
+// };
+
+// const manager = new KernelSessionManager();
+// await manager.init('beaker_kernel', 'Beaker Kernel', context);
 
 export const modelTemplateOptions = [
 	naturalConversion,
@@ -20,15 +33,18 @@ export const modelTemplateOptions = [
 ].map((modelTemplate: any) => {
 	// TODO: Add templateCard attribute to Model later
 	modelTemplate.metadata.templateCard = {
-		id: -1,
+		id: modelTemplate.header.name,
 		name: modelTemplate.header.name,
 		x: 0,
 		y: 0
-	};
+	} as ModelTemplateCard;
 	return modelTemplate;
 });
 
-export function emptyModelTemplateEditor(name = 'name', description = '') {
+export function initializeModelTemplateEditor(model: Model | null = null) {
+	const name = model?.header?.name ?? 'name';
+	const description = model?.header?.description ?? 'description';
+
 	const modelTemplateEditor: ModelTemplateEditor = {
 		id: uuidv4(),
 		name,

--- a/packages/client/hmi-client/src/services/model-templating.ts
+++ b/packages/client/hmi-client/src/services/model-templating.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Position } from '@/types/common';
 import type { Model } from '@/types/Types';
-import type { ModelTemplateCard, ModelTemplateEditor } from '@/types/model-templating';
+import type { ModelTemplateCard, ModelTemplates } from '@/types/model-templating';
 import naturalConversion from './model-templates/natural-conversion.json';
 import naturalProduction from './model-templates/natural-production.json';
 import naturalDegredation from './model-templates/natural-degradation.json';
@@ -29,11 +29,11 @@ export const modelTemplateOptions = [
 	return modelTemplate;
 });
 
-export function initializeModelTemplateEditor(model: Model | null = null) {
+export function initializeModelTemplates(model: Model | null = null) {
 	const name = model?.header?.name ?? 'name';
 	const description = model?.header?.description ?? 'description';
 
-	const modelTemplateEditor: ModelTemplateEditor = {
+	const modelTemplates: ModelTemplates = {
 		id: uuidv4(),
 		name,
 		description,
@@ -41,38 +41,38 @@ export function initializeModelTemplateEditor(model: Model | null = null) {
 		models: [],
 		junctions: []
 	};
-	return modelTemplateEditor;
+	return modelTemplates;
 }
 
-function findCardIndexById(modelTemplateEditor: ModelTemplateEditor, id: string) {
-	return modelTemplateEditor.models.findIndex(({ metadata }) => metadata.templateCard.id === id);
+function findCardIndexById(modelTemplates: ModelTemplates, id: string) {
+	return modelTemplates.models.findIndex(({ metadata }) => metadata.templateCard.id === id);
 }
 
-export function addCard(modelTemplateEditor: ModelTemplateEditor, modelTemplate: any) {
+export function addCard(modelTemplates: ModelTemplates, modelTemplate: any) {
 	modelTemplate.metadata.templateCard.id = uuidv4();
-	modelTemplateEditor.models.push(modelTemplate);
+	modelTemplates.models.push(modelTemplate);
 }
 
-export function updateCardName(modelTemplateEditor: ModelTemplateEditor, name: string, id: string) {
-	const index = findCardIndexById(modelTemplateEditor, id);
-	modelTemplateEditor.models[index].metadata.templateCard.name = name;
+export function updateCardName(modelTemplates: ModelTemplates, name: string, id: string) {
+	const index = findCardIndexById(modelTemplates, id);
+	modelTemplates.models[index].metadata.templateCard.name = name;
 }
 
-export function removeCard(modelTemplateEditor: ModelTemplateEditor, id: string) {
+export function removeCard(modelTemplates: ModelTemplates, id: string) {
 	// Remove edges connected to the card
-	modelTemplateEditor.junctions.forEach((junction) => {
+	modelTemplates.junctions.forEach((junction) => {
 		junction.edges = junction.edges.filter((edge) => edge.target.cardId !== id);
 	});
-	junctionCleanUp(modelTemplateEditor);
+	junctionCleanUp(modelTemplates);
 
 	// Remove card
-	modelTemplateEditor.models = modelTemplateEditor.models.filter(
+	modelTemplates.models = modelTemplates.models.filter(
 		(model) => model.metadata.templateCard.id !== id
 	);
 }
 
-export function addJunction(modelTemplateEditor: ModelTemplateEditor, portPosition: Position) {
-	modelTemplateEditor.junctions.push({
+export function addJunction(modelTemplates: ModelTemplates, portPosition: Position) {
+	modelTemplates.junctions.push({
 		id: uuidv4(),
 		x: portPosition.x + 500,
 		y: portPosition.y - 10,
@@ -80,29 +80,27 @@ export function addJunction(modelTemplateEditor: ModelTemplateEditor, portPositi
 	});
 }
 
-export function junctionCleanUp(modelTemplateEditor: ModelTemplateEditor) {
+export function junctionCleanUp(modelTemplates: ModelTemplates) {
 	// If a junction ends up having one edge coming out of it, remove it
-	modelTemplateEditor.junctions = modelTemplateEditor.junctions.filter(
-		({ edges }) => edges.length > 1
-	);
+	modelTemplates.junctions = modelTemplates.junctions.filter(({ edges }) => edges.length > 1);
 }
 
 export function addEdge(
-	modelTemplateEditor: ModelTemplateEditor,
+	modelTemplates: ModelTemplates,
 	junctionId: string,
 	target: { cardId: string; portId: string },
 	portPosition: Position,
 	interpolatePointsFn?: Function
 ) {
-	const index = modelTemplateEditor.junctions.findIndex(({ id }) => id === junctionId);
-	const junctionToDrawFrom = modelTemplateEditor.junctions[index];
+	const index = modelTemplates.junctions.findIndex(({ id }) => id === junctionId);
+	const junctionToDrawFrom = modelTemplates.junctions[index];
 
 	const points: Position[] = [
 		{ x: junctionToDrawFrom.x + 10, y: junctionToDrawFrom.y + 10 },
 		{ x: portPosition.x, y: portPosition.y }
 	];
 
-	modelTemplateEditor.junctions[index].edges.push({
+	modelTemplates.junctions[index].edges.push({
 		id: uuidv4(),
 		target,
 		points: interpolatePointsFn ? interpolatePointsFn(...points) : points
@@ -110,4 +108,4 @@ export function addEdge(
 }
 
 // TODO: There isn't a way to do this in the UI yet
-// export function removeEdge(modelTemplateEditor: ModelTemplateEditor) {}
+// export function removeEdge(modelTemplates: ModelTemplates) {}

--- a/packages/client/hmi-client/src/services/model-templating.ts
+++ b/packages/client/hmi-client/src/services/model-templating.ts
@@ -9,18 +9,6 @@ import controlledConversion from './model-templates/controlled-conversion.json';
 import controlledProduction from './model-templates/controlled-production.json';
 import controlledDegredation from './model-templates/controlled-degradation.json';
 import observable from './model-templates/observable.json';
-// import { KernelSessionManager } from '@/services/jupyter';
-
-// const context = {
-// 	context: 'mira_model',
-// 	language: 'python3',
-// 	context_info: {
-// 		id: '8f1b00a3-00bd-47b1-925a-3e1227a0af9a'
-// 	}
-// };
-
-// const manager = new KernelSessionManager();
-// await manager.init('beaker_kernel', 'Beaker Kernel', context);
 
 export const modelTemplateOptions = [
 	naturalConversion,

--- a/packages/client/hmi-client/src/services/model-templating.ts
+++ b/packages/client/hmi-client/src/services/model-templating.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Position } from '@/types/common';
-import type { Model } from '@/types/Types';
 import type { ModelTemplateCard, ModelTemplates } from '@/types/model-templating';
 import naturalConversion from './model-templates/natural-conversion.json';
 import naturalProduction from './model-templates/natural-production.json';
@@ -29,14 +28,9 @@ export const modelTemplateOptions = [
 	return modelTemplate;
 });
 
-export function initializeModelTemplates(model: Model | null = null) {
-	const name = model?.header?.name ?? 'name';
-	const description = model?.header?.description ?? 'description';
-
+export function initializeModelTemplates() {
 	const modelTemplates: ModelTemplates = {
 		id: uuidv4(),
-		name,
-		description,
 		transform: { x: 0, y: 0, k: 1 },
 		models: [],
 		junctions: []

--- a/packages/client/hmi-client/src/temp/model-template-test.vue
+++ b/packages/client/hmi-client/src/temp/model-template-test.vue
@@ -1,7 +1,17 @@
 <template>
-	<tera-model-template-editor />
+	<div>
+		<tera-model-template-editor :model="model" />
+	</div>
 </template>
 
 <script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { getModel } from '@/services/model';
 import TeraModelTemplateEditor from '@/components/model-template/tera-model-template-editor.vue';
+
+const model = ref();
+
+onMounted(async () => {
+	model.value = (await getModel('1cf59726-00b6-48a9-8db6-b9940a8dde8e')) ?? undefined;
+});
 </script>

--- a/packages/client/hmi-client/src/types/model-templating.ts
+++ b/packages/client/hmi-client/src/types/model-templating.ts
@@ -1,6 +1,7 @@
 import type { Position } from '@/types/common';
 
-export interface ModelTemplateEditor {
+// FIXME: Not sure if we want name/description properties
+export interface ModelTemplates {
 	id: string;
 	name: string;
 	description: string;

--- a/packages/client/hmi-client/src/types/model-templating.ts
+++ b/packages/client/hmi-client/src/types/model-templating.ts
@@ -1,10 +1,7 @@
 import type { Position } from '@/types/common';
 
-// FIXME: Not sure if we want name/description properties
 export interface ModelTemplates {
 	id: string;
-	name: string;
-	description: string;
 	transform: {
 		x: number;
 		y: number;

--- a/packages/client/hmi-client/vite.config.local.ts
+++ b/packages/client/hmi-client/vite.config.local.ts
@@ -14,13 +14,13 @@ config.server.proxy = {
 		changeOrigin: true
 	},
 	'^/beaker_ws': {
-		target: `ws://${localhost}:3050`,
+		target: `ws://${localhost}:8888`,
 		rewrite: (path_str) => path_str.replace(/^\/beaker_ws/, ''),
 		changeOrigin: true,
 		ws: true
 	},
 	'^/beaker': {
-		target: `http://${localhost}:3050`,
+		target: `http://${localhost}:8888`,
 		rewrite: (path_str) => path_str.replace(/^\/beaker/, ''),
 		changeOrigin: true
 	}

--- a/packages/client/hmi-client/vite.config.local.ts
+++ b/packages/client/hmi-client/vite.config.local.ts
@@ -14,13 +14,13 @@ config.server.proxy = {
 		changeOrigin: true
 	},
 	'^/beaker_ws': {
-		target: `ws://${localhost}:8888`,
+		target: `ws://${localhost}:3050`,
 		rewrite: (path_str) => path_str.replace(/^\/beaker_ws/, ''),
 		changeOrigin: true,
 		ws: true
 	},
 	'^/beaker': {
-		target: `http://${localhost}:8888`,
+		target: `http://${localhost}:3050`,
 		rewrite: (path_str) => path_str.replace(/^\/beaker/, ''),
 		changeOrigin: true
 	}


### PR DESCRIPTION
# Description


https://github.com/DARPA-ASKEM/terarium/assets/28237258/ff0be308-d6af-494f-8d5d-9cf8cf3c1fce



- call `amr_to_template` from beaker
- flat view and flattened model state are available
- rearranged sidebar layout

### Testing
Put a valid model id into `model-template-test.vue` and go to `http://localhost:8080/model-template-test`

