### PR TITLE
Clearer stratify

### DIFF
--- a/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
@@ -2,11 +2,13 @@
 	<div class="strata-group" :style="`border-left: 9px solid ${props.config.borderColour}`">
 		<div class="input-row">
 			<div class="sub-header">
-				<label>Directed</label>
-				<InputSwitch @change="emit('update-self', updatedConfig)" v-model="directed" />
+				<label class="multi-line-label">Create new transitions between stratas</label>
+				<InputSwitch @change="emit('update-self', updatedConfig)" v-model="useStructure" />
 			</div>
 			<div class="sub-header">
-				<label>Cartesian product</label>
+				<label class="multi-line-label"
+					>Allow existing interactions to invole multiple stratas</label
+				>
 				<InputSwitch @change="emit('update-self', updatedConfig)" v-model="cartesianProduct" />
 			</div>
 		</div>
@@ -64,8 +66,9 @@ const strataName = ref(props.config.name);
 const selectedVariables = ref<string[]>(props.config.selectedVariables);
 const labels = ref(props.config.groupLabels);
 const cartesianProduct = ref<boolean>(props.config.cartesianProduct);
-const directed = ref<boolean>(props.config.directed);
-const structure = ref<any>(props.config.structure); // currently not used
+const directed = ref<boolean>(props.config.directed); // Currently not used, assume to be true
+const structure = ref<any>(props.config.structure); // Proxied by "useStructure"
+const useStructure = ref<any>(props.config.useStructure);
 
 const updatedConfig = computed<StratifyGroup>(() => ({
 	borderColour: props.config.borderColour,
@@ -74,7 +77,8 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	groupLabels: labels.value,
 	cartesianProduct: cartesianProduct.value,
 	directed: directed.value,
-	structure: structure.value
+	structure: structure.value,
+	useStructure: useStructure.value
 }));
 
 watch(
@@ -84,6 +88,8 @@ watch(
 		selectedVariables.value = props.config.selectedVariables;
 		labels.value = props.config.groupLabels;
 		cartesianProduct.value = props.config.cartesianProduct;
+		structure.value = props.config.structure;
+		useStructure.value = props.config.useStructure;
 	}
 );
 </script>
@@ -116,6 +122,10 @@ watch(
 
 .subdued-text {
 	color: var(--text-color-subdued);
+}
+
+.multi-line-label {
+	max-width: 12rem;
 }
 
 .input-row {

--- a/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/stratification/tera-stratification-group-form.vue
@@ -2,12 +2,12 @@
 	<div class="strata-group" :style="`border-left: 9px solid ${props.config.borderColour}`">
 		<div class="input-row">
 			<div class="sub-header">
-				<label class="multi-line-label">Create new transitions between stratas</label>
+				<label class="multi-line-label">Create new transitions between stratum</label>
 				<InputSwitch @change="emit('update-self', updatedConfig)" v-model="useStructure" />
 			</div>
 			<div class="sub-header">
 				<label class="multi-line-label"
-					>Allow existing interactions to invole multiple stratas</label
+					>Allow existing interactions to invole multiple stratum</label
 				>
 				<InputSwitch @change="emit('update-self', updatedConfig)" v-model="cartesianProduct" />
 			</div>

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -9,6 +9,8 @@ export interface StratifyGroup {
 
 	directed: boolean;
 	structure: null | any[];
+
+	useStructure: boolean;
 }
 
 export interface StratifyCode {
@@ -27,9 +29,23 @@ export const blankStratifyGroup: StratifyGroup = {
 	name: '',
 	selectedVariables: [],
 	groupLabels: '',
+
+	// Allow existing transitions to involve multiple strata
 	cartesianProduct: true,
-	directed: false,
-	structure: null
+
+	// Create new transitions between strata, this act as a proxy to MIRA "structure", which is
+	//   null = everything
+	//   [] = nothing
+	//   [[a, b], [c, d]] = somewhere in between
+	//
+	// Here we use a simpler proxy useStructure, where
+	//   true => structure = null
+	//   false => structuer = []
+	structure: null,
+	useStructure: true,
+
+	// Always true for now - Feb 2024
+	directed: true
 };
 
 export const StratifyMiraOperation: Operation = {

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -207,7 +207,8 @@ const stratifyRequest = () => {
 			key: strataOption.name,
 			strata: strataOption.groupLabels.split(',').map((d) => d.trim()),
 			concepts_to_stratify: strataOption.selectedVariables,
-			cartesian_control: strataOption.cartesianProduct
+			cartesian_control: strataOption.cartesianProduct,
+			structure: strataOption.useStructure === true ? null : []
 		}
 	};
 


### PR DESCRIPTION
### Summary
This enables fuller MIRA stratify capabilities, and try to use an easier to understand language.
- directed: this is hidden and assume to be true
- structure: this is proxied by useStructure (true | false), where `true = None = all combinations` and `false = [] = nothing`

Cartesian =~ Allow existing transitions to involve multiple strata
Structure =~ Create new transitions between strata

<img width="1457" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/19c04615-82ae-4fab-9912-b120616d7d4c">


### Testing
Structure toggle works, you need to have beaker instance running.