### PR TITLE
Update text position in PetrinetRenderer

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -221,7 +221,7 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 		// species text
 		species
 			.append('text')
-			.attr('y', () => 5)
+			.attr('y', (d) => setFontSize(d.id) / 4)
 			.style('font-family', 'STIX Two Text, serif')
 			.style('font-style', 'italic')
 			.style('font-size', (d) => setFontSize(d.id))

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -118,7 +118,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 		// transitions label text
 		transitions
 			.append('text')
-			.attr('y', () => 12)
+			.attr('y', (d) => setFontSize(d.id) / 4)
 			.style('text-anchor', 'middle')
 			.style('font-family', 'STIX Two Text, serif')
 			.style('font-style', 'italic')
@@ -166,7 +166,7 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 		// species text
 		species
 			.append('text')
-			.attr('y', () => 5)
+			.attr('y', (d) => setFontSize(d.id) / 4)
 			.style('text-anchor', 'middle')
 			.style('font-family', 'STIX Two Text, serif')
 			.style('font-style', 'italic')


### PR DESCRIPTION
Previously the y-position of the text was hard coded because the font size was hard coded as 18px. When I added the variable font size, I forgot that the y-position needs to be adjusted too.

BEFORE
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/f07d4f9c-ab44-492c-93d4-571149e1cece)

![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/c8bc1813-40d8-4f93-9278-2c2f426f255b)


AFTER
<img width="1405" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/120480244/7681849e-c7c5-44cd-8af4-81db99e47346">


<img width="1398" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/120480244/fe3a911e-3b67-4368-a889-b998db09b2fa">
