### PR TITLE
Jamie fix resource panel accordion counts when section is empty

### DIFF
--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -55,7 +55,7 @@
 							<template v-if="type === AssetType.Publication">External Publications</template>
 							<template v-else-if="type === AssetType.Document">Documents</template>
 							<template v-else>{{ capitalize(type) }}</template>
-							<aside v-if="assetItems.size > 0">({{ assetItems.size }})</aside>
+							<aside>({{ assetItems.size }})</aside>
 						</div>
 						<!-- New asset buttons for some types -->
 						<Button

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -136,6 +136,7 @@
 						"
 					/>
 				</Button>
+				<section v-if="assetItems.size == 0" class="empty-resource">Empty</section>
 			</AccordionTab>
 		</Accordion>
 
@@ -260,6 +261,11 @@ header {
 	}
 }
 
+.empty-resource {
+	margin-left: 2.5rem;
+	font-size: var(--font-caption);
+	color: var(--text-color-subdued);
+}
 .clear-icon {
 	position: absolute;
 	right: 48px;


### PR DESCRIPTION
**BEFORE**
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/b2285918-9fc0-4933-9f08-96704f966ced)

**AFTER**
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/48bac9ed-5347-43c2-8b0f-711d07b67289)
