### PR TITLE
Facet types not matching

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ConceptController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ConceptController.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.controller.dataservice;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -212,10 +213,15 @@ public class ConceptController {
 			@ApiResponse(responseCode = "500", description = "There was an issue retrieving concepts from the data store", content = @Content)
 	})
 	public ResponseEntity<ConceptFacetSearchResponse> searchConceptsUsingFacets(
-			@RequestParam(value = "types", required = false) final List<TaggableType> types,
+			@RequestParam(value = "types", required = false) final List<String> types,
 			@RequestParam(value = "curies", required = false) final List<String> curies) {
 		try {
-			return ResponseEntity.ok(conceptService.searchConceptsUsingFacets(types, curies));
+			List<TaggableType> types2 = new ArrayList<>(types.size());
+			for (String type : types) {
+				TaggableType t = TaggableType.findByType(type);
+				types2.add(t);
+			}
+			return ResponseEntity.ok(conceptService.searchConceptsUsingFacets(types2, curies));
 		} catch (RuntimeException e) {
 			final String error = "Unable to search concepts using facets";
 			log.error(error, e);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/TaggableType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/TaggableType.java
@@ -3,11 +3,11 @@ package software.uncharted.terarium.hmiserver.models.dataservice;
 import java.util.Arrays;
 
 public enum TaggableType {
-	DATASETS("datasets"),
+	DATASETS("DATASET"),
 	FEATURES("features"),
 	INTERMEDIATES("intermediates"),
 	MODEL_PARAMETERS("model_parameters"),
-	MODELS("models"),
+	MODELS("MODEL"),
 	PROJECTS("projects"),
 	PUBLICATIONS("PUBLICATION"),
 	QUALIFIERS("qualifiers"),

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/TaggableType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/TaggableType.java
@@ -9,7 +9,7 @@ public enum TaggableType {
 	MODEL_PARAMETERS("model_parameters"),
 	MODELS("models"),
 	PROJECTS("projects"),
-	PUBLICATIONS("publications"),
+	PUBLICATIONS("PUBLICATION"),
 	QUALIFIERS("qualifiers"),
 	SIMULATION_PARAMETERS("simulation_parameters"),
 	SIMULATION_PLANS("simulation_plans"),


### PR DESCRIPTION
# Description

Stops the 400 errors in the client network console

Fundamentally there is a disconnect between the UI's `Types.ts AssetType` values and `TaggableTypes.java` but I haven't looked to see where these are used completely.  

Resolves #(issue)
