### PR TITLE
fix[hmi-server]: duplicate assets can be added to a project

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectAssetService.java
@@ -33,49 +33,27 @@ public class ProjectAssetService {
 	final WorkflowService workflowService;
 	final CodeService codeService;
 
-	public List<ProjectAsset> findAllByProjectId(@NotNull final UUID projectId) {
-		return projectAssetRepository.findAllByProjectId(projectId);
-	}
 
 	/**
 	 * Find all active assets for a project.  Active assets are defined as those that are not deleted and not temporary.
-	 * @param projectId
-	 * @param types
-	 * @return
+	 * @param projectId The project ID
+	 * @param types The types of assets to find
+	 * @return The list of active assets for the project
 	 */
 	public List<ProjectAsset> findActiveAssetsForProject(@NotNull final UUID projectId,
 			final Collection<@NotNull AssetType> types) {
 		return projectAssetRepository.findAllByProjectIdAndAssetTypeInAndDeletedOnIsNullAndTemporaryFalse(projectId, types);
 	}
 
-	public ProjectAsset save(final ProjectAsset asset) {
-		return projectAssetRepository.save(asset);
-	}
 
-	public boolean deleteByAssetId(@NotNull final UUID projectId, @NotNull final AssetType type,
-			@NotNull final UUID originalAssetId) {
-		final ProjectAsset asset = projectAssetRepository
-				.findByProjectIdAndAssetIdAndAssetType(projectId, originalAssetId, type);
+	public boolean deleteByAssetId(@NotNull final UUID projectId, @NotNull final AssetType type, @NotNull final UUID originalAssetId) {
+		final ProjectAsset asset = projectAssetRepository.findByProjectIdAndAssetIdAndAssetType(projectId, originalAssetId, type);
 		if (asset == null) {
 			return false;
 		}
 		asset.setDeletedOn(Timestamp.from(Instant.now()));
-		return (save(asset) != null);
-	}
-
-	public boolean delete(final UUID id) {
-		final ProjectAsset asset = projectAssetRepository.findById(id).orElse(null);
-		if (asset == null) {
-			return false;
-		}
-		asset.setDeletedOn(Timestamp.from(Instant.now()));
-		return (save(asset) != null);
-	}
-
-	public ProjectAsset findByProjectIdAndAssetIdAndAssetType(@NotNull final UUID projectId,
-			@NotNull final UUID assetId,
-			@NotNull final AssetType type) {
-		return projectAssetRepository.findByProjectIdAndAssetIdAndAssetType(projectId, assetId, type);
+		projectAssetRepository.save(asset);
+		return true;
 	}
 
 	private boolean populateProjectAssetFields(final ProjectAsset projectAsset, final AssetType assetType, final UUID id)
@@ -154,6 +132,10 @@ public class ProjectAssetService {
 			final AssetType assetType) {
 		return Optional.ofNullable(projectAssetRepository
 				.findByProjectIdAndAssetNameAndAssetTypeAndDeletedOnIsNull(projectId, assetName, assetType));
+	}
+
+	public Optional<ProjectAsset> getProjectAssetByProjectIdAndAssetId(final UUID id, final UUID assetId) {
+		return Optional.ofNullable(projectAssetRepository.findByProjectIdAndAssetId(id, assetId));
 	}
 
 }


### PR DESCRIPTION
Our project asset controller now throws a 409 error code when a duplicate asset tries to get added to a project.

In addition, a few other fixes:
* Cleaning up unused methods in `ProjectAssetService`.
* Found a previously reported bug in our front end for adding an xdd document to a project. This was a 2-for-1 bug where the code didn't actually work as explained, and there was some typing issues that made my skin crawl :)

Also to note, the current implementation of `useProjects` and `ProjectService` hide away any helpful error messages from the back end. We may want to revisit this design in the near future. I've updated a TODO doc with this idea?


Resolves #2813 
