### PR TITLE
Update pyciemss calibrate

### DIFF
--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -102,6 +102,15 @@ export async function getRunResult(runId: string, filename: string) {
 	}
 }
 
+// Return the presigned download URL of the calibration output blob
+// This is only applicable to CIEMSS functionalities
+export async function getCalibrateBlobURL(runId: string) {
+	const resp = await API.get(`simulations/${runId}/download-url`, {
+		params: { filename: 'parameters.dill' }
+	});
+	return resp.data.url;
+}
+
 export async function getRunResultCiemss(runId: string, filename = 'result.csv') {
 	const resultCsv = await getRunResult(runId, filename);
 	const csvData = csvParse(resultCsv);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -8,7 +8,7 @@ import { CalibrateMap } from '@/services/calibrate-workflow';
 export interface CalibrationOperationStateCiemss {
 	chartConfigs: ChartConfig[];
 	mapping: CalibrateMap[];
-	// simulationsInProgress: string[];
+	simulationsInProgress: string[];
 
 	calibrationId: string;
 	simulationId: string;
@@ -23,7 +23,7 @@ export const CalibrationOperationCiemss: Operation = {
 		{ type: 'modelConfigId', label: 'Model configuration' },
 		{ type: 'datasetId', label: 'Dataset' }
 	],
-	outputs: [{ type: 'calibrateDill' }],
+	outputs: [{ type: 'simulationId' }],
 	isRunnable: true,
 
 	// TODO: Figure out mapping
@@ -53,7 +53,7 @@ export const CalibrationOperationCiemss: Operation = {
 		const init: CalibrationOperationStateCiemss = {
 			chartConfigs: [],
 			mapping: [{ modelVariable: '', datasetVariable: '' }],
-			// simulationsInProgress: [],
+			simulationsInProgress: [],
 			calibrationId: '',
 			simulationId: ''
 		};

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -8,7 +8,10 @@ import { CalibrateMap } from '@/services/calibrate-workflow';
 export interface CalibrationOperationStateCiemss {
 	chartConfigs: ChartConfig[];
 	mapping: CalibrateMap[];
-	simulationsInProgress: string[];
+	// simulationsInProgress: string[];
+
+	calibrationId: string;
+	simulationId: string;
 }
 
 export const CalibrationOperationCiemss: Operation = {
@@ -20,7 +23,7 @@ export const CalibrationOperationCiemss: Operation = {
 		{ type: 'modelConfigId', label: 'Model configuration' },
 		{ type: 'datasetId', label: 'Dataset' }
 	],
-	outputs: [{ type: 'number' }],
+	outputs: [{ type: 'calibrateDill' }],
 	isRunnable: true,
 
 	// TODO: Figure out mapping
@@ -50,7 +53,9 @@ export const CalibrationOperationCiemss: Operation = {
 		const init: CalibrationOperationStateCiemss = {
 			chartConfigs: [],
 			mapping: [{ modelVariable: '', datasetVariable: '' }],
-			simulationsInProgress: []
+			// simulationsInProgress: [],
+			calibrationId: '',
+			simulationId: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -182,7 +182,7 @@ import { Poller, PollerState } from '@/api/api';
 import { getTimespan } from '@/workflow/util';
 import { logger } from '@/utils/logger';
 import { useToastService } from '@/services/toast';
-import { CalibrationOperationCiemss, CalibrationOperationStateCiemss } from './calibrate-operation';
+import { CalibrationOperationStateCiemss } from './calibrate-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
@@ -209,7 +209,6 @@ const currentDatasetFileName = ref<string>();
 const simulationIds = computed<any | undefined>(() => props.node.outputs[0]?.value);
 
 const runResults = ref<RunResults>({});
-const completedRunId = ref<string>();
 
 const showSpinner = ref(false);
 const progress = ref({ status: ProgressState.Retrieving, value: 0 });
@@ -326,14 +325,11 @@ const getStatus = async (simulationId: string) => {
 		throw Error('Failed Runs');
 	}
 
-	console.log('hihi');
-
-	completedRunId.value = simulationId;
-	updateOutputPorts(completedRunId);
+	updateOutputPorts(simulationId);
 	showSpinner.value = false;
 };
 
-const updateOutputPorts = async (runId) => {
+const updateOutputPorts = async (runId: string) => {
 	const portLabel = props.node.inputs[0].label;
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs.push({
@@ -343,11 +339,9 @@ const updateOutputPorts = async (runId) => {
 	emit('update-state', state);
 
 	emit('append-output-port', {
-		type: CalibrationOperationCiemss.outputs[0].type,
+		type: 'calibrateDill',
 		label: `${portLabel} Result`,
-		value: {
-			runId
-		}
+		value: runId
 	});
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -102,7 +102,7 @@
 			>
 				<div v-if="!showSpinner" class="form-section">
 					<h4>Variables</h4>
-					<section v-if="modelConfig && node.state.chartConfigs.length">
+					<section v-if="modelConfig && node.state.chartConfigs.length && csvAsset">
 						<tera-simulate-chart
 							v-for="(cfg, index) of node.state.chartConfigs"
 							:key="cfg.selectedRun"
@@ -539,8 +539,6 @@ watch(
 		// Update selected output
 		if (props.node.active) {
 			selectedOutputId.value = props.node.active;
-
-			console.log('hihihi', props.node.active);
 
 			// FIXME: could still be running
 			const state = props.node.state;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -105,7 +105,7 @@
 					<section v-if="modelConfig && node.state.chartConfigs.length">
 						<tera-simulate-chart
 							v-for="(cfg, index) of node.state.chartConfigs"
-							:key="index"
+							:key="cfg.selectedRun"
 							:run-results="runResults"
 							:chartConfig="cfg"
 							:initial-data="csvAsset"
@@ -356,7 +356,7 @@ const getCalibrateStatus = async (simulationId: string) => {
 			// end: state.currentTimespan.end
 		},
 		extra: {
-			num_samples: 50,
+			num_samples: 5,
 			method: 'dopri5',
 			inferred_parameters: simulationId
 		},
@@ -398,10 +398,18 @@ const getCalibrateStatus = async (simulationId: string) => {
 const updateOutputPorts = async (calibrationId: string, simulationId: string) => {
 	const portLabel = props.node.inputs[0].label;
 	const state = _.cloneDeep(props.node.state);
-	state.chartConfigs.push({
-		selectedRun: simulationId,
-		selectedVariable: []
-	});
+
+	// state.chartConfigs.push({
+	// 	selectedRun: simulationId,
+	// 	selectedVariable: []
+	// });
+
+	state.chartConfigs = [
+		{
+			selectedRun: simulationId,
+			selectedVariable: []
+		}
+	];
 
 	state.calibrationId = calibrationId;
 	state.simulationId = simulationId;
@@ -531,6 +539,8 @@ watch(
 		// Update selected output
 		if (props.node.active) {
 			selectedOutputId.value = props.node.active;
+
+			console.log('hihihi', props.node.active);
 
 			// FIXME: could still be running
 			const state = props.node.state;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -147,10 +147,11 @@ import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
 import Column from 'primevue/column';
 import {
-	getRunResultCiemss,
+	/* getRunResultCiemss, */
 	makeCalibrateJobCiemss,
 	simulationPollAction,
-	querySimulationInProgress
+	querySimulationInProgress,
+	getCalibrateBlobURL
 } from '@/services/models/simulation-service';
 import {
 	CalibrationRequestCiemss,
@@ -325,6 +326,8 @@ const getStatus = async (simulationId: string) => {
 		throw Error('Failed Runs');
 	}
 
+	console.log('hihi');
+
 	completedRunId.value = simulationId;
 	updateOutputPorts(completedRunId);
 	showSpinner.value = false;
@@ -440,8 +443,14 @@ watch(
 	() => simulationIds.value,
 	async () => {
 		if (!simulationIds.value) return;
-		const output = await getRunResultCiemss(simulationIds.value[0].runId, 'result.csv');
+
+		const dillURL = await getCalibrateBlobURL(simulationIds.value[0].runId);
+		console.log('dill URL is', dillURL);
+
+		/*
+		const output = await getRunResultCiemss(simulationIds.value[0].runId, result.csv');
 		runResults.value = output.runResults;
+		*/
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -34,41 +34,36 @@ export const getGraphDataFromDatasetCSV = (
 	mapping?: { [key: string]: string }[],
 	runType?: RunType
 ): DataseriesConfig | null => {
-	// Julia's output has a (t) at the end of the variable name, so we need to remove it
-	let v = runType === RunType.Julia ? columnVar.slice(0, -3) : columnVar;
-	let tVar = 'timestamp';
+	// TA3 quirks, adjust variable names - FIXME
+	const selectedVariableLookup =
+		runType === RunType.Julia ? columnVar.slice(0, -3) : columnVar.slice(0, -6);
+	const timeVariableLookup = 'timestamp';
 
-	// get the dataset variable from the mapping of model variable to dataset variable if there's a mapping
+	// Default
+	let selectedVariable = selectedVariableLookup;
+	let timeVariable = timeVariableLookup;
+
+	// Map variable names to dataset column names
 	if (mapping) {
-		if (!(mapping.length === 1 && Object.values(mapping[0]).some((val) => !val))) {
-			const varMap = mapping.find((m) => m.modelVariable === columnVar);
-			if (varMap) {
-				v = varMap.datasetVariable;
-			}
+		let result = mapping.find((m) => m.modelVariable === selectedVariable);
+		if (result) {
+			selectedVariable = result.datasetVariable;
+		}
 
-			// if there's a mapping for timestamp, then the model variable is guaranteed to be 'timestamp'
-			const tMap = mapping.find((m) => m.modelVariable === 'timestamp');
-			if (tMap) {
-				tVar = tMap.datasetVariable;
-			}
+		result = mapping.find((m) => m.modelVariable === timeVariable);
+		if (result) {
+			timeVariable = result.datasetVariable;
 		}
 	}
 
-	// get  the index of the timestamp column
-	let tIndex = dataset.headers.indexOf(tVar);
-	// if the timestamp column is not found, default to 0 as this is what is assumed to be the default
-	// timestamp column in the pyciemss backend
-	tIndex = tIndex === -1 ? 0 : tIndex;
-
-	// get the index of the variable column
-	let colIdx: number = -1;
+	// Graph dataset index columns for x: timeVariable and y: selectedVariable
+	let tIndex = -1;
+	let sIndex = -1;
 	for (let i = 0; i < dataset.headers.length; i++) {
-		if (dataset.headers[i].trim() === v.trim()) {
-			colIdx = i;
-			break;
-		}
+		if (timeVariable.trim() === dataset.headers[i].trim()) tIndex = i;
+		if (selectedVariable.trim() === dataset.headers[i].trim()) sIndex = i;
 	}
-	if (colIdx === -1) {
+	if (tIndex === -1 || sIndex === -1) {
 		return null;
 	}
 
@@ -76,7 +71,7 @@ export const getGraphDataFromDatasetCSV = (
 		// ignore the first row, it's the header
 		data: dataset.csv.slice(1).map((datum: string[]) => ({
 			x: +datum[tIndex],
-			y: +datum[colIdx]
+			y: +datum[sIndex]
 		})),
 		label: `${columnVar} - dataset`,
 		fill: false,


### PR DESCRIPTION
### Summary
Getting CIEMSS calibrate inline with other operator designs, and working with dill blob. 

This is the first part:
- Get CIEMSS calibrate back in order as it has been months since we updated the design
- Using and accessing inferred_parameters (the dill file) for a projection

The second part will be hooking up the loss-values (send via rabbitMQ) and gettng the CIEMSS-simulate to optionally accept an inferrred_paramter (the dill file) to run.

Note because we are still doing two parts (calibrate, then simulate), the state object had to be augmented to keep track of both types of simulation ids (calibration-id, forecast-id). The naming here is a bit tangled up with the existing nomenclature, suggestions welcome but might be dealt with in later PRs.


<img width="1408" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/bd87163c-e1b4-4ed6-85c3-be7644b3e1be">



## Testing
CIEMSS calibrate runs