### PR TITLE
cleanup preview and selection

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
@@ -6,10 +6,8 @@
 				<tera-output-dropdown
 					v-if="options && output"
 					:options="options"
-					:is-selectable="isSelectable ?? false"
 					:is-loading="isLoading"
 					:output="output"
-					@update:output="(e) => emit('update:output', e)"
 					@update:selection="(e) => emit('update:selection', e)"
 				/>
 			</header>
@@ -37,13 +35,12 @@ defineProps<{
 	output?: WorkflowOutput<any>['id'];
 	canSaveAsset?: boolean;
 	isLoading?: boolean;
-	isSelectable?: boolean;
 	hideHeader?: boolean;
 }>();
 
 const slots = useSlots();
 
-const emit = defineEmits(['update:output', 'update:selection']);
+const emit = defineEmits(['update:selection']);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
@@ -9,7 +9,7 @@
 		option-label="label"
 		option-group-children="items"
 		option-group-label="label"
-		@update:model-value="emit('update:output', $event)"
+		@update:model-value="emit('update:selection', $event)"
 		:loading="isLoading"
 	>
 		<template #optiongroup="slotProps">
@@ -17,13 +17,6 @@
 		</template>
 		<template #option="slotProps">
 			<div class="dropdown-option">
-				<Checkbox
-					v-if="isSelectable"
-					@click.stop
-					:model-value="slotProps.option?.isSelected"
-					@update:model-value="emit('update:selection', slotProps.option?.id)"
-					binary
-				/>
 				<span>{{ slotProps.option?.label }}</span>
 				<span
 					v-if="slotProps.option?.status === WorkflowPortStatus.CONNECTED"
@@ -38,16 +31,14 @@
 <script setup lang="ts">
 import { WorkflowOutput, WorkflowPortStatus } from '@/types/workflow';
 import Dropdown from 'primevue/dropdown';
-import Checkbox from 'primevue/checkbox';
 
 defineProps<{
 	options: WorkflowOutput<any>[] | { label: string; items: WorkflowOutput<any>[] }[];
 	output: WorkflowOutput<any>['id'];
-	isSelectable?: boolean;
 	isLoading?: boolean;
 }>();
 
-const emit = defineEmits(['update:selection', 'update:output']);
+const emit = defineEmits(['update:selection']);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -348,9 +348,14 @@ export function selectOutput(
 	operator: WorkflowNode<any>,
 	selectedWorkflowOutputId: WorkflowOutput<any>['id']
 ) {
+	operator.outputs.forEach((output) => {
+		output.isSelected = false;
+	});
+
 	// Update the Operator state with the selected one
 	const selected = operator.outputs.find((output) => output.id === selectedWorkflowOutputId);
 	if (selected) {
+		selected.isSelected = true;
 		operator.state = Object.assign(operator.state, _.cloneDeep(selected.state));
 		operator.status = selected.operatorStatus ?? OperatorStatus.DEFAULT;
 		operator.active = selected.id;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -98,8 +98,7 @@
 				title="Preview"
 				:options="outputs"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				is-selectable
 			>
 				<h4>Loss</h4>
@@ -202,13 +201,7 @@ import { CalibrationOperationStateCiemss } from './calibrate-operation';
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
 }>();
-const emit = defineEmits([
-	'append-output',
-	'close',
-	'select-output',
-	'update-output-port',
-	'update-state'
-]);
+const emit = defineEmits(['append-output', 'close', 'select-output', 'update-state']);
 const toast = useToastService();
 
 enum CalibrateTabs {
@@ -421,11 +414,11 @@ const getCalibrateStatus = async (simulationId: string) => {
 	const output = await getRunResultCiemss(sampleSimulateId, 'result.csv');
 	runResults.value = output.runResults;
 
-	updateOutputPorts(simulationId, sampleSimulateId);
+	appendOutput(simulationId, sampleSimulateId);
 	showSpinner.value = false;
 };
 
-const updateOutputPorts = async (calibrationId: string, simulationId: string) => {
+const appendOutput = async (calibrationId: string, simulationId: string) => {
 	const portLabel = props.node.inputs[0].label;
 	const state = _.cloneDeep(props.node.state);
 
@@ -462,15 +455,8 @@ const addChart = () => {
 	emit('update-state', state);
 };
 
-const onUpdateOutput = (id: string) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 // Used from button to add new entry to the mapping object

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -105,7 +105,7 @@
 			<tera-drilldown-preview
 				title="Validation results"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
+				@update:selection="onSelection"
 				:options="outputs"
 				is-selectable
 			>
@@ -474,7 +474,7 @@ const setRequestParameters = (modelParameters: ModelParameter[]) => {
 	});
 };
 
-const onUpdateOutput = (id: string) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -7,8 +7,7 @@
 				:output="selectedOutputId"
 				is-selectable
 				:options="outputs"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 			/>
 		</template>
 		<section :tabName="ConfigTabs.Wizard">
@@ -253,13 +252,7 @@ const outputs = computed(() => {
 	return [];
 });
 
-const emit = defineEmits([
-	'append-output',
-	'update-state',
-	'select-output',
-	'update-output-port',
-	'close'
-]);
+const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
 
 interface BasicKnobs {
 	name: string;
@@ -620,14 +613,8 @@ const createConfiguration = async () => {
 	});
 };
 
-const onUpdateOutput = (id) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 const fetchConfigurations = async (modelId: string) => {

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -45,8 +45,7 @@
 				<tera-drilldown-preview
 					title="Model Preview"
 					v-model:output="selectedOutputId"
-					@update:output="onUpdateOutput"
-					@update:selection="onUpdateSelection"
+					@update:selection="onSelection"
 					:options="outputs"
 					is-selectable
 					class="h-full"
@@ -111,13 +110,7 @@ import { ModelEditOperationState } from './model-edit-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelEditOperationState>;
 }>();
-const emit = defineEmits([
-	'append-output',
-	'update-state',
-	'close',
-	'select-output',
-	'update-output-port'
-]);
+const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output']);
 
 enum ModelEditTabs {
 	Wizard = 'Wizard',
@@ -327,15 +320,8 @@ const saveCodeToState = (code: string, hasCodeBeenRun: boolean) => {
 	emit('update-state', state);
 };
 
-const onUpdateOutput = (id: string) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 watch(

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -5,8 +5,7 @@
 			<tera-output-dropdown
 				:options="outputs"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				:is-loading="isProcessing"
 				is-selectable
 			/>
@@ -280,7 +279,7 @@ onMounted(async () => {
 	clonedState.value = cloneDeep(props.node.state);
 
 	if (selectedOutputId.value) {
-		onUpdateOutput(selectedOutputId.value);
+		onSelection(selectedOutputId.value);
 	}
 
 	if (documentId.value) {
@@ -547,21 +546,14 @@ watch(
 	{ deep: true }
 );
 
-function onUpdateOutput(id) {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-}
+};
 
 function updateNodeLabel(id: string, label: string) {
 	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.id === id));
 	if (!outputPort) return;
 	outputPort.label = label;
-	emit('update-output-port', outputPort);
-}
-
-function onUpdateSelection(id) {
-	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
 	emit('update-output-port', outputPort);
 }
 </script>

--- a/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-document/tera-model-from-document-drilldown.vue
@@ -5,8 +5,7 @@
 			<tera-output-dropdown
 				:options="outputs"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				:is-loading="assetLoading"
 				is-selectable
 			/>
@@ -224,7 +223,7 @@ const savingAsset = ref(false);
 onMounted(async () => {
 	clonedState.value = cloneDeep(props.node.state);
 	if (selectedOutputId.value) {
-		onUpdateOutput(selectedOutputId.value);
+		onSelection(selectedOutputId.value);
 	}
 
 	const documentId = props.node.inputs?.[0]?.value?.[0];
@@ -277,16 +276,9 @@ function onUpdateInclude(asset: AssetBlock<EquationBlock | EquationFromImageBloc
 	emit('update-state', clonedState.value);
 }
 
-function onUpdateOutput(id) {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-}
-
-function onUpdateSelection(id) {
-	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
-}
+};
 
 async function onRun() {
 	const equations = clonedState.value.equations

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -61,8 +61,7 @@
 				title="Simulation output"
 				:options="outputs"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				:is-loading="showSpinner"
 				is-selectable
 			>
@@ -182,13 +181,7 @@ import { SimulateCiemssOperation, SimulateCiemssOperationState } from './simulat
 const props = defineProps<{
 	node: WorkflowNode<SimulateCiemssOperationState>;
 }>();
-const emit = defineEmits([
-	'append-output',
-	'update-state',
-	'select-output',
-	'update-output-port',
-	'close'
-]);
+const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
 
 const hasValidDatasetName = computed<boolean>(() => saveAsName.value !== '');
 
@@ -364,15 +357,8 @@ const lazyLoadSimulationData = async (runId: string) => {
 	rawContent.value[runId] = createCsvAssetFromRunResults(runResults.value[runId]);
 };
 
-const onUpdateOutput = (id) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 const configurationChange = (index: number, config: ChartConfig) => {

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -120,8 +120,7 @@
 				v-model:output="selectedOutputId"
 				is-selectable
 				:is-loading="showSpinner"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 			>
 				<tera-simulate-chart
 					v-for="(cfg, index) of node.state.chartConfigs"
@@ -184,13 +183,7 @@ import { SimulateEnsembleCiemssOperationState } from './simulate-ensemble-ciemss
 const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits([
-	'append-output',
-	'select-output',
-	'update-output-port',
-	'update-state',
-	'close'
-]);
+const emit = defineEmits(['append-output', 'select-output', 'update-state', 'close']);
 
 const dataLabelPlugin = [ChartDataLabels];
 
@@ -251,15 +244,8 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	emit('update-state', state);
 };
 
-const onUpdateOutput = (id) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 const calculateWeights = () => {

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -37,8 +37,7 @@
 				title="Simulation output"
 				:options="outputs"
 				v-model:output="selectedOutputId"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				:is-loading="showSpinner"
 				is-selectable
 			>
@@ -159,13 +158,7 @@ import { SimulateJuliaOperation, SimulateJuliaOperationState } from './simulate-
 const props = defineProps<{
 	node: WorkflowNode<SimulateJuliaOperationState>;
 }>();
-const emit = defineEmits([
-	'append-output',
-	'update-state',
-	'select-output',
-	'update-output-port',
-	'close'
-]);
+const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
 
 const timespan = ref<TimeSpan>(props.node.state.currentTimespan);
 
@@ -330,15 +323,8 @@ const lazyLoadSimulationData = async (runId: string) => {
 	rawContent.value[runId] = createCsvAssetFromRunResults(runResults.value, runId);
 };
 
-const onUpdateOutput = (id) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
-};
-
-const onUpdateSelection = (id) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
 };
 
 const configurationChange = (index: number, config: ChartConfig) => {

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -47,8 +47,7 @@
 			<tera-drilldown-preview
 				title="Stratify output"
 				:options="outputs"
-				@update:output="onUpdateOutput"
-				@update:selection="onUpdateSelection"
+				@update:selection="onSelection"
 				v-model:output="selectedOutputId"
 				is-selectable
 			>
@@ -368,14 +367,7 @@ const saveCodeToState = (code: string, hasCodeBeenRun: boolean) => {
 	emit('update-state', state);
 };
 
-const onUpdateSelection = (id: string) => {
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.isSelected = !outputPort?.isSelected;
-	emit('update-output-port', outputPort);
-};
-
-const onUpdateOutput = (id: string) => {
+const onSelection = (id: string) => {
 	emit('select-output', id);
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-node-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-node-mira.vue
@@ -1,8 +1,14 @@
 <template>
 	<section>
-		<tera-operator-placeholder :operation-type="node.operationType">
+		<tera-operator-placeholder v-if="!outputPreview" :operation-type="node.operationType">
 			<template v-if="!node.inputs[0].value">Attach a model</template>
 		</tera-operator-placeholder>
+		<tera-model-diagram
+			v-if="outputPreview"
+			:model="outputPreview"
+			:is-editable="false"
+			is-preview
+		/>
 		<Button
 			v-if="node.inputs[0].value"
 			@click="emit('open-drilldown')"
@@ -14,16 +20,34 @@
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
+import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-model-diagram.vue';
 import Button from 'primevue/button';
+import { getModel } from '@/services/model';
+import { Model } from '@/types/Types';
 import { StratifyOperationStateMira } from './stratify-mira-operation';
 
 const emit = defineEmits(['open-drilldown']);
+const outputPreview = ref<Model | null>();
 
-defineProps<{
+const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
+
+watch(
+	() => props.node.active,
+	async () => {
+		const active = props.node.active;
+		if (!active) return;
+
+		const port = props.node.outputs.find((d) => d.id === active);
+		if (!port) return;
+		outputPreview.value = await getModel(port.value?.[0]);
+	},
+	{ immediate: true }
+);
 </script>
 
 <style scoped></style>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -104,7 +104,6 @@
 						<component
 							:is="registry.getNode(node.operationType)"
 							:node="node"
-							@append-output-port="() => appendOutputPort()"
 							@append-output="(event: any) => appendOutput(node, event)"
 							@append-input-port="(event: any) => appendInputPort(node, event)"
 							@update-state="(event: any) => updateWorkflowNodeState(node, event)"
@@ -176,12 +175,11 @@
 			v-if="dialogIsOpened && currentActiveNode"
 			:is="registry.getDrilldown(currentActiveNode.operationType)"
 			:node="currentActiveNode"
-			@append-output-port="() => appendOutputPort()"
 			@append-output="(event: any) => appendOutput(currentActiveNode, event)"
 			@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
-			@update-output-port="(event: any) => updateOutputPort(currentActiveNode, event)"
 			@close="dialogIsOpened = false"
+			@update-output-port="(event: any) => updateOutputPort(currentActiveNode, event)"
 		>
 		</component>
 	</Teleport>
@@ -366,41 +364,6 @@ function appendOutput(
 	workflowDirty = true;
 }
 
-// @deprecated
-// FIXME: Leaving this in here to warn against existing development - remove after hackathon, Feb 2022.
-function appendOutputPort() {
-	/*
-	node: WorkflowNode<any> | null,
-	port: { type: string; label?: string; value: any; state?: any; isSelected?: boolean }
-	*/
-	console.error('This function is no longer supported, use <append-output> intstead');
-	throw new Error('This function is no longer supported, use <append-output> intstead');
-
-	/*
-	if (!node) return;
-
-	const uuid = uuidv4();
-
-	const outputPort: WorkflowOutput<any> = {
-		id: uuid,
-		type: port.type,
-		label: port.label,
-		value: isArray(port.value) ? port.value : [port.value],
-		isOptional: false,
-		status: WorkflowPortStatus.NOT_CONNECTED,
-		state: port.state,
-		timestamp: new Date()
-	};
-
-	if ('isSelected' in port) outputPort.isSelected = port.isSelected;
-
-	node.outputs.push(outputPort);
-	node.active = uuid;
-
-	workflowDirty = true;
-	*/
-}
-
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
 	workflowService.updateNodeState(wf.value, node.id, state);
@@ -409,12 +372,14 @@ function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 
 function selectOutput(node: WorkflowNode<any> | null, selectedOutputId: string) {
 	if (!node) return;
+	console.log('Select output', node.displayName, selectedOutputId);
 	workflowService.selectOutput(node, selectedOutputId);
 	workflowDirty = true;
 }
 
 function updateOutputPort(node: WorkflowNode<any> | null, workflowOutput: WorkflowOutput<any>) {
 	if (!node) return;
+	console.error('doh doh doh');
 	workflowService.updateOutputPort(node, workflowOutput);
 	workflowDirty = true;
 }

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -372,14 +372,12 @@ function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 
 function selectOutput(node: WorkflowNode<any> | null, selectedOutputId: string) {
 	if (!node) return;
-	console.log('Select output', node.displayName, selectedOutputId);
 	workflowService.selectOutput(node, selectedOutputId);
 	workflowDirty = true;
 }
 
 function updateOutputPort(node: WorkflowNode<any> | null, workflowOutput: WorkflowOutput<any>) {
 	if (!node) return;
-	console.error('doh doh doh');
 	workflowService.updateOutputPort(node, workflowOutput);
 	workflowDirty = true;
 }


### PR DESCRIPTION
### Summary
This cleans up the update-port and select-port semantic in the workflow operators. There are numerous instances where the signals are crisscrossed and hard to figure out whether the intention is to select output or update the output-port's attributes.

Also remove the multi-select from the preview drilldown, only a single output will be exposed by any given operator.
