### PR TITLE
Beaker correction

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -306,7 +306,7 @@ const handleModelPreview = (data: any) => {
 		model.value?.metadata?.timeseries !== undefined ? model.value?.metadata?.timeseries : {};
 };
 
-const selectedOutputId = ref<string>('');
+const selectedOutputId = ref<string>(props.node.active ?? '');
 const selectedConfigId = computed(
 	() => props.node.outputs?.find((o) => o.id === selectedOutputId.value)?.value?.[0]
 );
@@ -580,6 +580,10 @@ const initialize = async () => {
 	try {
 		const jupyterContext = buildJupyterContext();
 		if (jupyterContext) {
+			if (kernelManager.jupyterSession !== null) {
+				// when coming from output dropdown change we should shutdown first
+				await kernelManager.shutdown();
+			}
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', jupyterContext);
 		}
 	} catch (error) {
@@ -614,7 +618,7 @@ watch(
 			await initialize();
 		}
 	},
-	{ immediate: true, deep: true }
+	{ deep: true }
 );
 
 onUnmounted(() => {

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -269,6 +269,10 @@ const inputChangeHandler = async () => {
 	try {
 		const jupyterContext = buildJupyterContext();
 		if (jupyterContext) {
+			if (kernelManager.jupyterSession !== null) {
+				// when coming from output dropdown change we should shutdown first
+				await kernelManager.shutdown();
+			}
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', buildJupyterContext());
 			isKernelReady.value = true;
 		}


### PR DESCRIPTION
# Description
Init was being called twice due to some immediate = true + onMounted silliness.
Also whenever output dropdown was changed we were creating new instance without shutting down old first.

# Testing

Opening + closing node, checking beaker logs
Opening + changing output + closing node, checking beaker logs
Ensuring the output dropdown still has correct init with changes 