### PR TITLE
Allow the use of the ARM image for beaker locally

### DIFF
--- a/containers/scripts/docker-compose-data-services.yml
+++ b/containers/scripts/docker-compose-data-services.yml
@@ -5,7 +5,6 @@ services:
   beaker:
     container_name: beaker
     image: ghcr.io/darpa-askem/beaker-kernel:latest
-    platform: linux/amd64
     networks:
       - terarium
     ports:


### PR DESCRIPTION
# Description

* Remove the `platform` requirement in the docker compose file.

* Works as expected on an ARM environment (MacBook Pro M2 Pro)