### PR TITLE
Update font sizes and styles in petrinet-renderer and nested-petrinet…

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/theme.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/theme.scss
@@ -1,4 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,400;0,600;1,400;1,600&display=swap');
+@import url('https://fonts.googleapis.com/css2&family=STIX+Two+Text:ital,wght@0,400..700;1,400..700&display=swap');
+
 @import './variables';
 @import './designer/_components';
 @import './extensions/vendor_extensions';

--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -14,7 +14,6 @@ const FONT_SIZE_REGULAR = 24;
 const FONT_SIZE_LARGE = 36;
 
 function setFontSize(label: string) {
-	console.log(label, label.length);
 	if (label.length < 3) {
 		return FONT_SIZE_LARGE;
 	}

--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -9,6 +9,21 @@ import { NodeData } from '@/model-representation/petrinet/petrinet-service';
 import CIRCLE_PACKING_CHILD_NORMALIZED_VECTORS from '@/model-representation/petrinet/circle-packing-vectors.json';
 import CIRCLE_PACKING_CHILD_NORMALIZED_RADII from '@/model-representation/petrinet/circle-packing-radii.json';
 
+const FONT_SIZE_SMALL = 18;
+const FONT_SIZE_REGULAR = 24;
+const FONT_SIZE_LARGE = 36;
+
+function setFontSize(label: string) {
+	console.log(label, label.length);
+	if (label.length < 3) {
+		return FONT_SIZE_LARGE;
+	}
+	if (label.length < 10) {
+		return FONT_SIZE_REGULAR;
+	}
+	return FONT_SIZE_SMALL;
+}
+
 export interface NestedPetrinetOptions extends Options {
 	nestedMap?: { [baseNodeId: string]: any };
 	transitionMatrices?: { [baseTransitionId: string]: any[] };
@@ -171,6 +186,7 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 			});
 		});
 
+		/* Don't show transition labels because we're showing matrices here */
 		// transitions label text
 		// transitions
 		// 	.append('text')
@@ -184,7 +200,10 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 		// transitions expression text
 		transitions
 			.append('text')
-			.attr('y', (d) => -d.height / 2 - 5)
+			.attr('y', (d) => -d.height / 2 - 8)
+			.style('font-family', 'STIX Two Text, serif')
+			.style('font-style', 'italic')
+			.style('font-size', FONT_SIZE_SMALL)
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
 			.style('stroke', '#FFF')
@@ -203,8 +222,12 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 		// species text
 		species
 			.append('text')
-			.attr('y', () => 8)
-			.style('font-size', '24px')
+			.attr('y', () => 5)
+			.style('font-family', 'STIX Two Text, serif')
+			.style('font-style', 'italic')
+			.style('font-size', (d) => setFontSize(d.id))
+			.style('stroke', '#FFF')
+			.attr('stroke-width', '0.5px')
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
 			.style('fill', 'var(--text-color-primary)')

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -23,7 +23,6 @@ const FONT_SIZE_REGULAR = 24;
 const FONT_SIZE_LARGE = 36;
 
 function setFontSize(label: string) {
-	console.log(label, label.length);
 	if (label.length < 3) {
 		return FONT_SIZE_LARGE;
 	}

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -18,6 +18,21 @@ export enum NodeType {
 	Transition = 'transition'
 }
 
+const FONT_SIZE_SMALL = 18;
+const FONT_SIZE_REGULAR = 24;
+const FONT_SIZE_LARGE = 36;
+
+function setFontSize(label: string) {
+	console.log(label, label.length);
+	if (label.length < 3) {
+		return FONT_SIZE_LARGE;
+	}
+	if (label.length < 10) {
+		return FONT_SIZE_REGULAR;
+	}
+	return FONT_SIZE_SMALL;
+}
+
 const MARKER_VIEWBOX = '-5 -5 10 10';
 const ARROW = 'M 0,-3.25 L 5 ,0 L 0,3.25';
 const pathFn = d3
@@ -104,8 +119,12 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 		// transitions label text
 		transitions
 			.append('text')
-			.attr('y', () => 5)
+			.attr('y', () => 12)
 			.style('text-anchor', 'middle')
+			.style('font-family', 'STIX Two Text, serif')
+			.style('font-style', 'italic')
+			.style('font-size', (d) => setFontSize(d.id))
+			.style('stroke', '#FFF')
 			.style('paint-order', 'stroke')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
@@ -114,7 +133,10 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 		// transitions expression text
 		transitions
 			.append('text')
-			.attr('y', (d) => -d.height / 2 - 5)
+			.attr('y', (d) => -d.height / 2 - 8)
+			.style('font-family', 'STIX Two Text, serif')
+			.style('font-style', 'italic')
+			.style('font-size', FONT_SIZE_SMALL)
 			.style('text-anchor', 'middle')
 			.style('paint-order', 'stroke')
 			.style('stroke', '#FFF')
@@ -147,6 +169,10 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.append('text')
 			.attr('y', () => 5)
 			.style('text-anchor', 'middle')
+			.style('font-family', 'STIX Two Text, serif')
+			.style('font-style', 'italic')
+			.style('font-size', (d) => setFontSize(d.id))
+			.style('stroke', '#FFF')
 			.style('paint-order', 'stroke')
 			.style('fill', 'var(--text-color-primary')
 			.style('pointer-events', 'none')
@@ -179,7 +205,9 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 				.classed('multi-edge-label', true)
 				.attr('x', point.x)
 				.attr('y', point.y + 6)
-				.style('font-size', 18)
+				.style('font-family', 'STIX Two Text, serif')
+				.style('font-style', 'italic')
+				.style('font-size', FONT_SIZE_REGULAR)
 				.style('paint-order', 'stroke')
 				.style('stroke', 'var(--gray-50)')
 				.style('stroke-width', '6px')


### PR DESCRIPTION
Imported a font called "STIX Two Text" that is nice for math: [https://fonts.google.com/specimen/STIX+Two+Text](https://fonts.google.com/specimen/STIX+Two+Text
)

Added a switch case that returns larger font size for shorter labels, medium font size for medium labels, and small font size for short labels.

**BEFORE**
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/5ddc017d-9ef2-46e6-b41b-befb283ed01a)


**AFTER**
<img width="1396" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/120480244/a9d08e23-ff9e-4dcc-b221-9ac6a3fb0cf1">


<img width="1364" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/120480244/35474882-300f-463c-9270-b9e90c3d22b2">
