### PR TITLE
fix: ensure workflow save on unload

### DIFF
--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -750,6 +750,12 @@ const pathFn = d3
 // Get around typescript complaints
 const drawPath = (v: any) => pathFn(v) as string;
 
+const unloadCheck = () => {
+	if (workflowDirty) {
+		workflowService.updateWorkflow(wf.value);
+	}
+};
+
 watch(
 	() => [props.assetId],
 	async () => {
@@ -768,6 +774,7 @@ watch(
 
 onMounted(() => {
 	document.addEventListener('mousemove', mouseUpdate);
+	window.addEventListener('beforeunload', unloadCheck);
 	saveTimer = setInterval(() => {
 		if (workflowDirty) {
 			workflowService.updateWorkflow(wf.value);
@@ -783,6 +790,7 @@ onUnmounted(() => {
 		clearInterval(saveTimer);
 	}
 	document.removeEventListener('mousemove', mouseUpdate);
+	window.removeEventListener('beforeunload', unloadCheck);
 });
 
 function cleanUpLayout() {


### PR DESCRIPTION
### Summary
This tries to ensure we have a chance to save before the page is unloaded, e.g. by hard-refreshing for because of the keycloak revnewal


### Test
This is a bit hard to test because of non-blocking, probably the easiest way to convince this works is to add logging to WorkflowController#updateWorkflow and check it is firing on page refresh.