### PR TITLE
Add way to propagate task response handler errors to users. Fix scaling issue for response handlers.

### DIFF
--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -183,6 +183,8 @@ spring.neo4j.authentication.password=${neo4j-password}
 ########################################################################################################################
 terarium.taskrunner.request-queue=terarium-request-queue
 terarium.taskrunner.response-exchange=terarium-response-exchange
+terarium.taskrunner.shared-response-queue=terarium-shared-response-queue
+terarium.taskrunner.handler-error-exchange=terarium-handler-error-exchange
 terarium.taskrunner.cancellation-exchange=terarium-cancellation-exchange
 terarium.taskrunner.durable-queues=true
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithUserDetails;
@@ -101,7 +100,7 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		}
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMModelCardRequest() throws Exception {
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/TaskServiceTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithUserDetails;
@@ -100,7 +101,7 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		}
 	}
 
-	// @Test
+	@Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMModelCardRequest() throws Exception {
 

--- a/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/service/TaskRunnerService.java
+++ b/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/service/TaskRunnerService.java
@@ -43,9 +43,6 @@ public class TaskRunnerService {
 	@Value("${terarium.taskrunner.response-exchange}")
 	public String TASK_RUNNER_RESPONSE_EXCHANGE;
 
-	@Value("${terarium.taskrunner.response-queue}")
-	public String TASK_RUNNER_RESPONSE_QUEUE;
-
 	@Value("${terarium.taskrunner.cancellation-exchange}")
 	public String TASK_RUNNER_CANCELLATION_EXCHANGE;
 

--- a/packages/taskrunner/src/main/resources/application.properties
+++ b/packages/taskrunner/src/main/resources/application.properties
@@ -16,7 +16,6 @@ spring.rabbitmq.password=${terarium.mq-password}
 ########################################################################################################################
 terarium.taskrunner.request-queue=terarium-request-queue
 terarium.taskrunner.response-exchange=terarium-response-exchange
-terarium.taskrunner.response-queue=terarium-response-queue
 terarium.taskrunner.cancellation-exchange=terarium-cancellation-exchange
 terarium.taskrunner.request-concurrency=16
 terarium.taskrunner.request-type=terarium

--- a/packages/taskrunner/src/test/java/software/uncharted/terarium/taskrunner/service/TaskRunnerServiceTests.java
+++ b/packages/taskrunner/src/test/java/software/uncharted/terarium/taskrunner/service/TaskRunnerServiceTests.java
@@ -50,6 +50,7 @@ public class TaskRunnerServiceTests extends TaskRunnerApplicationTests {
 	private final String TEST_INPUT = "{\"research_paper\":\"Test research paper\"}";
 	private final String FAILURE_INPUT = "{\"should_fail\":true}";
 	private final String SCRIPT_PATH = getClass().getResource("/echo.py").getPath();
+	private final String TASK_RUNNER_RESPONSE_QUEUE = "terarium-response-queue-test";
 
 	@BeforeEach
 	public void setup() {
@@ -57,7 +58,7 @@ public class TaskRunnerServiceTests extends TaskRunnerApplicationTests {
 		taskRunnerService.declareQueues();
 		taskRunnerService.declareAndBindTransientQueueWithRoutingKey(
 				taskRunnerService.TASK_RUNNER_RESPONSE_EXCHANGE,
-				taskRunnerService.TASK_RUNNER_RESPONSE_QUEUE, "");
+				TASK_RUNNER_RESPONSE_QUEUE, "");
 	}
 
 	@AfterEach
@@ -94,7 +95,7 @@ public class TaskRunnerServiceTests extends TaskRunnerApplicationTests {
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(
 				rabbitTemplate.getConnectionFactory());
-		container.setQueueNames(taskRunnerService.TASK_RUNNER_RESPONSE_QUEUE);
+		container.setQueueNames(TASK_RUNNER_RESPONSE_QUEUE);
 		container.setMessageListener(message -> {
 			try {
 				TaskResponse resp = mapper.readValue(message.getBody(), TaskResponse.class);
@@ -251,7 +252,7 @@ public class TaskRunnerServiceTests extends TaskRunnerApplicationTests {
 
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(
 				rabbitTemplate.getConnectionFactory());
-		container.setQueueNames(taskRunnerService.TASK_RUNNER_RESPONSE_QUEUE);
+		container.setQueueNames(TASK_RUNNER_RESPONSE_QUEUE);
 		container.setMessageListener(message -> {
 			try {
 				TaskResponse resp = mapper.readValue(message.getBody(), TaskResponse.class);

--- a/packages/taskrunner/src/test/resources/application-test.properties
+++ b/packages/taskrunner/src/test/resources/application-test.properties
@@ -13,7 +13,6 @@ spring.rabbitmq.password=${terarium.mq-password}
 ########################################################################################################################
 terarium.taskrunner.request-queue=terarium-request-queue-test
 terarium.taskrunner.response-exchange=terarium-response-exchange-test
-terarium.taskrunner.response-queue=terarium-response-queue-test
 terarium.taskrunner.cancellation-exchange=terarium-cancellation-exchange-test
 terarium.taskrunner.request-concurrency=16
 terarium.taskrunner.request-type=terarium


### PR DESCRIPTION
Previously the response handlers (which should execute once, regardless of how many hmi-servers are running), would execute per hmi-server instance. This fixes that.

Response handlers should only run once, previously they would run once per hmi-server instance. This PR fixes that.

Catch response handler errors and dispatch those any relevant SSE Emitters.
