### PR TITLE
update heuristic to distinguish regular and stratified petrinets

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -442,6 +442,8 @@ export const getModifierMap = (amr: Model) => {
 
 // Check if AMR is a stratified AMR
 export const getStratificationType = (amr: Model) => {
+	if (amr.semantics?.span && amr.semantics.span.length > 1) return StratifiedModel.Catlab;
+
 	const modifierMap = getModifierMap(amr);
 	// eslint-disable-next-line
 	for (const ele of modifierMap) {

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -4,7 +4,7 @@ import { Model, ModelConfiguration, PetriNetModel, PetriNetTransition } from '@/
 import { logger } from '@/utils/logger';
 import { IGraph } from '@graph-scaffolder/types';
 import { AxiosError } from 'axios';
-import _, { isEmpty, some } from 'lodash';
+import _ from 'lodash';
 
 // deprecated section - this is the acset representation, we should do the conversion on model-service
 interface PetriNet {
@@ -413,27 +413,58 @@ export const mergeMetadata = (amr: Model, amrOld: Model) => {
 	console.log(amr, amrOld);
 };
 
-/// /////////////////////////////////////////////////////////////////////////////
-// Stratification
-/// /////////////////////////////////////////////////////////////////////////////
+/**
+ * Stratification
+ * */
+
+// Heuristic to get the straitified modifier mappings, we assume that
+// - if there is a single unique value for modifier-key then it is not user initiated stratification
+// - if the modifier value starts with 'ncit:' then it is not a user initiated stratification
+export const getModifierMap = (amr: Model) => {
+	const modifierMap: Map<string, Set<string>> = new Map();
+	(amr.model as PetriNetModel).states.forEach((s) => {
+		if (s.grounding && s.grounding.modifiers) {
+			const modifiers = s.grounding.modifiers;
+			const keys: string[] = Object.keys(modifiers);
+			keys.forEach((key) => {
+				if (!modifierMap.has(key)) {
+					modifierMap.set(key, new Set());
+				}
+				const modifier = modifiers[key];
+				if (!modifier.startsWith('ncit:')) {
+					modifierMap.get(key)?.add(modifiers[key]);
+				}
+			});
+		}
+	});
+	return modifierMap;
+};
 
 // Check if AMR is a stratified AMR
 export const getStratificationType = (amr: Model) => {
-	if (amr.semantics?.span && amr.semantics.span.length > 1) return StratifiedModel.Catlab;
-
-	const hasModifiers = some(
-		(amr.model as PetriNetModel).states,
-		(s) =>
-			s.grounding &&
-			s.grounding.modifiers &&
-			!isEmpty(Object.keys(s.grounding.modifiers)) &&
-			// Temp hack to reject SBML type models with actual groundings, may not work
-			// all the time, MIRA will move strata info to metadata section - Oct 2023
-			s.id.includes('_')
-	);
-	if (hasModifiers) return StratifiedModel.Mira;
-
+	const modifierMap = getModifierMap(amr);
+	// eslint-disable-next-line
+	for (const ele of modifierMap) {
+		if (ele[1].size > 1) {
+			return StratifiedModel.Mira;
+		}
+	}
 	return null;
+
+	// if (amr.semantics?.span && amr.semantics.span.length > 1) return StratifiedModel.Catlab;
+	//
+	// const hasModifiers = some(
+	// 	(amr.model as PetriNetModel).states,
+	// 	(s) =>
+	// 		s.grounding &&
+	// 		s.grounding.modifiers &&
+	// 		!isEmpty(Object.keys(s.grounding.modifiers)) &&
+	// 		// Temp hack to reject SBML type models with actual groundings, may not work
+	// 		// all the time, MIRA will move strata info to metadata section - Oct 2023
+	// 		s.id.includes('_')
+	// );
+	// if (hasModifiers) return StratifiedModel.Mira;
+	// return null;
 };
 
 export function newAMR(modelName: string) {


### PR DESCRIPTION
### Summary
Update heuristics
- only consider stratified if there are more than 1 stratas
- ignore specific keywords