### PR TITLE
fix[hmi-server]: incorrect parsing of some xdd documents

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -1004,7 +1004,7 @@ export interface AuthorityInstance {
 export interface KnownEntities {
     urlExtractions: XDDUrlExtraction[];
     askemObjects: Extraction[];
-    summaries: string[];
+    summaries: any[];
 }
 
 export interface KnownEntitiesCounts {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/services/DownloadService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/services/DownloadService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -92,7 +93,7 @@ public class DownloadService {
 			.disableRedirectHandling()
 			.build();
 
-		final HttpGet get = new HttpGet(url);
+		final HttpGet get = new HttpGet(URLEncoder.encode(url, StandardCharsets.UTF_8));
 		final HttpResponse response = httpclient.execute(get);
 
 		// Follow redirects until we actually get a document
@@ -146,7 +147,7 @@ public class DownloadService {
 			.disableRedirectHandling()
 			.build();
 
-		final HttpGet get = new HttpGet(url);
+		final HttpGet get = new HttpGet(URLEncoder.encode(url, StandardCharsets.UTF_8));
 		final HttpResponse response = httpclient.execute(get);
 
 		// Follow redirects until we actually get a document

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/KnownEntities.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/documentservice/KnownEntities.java
@@ -1,6 +1,7 @@
 package software.uncharted.terarium.hmiserver.models.documentservice;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -17,7 +18,7 @@ public class KnownEntities implements Serializable {
 	@JsonAlias("askem_object")
 	private List<Extraction> askemObjects;
 
-	private List<String> summaries;
+	private List<JsonNode> summaries;
 
 
 }


### PR DESCRIPTION
There are two bugs found here.
* The first is that we incorrectly assumed the type of `summaries` on the `KnownEntities` model. This may be the first time we've seen this be populated, or, xdd may have changed the schema without telling us, but, lets just assume we had it wrong here.

* The second was an issue with URL encoding if the pdfs had spaces in them.

This is just the back end work. Our front end will now need to accommodate this new type of summary


Resolves #2840 
