### PR TITLE
operator active output behaviour

### DIFF
--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -278,7 +278,7 @@ export async function simulationPollAction(
 	simulationIds: string[],
 	node: WorkflowNode<any>,
 	progress: Ref<{ status: ProgressState; value: number }>,
-	emitFn: (event: 'append-output-port' | 'update-state', ...args: any[]) => void
+	emitFn: (event: 'append-output' | 'update-state', ...args: any[]) => void
 ) {
 	const requestList: Promise<Simulation | null>[] = [];
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -203,7 +203,7 @@ const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'close',
 	'select-output',
 	'update-output-port',
@@ -441,7 +441,7 @@ const updateOutputPorts = async (calibrationId: string, simulationId: string) =>
 
 	emit('update-state', state);
 
-	emit('append-output-port', {
+	emit('append-output', {
 		type: 'calibrateSimulationId',
 		label: `${portLabel} Result`,
 		value: [calibrationId]

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -232,7 +232,7 @@ const dataLabelPlugin = [ChartDataLabels];
 const props = defineProps<{
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 
 enum CalibrateView {
 	Input = 'Input',

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -75,7 +75,7 @@ import {
 const props = defineProps<{
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'update-state', 'open-drilldown']);
 
 const showSpinner = ref(false);
 const modelConfigIds = computed<string[]>(() => props.node.inputs[0].value as string[]);
@@ -161,7 +161,7 @@ const getStatus = async (simulationId: string) => {
 
 const updateOutputPorts = async (runId) => {
 	const portLabel = props.node.inputs[0].label;
-	emit('append-output-port', {
+	emit('append-output', {
 		type: CalibrateEnsembleCiemssOperation.outputs[0].type,
 		label: `${portLabel} Result`,
 		value: { runId }

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -259,7 +259,7 @@ const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateJulia>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'update-state',
 	'select-output',
 	'update-output-port',
@@ -473,7 +473,7 @@ const watchCompletedRunList = async (runIdList: string[]) => {
 	const state = _.cloneDeep(props.node.state);
 	state.intermediateLoss = lossValues;
 
-	emit('append-output-port', {
+	emit('append-output', {
 		type: CalibrationOperationJulia.outputs[0].type,
 		label: `Output - ${props.node.outputs.length + 1}`,
 		value: runIdList,

--- a/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-node.vue
@@ -40,7 +40,7 @@ const props = defineProps<{
 	node: WorkflowNode<CodeAssetState>;
 }>();
 
-const emit = defineEmits(['update-state', 'append-output-port', 'open-drilldown']);
+const emit = defineEmits(['update-state', 'append-output', 'open-drilldown']);
 
 const code = ref<Code | null>(null);
 const codeAssets = useProjects().getActiveProjectAssets(AssetType.Code);
@@ -61,7 +61,7 @@ watch(
 
 			if (_.isEmpty(props.node.outputs)) {
 				const blocks = await getCodeBlocks(code.value);
-				emit('append-output-port', {
+				emit('append-output', {
 					type: 'codeAssetId',
 					label: `${code.value.name} code blocks (${blocks.length})`,
 					value: [code.value.id]

--- a/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
@@ -30,7 +30,7 @@ import { DatasetTransformerState } from './dataset-transformer-operation';
 const props = defineProps<{
 	node: WorkflowNode<DatasetTransformerState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 
 const showKernels = ref(<boolean>false);
 const showChatThoughts = ref(<boolean>false);
@@ -67,7 +67,7 @@ onMounted(async () => {
 });
 
 const addOutputPort = (data: any) => {
-	emit('append-output-port', {
+	emit('append-output', {
 		id: data.id,
 		label: data.name,
 		type: 'datasetId',

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-node.vue
@@ -76,7 +76,7 @@ const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
 }>();
 
-const emit = defineEmits(['append-output-port', 'update-state', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'update-state', 'open-drilldown']);
 
 const datasets = useProjects().getActiveProjectAssets(AssetType.Dataset);
 
@@ -106,7 +106,7 @@ async function getDatasetById(id: string) {
 				datasetId: dataset.value.id
 			});
 
-			emit('append-output-port', {
+			emit('append-output', {
 				type: 'datasetId',
 				label: dataset.value.name,
 				value: [dataset.value.id]

--- a/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-node.vue
@@ -35,7 +35,7 @@ import { getDocumentAsset } from '@/services/document-assets';
 import teraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { DocumentOperationState } from './document-operation';
 
-const emit = defineEmits(['open-drilldown', 'update-state', 'append-output-port']);
+const emit = defineEmits(['open-drilldown', 'update-state', 'append-output']);
 const props = defineProps<{
 	node: WorkflowNode<DocumentOperationState>;
 }>();
@@ -97,13 +97,14 @@ watch(
 			emit('update-state', state);
 
 			if (!props.node.outputs.find((port) => port.type === 'documentId')) {
-				emit('append-output-port', {
+				emit('append-output', {
 					type: 'documentId',
 					label: `document`,
 					value: [document.value.id]
 				});
 			}
 
+			/*
 			if (!props.node.outputs.find((port) => port.type === 'equations') && !isEmpty(equations)) {
 				const selected = equations.filter((e) => e.includeInProcess);
 				emit('append-output-port', {
@@ -145,6 +146,7 @@ watch(
 					]
 				});
 			}
+			*/
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -152,7 +152,7 @@ const props = defineProps<{
 	node: WorkflowNode<FunmanOperationState>;
 }>();
 
-const emit = defineEmits(['append-output-port', 'select-output', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'select-output', 'update-state', 'close']);
 
 enum FunmanTabs {
 	Wizard = 'Wizard',
@@ -316,7 +316,7 @@ const getStatus = async (runId: string) => {
 
 const addOutputPorts = async (runId: string) => {
 	const portLabel = props.node.inputs[0].label;
-	emit('append-output-port', {
+	emit('append-output', {
 		label: `${portLabel} Result ${props.node.outputs.length + 1}`,
 		type: FunmanOperation.outputs[0].type,
 		value: runId,

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config-node.vue
@@ -29,14 +29,14 @@ import { ModelConfigOperationState } from './model-config-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelConfigOperationState>;
 }>();
-const emit = defineEmits(['append-output-port', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'open-drilldown']);
 
 const modelConfigs = ref<ModelConfiguration[]>([]);
 
 const refresh = async (modelId: string) => {
 	modelConfigs.value = await getModelConfigurations(modelId);
 	modelConfigs.value.forEach((config) => {
-		emit('append-output-port', {
+		emit('append-output', {
 			type: 'modelConfigId',
 			label: config.name,
 			value: [config.id]

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -136,7 +136,7 @@ const outputs = computed(() => {
 });
 
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'update-state',
 	'select-output',
 	'update-output-port',
@@ -360,7 +360,7 @@ const createConfiguration = async () => {
 	}
 
 	useToastService().success('', 'Created model configuration');
-	emit('append-output-port', {
+	emit('append-output', {
 		type: ModelConfigOperation.outputs[0].type,
 		label: state.name,
 		value: data.id,

--- a/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling-node.vue
@@ -19,12 +19,7 @@ import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeho
 const props = defineProps<{
 	node: WorkflowNode<any>;
 }>();
-const emit = defineEmits([
-	'open-drilldown',
-	'append-input-port',
-	'append-output-port',
-	'update-state'
-]);
+const emit = defineEmits(['open-drilldown', 'append-input-port', 'update-state']);
 
 watch(
 	() => props.node.inputs,

--- a/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
@@ -38,7 +38,7 @@
 					class="ace-editor"
 					:options="{ showPrintMargin: false }"
 				/>
-				<!-- 
+				<!--
 				<template #footer>
 					<Button style="margin-right: auto" icon="pi pi-play" label="Run" size="large" @click="runCodeModelCoupling" />
 				</template> -->
@@ -109,7 +109,7 @@ import { ModelCouplingState } from './model-coupling-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelCouplingState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 const modelCouplingResult = ref<any>(null);
 
 enum ModelCouplingTabgs {
@@ -199,7 +199,7 @@ const saveNewModel = async (modelName: string, options: SaveOptions) => {
 	}
 
 	if (options.appendOutputPort) {
-		emit('append-output-port', {
+		emit('append-output', {
 			id: uuidv4(),
 			label: modelName,
 			type: 'modelId',

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -95,7 +95,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelEditOperationState>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'update-state',
 	'close',
 	'select-output',
@@ -275,7 +275,7 @@ const saveNewModel = async (modelName: string, options: SaveOptions) => {
 	}
 
 	if (options.appendOutputPort) {
-		emit('append-output-port', {
+		emit('append-output', {
 			id: uuidv4(),
 			label: modelName,
 			type: 'modelId',

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -178,7 +178,7 @@ const emit = defineEmits([
 	'close',
 	'update-state',
 	'select-output',
-	'append-output-port',
+	'append-output',
 	'update-output-port'
 ]);
 
@@ -364,7 +364,7 @@ async function handleCode() {
 
 		clonedState.value.modelId = modelId;
 
-		emit('append-output-port', {
+		emit('append-output', {
 			label: `Output - ${props.node.outputs.length + 1}`,
 			state: cloneDeep(clonedState.value),
 			isSelected: false,
@@ -429,7 +429,7 @@ async function handleDecapodesPreview(data: any) {
 		const m = await getModel(response.id);
 		if (m && m.id) {
 			clonedState.value.modelId = m.id;
-			emit('append-output-port', {
+			emit('append-output', {
 				label: `Output - ${props.node.outputs.length + 1}`,
 				state: cloneDeep(clonedState.value),
 				isSelected: false,

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/model-from-document-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/model-from-document-operation.ts
@@ -31,7 +31,7 @@ export const ModelFromDocumentOperation: Operation = {
 	displayName: 'Create model from equations',
 	isRunnable: true,
 	inputs: [
-		{ type: 'equations', label: 'Equations' },
+		// { type: 'equations', label: 'Equations' },
 		{ type: 'documentId', label: 'Text' }
 	],
 	outputs: [],

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -227,7 +227,7 @@ onMounted(async () => {
 		onUpdateOutput(selectedOutputId.value);
 	}
 
-	const documentId = props.node.inputs?.[1]?.value?.[0];
+	const documentId = props.node.inputs?.[0]?.value?.[0];
 	const equations: AssetBlock<DocumentExtraction>[] =
 		props.node.inputs?.[0]?.value?.[0]?.equations?.filter((e) => e.includeInProcess);
 	assetLoading.value = true;

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -149,7 +149,7 @@ import {
 const emit = defineEmits([
 	'close',
 	'update-state',
-	'append-output-port',
+	'append-output',
 	'select-output',
 	'update-output-port'
 ]);
@@ -307,7 +307,7 @@ async function onRun() {
 	generateCard(document.value?.id, modelId);
 
 	clonedState.value.modelId = modelId;
-	emit('append-output-port', {
+	emit('append-output', {
 		label: `Output - ${props.node.outputs.length + 1}`,
 		state: cloneDeep(clonedState.value),
 		isSelected: false,

--- a/packages/client/hmi-client/src/workflow/ops/model-optimize/tera-model-optimize.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-optimize/tera-model-optimize.vue
@@ -234,7 +234,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelOptimizeOperationState>;
 }>();
 
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 
 enum OptimizeTabs {
 	Wizard = 'Wizard',

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
@@ -33,7 +33,7 @@ import { ModelTransformerState } from './model-transformer-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelTransformerState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 
 const modelId = computed(() => {
 	// for now we are only using 1 model configuration for the llm at a time, this can be expanded in the future
@@ -83,7 +83,7 @@ const addOutputPort = async (data) => {
 	// set default configuration
 	await addDefaultConfiguration(model);
 
-	emit('append-output-port', {
+	emit('append-output', {
 		id: uuidv4(),
 		label: model.header.name,
 		type: 'modelId',

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -57,7 +57,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
 }>();
 
-const emit = defineEmits(['update-state', 'append-output-port', 'open-drilldown']);
+const emit = defineEmits(['update-state', 'append-output', 'open-drilldown']);
 const models = useProjects().getActiveProjectAssets(AssetType.Model);
 
 enum ModelNodeView {
@@ -76,7 +76,7 @@ async function getModelById(modelId: string) {
 		const state = _.cloneDeep(props.node.state);
 		state.modelId = model.value?.id;
 		emit('update-state', state);
-		emit('append-output-port', {
+		emit('append-output', {
 			type: 'modelId',
 			label: model.value.header.name,
 			value: [model.value.id]
@@ -94,7 +94,7 @@ onMounted(async () => {
 		model.value = await getModel(state.modelId);
 
 		if (props.node.outputs.length === 0 && model.value) {
-			emit('append-output-port', {
+			emit('append-output', {
 				type: 'modelId',
 				label: model.value.header.name,
 				value: [model.value.id]

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -183,7 +183,7 @@ const props = defineProps<{
 	node: WorkflowNode<SimulateCiemssOperationState>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'update-state',
 	'select-output',
 	'update-output-port',
@@ -332,7 +332,7 @@ const watchCompletedRunId = async (runId: string) => {
 
 	const sim = await getSimulation(runId);
 
-	emit('append-output-port', {
+	emit('append-output', {
 		type: SimulateCiemssOperation.outputs[0].type,
 		label: `Output - ${props.node.outputs.length + 1}`,
 		value: runId,

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -196,7 +196,7 @@ const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'select-output',
 	'update-output-port',
 	'update-state',
@@ -400,7 +400,7 @@ const getStatus = async (simulationId: string) => {
 const updateOutputPorts = (simulationId: string) => {
 	const portLabel = props.node.inputs[0].label;
 	const state = props.node.state;
-	emit('append-output-port', {
+	emit('append-output', {
 		type: 'simulationId',
 		label: `${portLabel} Result`,
 		value: [simulationId],

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -54,7 +54,7 @@ import {
 const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'update-state', 'open-drilldown']);
 
 const showSpinner = ref(false);
 const completedRunId = ref<string>();
@@ -100,7 +100,7 @@ const getStatus = async (simulationId: string) => {
 
 const updateOutputPorts = async (runId) => {
 	const portLabel = props.node.inputs[0].label;
-	emit('append-output-port', {
+	emit('append-output', {
 		type: SimulateEnsembleCiemssOperation.outputs[0].type,
 		label: `${portLabel} Result`,
 		value: { runId }

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -160,7 +160,7 @@ const props = defineProps<{
 	node: WorkflowNode<SimulateJuliaOperationState>;
 }>();
 const emit = defineEmits([
-	'append-output-port',
+	'append-output',
 	'update-state',
 	'select-output',
 	'update-output-port',
@@ -292,7 +292,7 @@ const watchCompletedRunId = async (runId: string) => {
 
 	const sim = await getSimulation(runId);
 
-	emit('append-output-port', {
+	emit('append-output', {
 		type: SimulateJuliaOperation.outputs[0].type,
 		label: `Output - ${props.node.outputs.length + 1}`,
 		value: runId,

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -370,7 +370,9 @@ watch(() => completedRunId.value, watchCompletedRunId, { immediate: true });
 watch(
 	() => selectedRunId.value,
 	() => {
-		lazyLoadSimulationData(selectedRunId.value);
+		if (selectedRunId.value) {
+			lazyLoadSimulationData(selectedRunId.value);
+		}
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -128,7 +128,7 @@ import {
 const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
-const emit = defineEmits(['append-output-port', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close']);
 
 enum StratifyTabs {
 	Wizard = 'Wizard',
@@ -291,7 +291,7 @@ const saveNewModel = async (modelName: string, options: SaveOptions) => {
 	}
 
 	if (options.appendOutputPort) {
-		emit('append-output-port', {
+		emit('append-output', {
 			id: uuidv4(),
 			label: modelName,
 			type: 'modelId',

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -105,6 +105,7 @@
 							:is="registry.getNode(node.operationType)"
 							:node="node"
 							@append-output-port="(event: any) => appendOutputPort(node, event)"
+							@append-output="(event: any) => appendOutput(currentActiveNode, event)"
 							@append-input-port="(event: any) => appendInputPort(node, event)"
 							@update-state="(event: any) => updateWorkflowNodeState(node, event)"
 							@open-drilldown="openDrilldown(node)"
@@ -176,6 +177,7 @@
 			:is="registry.getDrilldown(currentActiveNode.operationType)"
 			:node="currentActiveNode"
 			@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
+			@append-output="(event: any) => appendOutput(currentActiveNode, event)"
 			@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
 			@update-output-port="(event: any) => updateOutputPort(currentActiveNode, event)"
@@ -326,6 +328,42 @@ function appendInputPort(
 		isOptional: false,
 		status: WorkflowPortStatus.NOT_CONNECTED
 	});
+}
+
+/**
+ * The operator creates a new output, this will mark the
+ * output as selected, and revert the selection status of
+ * existing outputs
+ * */
+function appendOutput(
+	node: WorkflowNode<any> | null,
+	port: { type: string; label?: string; value: any; state?: any; isSelected?: boolean }
+) {
+	if (!node) return;
+
+	const uuid = uuidv4();
+	const outputPort: WorkflowOutput<any> = {
+		id: uuid,
+		type: port.type,
+		label: port.label,
+		value: isArray(port.value) ? port.value : [port.value],
+		isOptional: false,
+		status: WorkflowPortStatus.NOT_CONNECTED,
+		state: port.state,
+		isSelected: true,
+		timestamp: new Date()
+	};
+
+	// Revert
+	node.outputs.forEach((o) => {
+		o.isSelected = false;
+	});
+
+	// Append and set active
+	node.outputs.push(outputPort);
+	node.active = uuid;
+
+	workflowDirty = true;
 }
 
 function appendOutputPort(

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -366,10 +366,16 @@ function appendOutput(
 	workflowDirty = true;
 }
 
-function appendOutputPort(
+// @deprecated
+function appendOutputPort() {
+/*
 	node: WorkflowNode<any> | null,
 	port: { type: string; label?: string; value: any; state?: any; isSelected?: boolean }
-) {
+	*/
+	console.error('This function is no longer supported, use <append-output> intstead');
+	throw new Error('This function is no longer supported, use <append-output> intstead');
+
+	/*
 	if (!node) return;
 
 	const uuid = uuidv4();
@@ -391,6 +397,7 @@ function appendOutputPort(
 	node.active = uuid;
 
 	workflowDirty = true;
+	*/
 }
 
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -104,7 +104,7 @@
 						<component
 							:is="registry.getNode(node.operationType)"
 							:node="node"
-							@append-output-port="(event: any) => appendOutputPort(node, event)"
+							@append-output-port="() => appendOutputPort()"
 							@append-output="(event: any) => appendOutput(currentActiveNode, event)"
 							@append-input-port="(event: any) => appendInputPort(node, event)"
 							@update-state="(event: any) => updateWorkflowNodeState(node, event)"
@@ -176,7 +176,7 @@
 			v-if="dialogIsOpened && currentActiveNode"
 			:is="registry.getDrilldown(currentActiveNode.operationType)"
 			:node="currentActiveNode"
-			@append-output-port="(event: any) => appendOutputPort(currentActiveNode, event)"
+			@append-output-port="() => appendOutputPort()"
 			@append-output="(event: any) => appendOutput(currentActiveNode, event)"
 			@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
@@ -367,8 +367,9 @@ function appendOutput(
 }
 
 // @deprecated
+// FIXME: Leaving this in here to warn against existing development - remove after hackathon, Feb 2022.
 function appendOutputPort() {
-/*
+	/*
 	node: WorkflowNode<any> | null,
 	port: { type: string; label?: string; value: any; state?: any; isSelected?: boolean }
 	*/


### PR DESCRIPTION
### Summary
This modifies the behaviour such that a successful run of an operator will make that operator the active output. Moreover, because we agreed to have a singular exposed output per operator, the emission `append-output-port` is renamed to `append-output` to better reflect what is actually happening.

```
I am going to take a crack at harmonizing the behaviour of the preview-dropdown we have in the operators, just chitchatting with Pascale
- if we run something, the output should be selected automatically, currently this seems to be a mix of auto and manual selection after "run" is clicked
- successive runs will replace the existing output. 
- when selected output changes it will propagate the carried value downstream and mark downstream operators as invalid (to be done later but before eval)
```