### PR TITLE
fix: stratified matrix expressions

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix-modal.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix-modal.vue
@@ -77,7 +77,7 @@ const props = defineProps<{
 
 const emit = defineEmits(['close-modal', 'update-configuration']);
 
-const matrixShouldEval = ref(true);
+const matrixShouldEval = ref(false);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -131,7 +131,7 @@ watch(
 							if (!output[cell.row]) {
 								output[cell.row] = [];
 							}
-							output[cell.row][cell.col] = await getMatrixValue(cell.content.id, props.shouldEval);
+							output[cell.row][cell.col] = await getMatrixValue(cell.content.id);
 						}
 					})
 				)
@@ -188,10 +188,10 @@ function onEnterValueCell(variableName: string, rowIdx: number, colIdx: number) 
 
 // See ES2_2a_start in "Eval do not touch"
 // Returns the presentation mathml
-async function getMatrixValue(variableName: string, shouldEvaluate: boolean) {
+async function getMatrixValue(variableName: string) {
 	const expressionBase = getMatrixExpression(variableName);
 
-	if (shouldEvaluate) {
+	if (props.shouldEval) {
 		const expressionEval = await pythonInstance.evaluateExpression(
 			expressionBase,
 			parametersValueMap.value


### PR DESCRIPTION
# Description

I set the evaluate expressions to false by default so that we don't run into blank cells for now. You can see in the video that Pyodide is throwing errors on the Carcoine model but not the SIR.

It seems to not like the variable names:
```
pyodide.asm.js:9 Uncaught PythonError: Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 460, in eval_code
    CodeRunner(
  File "/lib/python311.zip/_pyodide/_base.py", line 248, in __init__
    self.ast = next(self._gen)
               ^^^^^^^^^^^^^^^
  File "/lib/python311.zip/_pyodide/_base.py", line 144, in _parse_and_compile_gen
    mod = compile(source, filename, mode, flags | ast.PyCF_ONLY_AST)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 2
    beta_0,beta_1,beta_2,beta_3,epsilon_0,epsilon_1,gamma_0,gamma_1,alpha_0,alpha_1,p_old_young,p_young_old,lambda,mu,City = sympy.symbols('beta_0 beta_1 beta_2 beta_3 epsilon_0 epsilon_1 gamma_0 gamma_1 alpha_0 alpha_1 p_old_young p_young_old lambda mu City')
```


https://github.com/DARPA-ASKEM/terarium/assets/28237258/a870c329-b334-4dcb-8380-342bb22b34c1



