### PR TITLE
minor update

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
@@ -18,7 +18,7 @@ export const SimulateCiemssOperation: Operation = {
 	description: 'given a model id, and configuration id, run a simulation',
 	inputs: [
 		{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: false },
-		{ type: 'calibrateSimulationId', label: 'Calibration', acceptMultiple: false }
+		{ type: 'calibrateSimulationId', label: 'Calibration', acceptMultiple: false, isOptional: true }
 	],
 	outputs: [{ type: 'simulationId' }],
 	isRunnable: true,


### PR DESCRIPTION
# Description
Minor update to the simulate-ciemss-operation. 
I noticed that it can now take an optional calibrationSimulationId.
Just marking this off as `isOptional`

![image](https://github.com/DARPA-ASKEM/terarium/assets/17088680/27752931-f0c7-4930-8404-58d02ed12759)
