### PR TITLE
model card on document upload

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-upload-resources-modal.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-upload-resources-modal.vue
@@ -72,6 +72,7 @@ import InputText from 'primevue/inputtext';
 import { useToastService } from '@/services/toast';
 import TeraImportGithubFile from '@/components/widgets/tera-import-github-file.vue';
 import { extractPDF } from '@/services/knowledge';
+import { modelCard } from '@/services/goLLM';
 
 defineProps<{
 	visible: boolean;
@@ -153,6 +154,11 @@ async function upload() {
 				const newAsset = useProjects().addAsset(assetType, id);
 				if (name && name.toLowerCase().endsWith('.pdf')) {
 					extractPDF(id);
+				} else if (
+					(name && name.toLowerCase().endsWith('.txt')) ||
+					(name && name.toLowerCase().endsWith('.md'))
+				) {
+					modelCard(id);
 				}
 				return newAsset;
 			})

--- a/packages/client/hmi-client/src/services/document-assets.ts
+++ b/packages/client/hmi-client/src/services/document-assets.ts
@@ -2,10 +2,12 @@
  * Documents Asset
  */
 
-import API from '@/api/api';
+import API, { PollerState } from '@/api/api';
 import type { AddDocumentAssetFromXDDResponse, Document, DocumentAsset } from '@/types/Types';
 import { logger } from '@/utils/logger';
 import { Ref } from 'vue';
+import { fetchExtraction } from './knowledge';
+import { modelCard } from './goLLM';
 
 /**
  * Get all documents
@@ -209,16 +211,25 @@ async function createDocumentFromXDD(
 	projectId: string
 ): Promise<AddDocumentAssetFromXDDResponse | null> {
 	if (!document || !projectId) return null;
-	const response = await API.post(`/document-asset/create-document-from-xdd`, {
-		document,
-		projectId
-	});
+	const response = await API.post<AddDocumentAssetFromXDDResponse>(
+		`/document-asset/create-document-from-xdd`,
+		{
+			document,
+			projectId
+		}
+	);
 
 	if (!response || response.status >= 400) {
 		logger.error('Error upload file from doi');
 		return null;
 	}
 
+	if (response.data.extractionJobId) {
+		const result = await fetchExtraction(response.data.extractionJobId);
+		if (result.state === PollerState.Done) {
+			modelCard(response.data.documentAssetId);
+		}
+	}
 	return response.data;
 }
 export {

--- a/packages/client/hmi-client/src/services/goLLM.ts
+++ b/packages/client/hmi-client/src/services/goLLM.ts
@@ -8,12 +8,11 @@ import { logger } from '@/utils/logger';
  * @param {string} documentId - The document ID.
  * @param {string} modelId - The model ID.
  */
-export async function modelCard(documentId: string, modelId: string): Promise<void> {
+export async function modelCard(documentId: string): Promise<void> {
 	try {
 		const response = await API.post<TaskResponse>('/gollm/model-card', null, {
 			params: {
-				'document-id': documentId,
-				'model-id': modelId
+				'document-id': documentId
 			}
 		});
 

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -2,6 +2,7 @@ import API, { Poller, PollerState, PollResponse, PollerResult } from '@/api/api'
 import { AxiosError, AxiosResponse } from 'axios';
 import type { Code, Dataset, ExtractionResponse, Model } from '@/types/Types';
 import { logger } from '@/utils/logger';
+import { modelCard } from './goLLM';
 
 /**
  * Fetch information from the extraction service via the Poller utility
@@ -192,6 +193,7 @@ export const extractPDF = async (documentId: string) => {
 		if (resp) {
 			const pollResult = await fetchExtraction(resp);
 			if (pollResult?.state === PollerState.Done) {
+				modelCard(documentId);
 				pdfExtractions(documentId, Extractor.SKEMA);
 				pdfExtractions(documentId, Extractor.MIT);
 			}

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -141,6 +141,6 @@ export async function generateModelCard(
 	}
 
 	if (modelServiceType === ModelServiceType.TA4) {
-		await modelCard(documentId, modelId);
+		await modelCard(documentId);
 	}
 }

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -902,7 +902,7 @@ export interface ModelMetadata {
     processed_at?: number;
     processed_by?: string;
     variable_statements?: VariableStatement[];
-    gollm_card?: any;
+    gollmCard?: any;
 }
 
 export interface ModelGrounding {

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -207,7 +207,7 @@ const documentId = computed(() => props.node.inputs?.[1]?.value?.[0]);
 
 const document = ref<DocumentAsset | null>(null);
 
-const goLLMCard = computed<any>(() => document.value?.metadata?.gollm_card);
+const goLLMCard = computed<any>(() => document.value?.metadata?.gollmCard);
 
 const inputCodeBlocks = ref<AssetBlock<CodeBlock>[]>([]);
 
@@ -490,8 +490,8 @@ async function fetchModel() {
 			model.metadata.card = card.value;
 		}
 
-		if (!model.metadata?.gollm_card && goLLMCard.value) {
-			model.metadata.gollm_card = goLLMCard.value;
+		if (!model.metadata?.gollmCard && goLLMCard.value) {
+			model.metadata.gollmCard = goLLMCard.value;
 		}
 
 		model = await updateModel(model);

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -152,7 +152,7 @@ import 'ace-builds/src-noconflict/mode-python';
 import 'ace-builds/src-noconflict/mode-julia';
 import 'ace-builds/src-noconflict/mode-r';
 import { AssetType, ProgrammingLanguage } from '@/types/Types';
-import type { Card, Code, Model } from '@/types/Types';
+import type { Card, Code, DocumentAsset, Model } from '@/types/Types';
 import { AssetBlock, WorkflowNode, WorkflowOutput } from '@/types/workflow';
 import { KernelSessionManager } from '@/services/jupyter';
 import { logger } from '@/utils/logger';
@@ -173,6 +173,7 @@ import TeraModelCard from '@/components/model/petrinet/tera-model-card.vue';
 import TeraOutputDropdown from '@/components/drilldown/tera-output-dropdown.vue';
 import { ModelServiceType } from '@/types/common';
 import { extensionFromProgrammingLanguage } from '@/utils/data-util';
+import { getDocumentAsset } from '@/services/document-assets';
 import { ModelFromCodeState } from './model-from-code-operation';
 
 const props = defineProps<{
@@ -203,6 +204,10 @@ const kernelManager = new KernelSessionManager();
 
 const selectedModel = ref<Model | null>(null);
 const documentId = computed(() => props.node.inputs?.[1]?.value?.[0]);
+
+const document = ref<DocumentAsset | null>(null);
+
+const goLLMCard = computed<any>(() => document.value?.metadata?.gollm_card);
 
 const inputCodeBlocks = ref<AssetBlock<CodeBlock>[]>([]);
 
@@ -276,12 +281,16 @@ const selectedOutput = computed<WorkflowOutput<ModelFromCodeState> | undefined>(
 );
 
 const card = ref<Card | null>(null);
-const goLLMCard = ref<any>(null);
 
 onMounted(async () => {
 	clonedState.value = cloneDeep(props.node.state);
+
 	if (selectedOutputId.value) {
 		onUpdateOutput(selectedOutputId.value);
+	}
+
+	if (documentId.value) {
+		document.value = await getDocumentAsset(documentId.value);
 	}
 
 	fetchingInputBlocks.value = true;

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -510,6 +510,7 @@ function isSaveModelDisabled(): boolean {
 	return !selectedModel.value || !!activeProjectModelIds?.includes(selectedModel.value.id);
 }
 
+// generates the model card and fetches the model when finished
 async function generateCard(docId, modelId) {
 	if (!docId || !modelId) return;
 

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -417,6 +417,7 @@ function removeEquation(index: number) {
 	emit('update-state', clonedState.value);
 }
 
+// generates the model card and fetches the model when finished
 async function generateCard(docId, modelId) {
 	if (!docId || !modelId) return;
 

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -237,7 +237,7 @@ const assetLoading = ref(false);
 const loadingModel = ref(false);
 const selectedModel = ref<Model | null>(null);
 const card = ref<Card | null>(null);
-const goLLMCard = ref<any>(null);
+const goLLMCard = computed<any>(() => document.value?.metadata?.gollm_card);
 
 const formSteps = ref([
 	{

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -237,7 +237,7 @@ const assetLoading = ref(false);
 const loadingModel = ref(false);
 const selectedModel = ref<Model | null>(null);
 const card = ref<Card | null>(null);
-const goLLMCard = computed<any>(() => document.value?.metadata?.gollm_card);
+const goLLMCard = computed<any>(() => document.value?.metadata?.gollmCard);
 
 const formSteps = ref([
 	{
@@ -368,8 +368,8 @@ async function fetchModel() {
 			model.metadata.card = card.value;
 		}
 
-		if (!model.metadata?.gollm_card && goLLMCard.value) {
-			model.metadata.gollm_card = goLLMCard.value;
+		if (!model.metadata?.gollmCard && goLLMCard.value) {
+			model.metadata.gollmCard = goLLMCard.value;
 		}
 
 		model = await updateModel(model);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -76,7 +76,7 @@ public class GoLLMController {
 				if (document.getMetadata() == null){
 					document.setMetadata(new java.util.HashMap<>());
 				}
-				document.getMetadata().put("goLLM_card", card.response);
+				document.getMetadata().put("gollmCard", card.response);
 				
 				documentAssetService.updateAsset(document);
 			} catch (final IOException e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -18,7 +18,6 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import software.uncharted.terarium.hmiserver.annotations.IgnoreRequestLogging;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
-import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
@@ -26,7 +25,6 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.TaskResponseHandler;
 import software.uncharted.terarium.hmiserver.service.TaskService;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
-import software.uncharted.terarium.hmiserver.service.data.ModelService;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -41,7 +39,6 @@ public class GoLLMController {
 	final private ObjectMapper objectMapper;
 	final private TaskService taskService;
 	final private DocumentAssetService documentAssetService;
-	final private ModelService modelService;
 
 	final private String MODEL_CARD_SCRIPT = "gollm:model_card";
 
@@ -58,7 +55,6 @@ public class GoLLMController {
 
 	@Data
 	private static class ModelCardProperties {
-		UUID modelId;
 		UUID documentId;
 	}
 
@@ -73,12 +69,16 @@ public class GoLLMController {
 			try {
 				final String serializedString = objectMapper.writeValueAsString(resp.getAdditionalProperties());
 				final ModelCardProperties props = objectMapper.readValue(serializedString, ModelCardProperties.class);
-				log.info("Writing model card to database for model {}", props.getModelId());
-				final Model model = modelService.getAsset(props.getModelId())
+				log.info("Writing model card to database for document {}", props.getDocumentId());
+				final DocumentAsset document = documentAssetService.getAsset(props.getDocumentId())
 						.orElseThrow();
 				final ModelCardResponse card = objectMapper.readValue(resp.getOutput(), ModelCardResponse.class);
-				model.getMetadata().setGollmCard(card.response);
-				modelService.updateAsset(model);
+				if (document.getMetadata() == null){
+					document.setMetadata(new java.util.HashMap<>());
+				}
+				document.getMetadata().put("goLLM_card", card.response);
+				
+				documentAssetService.updateAsset(document);
 			} catch (final IOException e) {
 				log.error("Failed to write model card to database", e);
 			}
@@ -99,16 +99,9 @@ public class GoLLMController {
 			@ApiResponse(responseCode = "500", description = "There was an issue dispatching the request", content = @Content)
 	})
 	public ResponseEntity<TaskResponse> createModelCardTask(
-			@RequestParam(name = "document-id", required = true) final UUID documentId,
-			@RequestParam(name = "model-id", required = true) final UUID modelId) {
+			@RequestParam(name = "document-id", required = true) final UUID documentId) {
 
 		try {
-			// Ensure the model is valid
-			final Optional<Model> model = modelService.getAsset(modelId);
-			if (model.isEmpty()) {
-				return ResponseEntity.notFound().build();
-			}
-
 			// Grab the document
 			final Optional<DocumentAsset> document = documentAssetService.getAsset(documentId);
 			if (document.isEmpty()) {
@@ -137,7 +130,6 @@ public class GoLLMController {
 			req.setInput(objectMapper.writeValueAsBytes(input));
 
 			final ModelCardProperties props = new ModelCardProperties();
-			props.setModelId(modelId);
 			props.setDocumentId(documentId);
 			req.setAdditionalProperties(props);
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelMetadata.java
@@ -44,7 +44,7 @@ public class ModelMetadata implements SupportAdditionalProperties {
 	private Card card;
 
 	@TSOptional
-	@JsonProperty("gollm_card")
+	@JsonProperty("gollmCard")
 	private Object gollmCard;
 
 	@TSOptional


### PR DESCRIPTION
# Description

* GOLLM model card generated on model upload.
* Im not entirely happy with how to implement this but we will need to move the pdfextractions calls to the backend and have everything run there for the ideal UX.  For now gollm needs to wait for pdfextractions to finished in order to get the text to runs the card.

Resolves #(issue)
