### PR TITLE
Small fixes. Add cache bust to puill latest GoLLM in taskrunner build

### DIFF
--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
@@ -10,12 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithUserDetails;
 
+import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
 import software.uncharted.terarium.hmiserver.configuration.MockUser;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 
+@Slf4j
 public class TaskServiceTest extends TerariumApplicationTests {
 
 	@Autowired
@@ -106,7 +108,7 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		req.setScript("gollm:model_card");
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req);
+		List<TaskResponse> responses = taskService.runTaskBlocking(req, 300);
 
 		Assertions.assertEquals(3, responses.size());
 		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
@@ -116,6 +118,8 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		for (TaskResponse resp : responses) {
 			Assertions.assertEquals(taskId, resp.getId());
 		}
+
+		log.info(new String(responses.get(responses.size() - 1).getOutput()));
 	}
 
 	// @Test

--- a/packages/taskrunner/docker/Dockerfile.GoLLM
+++ b/packages/taskrunner/docker/Dockerfile.GoLLM
@@ -14,19 +14,6 @@ FROM python:3.10-slim
 
 WORKDIR /
 
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends wget && \
-	rm -rf /var/lib/apt/lists/*
-
-RUN wget -O gollm.tar.gz https://github.com/DARPA-ASKEM/GoLLM/archive/refs/heads/main.tar.gz && \
-	tar -zxvf gollm.tar.gz && \
-	mv GoLLM-* GoLLM
-
-WORKDIR /GoLLM
-
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install -e .
-
 # Install OpenJDK JRE
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends openjdk-17-jre-headless && \
@@ -37,6 +24,21 @@ COPY --from=taskrunner_builder /taskrunner/build/libs/*.jar /taskrunner.jar
 
 # Copy the echo script for testing
 COPY ./packages/taskrunner/src/test/resources/echo.py /echo.py
+
+# Install wget
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends wget && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN echo "Cache bust so we can always pull latest GoLLM" $(date -u)
+RUN wget -O gollm.tar.gz https://github.com/DARPA-ASKEM/GoLLM/archive/refs/heads/main.tar.gz && \
+	tar -zxvf gollm.tar.gz && \
+	mv GoLLM-* GoLLM
+
+WORKDIR /GoLLM
+
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -e .
 
 WORKDIR /
 

--- a/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/service/Task.java
+++ b/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/service/Task.java
@@ -316,6 +316,9 @@ public class Task {
 				}
 			}).start();
 
+		} catch (Exception e) {
+			status = TaskStatus.FAILED;
+			throw e;
 		} finally {
 			lock.unlock();
 		}

--- a/packages/taskrunner/src/test/java/software/uncharted/terarium/taskrunner/service/TaskTests.java
+++ b/packages/taskrunner/src/test/java/software/uncharted/terarium/taskrunner/service/TaskTests.java
@@ -196,7 +196,7 @@ public class TaskTests extends TaskRunnerApplicationTests {
 					for (int i = 0; i < 10; i++) {
 						boolean res = task.cancel();
 						if (cancelled) {
-							Assertions.assertTrue(false);
+							Assertions.assertFalse(res);
 						} else {
 							Assertions.assertTrue(res);
 							cancelled = true;


### PR DESCRIPTION
The issue @blanchco  was encountering is because the dockerfile layer that pulls the GoLLM repo was getting cached, so it was running code that was out of date :)

Ideally we want to actually hardcode a GoLLM release, but for now, since we are iterating so quickly its nice to just use the latest by default.