### PR TITLE
fix: better default camera positioning

### DIFF
--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -18,8 +18,8 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 	const g = new dagre.graphlib.Graph({ compound: true });
 	g.setGraph({});
 	g.setDefaultEdgeLabel(() => ({}));
-	let nodeWidth;
-	let nodeHeight;
+	let nodeWidth: number = 0;
+	let nodeHeight: number = 0;
 
 	graphScaffolder.traverseGraph(graphData, (node: INode<V>) => {
 		if (node.width && node.height) {
@@ -101,10 +101,17 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 		let maxY = Number.MIN_VALUE;
 		graphData.nodes.forEach((node) => {
 			if (node.x < minX) minX = node.x;
-			if (node.x > maxX) maxX = node.x;
+			if (node.x + node.width > maxX) maxX = node.x + node.width;
 			if (node.y < minY) minY = node.y;
-			if (node.y > maxY) maxY = node.y;
+			if (node.y + node.height > maxY) maxY = node.y + node.height;
 		});
+
+		// Give the bounds a little extra buffer
+		const buffer = 5;
+		maxX += buffer;
+		maxY += buffer;
+		minX -= buffer;
+		minY -= buffer;
 
 		graphData.width = Math.abs(maxX - minX) + 2 * nodeWidth;
 		graphData.height = Math.abs(maxY - minY) + 2 * nodeHeight;

--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -18,8 +18,6 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 	const g = new dagre.graphlib.Graph({ compound: true });
 	g.setGraph({});
 	g.setDefaultEdgeLabel(() => ({}));
-	let nodeWidth: number = 0;
-	let nodeHeight: number = 0;
 
 	graphScaffolder.traverseGraph(graphData, (node: INode<V>) => {
 		if (node.width && node.height) {
@@ -30,12 +28,8 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 				x: node.x,
 				y: node.y
 			});
-			nodeWidth = node.width;
-			nodeHeight = node.height;
 		} else {
 			g.setNode(node.id, { label: node.label, x: node.x, y: node.y });
-			nodeWidth = node.width;
-			nodeHeight = node.height;
 		}
 		if (!_.isEmpty(node.nodes)) {
 			// eslint-disable-next-line
@@ -100,21 +94,21 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 		let minY = Number.MAX_VALUE;
 		let maxY = Number.MIN_VALUE;
 		graphData.nodes.forEach((node) => {
-			if (node.x < minX) minX = node.x;
-			if (node.x + node.width > maxX) maxX = node.x + node.width;
-			if (node.y < minY) minY = node.y;
-			if (node.y + node.height > maxY) maxY = node.y + node.height;
+			if (node.x - 0.5 * node.width < minX) minX = node.x - 0.5 * node.width;
+			if (node.x + 0.5 * node.width > maxX) maxX = node.x + 0.5 * node.width;
+			if (node.y - 0.5 * node.height < minY) minY = node.y - 0.5 * node.height;
+			if (node.y + 0.5 * node.height > maxY) maxY = node.y + 0.5 * node.height;
 		});
 
 		// Give the bounds a little extra buffer
-		const buffer = 5;
+		const buffer = 10;
 		maxX += buffer;
 		maxY += buffer;
 		minX -= buffer;
 		minY -= buffer;
 
-		graphData.width = Math.abs(maxX - minX) + 2 * nodeWidth;
-		graphData.height = Math.abs(maxY - minY) + 2 * nodeHeight;
+		graphData.width = Math.abs(maxX - minX);
+		graphData.height = Math.abs(maxY - minY);
 	}
 
 	return graphData;


### PR DESCRIPTION
### Summary
Better camera positioning to capture entire graph, this solves the problems where sometimes the nodes are chopped off because the dimensionalities of the nodes themselves are not accounted for in the final bounding box.

SIR: 

<img width="187" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/ff5a73d4-3699-4194-9220-1c8ae9b7c54d">

SEIRD:

<img width="181" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/f2a3e3ad-072a-47c6-ae0d-6e391aed9c8a">
