### PR TITLE
Fix: Inputs can be optional

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -79,7 +79,7 @@ export const addNode = (
 			label: port.label,
 			status: WorkflowPortStatus.NOT_CONNECTED,
 			value: null,
-			isOptional: false,
+			isOptional: port.isOptional ?? false,
 			acceptMultiple: port.acceptMultiple
 		})),
 		outputs: [],

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -46,6 +46,7 @@ export enum WorkflowPortStatus {
 export interface OperationData {
 	type: string;
 	label?: string;
+	isOptional?: boolean;
 	acceptMultiple?: boolean;
 }
 


### PR DESCRIPTION
# Description
Add isOptional to Operation.input and output types.
Use this if its available when grabbing ports
