### PR TITLE
chore: decapodes data structures

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -341,7 +341,7 @@ export interface ContextHeader {
     id: string;
     description: string;
     name: string;
-    parentContext: string;
+    parentModel: string;
 }
 
 export interface ContextMesh {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -276,10 +276,113 @@ export interface TypingSemantics {
     system: any;
 }
 
+export interface Configuration {
+    parameters: { [index: string]: ConfigurationParameter };
+    initialConditions: { [index: string]: ConfigurationCondition };
+    boundryConditions: { [index: string]: ConfigurationCondition };
+    datasets: { [index: string]: ConfigurationDataset };
+}
+
+export interface ConfigurationCondition {
+    _type: string;
+    type: string;
+    value: string;
+    domainMesh: string;
+}
+
+export interface ConfigurationDataset {
+    _type: string;
+    type: string;
+    name: string;
+    description: string;
+    file: ConfigurationDatasetFile;
+}
+
+export interface ConfigurationDatasetFile {
+    _type: string;
+    uri: string;
+    format: string;
+    shape: number[];
+}
+
+export interface ConfigurationHeader {
+    id: string;
+    description: string;
+    name: string;
+    parentContext: string;
+}
+
+export interface ConfigurationParameter {
+    _type: string;
+    type: string;
+    value: any;
+}
+
+export interface Context {
+    constants: { [index: string]: ContextConstant };
+    spatialConstraints: any;
+    temporalConstraints: any;
+    primalDualRelations: ContextPrimalDualRelation[];
+    meshSubmeshRelations: ContextMeshSubmeshRelation[];
+    meshes: ContextMesh[];
+}
+
+export interface ContextConstant {
+    _type: string;
+    value: any;
+}
+
+export interface ContextFile {
+    uri: string;
+    format: string;
+}
+
+export interface ContextHeader {
+    id: string;
+    description: string;
+    name: string;
+    parentContext: string;
+}
+
+export interface ContextMesh {
+    id: string;
+    description: string;
+    dimensionality: any;
+    vertexCount: number;
+    edgeCount: number;
+    faceCount: number;
+    volumeCount: number;
+    regions: any[];
+    checksum: string;
+    file: ContextFile;
+}
+
+export interface ContextMeshSubmeshRelation {
+    mesh: string;
+    submesh: string;
+    relation: any;
+}
+
+export interface ContextPrimalDualRelation {
+    primal: string;
+    dual: string;
+    method: any;
+}
+
 export interface DecapodesComponent {
     modelInterface: string[];
     model: DecapodesExpression;
     _type: string;
+}
+
+export interface DecapodesConfiguration extends TerariumAsset {
+    header: ConfigurationHeader;
+    configuration: Configuration;
+}
+
+export interface DecapodesContext extends TerariumAsset {
+    header: ContextHeader;
+    context: Context;
 }
 
 export interface DecapodesEquation {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/ElasticsearchConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/ElasticsearchConfiguration.java
@@ -89,8 +89,7 @@ public class ElasticsearchConfiguration {
 		return String.join("_", index.prefix, index.decapodesConfigurationRoot, index.suffix);
 	}
 
-	public String getDecapodesContext() {
+	public String getDecapodesContextIndex() {
 		return String.join("_", index.prefix, index.decapodesContext, index.suffix);
 	}
-
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/ElasticsearchConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/configuration/ElasticsearchConfiguration.java
@@ -36,7 +36,9 @@ public class ElasticsearchConfiguration {
 			String notebookSessionRoot,
 			String simulationRoot,
 			String workflowRoot,
-			String externalPublicationRoot) {
+			String externalPublicationRoot,
+			String decapodesConfigurationRoot,
+			String decapodesContext) {
 	}
 
 	public String getCodeIndex() {
@@ -82,4 +84,13 @@ public class ElasticsearchConfiguration {
 	public String getExternalPublicationIndex() {
 		return String.join("_", index.prefix, index.externalPublicationRoot, index.suffix);
 	}
+
+	public String getDecapodesConfigurationIndex() {
+		return String.join("_", index.prefix, index.decapodesConfigurationRoot, index.suffix);
+	}
+
+	public String getDecapodesContext() {
+		return String.join("_", index.prefix, index.decapodesContext, index.suffix);
+	}
+
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesConfigurationController.java
@@ -1,0 +1,223 @@
+package software.uncharted.terarium.hmiserver.controller.dataservice;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
+import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
+import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
+import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceQueryParam;
+import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceType;
+import software.uncharted.terarium.hmiserver.security.Roles;
+import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
+import software.uncharted.terarium.hmiserver.service.data.ModelService;
+import software.uncharted.terarium.hmiserver.service.data.DecapodesConfigurationService;
+import software.uncharted.terarium.hmiserver.service.data.ProvenanceSearchService;
+
+@RequestMapping("/decapodes-configurations")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class DecapodesConfigurationController {
+
+	final DecapodesConfigurationService decapodesConfigurationService;
+
+	final ModelService modelService;
+
+	final DocumentAssetService documentAssetService;
+
+	final ProvenanceSearchService provenanceSearchService;
+
+	final ObjectMapper objectMapper;
+
+	@GetMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Gets a model by ID")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Model found.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
+			@ApiResponse(responseCode = "204", description = "There was no model found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "There was an issue retrieving the model from the data store", content = @Content)
+	})
+	ResponseEntity<Model> getModel(@PathVariable("id") UUID id) {
+
+		try {
+
+			// Fetch the model from the data-service
+			Optional<Model> model = modelService.getModel(id);
+			if (model.isEmpty()) {
+				return ResponseEntity.noContent().build();
+			}
+
+			// Find the Document Assets linked via provenance to the model
+			ProvenanceQueryParam body = new ProvenanceQueryParam();
+			body.setRootId(id);
+			body.setRootType(ProvenanceType.MODEL);
+			body.setTypes(List.of(ProvenanceType.DOCUMENT));
+			final Set<String> documentIds = provenanceSearchService.modelsFromDocument(body);
+			if (!documentIds.isEmpty()) {
+				// Make sure we have an attributes list
+				if (model.get().getMetadata().getAttributes() == null)
+					model.get().getMetadata().setAttributes(new ArrayList<>());
+
+				documentIds.forEach(documentId -> {
+					try {
+						// Fetch the Document extractions
+						final Optional<DocumentAsset> document = documentAssetService
+								.getDocumentAsset(UUID.fromString(documentId));
+						if (document.isPresent()) {
+							final List<JsonNode> extractions = objectMapper.convertValue(
+									document.get().getMetadata().get("attributes"),
+									new TypeReference<List<JsonNode>>() {
+									});
+
+							// Append the Document extractions to the Model extractions, just for the
+							// front-end.
+							// Those are NOT to be saved back to the data-service.
+							model.get().getMetadata().getAttributes().addAll(extractions);
+						}
+					} catch (Exception e) {
+						log.error("Unable to get the document " + documentId, e);
+					}
+				});
+			} else {
+				log.debug("Unable to get the, or empty, provenance search models_from_document for model " + id);
+			}
+
+			// Return the model
+			return ResponseEntity.ok(model.get());
+		} catch (IOException e) {
+			final String error = "Unable to get model";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@GetMapping("/search")
+	@Secured(Roles.USER)
+	@Operation(summary = "Search models with a query")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Models found.", content = @Content(array = @ArraySchema(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class)))),
+			@ApiResponse(responseCode = "204", description = "There are no models found and no errors occurred", content = @Content),
+			@ApiResponse(responseCode = "500", description = "There was an issue retrieving models from the data store", content = @Content)
+	})
+	public ResponseEntity<List<Model>> searchModels(
+			@RequestBody JsonNode query,
+			@RequestParam(name = "page-size", defaultValue = "100", required = false) final Integer pageSize,
+			@RequestParam(name = "page", defaultValue = "0", required = false) final Integer page) {
+
+		try {
+			return ResponseEntity.ok(modelService.searchModels(page, pageSize, query));
+		} catch (IOException e) {
+			final String error = "Unable to search models";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@PutMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Update a model")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Model updated.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue updating the model", content = @Content)
+	})
+	ResponseEntity<Model> updateModel(
+			@PathVariable("id") UUID id,
+			@RequestBody Model model) {
+
+		try {
+			model.setId(id);
+			final Optional<Model> updated = modelService.updateModel(model);
+			if (updated.isEmpty()) {
+				return ResponseEntity.notFound().build();
+			}
+			return ResponseEntity.ok(updated.get());
+		} catch (IOException e) {
+			final String error = "Unable to update model";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@DeleteMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Deletes an model")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Deleted model", content = {
+					@Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDeleted.class)) }),
+			@ApiResponse(responseCode = "404", description = "Model could not be found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "An error occurred while deleting", content = @Content)
+	})
+	ResponseEntity<ResponseDeleted> deleteModel(
+			@PathVariable("id") UUID id) {
+
+		try {
+			modelService.deleteModel(id);
+			return ResponseEntity.ok(new ResponseDeleted("Model", id));
+		} catch (IOException e) {
+			final String error = "Unable to delete model";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@PostMapping
+	@Secured(Roles.USER)
+	@Operation(summary = "Create a new decapodes configuration")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "201", description = "Decapodes configuration created.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue creating the decapodes configuration", content = @Content)
+	})
+	ResponseEntity<DecapodesConfiguration> createDecapodesConfiguration(
+			@RequestBody DecapodesConfiguration config) {
+
+		try {
+			config = decapodesConfigurationService.createDecapodesConfiguration(config);
+			return ResponseEntity.status(HttpStatus.CREATED).body(config);
+		} catch (IOException e) {
+			final String error = "Unable to create decapodes configuration";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesConfigurationController.java
@@ -1,8 +1,6 @@
 package software.uncharted.terarium.hmiserver.controller.dataservice;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -21,10 +19,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -33,16 +27,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
-import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
-import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesConfiguration;
-import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceQueryParam;
-import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceType;
 import software.uncharted.terarium.hmiserver.security.Roles;
-import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
-import software.uncharted.terarium.hmiserver.service.data.ModelService;
 import software.uncharted.terarium.hmiserver.service.data.DecapodesConfigurationService;
-import software.uncharted.terarium.hmiserver.service.data.ProvenanceSearchService;
 
 @RequestMapping("/decapodes-configurations")
 @RestController
@@ -52,95 +39,28 @@ public class DecapodesConfigurationController {
 
 	final DecapodesConfigurationService decapodesConfigurationService;
 
-	final ModelService modelService;
-
-	final DocumentAssetService documentAssetService;
-
-	final ProvenanceSearchService provenanceSearchService;
-
-	final ObjectMapper objectMapper;
-
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
-	@Operation(summary = "Gets a model by ID")
+	@Operation(summary = "Gets a decapodes configuration by ID")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Model found.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
-			@ApiResponse(responseCode = "204", description = "There was no model found", content = @Content),
-			@ApiResponse(responseCode = "500", description = "There was an issue retrieving the model from the data store", content = @Content)
+			@ApiResponse(responseCode = "200", description = "Decapodes configuration found.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesConfiguration.class))),
+			@ApiResponse(responseCode = "204", description = "There was no decapodes configuration found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "There was an issue retrieving the decapodes configuration from the data store", content = @Content)
 	})
-	ResponseEntity<Model> getModel(@PathVariable("id") UUID id) {
+	ResponseEntity<DecapodesConfiguration> getDecapodesConfiguration(@PathVariable("id") UUID id) {
 
 		try {
 
-			// Fetch the model from the data-service
-			Optional<Model> model = modelService.getModel(id);
-			if (model.isEmpty()) {
+			// Fetch the decapodes configuration from the data-service
+			Optional<DecapodesConfiguration> configuration = decapodesConfigurationService.getDecapodesConfiguration(id);
+			if (configuration.isEmpty()) {
 				return ResponseEntity.noContent().build();
 			}
 
-			// Find the Document Assets linked via provenance to the model
-			ProvenanceQueryParam body = new ProvenanceQueryParam();
-			body.setRootId(id);
-			body.setRootType(ProvenanceType.MODEL);
-			body.setTypes(List.of(ProvenanceType.DOCUMENT));
-			final Set<String> documentIds = provenanceSearchService.modelsFromDocument(body);
-			if (!documentIds.isEmpty()) {
-				// Make sure we have an attributes list
-				if (model.get().getMetadata().getAttributes() == null)
-					model.get().getMetadata().setAttributes(new ArrayList<>());
-
-				documentIds.forEach(documentId -> {
-					try {
-						// Fetch the Document extractions
-						final Optional<DocumentAsset> document = documentAssetService
-								.getDocumentAsset(UUID.fromString(documentId));
-						if (document.isPresent()) {
-							final List<JsonNode> extractions = objectMapper.convertValue(
-									document.get().getMetadata().get("attributes"),
-									new TypeReference<List<JsonNode>>() {
-									});
-
-							// Append the Document extractions to the Model extractions, just for the
-							// front-end.
-							// Those are NOT to be saved back to the data-service.
-							model.get().getMetadata().getAttributes().addAll(extractions);
-						}
-					} catch (Exception e) {
-						log.error("Unable to get the document " + documentId, e);
-					}
-				});
-			} else {
-				log.debug("Unable to get the, or empty, provenance search models_from_document for model " + id);
-			}
-
-			// Return the model
-			return ResponseEntity.ok(model.get());
+			// Return the configuration
+			return ResponseEntity.ok(configuration.get());
 		} catch (IOException e) {
-			final String error = "Unable to get model";
-			log.error(error, e);
-			throw new ResponseStatusException(
-					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-					error);
-		}
-	}
-
-	@GetMapping("/search")
-	@Secured(Roles.USER)
-	@Operation(summary = "Search models with a query")
-	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Models found.", content = @Content(array = @ArraySchema(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class)))),
-			@ApiResponse(responseCode = "204", description = "There are no models found and no errors occurred", content = @Content),
-			@ApiResponse(responseCode = "500", description = "There was an issue retrieving models from the data store", content = @Content)
-	})
-	public ResponseEntity<List<Model>> searchModels(
-			@RequestBody JsonNode query,
-			@RequestParam(name = "page-size", defaultValue = "100", required = false) final Integer pageSize,
-			@RequestParam(name = "page", defaultValue = "0", required = false) final Integer page) {
-
-		try {
-			return ResponseEntity.ok(modelService.searchModels(page, pageSize, query));
-		} catch (IOException e) {
-			final String error = "Unable to search models";
+			final String error = "Unable to get decapodes configuration";
 			log.error(error, e);
 			throw new ResponseStatusException(
 					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
@@ -150,24 +70,24 @@ public class DecapodesConfigurationController {
 
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
-	@Operation(summary = "Update a model")
+	@Operation(summary = "Update a decapodes configuration")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Model updated.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
-			@ApiResponse(responseCode = "500", description = "There was an issue updating the model", content = @Content)
+			@ApiResponse(responseCode = "200", description = "Decapodes configuraiton updated.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesConfiguration.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue updating the decapodes configuration", content = @Content)
 	})
-	ResponseEntity<Model> updateModel(
+	ResponseEntity<DecapodesConfiguration> updateDecapodesConfiguration(
 			@PathVariable("id") UUID id,
-			@RequestBody Model model) {
+			@RequestBody DecapodesConfiguration configuration) {
 
 		try {
-			model.setId(id);
-			final Optional<Model> updated = modelService.updateModel(model);
+			configuration.setId(id);
+			final Optional<DecapodesConfiguration> updated = decapodesConfigurationService.updateDecapodesConfiguration(configuration);
 			if (updated.isEmpty()) {
 				return ResponseEntity.notFound().build();
 			}
 			return ResponseEntity.ok(updated.get());
 		} catch (IOException e) {
-			final String error = "Unable to update model";
+			final String error = "Unable to update decapodes configuration";
 			log.error(error, e);
 			throw new ResponseStatusException(
 					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
@@ -177,21 +97,21 @@ public class DecapodesConfigurationController {
 
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
-	@Operation(summary = "Deletes an model")
+	@Operation(summary = "Deletes an decapodes configuration")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Deleted model", content = {
+			@ApiResponse(responseCode = "200", description = "Deleted decapodes configuration", content = {
 					@Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDeleted.class)) }),
-			@ApiResponse(responseCode = "404", description = "Model could not be found", content = @Content),
+			@ApiResponse(responseCode = "404", description = "DecapodesConfiguration could not be found", content = @Content),
 			@ApiResponse(responseCode = "500", description = "An error occurred while deleting", content = @Content)
 	})
-	ResponseEntity<ResponseDeleted> deleteModel(
+	ResponseEntity<ResponseDeleted> deleteDecapodesConfiguration(
 			@PathVariable("id") UUID id) {
 
 		try {
-			modelService.deleteModel(id);
-			return ResponseEntity.ok(new ResponseDeleted("Model", id));
+			decapodesConfigurationService.deleteDecapodesConfiguration(id);
+			return ResponseEntity.ok(new ResponseDeleted("DecapodesConfiguration", id));
 		} catch (IOException e) {
-			final String error = "Unable to delete model";
+			final String error = "Unable to delete decapodes configuration";
 			log.error(error, e);
 			throw new ResponseStatusException(
 					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
@@ -203,7 +123,7 @@ public class DecapodesConfigurationController {
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new decapodes configuration")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "201", description = "Decapodes configuration created.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Model.class))),
+			@ApiResponse(responseCode = "201", description = "Decapodes configuration created.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesConfiguration.class))),
 			@ApiResponse(responseCode = "500", description = "There was an issue creating the decapodes configuration", content = @Content)
 	})
 	ResponseEntity<DecapodesConfiguration> createDecapodesConfiguration(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesContextController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DecapodesContextController.java
@@ -1,0 +1,142 @@
+package software.uncharted.terarium.hmiserver.controller.dataservice;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
+import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesContext;
+import software.uncharted.terarium.hmiserver.security.Roles;
+import software.uncharted.terarium.hmiserver.service.data.DecapodesContextService;
+
+@RequestMapping("/decapodes-contexts")
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class DecapodesContextController {
+
+	final DecapodesContextService decapodesContextService;
+
+	@GetMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Gets a decapodes context by ID")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Decapodes context found.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesContext.class))),
+			@ApiResponse(responseCode = "204", description = "There was no decapodes context found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "There was an issue retrieving the decapodes context from the data store", content = @Content)
+	})
+	ResponseEntity<DecapodesContext> getDecapodesContext(@PathVariable("id") UUID id) {
+
+		try {
+
+			// Fetch the decapodes context from the data-service
+			Optional<DecapodesContext> context = decapodesContextService.getDecapodesContext(id);
+			if (context.isEmpty()) {
+				return ResponseEntity.noContent().build();
+			}
+
+			return ResponseEntity.ok(context.get());
+		} catch (IOException e) {
+			final String error = "Unable to get decapodes context";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@PutMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Update a decapodes context")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Decapodes context updated.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesContext.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue updating the decapodes context", content = @Content)
+	})
+	ResponseEntity<DecapodesContext> updateDecapodesContext(
+			@PathVariable("id") UUID id,
+			@RequestBody DecapodesContext context) {
+
+		try {
+			context.setId(id);
+			final Optional<DecapodesContext> updated = decapodesContextService.updateDecapodesContext(context);
+			if (updated.isEmpty()) {
+				return ResponseEntity.notFound().build();
+			}
+			return ResponseEntity.ok(updated.get());
+		} catch (IOException e) {
+			final String error = "Unable to update decapodes context";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@DeleteMapping("/{id}")
+	@Secured(Roles.USER)
+	@Operation(summary = "Deletes an decapodes context")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Deleted decapodes context", content = {
+					@Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ResponseDeleted.class)) }),
+			@ApiResponse(responseCode = "404", description = "DecapodesContext could not be found", content = @Content),
+			@ApiResponse(responseCode = "500", description = "An error occurred while deleting", content = @Content)
+	})
+	ResponseEntity<ResponseDeleted> deleteDecapodesContext(
+			@PathVariable("id") UUID id) {
+
+		try {
+			decapodesContextService.deleteDecapodesContext(id);
+			return ResponseEntity.ok(new ResponseDeleted("DecapodesContext", id));
+		} catch (IOException e) {
+			final String error = "Unable to delete decapodes context";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+	@PostMapping
+	@Secured(Roles.USER)
+	@Operation(summary = "Create a new decapodes context")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "201", description = "Decapodes context created.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DecapodesContext.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue creating the decapodes context", content = @Content)
+	})
+	ResponseEntity<DecapodesContext> createDecapodesContext(
+			@RequestBody DecapodesContext context) {
+
+		try {
+			context = decapodesContextService.createDecapodesContext(context);
+			return ResponseEntity.status(HttpStatus.CREATED).body(context);
+		} catch (IOException e) {
+			final String error = "Unable to create decapodes context";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/ModelConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/ModelConfiguration.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
+import com.fasterxml.jackson.databind.JsonNode;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 import software.uncharted.terarium.hmiserver.models.SupportAdditionalProperties;
@@ -26,6 +27,6 @@ public class ModelConfiguration extends TerariumAsset implements SupportAddition
 	@JsonProperty("model_id")
 	private UUID modelId;
 
-	private Object configuration;
+	private JsonNode configuration;
 
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/ModelConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/ModelConfiguration.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
-import com.fasterxml.jackson.databind.JsonNode;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 import software.uncharted.terarium.hmiserver.models.SupportAdditionalProperties;
@@ -27,6 +26,6 @@ public class ModelConfiguration extends TerariumAsset implements SupportAddition
 	@JsonProperty("model_id")
 	private UUID modelId;
 
-	private JsonNode configuration;
+	private Object configuration;
 
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Configuration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Configuration.java
@@ -1,0 +1,25 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class Configuration implements Serializable {
+
+	private Map<String, ConfigurationParameter> parameters;
+
+	@JsonAlias("initial_conditions")
+	private Map<String, ConfigurationCondition> initialConditions;
+
+	@JsonAlias("boundary_conditions")
+	private Map<String, ConfigurationCondition> boundryConditions;
+
+	private Map<String, ConfigurationDataset> datasets;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Configuration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Configuration.java
@@ -1,6 +1,5 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationCondition.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationCondition.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 @Accessors(chain = true)
 @TSModel
 public class ConfigurationCondition implements Serializable {
+	private String _type;
 	private String type;
 	private String value;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationCondition.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationCondition.java
@@ -1,0 +1,19 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ConfigurationCondition implements Serializable {
+	private String type;
+	private String value;
+
+	@JsonAlias("domain_mesh")
+	private String domainMesh;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDataset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDataset.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 @Accessors(chain = true)
 @TSModel
 public class ConfigurationDataset implements Serializable {
+	private String _type;
 	private String type;
 	private String name;
 	private String description;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDataset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDataset.java
@@ -1,0 +1,23 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import java.util.List;
+import java.lang.Number;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import lombok.experimental.Accessors;
+import java.io.Serializable;
+
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ConfigurationDataset implements Serializable {
+	private String type;
+	private String name;
+	private String description;
+
+	private ConfigurationDatasetFile file;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 @Accessors(chain = true)
 @TSModel
 public class ConfigurationDatasetFile implements Serializable {
+	private String _type;
 	private String uri;
 	private String format;
 	private List<Number> shape;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
@@ -3,7 +3,6 @@ package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 import java.util.List;
 import java.lang.Number;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationDatasetFile.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import java.util.List;
+import java.lang.Number;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import lombok.experimental.Accessors;
+import java.io.Serializable;
+
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ConfigurationDatasetFile implements Serializable {
+	private String uri;
+	private String format;
+	private List<Number> shape;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationHeader.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationHeader.java
@@ -1,12 +1,10 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import java.io.Serializable;
-import java.util.Map;
 
 @Data
 @Accessors(chain = true)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationHeader.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationHeader.java
@@ -1,0 +1,21 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ConfigurationHeader implements Serializable {
+	private String id;
+	private String description;
+	private String name;
+
+	@JsonAlias("parentContext")
+	private String parentContext;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationParameter.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationParameter.java
@@ -1,6 +1,5 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -11,6 +10,7 @@ import java.io.Serializable;
 @Accessors(chain = true)
 @TSModel
 public class ConfigurationParameter implements Serializable {
+	private String _type;
 	private String type;
 	private Object value;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationParameter.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ConfigurationParameter.java
@@ -1,0 +1,16 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ConfigurationParameter implements Serializable {
+	private String type;
+	private Object value;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
@@ -1,6 +1,5 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -14,7 +13,7 @@ import java.util.List;
 @TSModel
 public class Context implements Serializable {
 
-	private Object constants;
+	private Map<String, ContextConstant> constants;
 
 	@JsonAlias("spatial_constraints")
 	private Object spatialConstraints;
@@ -23,10 +22,10 @@ public class Context implements Serializable {
 	private Object temporalConstraints;
 
 	@JsonAlias("primal_dual_relations")
-	private List<Object> primalDualRelations;
+	private List<ContextPrimalDualRelation> primalDualRelations;
 
 	@JsonAlias("mesh_submesh_relations")
-	private List<Object> meshSubmeshRelations;
+	private List<ContextMeshSubmeshRelation> meshSubmeshRelations;
 
-	private List<Object> meshes;
+	private List<ContextMesh> meshes;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
@@ -1,0 +1,32 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class Context implements Serializable {
+
+	private Object constants;
+
+	@JsonAlias("spatial_constraints")
+	private Object spatialConstraints;
+
+	@JsonAlias("temporal_constraints")
+	private Object temporalConstraints;
+
+	@JsonAlias("primal_dual_relations")
+	private List<Object> primalDualRelations;
+
+	@JsonAlias("mesh_submesh_relations")
+	private List<Object> meshSubmeshRelations;
+
+	private List<Object> meshes;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/Context.java
@@ -3,6 +3,7 @@ package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
+import com.fasterxml.jackson.databind.JsonNode;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import java.io.Serializable;
 import java.util.Map;
@@ -16,10 +17,10 @@ public class Context implements Serializable {
 	private Map<String, ContextConstant> constants;
 
 	@JsonAlias("spatial_constraints")
-	private Object spatialConstraints;
+	private JsonNode spatialConstraints;
 
 	@JsonAlias("temporal_constraints")
-	private Object temporalConstraints;
+	private JsonNode temporalConstraints;
 
 	@JsonAlias("primal_dual_relations")
 	private List<ContextPrimalDualRelation> primalDualRelations;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextConstant.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextConstant.java
@@ -9,11 +9,7 @@ import java.io.Serializable;
 @Data
 @Accessors(chain = true)
 @TSModel
-public class ConfigurationCondition implements Serializable {
+public class ContextConstant implements Serializable {
 	private String _type;
-	private String type;
-	private String value;
-
-	@JsonAlias("domain_mesh")
-	private String domainMesh;
+	private Object value;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextFile.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextFile.java
@@ -9,11 +9,7 @@ import java.io.Serializable;
 @Data
 @Accessors(chain = true)
 @TSModel
-public class ConfigurationCondition implements Serializable {
-	private String _type;
-	private String type;
-	private String value;
-
-	@JsonAlias("domain_mesh")
-	private String domainMesh;
+public class ContextFile implements Serializable {
+	private String uri;
+	private String format;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
@@ -1,12 +1,10 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import java.io.Serializable;
-import java.util.Map;
 
 @Data
 @Accessors(chain = true)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
@@ -11,11 +11,11 @@ import java.util.Map;
 @Data
 @Accessors(chain = true)
 @TSModel
-public class ConfigurationHeader implements Serializable {
+public class ContextHeader implements Serializable {
 	private String id;
 	private String description;
 	private String name;
 
-	@JsonAlias("parent_context")
+	@JsonAlias("parent_model")
 	private String parentContext;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextHeader.java
@@ -15,5 +15,5 @@ public class ContextHeader implements Serializable {
 	private String name;
 
 	@JsonAlias("parent_model")
-	private String parentContext;
+	private String parentModel;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextMesh.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextMesh.java
@@ -1,0 +1,35 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class ContextMesh implements Serializable {
+	private String id;
+	private String description;
+	private Object dimensionality;
+
+	@JsonAlias("vertex_count")
+	private Long vertexCount;
+
+	@JsonAlias("edge_count")
+	private Long edgeCount;
+
+	@JsonAlias("face_count")
+	private Long faceCount;
+
+	@JsonAlias("volume_count")
+	private Long volumeCount;
+
+	private List<Object> regions;
+
+	private String checksum;
+
+	private ContextFile file;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextMeshSubmeshRelation.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextMeshSubmeshRelation.java
@@ -9,11 +9,8 @@ import java.io.Serializable;
 @Data
 @Accessors(chain = true)
 @TSModel
-public class ConfigurationCondition implements Serializable {
-	private String _type;
-	private String type;
-	private String value;
-
-	@JsonAlias("domain_mesh")
-	private String domainMesh;
+public class ContextMeshSubmeshRelation implements Serializable {
+	private String mesh;
+	private String submesh;
+	private Object relation;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextPrimalDualRelation.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextPrimalDualRelation.java
@@ -9,11 +9,8 @@ import java.io.Serializable;
 @Data
 @Accessors(chain = true)
 @TSModel
-public class ConfigurationCondition implements Serializable {
-	private String _type;
-	private String type;
-	private String value;
-
-	@JsonAlias("domain_mesh")
-	private String domainMesh;
+public class ContextPrimalDualRelation implements Serializable {
+	private String primal;
+	private String dual;
+	private Object method;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextPrimalDualRelation.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/ContextPrimalDualRelation.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.experimental.Accessors;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import java.io.Serializable;
@@ -12,5 +13,5 @@ import java.io.Serializable;
 public class ContextPrimalDualRelation implements Serializable {
 	private String primal;
 	private String dual;
-	private Object method;
+	private JsonNode method;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
@@ -1,0 +1,17 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import java.io.Serializable;
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class DecapodesConfiguration implements Serializable {
+	private ConfigurationHeader header;
+	private Configuration configuration;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
@@ -1,17 +1,21 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import jakarta.persistence.*;
 import com.fasterxml.jackson.annotation.JsonAlias;
-import lombok.Data;
-import lombok.experimental.Accessors;
-import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import jakarta.persistence.*;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.UUID;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.models.SupportAdditionalProperties;
+import software.uncharted.terarium.hmiserver.models.dataservice.TerariumAsset;
 
 @Data
 @Accessors(chain = true)
 @TSModel
-public class DecapodesConfiguration implements Serializable {
+public class DecapodesConfiguration extends TerariumAsset implements Serializable {
 	private ConfigurationHeader header;
 	private Configuration configuration;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesConfiguration.java
@@ -1,15 +1,10 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import jakarta.persistence.*;
 import java.io.Serializable;
-import java.util.Map;
-import java.util.UUID;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
-import software.uncharted.terarium.hmiserver.models.SupportAdditionalProperties;
 import software.uncharted.terarium.hmiserver.models.dataservice.TerariumAsset;
 
 @Data

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesContext.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesContext.java
@@ -1,10 +1,7 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
-import jakarta.persistence.*;
 import java.io.Serializable;
-import java.util.Map;
-import java.util.UUID;
 import lombok.Data;
 import lombok.experimental.Accessors;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesContext.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/multiphysics/DecapodesContext.java
@@ -1,0 +1,20 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.multiphysics;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.models.dataservice.TerariumAsset;
+
+@Data
+@Accessors(chain = true)
+@TSModel
+public class DecapodesContext extends TerariumAsset implements Serializable {
+	private ContextHeader header;
+	private Context context;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesConfigurationService.java
@@ -1,0 +1,81 @@
+package software.uncharted.terarium.hmiserver.service.data;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import co.elastic.clients.elasticsearch._types.FieldSort;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import lombok.RequiredArgsConstructor;
+import software.uncharted.terarium.hmiserver.configuration.ElasticsearchConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.model.ModelConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesConfiguration;
+import software.uncharted.terarium.hmiserver.service.elasticsearch.ElasticsearchService;
+
+@Service
+@RequiredArgsConstructor
+public class DecapodesConfigurationService {
+
+	private final ElasticsearchService elasticService;
+	private final ElasticsearchConfiguration elasticConfig;
+
+	public List<DecapodesConfiguration> getDecapodesConfigurations(Integer page, Integer pageSize)
+			throws IOException {
+
+		final SearchRequest req = new SearchRequest.Builder()
+				.index(elasticConfig.getDecapodesConfigurationIndex())
+				.size(pageSize)
+				.query(q -> q.bool(b -> b.mustNot(mn -> mn.exists(e -> e.field("deletedOn")))))
+				.sort(new SortOptions.Builder()
+						.field(new FieldSort.Builder().field("timestamp").order(SortOrder.Asc).build()).build())
+				.build();
+
+		return elasticService.search(req, DecapodesConfiguration.class);
+	}
+
+	public Optional<DecapodesConfiguration> getDecapodesConfiguration(UUID id) throws IOException {
+		DecapodesConfiguration doc = elasticService.get(elasticConfig.getDecapodesConfigurationIndex(), id.toString(),
+				DecapodesConfiguration.class);
+		if (doc != null && doc.getDeletedOn() == null) {
+			return Optional.of(doc);
+		}
+		return Optional.empty();
+	}
+
+	public void deleteDecapodesConfiguration(UUID id) throws IOException {
+		Optional<DecapodesConfiguration> decapodesConfiguration = getDecapodesConfiguration(id);
+		if (decapodesConfiguration.isEmpty()) {
+			return;
+		}
+		decapodesConfiguration.get().setDeletedOn(Timestamp.from(Instant.now()));
+		updateDecapodesConfiguration(decapodesConfiguration.get());
+	}
+
+	public DecapodesConfiguration createDecapodesConfiguration(DecapodesConfiguration decapodesConfiguration) throws IOException {
+		decapodesConfiguration.setCreatedOn(Timestamp.from(Instant.now()));
+		elasticService.index(elasticConfig.getDecapodesConfigurationIndex(),
+				decapodesConfiguration.setId(UUID.randomUUID()).getId().toString(),
+				decapodesConfiguration);
+		return decapodesConfiguration;
+	}
+
+	public Optional<DecapodesConfiguration> updateDecapodesConfiguration(DecapodesConfiguration decapodesConfiguration)
+			throws IOException {
+		if (!elasticService.contains(elasticConfig.getDecapodesConfigurationIndex(),
+				decapodesConfiguration.getId().toString())) {
+			return Optional.empty();
+		}
+		decapodesConfiguration.setUpdatedOn(Timestamp.from(Instant.now()));
+		elasticService.index(elasticConfig.getDecapodesConfigurationIndex(), decapodesConfiguration.getId().toString(),
+				decapodesConfiguration);
+		return Optional.of(decapodesConfiguration);
+	}
+
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesConfigurationService.java
@@ -15,7 +15,6 @@ import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import lombok.RequiredArgsConstructor;
 import software.uncharted.terarium.hmiserver.configuration.ElasticsearchConfiguration;
-import software.uncharted.terarium.hmiserver.models.dataservice.model.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesConfiguration;
 import software.uncharted.terarium.hmiserver.service.elasticsearch.ElasticsearchService;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesContextService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DecapodesContextService.java
@@ -1,0 +1,80 @@
+package software.uncharted.terarium.hmiserver.service.data;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import co.elastic.clients.elasticsearch._types.FieldSort;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import lombok.RequiredArgsConstructor;
+import software.uncharted.terarium.hmiserver.configuration.ElasticsearchConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.multiphysics.DecapodesContext;
+import software.uncharted.terarium.hmiserver.service.elasticsearch.ElasticsearchService;
+
+@Service
+@RequiredArgsConstructor
+public class DecapodesContextService {
+
+	private final ElasticsearchService elasticService;
+	private final ElasticsearchConfiguration elasticConfig;
+
+	public List<DecapodesContext> getDecapodesContexts(Integer page, Integer pageSize)
+			throws IOException {
+
+		final SearchRequest req = new SearchRequest.Builder()
+				.index(elasticConfig.getDecapodesContextIndex())
+				.size(pageSize)
+				.query(q -> q.bool(b -> b.mustNot(mn -> mn.exists(e -> e.field("deletedOn")))))
+				.sort(new SortOptions.Builder()
+						.field(new FieldSort.Builder().field("timestamp").order(SortOrder.Asc).build()).build())
+				.build();
+
+		return elasticService.search(req, DecapodesContext.class);
+	}
+
+	public Optional<DecapodesContext> getDecapodesContext(UUID id) throws IOException {
+		DecapodesContext doc = elasticService.get(elasticConfig.getDecapodesContextIndex(), id.toString(),
+				DecapodesContext.class);
+		if (doc != null && doc.getDeletedOn() == null) {
+			return Optional.of(doc);
+		}
+		return Optional.empty();
+	}
+
+	public void deleteDecapodesContext(UUID id) throws IOException {
+		Optional<DecapodesContext> decapodesContext = getDecapodesContext(id);
+		if (decapodesContext.isEmpty()) {
+			return;
+		}
+		decapodesContext.get().setDeletedOn(Timestamp.from(Instant.now()));
+		updateDecapodesContext(decapodesContext.get());
+	}
+
+	public DecapodesContext createDecapodesContext(DecapodesContext decapodesContext) throws IOException {
+		decapodesContext.setCreatedOn(Timestamp.from(Instant.now()));
+		elasticService.index(elasticConfig.getDecapodesContextIndex(),
+				decapodesContext.setId(UUID.randomUUID()).getId().toString(),
+				decapodesContext);
+		return decapodesContext;
+	}
+
+	public Optional<DecapodesContext> updateDecapodesContext(DecapodesContext decapodesContext)
+			throws IOException {
+		if (!elasticService.contains(elasticConfig.getDecapodesContextIndex(),
+				decapodesContext.getId().toString())) {
+			return Optional.empty();
+		}
+		decapodesContext.setUpdatedOn(Timestamp.from(Instant.now()));
+		elasticService.index(elasticConfig.getDecapodesContextIndex(), decapodesContext.getId().toString(),
+				decapodesContext);
+		return Optional.of(decapodesContext);
+	}
+
+}

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -25,6 +25,8 @@ terarium.elasticsearch.index.notebook-session-root=notebooksession
 terarium.elasticsearch.index.simulation-root=simulation
 terarium.elasticsearch.index.workflow-root=workflow
 terarium.elasticsearch.index.external-publication=externalpublication
+terarium.elasticsearch.index.decapodes-configuration-root=decapodesconfiguration
+terarium.elasticsearch.index.decapodes-context-root=decapodescontext
 management.health.elasticsearch.enabled=false
 
 ########################################################################################################################

--- a/packages/server/src/main/resources/static/es/index-templates/tds_1.0_decapodes_configuration_index_template.json
+++ b/packages/server/src/main/resources/static/es/index-templates/tds_1.0_decapodes_configuration_index_template.json
@@ -1,0 +1,262 @@
+{
+    "index_patterns": [
+        "*_decapodesconfiguration_tera_1.0"
+    ],
+    "version": 1,
+    "priority": 500,
+    "_meta": {
+        "description": "This index template is the standard template for all Terarium DECAPODES CONFIGURATION indices"
+    },
+    "template": {
+        "settings": {
+            "index": {
+                "number_of_shards": 16,
+                "number_of_replicas": 1,
+                "refresh_interval": "1s"
+            },
+            "analysis": {
+                "analyzer": {
+                    "english_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "standard",
+                        "char_filter": [
+                            "html_strip"
+                        ],
+                        "filter": [
+                            "english_possessive_stemmer",
+                            "lowercase",
+                            "word_delimiter",
+                            "english_stop",
+                            "english_stemmer"
+                        ]
+                    }
+                },
+                "normalizer": {
+                    "lowercase_normalizer": {
+                        "type": "custom",
+                        "filter": [
+                            "lowercase"
+                        ]
+                    },
+                    "domain_normalizer": {
+                        "type": "custom",
+                        "char_filter": [
+                            "exclude_url_prefix",
+                            "exclude_url_portandsuffix",
+                            "exclude_subdomain_from_hostname"
+                        ]
+                    },
+                    "hostname_normalizer": {
+                        "type": "custom",
+                        "char_filter": [
+                            "exclude_url_prefix",
+                            "exclude_url_portandsuffix"
+                        ]
+                    }
+                },
+                "filter": {
+                    "english_stemmer": {
+                        "type": "stemmer",
+                        "language": "english"
+                    },
+                    "english_stop": {
+                        "type": "stop",
+                        "stopwords": "_english_"
+                    },
+                    "english_possessive_stemmer": {
+                        "type": "stemmer",
+                        "language": "possessive_english"
+                    }
+                },
+                "char_filter": {
+                    "digits_only": {
+                        "type": "pattern_replace",
+                        "pattern": "(\\D)",
+                        "replacement": ""
+                    },
+                    "wordchars_only": {
+                        "type": "pattern_replace",
+                        "pattern": "(\\W)",
+                        "replacement": ""
+                    },
+                    "exclude_url_prefix": {
+                        "flags": "CASE_INSENSITIVE",
+                        "type": "pattern_replace",
+                        "pattern": "((https?)|(ftp))://",
+                        "replacement": ""
+                    },
+                    "exclude_url_portandsuffix": {
+                        "type": "pattern_replace",
+                        "pattern": "(:|/).*",
+                        "replacement": ""
+                    },
+                    "exclude_subdomain_from_hostname": {
+                        "type": "pattern_replace",
+                        "pattern": "^([\\w\\-]+)\\.(?=([\\w\\-]+)\\.([\\w\\-]+))",
+                        "replacement": ""
+                    }
+                }
+            }
+        },
+        "mappings": {
+            "dynamic_templates": [
+                {
+                    "url_feature": {
+                        "path_match": "feature.url*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "normalizer": "lowercase_normalizer",
+                            "fields": {
+                                "domain": {
+                                    "normalizer": "domain_normalizer",
+                                    "type": "keyword"
+                                },
+                                "hostname": {
+                                    "normalizer": "hostname_normalizer",
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "website_feature": {
+                        "path_match": "feature.website*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "eager_global_ordinals": true,
+                            "fields": {
+                                "domain": {
+                                    "normalizer": "domain_normalizer",
+                                    "type": "keyword"
+                                },
+                                "hostname": {
+                                    "normalizer": "hostname_normalizer",
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "extra_text_feature": {
+                        "path_match": "feature.extra_body_text*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 2048,
+                            "fields": {
+                                "fuzzy": {
+                                    "type": "text",
+                                    "analyzer": "english_analyzer"
+                                },
+                                "language_en": {
+                                    "analyzer": "english_analyzer",
+                                    "type": "text"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "string_features": {
+                        "path_match": "feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "eager_global_ordinals": true
+                        }
+                    }
+                },
+                {
+                    "analyzed_string_features": {
+                        "path_match": "analyzed_feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "text",
+                            "analyzer": "english_analyzer",
+                            "fields": {
+                                "exact": {
+                                    "type": "keyword",
+                                    "ignore_above": 512
+                                },
+                                "language_en": {
+                                    "analyzer": "english_analyzer",
+                                    "type": "text"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "integer_features": {
+                        "path_match": "integer_feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                {
+                    "flat_features": {
+                        "path_match": "flat_feature.*",
+                        "mapping": {
+                            "type": "flattened",
+                            "index": false
+                        }
+                    }
+                },
+                {
+                    "dense_vectors": {
+                        "path_match": "vector_feature.*",
+                        "mapping": {
+                            "type": "dense_vector",
+                            "dims": 768,
+                            "index": true,
+                            "similarity": "dot_product"
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "header": {
+                  "properties": {
+                      "id": {
+                          "type": "keyword"
+                      },
+                      "name": {
+                          "type": "text",
+                          "fields": {
+                              "keyword": {
+                                  "type": "keyword",
+                                  "ignore_above": 256
+                              }
+                          }
+                      },
+                      "description": {
+                          "type": "text",
+                          "fields": {
+                              "keyword": {
+                                  "type": "keyword",
+                                  "ignore_above": 256
+                              }
+                          }
+                      },
+                      "parent_context": {
+                          "type": "keyword"
+                      }
+                  }
+                },
+                "configuration": {
+                    "type": "object",
+                    "enabled": false
+                }
+            }
+        }
+    }
+}

--- a/packages/server/src/main/resources/static/es/index-templates/tds_1.0_decapodes_context_index_template.json
+++ b/packages/server/src/main/resources/static/es/index-templates/tds_1.0_decapodes_context_index_template.json
@@ -1,0 +1,262 @@
+{
+    "index_patterns": [
+        "*_decapodescontext_tera_1.0"
+    ],
+    "version": 1,
+    "priority": 500,
+    "_meta": {
+        "description": "This index template is the standard template for all Terarium DECAPODES CONTEXT indices"
+    },
+    "template": {
+        "settings": {
+            "index": {
+                "number_of_shards": 16,
+                "number_of_replicas": 1,
+                "refresh_interval": "1s"
+            },
+            "analysis": {
+                "analyzer": {
+                    "english_analyzer": {
+                        "type": "custom",
+                        "tokenizer": "standard",
+                        "char_filter": [
+                            "html_strip"
+                        ],
+                        "filter": [
+                            "english_possessive_stemmer",
+                            "lowercase",
+                            "word_delimiter",
+                            "english_stop",
+                            "english_stemmer"
+                        ]
+                    }
+                },
+                "normalizer": {
+                    "lowercase_normalizer": {
+                        "type": "custom",
+                        "filter": [
+                            "lowercase"
+                        ]
+                    },
+                    "domain_normalizer": {
+                        "type": "custom",
+                        "char_filter": [
+                            "exclude_url_prefix",
+                            "exclude_url_portandsuffix",
+                            "exclude_subdomain_from_hostname"
+                        ]
+                    },
+                    "hostname_normalizer": {
+                        "type": "custom",
+                        "char_filter": [
+                            "exclude_url_prefix",
+                            "exclude_url_portandsuffix"
+                        ]
+                    }
+                },
+                "filter": {
+                    "english_stemmer": {
+                        "type": "stemmer",
+                        "language": "english"
+                    },
+                    "english_stop": {
+                        "type": "stop",
+                        "stopwords": "_english_"
+                    },
+                    "english_possessive_stemmer": {
+                        "type": "stemmer",
+                        "language": "possessive_english"
+                    }
+                },
+                "char_filter": {
+                    "digits_only": {
+                        "type": "pattern_replace",
+                        "pattern": "(\\D)",
+                        "replacement": ""
+                    },
+                    "wordchars_only": {
+                        "type": "pattern_replace",
+                        "pattern": "(\\W)",
+                        "replacement": ""
+                    },
+                    "exclude_url_prefix": {
+                        "flags": "CASE_INSENSITIVE",
+                        "type": "pattern_replace",
+                        "pattern": "((https?)|(ftp))://",
+                        "replacement": ""
+                    },
+                    "exclude_url_portandsuffix": {
+                        "type": "pattern_replace",
+                        "pattern": "(:|/).*",
+                        "replacement": ""
+                    },
+                    "exclude_subdomain_from_hostname": {
+                        "type": "pattern_replace",
+                        "pattern": "^([\\w\\-]+)\\.(?=([\\w\\-]+)\\.([\\w\\-]+))",
+                        "replacement": ""
+                    }
+                }
+            }
+        },
+        "mappings": {
+            "dynamic_templates": [
+                {
+                    "url_feature": {
+                        "path_match": "feature.url*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "normalizer": "lowercase_normalizer",
+                            "fields": {
+                                "domain": {
+                                    "normalizer": "domain_normalizer",
+                                    "type": "keyword"
+                                },
+                                "hostname": {
+                                    "normalizer": "hostname_normalizer",
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "website_feature": {
+                        "path_match": "feature.website*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "eager_global_ordinals": true,
+                            "fields": {
+                                "domain": {
+                                    "normalizer": "domain_normalizer",
+                                    "type": "keyword"
+                                },
+                                "hostname": {
+                                    "normalizer": "hostname_normalizer",
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "extra_text_feature": {
+                        "path_match": "feature.extra_body_text*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 2048,
+                            "fields": {
+                                "fuzzy": {
+                                    "type": "text",
+                                    "analyzer": "english_analyzer"
+                                },
+                                "language_en": {
+                                    "analyzer": "english_analyzer",
+                                    "type": "text"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "string_features": {
+                        "path_match": "feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword",
+                            "ignore_above": 512,
+                            "eager_global_ordinals": true
+                        }
+                    }
+                },
+                {
+                    "analyzed_string_features": {
+                        "path_match": "analyzed_feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "text",
+                            "analyzer": "english_analyzer",
+                            "fields": {
+                                "exact": {
+                                    "type": "keyword",
+                                    "ignore_above": 512
+                                },
+                                "language_en": {
+                                    "analyzer": "english_analyzer",
+                                    "type": "text"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "integer_features": {
+                        "path_match": "integer_feature.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                {
+                    "flat_features": {
+                        "path_match": "flat_feature.*",
+                        "mapping": {
+                            "type": "flattened",
+                            "index": false
+                        }
+                    }
+                },
+                {
+                    "dense_vectors": {
+                        "path_match": "vector_feature.*",
+                        "mapping": {
+                            "type": "dense_vector",
+                            "dims": 768,
+                            "index": true,
+                            "similarity": "dot_product"
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "header": {
+                  "properties": {
+                      "id": {
+                          "type": "keyword"
+                      },
+                      "name": {
+                          "type": "text",
+                          "fields": {
+                              "keyword": {
+                                  "type": "keyword",
+                                  "ignore_above": 256
+                              }
+                          }
+                      },
+                      "description": {
+                          "type": "text",
+                          "fields": {
+                              "keyword": {
+                                  "type": "keyword",
+                                  "ignore_above": 256
+                              }
+                          }
+                      },
+                      "parent_model": {
+                          "type": "keyword"
+                      }
+                  }
+                },
+                "context": {
+                    "type": "object",
+                    "enabled": false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
Add objects for decapode configuration and decapodes context and decapodes configuration.

Some fields are captured as Object, since the fields captures disjunctive typing. e.g. `{ value: 123, format: 'x' }` or `{ uri: 'abc' }` or `8` ... they can be typed out more carefully if needed, but most of these objects are just pass-throughs.


### Testing
CRUD operations of configuration/context through swagger-ui.