### PR TITLE
fix initials/parameters display due to incorrect stratification usage

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -189,12 +189,26 @@ const stratifiedModelType = computed(() => {
 
 const parameters = computed<Map<string, string[]>>(() => {
 	if (!model.value) return new Map();
-	return getUnstratifiedParameters(model.value);
+	if (stratifiedModelType.value) {
+		return getUnstratifiedParameters(model.value);
+	}
+	const result = new Map<string, string[]>();
+	model.value.semantics?.ode.parameters?.forEach((p) => {
+		result.set(p.id, [p.id]);
+	});
+	return result;
 });
 
 const initials = computed<Map<string, string[]>>(() => {
 	if (!model.value) return new Map();
-	return getUnstratifiedInitials(model.value);
+	if (stratifiedModelType.value) {
+		return getUnstratifiedInitials(model.value);
+	}
+	const result = new Map<string, string[]>();
+	model.value.semantics?.ode.initials?.forEach((initial) => {
+		result.set(initial.target, [initial.target]);
+	});
+	return result;
 });
 
 const tableFormattedInitials = computed<ModelConfigTableData[]>(() => {


### PR DESCRIPTION
### Summary
Fix model configuration display issues because it is treating the model as if it is stratified when it is not. This ends up hiding parameters that have underscores in their names that arose naturally, as oppose to underscores that arose from stratifications through MIRA.

<img width="660" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/17d18a11-b370-45fe-b41f-ba2002fa6133">


Fixes: https://github.com/DARPA-ASKEM/terarium/issues/2753