### PR TITLE
mira model template preview for regnet/stockflow framework types

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-node.vue
@@ -111,6 +111,7 @@ const generateTemplatePreview = async () => {
 			.register('reset_response', () => null) // noop
 			.register('model_preview', (data) => {
 				templatePreview.value = `data:image/png;base64, ${data?.content?.['image/png']}`;
+				kernelManager.shutdown();
 			});
 	} catch (err) {
 		console.error(err);


### PR DESCRIPTION
### Summary
Using beaker to generate model preview. For:
- petrinet: use our own renderer
- stock and flow: use MMT preview
- regnet: use MMT preview

For example: Stock and flow SIR model
<img width="247" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/95153e9a-07d7-42a6-a651-7ff825c616ee">


### Testing
Requires beaker, you can get an example stock-n-flow from: https://raw.githubusercontent.com/DARPA-ASKEM/simulation-integration/main/data/models/SEIR_stockflow.json