### PR TITLE
Task caching and fixes

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -34,6 +34,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
+import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.data.DatasetService;
@@ -44,7 +45,6 @@ import software.uncharted.terarium.hmiserver.service.tasks.ConfigureFromDatasetR
 import software.uncharted.terarium.hmiserver.service.tasks.ConfigureModelResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.ModelCardResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
-import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskType;
 
 @RequestMapping("/gollm")
 @RestController
@@ -107,6 +107,7 @@ public class GoLLMController {
 
 			// Create the task
 			final TaskRequest req = new TaskRequest();
+			req.setType(TaskType.GOLLM);
 			req.setScript(ModelCardResponseHandler.NAME);
 			req.setInput(objectMapper.writeValueAsBytes(input));
 
@@ -115,7 +116,7 @@ public class GoLLMController {
 			req.setAdditionalProperties(props);
 
 			// send the request
-			return ResponseEntity.ok().body(taskService.runTaskAsync(req, TaskType.GOLLM));
+			return ResponseEntity.ok().body(taskService.runTaskAsync(req));
 
 		} catch (final Exception e) {
 			final String error = "Unable to dispatch task request";
@@ -163,6 +164,7 @@ public class GoLLMController {
 
 			// Create the task
 			final TaskRequest req = new TaskRequest();
+			req.setType(TaskType.GOLLM);
 			req.setScript(ConfigureModelResponseHandler.NAME);
 			req.setInput(objectMapper.writeValueAsBytes(input));
 
@@ -172,7 +174,7 @@ public class GoLLMController {
 			req.setAdditionalProperties(props);
 
 			// send the request
-			return ResponseEntity.ok().body(taskService.runTaskAsync(req, TaskType.GOLLM));
+			return ResponseEntity.ok().body(taskService.runTaskAsync(req));
 
 		} catch (final Exception e) {
 			final String error = "Unable to dispatch task request";
@@ -241,6 +243,7 @@ public class GoLLMController {
 
 			// Create the task
 			final TaskRequest req = new TaskRequest();
+			req.setType(TaskType.GOLLM);
 			req.setScript(ConfigureFromDatasetResponseHandler.NAME);
 			req.setInput(objectMapper.writeValueAsBytes(input));
 
@@ -250,7 +253,7 @@ public class GoLLMController {
 			req.setAdditionalProperties(props);
 
 			// send the request
-			return ResponseEntity.ok().body(taskService.runTaskAsync(req, TaskType.GOLLM));
+			return ResponseEntity.ok().body(taskService.runTaskAsync(req));
 
 		} catch (final Exception e) {
 			final String error = "Unable to dispatch task request";
@@ -289,11 +292,12 @@ public class GoLLMController {
 
 			// Create the task
 			final TaskRequest req = new TaskRequest();
+			req.setType(TaskType.GOLLM);
 			req.setScript(CompareModelResponseHandler.NAME);
 			req.setInput(objectMapper.writeValueAsBytes(input));
 
 			// send the request
-			return ResponseEntity.ok().body(taskService.runTaskAsync(req, TaskType.GOLLM));
+			return ResponseEntity.ok().body(taskService.runTaskAsync(req));
 
 		} catch (final Exception e) {
 			final String error = "Unable to dispatch task request";

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
@@ -56,8 +56,8 @@ public class MiraController {
 		public Model response;
 	};
 
-	private boolean endsWith(String filename, List<String> suffixes) {
-		for (String suffix : suffixes) {
+	private boolean endsWith(final String filename, final List<String> suffixes) {
+		for (final String suffix : suffixes) {
 			if (filename.endsWith(suffix)) {
 				return true;
 			}
@@ -76,7 +76,7 @@ public class MiraController {
 			@RequestBody final ModelConversionRequest conversionRequest) {
 
 		try {
-			TaskRequest req = new TaskRequest();
+			final TaskRequest req = new TaskRequest();
 			req.setInput(conversionRequest.getModelContent().getBytes());
 
 			if (endsWith(conversionRequest.getModelName(), List.of(".mdl"))) {
@@ -91,10 +91,8 @@ public class MiraController {
 						"Unknown model type");
 			}
 
-			List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.MIRA,
+			final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA,
 					REQUEST_TIMEOUT_SECONDS);
-
-			TaskResponse resp = responses.get(responses.size() - 1);
 
 			if (resp.getStatus() != TaskStatus.SUCCESS) {
 				throw new ResponseStatusException(
@@ -102,10 +100,10 @@ public class MiraController {
 						"Unable to generate vectors for knn search");
 			}
 
-			byte[] outputBytes = resp.getOutput();
-			JsonNode output = objectMapper.readTree(outputBytes);
+			final byte[] outputBytes = resp.getOutput();
+			final JsonNode output = objectMapper.readTree(outputBytes);
 
-			ModelConversionResponse modelResp = objectMapper.convertValue(output, ModelConversionResponse.class);
+			final ModelConversionResponse modelResp = objectMapper.convertValue(output, ModelConversionResponse.class);
 
 			return ResponseEntity.status(HttpStatus.CREATED).body(modelService.createAsset(modelResp.getResponse()));
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
@@ -23,12 +23,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
+import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
-import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskType;
 
 @RequestMapping("/mira")
 @RestController
@@ -77,6 +77,7 @@ public class MiraController {
 
 		try {
 			final TaskRequest req = new TaskRequest();
+			req.setType(TaskType.MIRA);
 			req.setInput(conversionRequest.getModelContent().getBytes());
 
 			if (endsWith(conversionRequest.getModelName(), List.of(".mdl"))) {
@@ -91,8 +92,7 @@ public class MiraController {
 						"Unknown model type");
 			}
 
-			final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA,
-					REQUEST_TIMEOUT_SECONDS);
+			final TaskResponse resp = taskService.runTaskSync(req, REQUEST_TIMEOUT_SECONDS);
 
 			if (resp.getStatus() != TaskStatus.SUCCESS) {
 				throw new ResponseStatusException(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/search/SearchByAssetTypeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/search/SearchByAssetTypeController.java
@@ -1,13 +1,8 @@
 package software.uncharted.terarium.hmiserver.controller.search;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import org.redisson.api.RMapCache;
-import org.redisson.api.RedissonClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,19 +27,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.annotation.PostConstruct;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.configuration.ElasticsearchConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
+import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.elasticsearch.ElasticsearchService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
-import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskType;
 
 @RequestMapping("/search-by-asset-type")
 @RestController
@@ -54,15 +48,12 @@ public class SearchByAssetTypeController {
 
 	final private ObjectMapper objectMapper;
 	final private TaskService taskService;
-	final private RedissonClient redissonClient;
 	final private ElasticsearchService esService;
 	final private ElasticsearchConfiguration esConfig;
-	private RMapCache<byte[], List<Float>> queryVectorCache;
 
 	static final private long CACHE_TTL_SECONDS = 60 * 60 * 2; // 2 hours
 	static final private long REQUEST_TIMEOUT_SECONDS = 30;
 	static final private String EMBEDDING_MODEL = "text-embedding-ada-002";
-	static final private String REDIS_EMBEDDING_CACHE_KEY = "knn-vector-cache";
 
 	static final private List<String> EXCLUDE_FIELDS = List.of("embeddings", "text", "topics");
 
@@ -77,11 +68,6 @@ public class SearchByAssetTypeController {
 	@Data
 	private static class EmbeddingsResponse {
 		List<Float> response;
-	}
-
-	@PostConstruct
-	public void init() {
-		queryVectorCache = redissonClient.getMapCache(REDIS_EMBEDDING_CACHE_KEY);
 	}
 
 	@GetMapping("/{asset-type}")
@@ -118,44 +104,32 @@ public class SearchByAssetTypeController {
 
 			KnnQuery knn = null;
 			if (text != null && !text.isEmpty()) {
-				// sha256 the text to use as a cache key
-				final MessageDigest md = MessageDigest.getInstance("SHA-256");
-				final byte[] hash = md.digest(text.getBytes(StandardCharsets.UTF_8));
 
-				// check if we already have the vectors cached
-				List<Float> vector = queryVectorCache.get(hash);
-				if (vector == null) {
+				// create the embedding search request
+				final GoLLMSearchRequest embeddingRequest = new GoLLMSearchRequest();
+				embeddingRequest.setText(text);
+				embeddingRequest.setEmbeddingModel(EMBEDDING_MODEL);
 
-					// set the embedding model
+				final TaskRequest req = new TaskRequest();
+				req.setType(TaskType.GOLLM);
+				req.setInput(embeddingRequest);
+				req.setScript("gollm:embedding");
 
-					final GoLLMSearchRequest embeddingRequest = new GoLLMSearchRequest();
-					embeddingRequest.setText(text);
-					embeddingRequest.setEmbeddingModel(EMBEDDING_MODEL);
+				final TaskResponse resp = taskService.runTaskSync(req, REQUEST_TIMEOUT_SECONDS);
 
-					final TaskRequest req = new TaskRequest();
-					req.setInput(embeddingRequest);
-					req.setScript("gollm:embedding");
-
-					final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM,
-							REQUEST_TIMEOUT_SECONDS);
-
-					if (resp.getStatus() != TaskStatus.SUCCESS) {
-						throw new ResponseStatusException(
-								org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-								"Unable to generate vectors for knn search");
-					}
-
-					final byte[] outputBytes = resp.getOutput();
-					final JsonNode output = objectMapper.readTree(outputBytes);
-
-					final EmbeddingsResponse embeddingResp = objectMapper.convertValue(output,
-							EmbeddingsResponse.class);
-
-					vector = embeddingResp.getResponse();
-
-					// store the vectors in the cache
-					queryVectorCache.put(hash, vector, CACHE_TTL_SECONDS, TimeUnit.SECONDS);
+				if (resp.getStatus() != TaskStatus.SUCCESS) {
+					throw new ResponseStatusException(
+							org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+							"Unable to generate vectors for knn search");
 				}
+
+				final byte[] outputBytes = resp.getOutput();
+				final JsonNode output = objectMapper.readTree(outputBytes);
+
+				final EmbeddingsResponse embeddingResp = objectMapper.convertValue(output,
+						EmbeddingsResponse.class);
+
+				final List<Float> vector = embeddingResp.getResponse();
 
 				knn = new KnnQuery.Builder()
 						.field("embeddings.vector")

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/search/SearchByAssetTypeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/search/SearchByAssetTypeController.java
@@ -136,10 +136,8 @@ public class SearchByAssetTypeController {
 					req.setInput(embeddingRequest);
 					req.setScript("gollm:embedding");
 
-					final List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM,
+					final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM,
 							REQUEST_TIMEOUT_SECONDS);
-
-					final TaskResponse resp = responses.get(responses.size() - 1);
 
 					if (resp.getStatus() != TaskStatus.SUCCESS) {
 						throw new ResponseStatusException(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/task/TaskFuture.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/task/TaskFuture.java
@@ -1,0 +1,18 @@
+package software.uncharted.terarium.hmiserver.models.task;
+
+import java.io.Serializable;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Accessors(chain = true)
+@NoArgsConstructor
+@Data
+public class TaskFuture implements Serializable {
+	private UUID id;
+	private TaskResponse latestResponse;
+	private CompletableFuture<TaskResponse> completeFuture;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
@@ -1,16 +1,18 @@
 package software.uncharted.terarium.hmiserver.service.tasks;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.catalina.connector.ClientAbortException;
+import org.redisson.api.RLock;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
@@ -30,9 +32,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.configuration.Config;
+import software.uncharted.terarium.hmiserver.models.task.TaskFuture;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
@@ -46,9 +50,9 @@ public class TaskService {
 		GOLLM("gollm"),
 		MIRA("mira");
 
-		private String value;
+		private final String value;
 
-		TaskType(String value) {
+		TaskType(final String value) {
 			this.value = value;
 		}
 
@@ -57,15 +61,37 @@ public class TaskService {
 		}
 	}
 
+	static final private String RESPONSE_CACHE_KEY = "task-service-response-cache";
+	static final private String TASK_ID_CACHE_KEY = "task-service-task-id-cache";
+	static final private String LOCK_KEY = "task-service-distributed-lock";
+	static final private long CACHE_TTL_SECONDS = 60 * 60 * 24; // 24 hours
+	static final private long CACHE_MAX_IDLE_SECONDS = 60 * 60 * 2; // 2 hours
+
+	// Always use a lease time for distributed locks to prevent application wide
+	// deadlocks. If for whatever reason the lock has not been released within a
+	// N seconds, it will automatically free itself.
+	static final private long REDIS_LOCK_LEASE_SECONDS = 60; // 1 minute
+
 	private final RabbitTemplate rabbitTemplate;
 	private final RabbitAdmin rabbitAdmin;
 	private final Config config;
 	private final ObjectMapper objectMapper;
 
-	private Map<String, TaskResponseHandler> responseHandlers = new ConcurrentHashMap<>();
-	private Map<UUID, SseEmitter> taskIdToEmitter = new ConcurrentHashMap<>();
+	private final Map<String, TaskResponseHandler> responseHandlers = new ConcurrentHashMap<>();
+	private final Map<UUID, SseEmitter> taskIdToEmitter = new ConcurrentHashMap<>();
 
-	private Map<UUID, BlockingQueue<TaskResponse>> responseQueues = new ConcurrentHashMap<>();
+	private final Map<UUID, CompletableFuture<TaskResponse>> responseFutures = new ConcurrentHashMap<>();
+
+	private final RedissonClient redissonClient;
+	private RMapCache<String, UUID> taskIdCache;
+	private RMapCache<UUID, TaskResponse> responseCache;
+	private RLock rLock;
+
+	// private final ConcurrentHashMap<String, UUID> taskIdCache = new
+	// ConcurrentHashMap<>();
+	// private final ConcurrentHashMap<UUID, TaskResponse> responseCache = new
+	// ConcurrentHashMap<>();
+	// private final ReentrantLock rLock = new ReentrantLock();
 
 	// The queue name that the taskrunner will consume on for requests.
 	@Value("${terarium.taskrunner.request-queue}")
@@ -77,73 +103,58 @@ public class TaskService {
 
 	// The _shared_ response exchange that each hmi-server instance will consume on.
 	// NOTE: messages will round robin between hmi-server instances.
-	@Value("${terarium.taskrunner.shared-response-queue}")
-	private String TASK_RUNNER_SHARED_RESPONSE_QUEUE;
+	@Value("${terarium.taskrunner.response-queue}")
+	private String TASK_RUNNER_RESPONSE_QUEUE;
 
-	// If the hmi-server experiences an error while handling the success response of
-	// a task, it will publish the error to this exchange. This will direct
-	// the message to all hmi-instances so that the correct instance holding the sse
-	// can forward the response to the user.
-	@Value("${terarium.taskrunner.handler-error-exchange}")
-	private String TASK_RUNNER_HANDLER_ERROR_EXCHANGE;
+	// Once a single instance of the hmi-server has processed a task response, it
+	// will publish to this exchange to broadcast the response to all other
+	// instances. This will direct the message to all hmi-instances so that the
+	// correct instance holding the sse can forward the response to the user.
+	@Value("${terarium.taskrunner.response-broadcast-exchange}")
+	private String TASK_RUNNER_RESPONSE_BROADCAST_EXCHANGE;
 
 	// The exchange name to publish cancellations to.
 	@Value("${terarium.taskrunner.cancellation-exchange}")
 	private String TASK_RUNNER_CANCELLATION_EXCHANGE;
 
-	private void declareAndBindTransientQueueWithRoutingKey(String exchangeName, String queueName, String routingKey) {
+	@PostConstruct
+	void init() {
+		// use a distributed cache and lock so that these can be synchronized across
+		// multiple instances of the hmi-server
+		responseCache = redissonClient.getMapCache(RESPONSE_CACHE_KEY);
+		taskIdCache = redissonClient.getMapCache(TASK_ID_CACHE_KEY);
+		rLock = redissonClient.getLock(LOCK_KEY);
+	}
+
+	private void declareAndBindTransientQueueWithRoutingKey(final String exchangeName, final String queueName,
+			final String routingKey) {
 		// Declare a direct exchange
-		DirectExchange exchange = new DirectExchange(exchangeName, config.getDurableQueues(), false);
+		final DirectExchange exchange = new DirectExchange(exchangeName, config.getDurableQueues(), false);
 		rabbitAdmin.declareExchange(exchange);
 
 		// Declare a queue
-		Queue queue = new Queue(queueName, config.getDurableQueues(), false, true);
+		final Queue queue = new Queue(queueName, config.getDurableQueues(), false, true);
 		rabbitAdmin.declareQueue(queue);
 
 		// Bind the queue to the exchange with a routing key
-		Binding binding = BindingBuilder.bind(queue).to(exchange).with(routingKey);
+		final Binding binding = BindingBuilder.bind(queue).to(exchange).with(routingKey);
 		rabbitAdmin.declareBinding(binding);
 	}
 
-	private void declareQueue(String queueName) {
+	private void declareQueue(final String queueName) {
 		// Declare a queue
-		Queue queue = new Queue(queueName, config.getDurableQueues(), false, false);
+		final Queue queue = new Queue(queueName, config.getDurableQueues(), false, false);
 		rabbitAdmin.declareQueue(queue);
 	}
 
-	public void sendTaskRequest(TaskRequest req, TaskType requestType) throws JsonProcessingException {
-
-		String requestQueue = String.format("%s-%s", TASK_RUNNER_REQUEST_QUEUE, requestType.toString());
-
-		// ensure the request queue exists
-		declareQueue(requestQueue);
-
-		// create the cancellation queue _BEFORE_ sending the request, because a
-		// cancellation can be send before the request is consumed on the other end if
-		// there is contention. We need this queue to exist to hold the message.
-		String queueName = req.getId().toString();
-		String routingKey = req.getId().toString();
-		declareAndBindTransientQueueWithRoutingKey(TASK_RUNNER_CANCELLATION_EXCHANGE, queueName, routingKey);
-
-		try {
-			// send the request to the task runner
-			log.info("Dispatching request {} on queue: {}", new String(req.getInput()), requestQueue);
-			final String jsonStr = objectMapper.writeValueAsString(req);
-			rabbitTemplate.convertAndSend(requestQueue, jsonStr);
-		} catch (Exception e) {
-			rabbitAdmin.deleteQueue(queueName);
-			throw e;
-		}
-	}
-
-	public void addResponseHandler(TaskResponseHandler handler) {
+	public void addResponseHandler(final TaskResponseHandler handler) {
 		responseHandlers.put(handler.getName(), handler);
 	}
 
 	public void cancelTask(final UUID taskId) {
 		// send the cancellation to the task runner
 		final String msg = "";
-		rabbitTemplate.convertAndSend(TASK_RUNNER_CANCELLATION_EXCHANGE, msg);
+		rabbitTemplate.convertAndSend(TASK_RUNNER_CANCELLATION_EXCHANGE, taskId.toString(), msg);
 	}
 
 	public SseEmitter subscribe(final UUID taskId) {
@@ -151,20 +162,41 @@ public class TaskService {
 		if (taskIdToEmitter.containsKey(taskId)) {
 			try {
 				taskIdToEmitter.get(taskId).complete();
-			} catch (IllegalStateException ignored) {
+			} catch (final IllegalStateException ignored) {
 			}
 		}
-		taskIdToEmitter.put(taskId, emitter);
+
+		try {
+			rLock.lock(REDIS_LOCK_LEASE_SECONDS, TimeUnit.SECONDS);
+
+			taskIdToEmitter.put(taskId, emitter);
+
+			final TaskResponse latestResp = responseCache.get(taskId);
+
+			if (latestResp != null &&
+					(latestResp.getStatus() == TaskStatus.SUCCESS ||
+							latestResp.getStatus() == TaskStatus.FAILED ||
+							latestResp.getStatus() == TaskStatus.CANCELLED)) {
+
+				// if this task has already resolved, send the response to the emitter
+				emitter.send(latestResp);
+			}
+		} catch (final Exception e) {
+			log.error("Error occured while attemping to send latest response to emitter", e);
+		} finally {
+			rLock.unlock();
+		}
+
 		return emitter;
 	}
 
 	// This is an anonymous queue, every instance the hmi-server will receive a
 	// message. Any operation that must occur on _every_ instance of the hmi-server
 	// should be triggered here.
-	@RabbitListener(bindings = @QueueBinding(value = @org.springframework.amqp.rabbit.annotation.Queue(autoDelete = "true", exclusive = "false", durable = "${terarium.taskrunner.durable-queues}"), exchange = @Exchange(value = "${terarium.taskrunner.response-exchange}", durable = "${terarium.taskrunner.durable-queues}", autoDelete = "false", type = ExchangeTypes.DIRECT), key = ""))
-	void onTaskResponseAllInstanceReceive(final Message message) {
+	@RabbitListener(bindings = @QueueBinding(value = @org.springframework.amqp.rabbit.annotation.Queue(autoDelete = "true", exclusive = "false", durable = "${terarium.taskrunner.durable-queues}"), exchange = @Exchange(value = "${terarium.taskrunner.response-broadcast-exchange}", durable = "${terarium.taskrunner.durable-queues}", autoDelete = "false", type = ExchangeTypes.DIRECT), key = ""), concurrency = "1")
+	private void onTaskResponseAllInstanceReceive(final Message message) {
 		try {
-			TaskResponse resp = decodeMessage(message, TaskResponse.class);
+			final TaskResponse resp = decodeMessage(message, TaskResponse.class);
 			if (resp == null) {
 				return;
 			}
@@ -173,14 +205,27 @@ public class TaskService {
 				log.info("Received response {} for task {}", new String(resp.getOutput()), resp.getId());
 			}
 
+			rLock.lock(REDIS_LOCK_LEASE_SECONDS, TimeUnit.SECONDS);
 			try {
-				if (responseQueues.containsKey(resp.getId())) {
-					BlockingQueue<TaskResponse> queue = responseQueues.get(resp.getId());
-					queue.put(resp);
+				final CompletableFuture<TaskResponse> future = responseFutures
+						.get(resp.getId());
+				if (future != null &&
+						(resp.getStatus() == TaskStatus.SUCCESS ||
+								resp.getStatus() == TaskStatus.CANCELLED ||
+								resp.getStatus() == TaskStatus.FAILED)) {
+					// complete the future
+					log.info("Completing future for task id {} with status {}", resp.getId(), resp.getStatus());
+					future.complete(resp);
+
+					// remove the future from the map
+					log.info("Removing future for task id {}", resp.getId());
+					responseFutures.remove(resp.getId());
 				}
-			} catch (Exception e) {
+			} catch (final Exception e) {
 				log.error("Error occured while writing to response queue for task {}",
 						resp.getId(), e);
+			} finally {
+				rLock.unlock();
 			}
 
 			final SseEmitter emitter = taskIdToEmitter.get(resp.getId());
@@ -192,12 +237,12 @@ public class TaskService {
 						log.warn("Error sending task response for task {}. User likely disconnected",
 								resp.getId());
 						taskIdToEmitter.remove(resp.getId());
-					} catch (IOException e) {
+					} catch (final IOException e) {
 						log.error("Error sending task response for task {}", resp.getId(), e);
 					}
 				}
 			}
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			log.error("Error processing task response message", e);
 		}
 	}
@@ -205,88 +250,68 @@ public class TaskService {
 	// This is a shared queue, messages will round robin between every instance of
 	// the hmi-server. Any operation that must occur once and only once should be
 	// triggered here.
-	@RabbitListener(bindings = @QueueBinding(value = @org.springframework.amqp.rabbit.annotation.Queue(value = "${terarium.taskrunner.shared-response-queue}", autoDelete = "true", exclusive = "false", durable = "${terarium.taskrunner.durable-queues}"), exchange = @Exchange(value = "${terarium.taskrunner.response-exchange}", durable = "${terarium.taskrunner.durable-queues}", autoDelete = "false", type = ExchangeTypes.DIRECT), key = ""))
-	void onTaskResponseOneInstanceReceives(final Message message) {
+	@RabbitListener(bindings = @QueueBinding(value = @org.springframework.amqp.rabbit.annotation.Queue(value = "${terarium.taskrunner.response-queue}", autoDelete = "true", exclusive = "false", durable = "${terarium.taskrunner.durable-queues}"), exchange = @Exchange(value = "${terarium.taskrunner.response-exchange}", durable = "${terarium.taskrunner.durable-queues}", autoDelete = "false", type = ExchangeTypes.DIRECT), key = ""), concurrency = "1")
+	private void onTaskResponseOneInstanceReceives(final Message message) {
 		try {
-			TaskResponse resp = decodeMessage(message, TaskResponse.class);
+			final TaskResponse resp = decodeMessage(message, TaskResponse.class);
 			if (resp == null) {
 				return;
 			}
 
 			try {
+				// execute the handler
 				if (responseHandlers.containsKey(resp.getScript())) {
 					responseHandlers.get(resp.getScript()).handle(resp);
 				}
-			} catch (Exception e) {
+			} catch (final Exception e) {
 				log.error("Error occured while executing response handler for task {}",
 						resp.getId(), e);
 
-				// publish the handler error
-				sendHandlerErrorToUser(resp.getId(), e.getMessage());
+				// if the handler fails processing a success, convert it to a failure
+				resp.setStatus(TaskStatus.FAILED);
+				resp.setOutput(e.getMessage().getBytes());
 			}
-		} catch (Exception e) {
+
+			rLock.lock(REDIS_LOCK_LEASE_SECONDS, TimeUnit.SECONDS);
+			try {
+				// add to the response cache
+				log.info("Writing response for task id {} for status {} to cache", resp.getId(),
+						resp.getStatus());
+				responseCache.put(resp.getId(), resp, CACHE_TTL_SECONDS, TimeUnit.SECONDS, CACHE_MAX_IDLE_SECONDS,
+						TimeUnit.SECONDS);
+			} finally {
+				rLock.unlock();
+			}
+
+			// once the handler has executed and the response cache is up to date, we now
+			// will broadcast to all hmi-server instances to dispatch the clientside events
+			broadcastTaskResponseToAllInstances(resp);
+
+		} catch (final Exception e) {
 			log.error("Error processing task response message", e);
 		}
 	}
 
-	// If an error occurs within a response handler, we will publish the error to an
-	// exchange so that every hmi-server instance receives it. This will allow the
-	// correct instance holding the sse emitter to forward the error to the user.
-	@RabbitListener(bindings = @QueueBinding(value = @org.springframework.amqp.rabbit.annotation.Queue(autoDelete = "true", exclusive = "false", durable = "${terarium.taskrunner.durable-queues}"), exchange = @Exchange(value = "${terarium.taskrunner.handler-error-exchange}", durable = "${terarium.taskrunner.durable-queues}", autoDelete = "false", type = ExchangeTypes.DIRECT), key = ""))
-	void onResponseHandlerError(final Message message) {
+	private void broadcastTaskResponseToAllInstances(final TaskResponse resp) {
 		try {
-			TaskResponse resp = decodeMessage(message, TaskResponse.class);
-			if (resp == null) {
-				return;
-			}
-
-			log.info("Received response handler error {} for task {}", new String(resp.getOutput()), resp.getId());
-
-			final SseEmitter emitter = taskIdToEmitter.get(resp.getId());
-			synchronized (taskIdToEmitter) {
-				if (emitter != null) {
-					try {
-						emitter.send(resp);
-					} catch (IllegalStateException | ClientAbortException e) {
-						log.warn("Error sending task response for task {}. User likely disconnected",
-								resp.getId());
-						taskIdToEmitter.remove(resp.getId());
-					} catch (IOException e) {
-						log.error("Error sending task response for task {}", resp.getId(), e);
-					}
-				}
-			}
-		} catch (Exception e) {
-			log.error("Error processing task response message", e);
-		}
-	}
-
-	private void sendHandlerErrorToUser(UUID taskId, String errorMessage) {
-		// publish the handler error
-		TaskResponse handlerErrResp = new TaskResponse();
-		handlerErrResp.setId(taskId);
-		handlerErrResp.setStatus(TaskStatus.FAILED);
-		handlerErrResp.setOutput(errorMessage.getBytes());
-
-		try {
-			final String jsonStr = objectMapper.writeValueAsString(handlerErrResp);
-			rabbitTemplate.convertAndSend(TASK_RUNNER_HANDLER_ERROR_EXCHANGE, jsonStr);
-		} catch (JsonProcessingException e) {
+			final String jsonStr = objectMapper.writeValueAsString(resp);
+			rabbitTemplate.convertAndSend(TASK_RUNNER_RESPONSE_BROADCAST_EXCHANGE, "", jsonStr);
+		} catch (final JsonProcessingException e) {
 			log.error("Error serializing handler error response", e);
 		}
 	}
 
-	public static <T> T decodeMessage(final Message message, Class<T> clazz) {
-		ObjectMapper mapper = new ObjectMapper();
+	private static <T> T decodeMessage(final Message message, final Class<T> clazz) {
+		final ObjectMapper mapper = new ObjectMapper();
 
 		try {
 			return mapper.readValue(message.getBody(), clazz);
-		} catch (Exception e) {
+		} catch (final Exception e) {
 			try {
-				JsonNode jsonMessage = mapper.readValue(message.getBody(), JsonNode.class);
+				final JsonNode jsonMessage = mapper.readValue(message.getBody(), JsonNode.class);
 				log.error("Unable to parse message as {}. Message: {}", clazz.getName(), jsonMessage.toPrettyString());
 				return null;
-			} catch (Exception e1) {
+			} catch (final Exception e1) {
 				log.error("Error decoding message as either {} or {}. Raw message is: {}", clazz.getName(),
 						JsonNode.class.getName(), message.getBody());
 				log.error("", e1);
@@ -295,57 +320,160 @@ public class TaskService {
 		}
 	}
 
-	public List<TaskResponse> runTaskBlocking(TaskRequest req, TaskType requestType, long timeoutSeconds)
-			throws JsonProcessingException, IOException, InterruptedException {
+	private TaskFuture runTaskAsyncInternal(final TaskRequest req, final TaskType requestType)
+			throws JsonProcessingException {
 
-		if (req.getId() == null) {
-			req.setId(UUID.randomUUID());
-		}
+		rLock.lock(REDIS_LOCK_LEASE_SECONDS, TimeUnit.SECONDS);
 
 		try {
-			// add to queue to wait on responses
-			BlockingQueue<TaskResponse> queue = new ArrayBlockingQueue<>(8);
-			responseQueues.put(req.getId(), queue);
+			// create sha256 hash of the request
+			final String hash = req.getSHA256();
 
-			// send the request
-			sendTaskRequest(req, requestType);
+			log.info("Computed SHA: {}", hash);
 
-			// add the queued response
-			List<TaskResponse> responses = new ArrayList<>();
-			TaskResponse resp = req.createResponse(TaskStatus.QUEUED);
-			queue.put(resp);
+			// generate the task id
+			req.setId(UUID.randomUUID());
 
-			while (true) {
-				// wait for responses
-				TaskResponse response = queue.poll(timeoutSeconds, TimeUnit.SECONDS);
-				if (response == null) {
-					throw new InterruptedException("Task did not complete within " + timeoutSeconds + " seconds");
+			// check if there is an id associated with the hash of the request already
+			log.info("Attempting to put {} under {}", req.getId(), hash);
+			final UUID existingId = taskIdCache.putIfAbsent(hash, req.getId(), CACHE_TTL_SECONDS, TimeUnit.SECONDS,
+					CACHE_MAX_IDLE_SECONDS, TimeUnit.SECONDS);
+
+			log.info("Got task id {} for hash", existingId);
+
+			if (existingId != null) {
+				// a task id already exits for the SHA256, this means the request has already
+				// been dispatched.
+				log.info("Task ID: {} already exists for SHA: {}", existingId, hash);
+				final TaskResponse resp = responseCache.get(existingId);
+
+				// only return responese if they have not failed or been cancelled
+				if (resp != null &&
+						(resp.getStatus() != TaskStatus.CANCELLING ||
+								resp.getStatus() != TaskStatus.CANCELLED ||
+								resp.getStatus() != TaskStatus.FAILED)) {
+
+					// if the response is in the cache, return it
+					log.info("Response for task id {} already exists, returning", existingId);
+
+					final TaskFuture future = new TaskFuture();
+					future.setId(existingId);
+					future.setLatestResponse(resp);
+					if (resp.getStatus() != TaskStatus.SUCCESS) {
+						// if the task has not completed, create a future to capture that
+						future.setCompleteFuture(
+								responseFutures.computeIfAbsent(existingId, v -> new CompletableFuture<>()));
+					}
+					return future;
 				}
-
-				log.info("Response id: {} status {}", response.getId(), response.getStatus());
-				responses.add(response);
-
-				if (response.getStatus() == TaskStatus.SUCCESS) {
-					return responses;
-				}
-
-				if (response.getStatus() == TaskStatus.CANCELLED) {
-					throw new InterruptedException("Task was cancelled");
-				}
-
-				if (response.getStatus() == TaskStatus.CANCELLED || response.getStatus() == TaskStatus.FAILED) {
-					throw new IOException("Task failed: " + new String(response.getOutput()));
-				}
+				// otherwise dispatch it again
+				log.info("No cached task response found for ID: {} for SHA: {}, creating new task", existingId, hash);
 			}
+
+			// create the response future
+			final CompletableFuture<TaskResponse> completeFuture = new CompletableFuture<>();
+			responseFutures.put(req.getId(), completeFuture);
+
+			log.info("Dispatching task for ID: {} for SHA: {}", req.getId(), hash);
+
+			// no cached request, create the response cache entry
+			final TaskResponse queuedResponse = req.createResponse(TaskStatus.QUEUED);
+			responseCache.put(req.getId(), queuedResponse, CACHE_TTL_SECONDS, TimeUnit.SECONDS, CACHE_MAX_IDLE_SECONDS,
+					TimeUnit.SECONDS);
+
+			// now send request
+			final String requestQueue = String.format("%s-%s", TASK_RUNNER_REQUEST_QUEUE, requestType.toString());
+
+			// ensure the request queue exists
+			declareQueue(requestQueue);
+
+			// create the cancellation queue _BEFORE_ sending the request, because a
+			// cancellation can be send before the request is consumed on the other end if
+			// there is contention. We need this queue to exist to hold the message.
+			final String queueName = req.getId().toString();
+			final String routingKey = req.getId().toString();
+			declareAndBindTransientQueueWithRoutingKey(TASK_RUNNER_CANCELLATION_EXCHANGE, queueName, routingKey);
+
+			try {
+				// send the request to the task runner
+				log.info("Dispatching request {} on queue: {}", new String(req.getInput()), requestQueue);
+				final String jsonStr = objectMapper.writeValueAsString(req);
+				rabbitTemplate.convertAndSend(requestQueue, jsonStr);
+
+				// set the latest response to queued and return
+				final TaskFuture future = new TaskFuture();
+				future.setId(req.getId());
+				future.setCompleteFuture(completeFuture);
+				future.setLatestResponse(queuedResponse);
+				return future;
+
+			} catch (final Exception e) {
+				// ensure cancellation queue is removed on failure
+				rabbitAdmin.deleteQueue(queueName);
+				throw e;
+			}
+
 		} finally {
-			// ensure we remove it from the queue when done
-			responseQueues.remove(req.getId());
+			rLock.unlock();
 		}
 	}
 
-	public List<TaskResponse> runTaskBlocking(TaskRequest req, TaskType requestType)
-			throws JsonProcessingException, IOException, InterruptedException {
-		return runTaskBlocking(req, requestType, 60);
+	public TaskResponse runTaskAsync(final TaskRequest req, final TaskType requestType)
+			throws JsonProcessingException {
+
+		final TaskFuture future = runTaskAsyncInternal(req, requestType);
+		if (future.getLatestResponse() == null) {
+			throw new RuntimeException("Task was not dispatched properly");
+		}
+		return future.getLatestResponse();
+	}
+
+	public TaskResponse runTaskSync(final TaskRequest req, final TaskType requestType,
+			final long timeoutSeconds)
+			throws JsonProcessingException, TimeoutException, InterruptedException, ExecutionException {
+
+		// send the request
+		final TaskFuture future = runTaskAsyncInternal(req, requestType);
+
+		// check the response in case it was cached
+		if (future.getLatestResponse().getStatus() == TaskStatus.SUCCESS) {
+			log.info("Task was already SUCCESS, returning cached response with id: {}",
+					future.getLatestResponse().getId());
+			return future.getLatestResponse();
+		} else {
+			log.info("Task was already dispatched, cached response for id: {} has status: {}",
+					future.getLatestResponse().getId(),
+					future.getLatestResponse().getStatus());
+		}
+
+		// if we are here, then the task is pending
+
+		try {
+			// wait for the response
+			log.info("Waiting for response for task id: {}", future.getId());
+			final TaskResponse resp = future.getCompleteFuture().get(timeoutSeconds, TimeUnit.SECONDS);
+			if (resp.getStatus() == TaskStatus.CANCELLED) {
+				throw new InterruptedException("Task was cancelled");
+			}
+			if (resp.getStatus() == TaskStatus.FAILED) {
+				throw new RuntimeException("Task failed: " + new String(resp.getOutput()));
+			}
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				throw new RuntimeException("Task did not complete successfully");
+			}
+			log.info("Future completed for task: {}", future.getId());
+			return resp;
+		} catch (final TimeoutException e) {
+			throw new TimeoutException(
+					"Task " + future.getId().toString() + " did not complete within " + timeoutSeconds + " seconds");
+		}
+	}
+
+	public TaskResponse runTaskSync(final TaskRequest req, final TaskType requestType)
+			throws JsonProcessingException, TimeoutException, ExecutionException, InterruptedException {
+
+		final int DEFAULT_TIMEOUT_SECONDS = 60;
+		return runTaskSync(req, requestType, DEFAULT_TIMEOUT_SECONDS);
 	}
 
 }

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -183,8 +183,8 @@ spring.neo4j.authentication.password=${neo4j-password}
 ########################################################################################################################
 terarium.taskrunner.request-queue=terarium-request-queue
 terarium.taskrunner.response-exchange=terarium-response-exchange
-terarium.taskrunner.shared-response-queue=terarium-shared-response-queue
-terarium.taskrunner.handler-error-exchange=terarium-handler-error-exchange
+terarium.taskrunner.response-queue=terarium-response-queue
+terarium.taskrunner.response-broadcast-exchange=terarium-response-broadcast-exchange
 terarium.taskrunner.cancellation-exchange=terarium-cancellation-exchange
 terarium.taskrunner.durable-queues=true
 
@@ -192,6 +192,7 @@ terarium.taskrunner.durable-queues=true
 # Logging
 ########################################################################################################################
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%level] %msg [%c:%L]%n
+logging.level.org.springframework.web=DEBUG
 
 ########################################################################################################################
 # Cache Logging

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
@@ -1,12 +1,24 @@
 package software.uncharted.terarium.hmiserver.service.tasks;
 
+import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithUserDetails;
@@ -20,7 +32,6 @@ import software.uncharted.terarium.hmiserver.configuration.MockUser;
 import software.uncharted.terarium.hmiserver.controller.mira.MiraController;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
-import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskType;
 
 @Slf4j
@@ -29,41 +40,43 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@Autowired
 	private TaskService taskService;
 
+	@Autowired
+	private RedissonClient redissonClient;
+
+	@BeforeEach
+	public void setup() throws IOException {
+		// remove everything from redis
+		redissonClient.getKeys().flushall();
+	}
+
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanCreateEchoTaskRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
-		String additionalProps = "These are additional properties";
+		final UUID taskId = UUID.randomUUID();
+		final String additionalProps = "These are additional properties";
 
-		byte[] input = "{\"input\":\"This is my input string\"}".getBytes();
+		final byte[] input = "{\"input\":\"This is my input string\"}".getBytes();
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript("/echo.py");
 		req.setInput(input);
 		req.setAdditionalProperties(additionalProps);
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
-
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-			Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
-		}
+		Assertions.assertEquals(taskId, resp.getId());
+		Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
 	}
 
-	private String generateRandomString(int length) {
-		String characterSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-		Random random = new Random();
-		StringBuilder builder = new StringBuilder(length);
+	private String generateRandomString(final int length) {
+		final String characterSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+		final Random random = new Random();
+		final StringBuilder builder = new StringBuilder(length);
 
 		for (int i = 0; i < length; i++) {
-			int randomIndex = random.nextInt(characterSet.length());
+			final int randomIndex = random.nextInt(characterSet.length());
 			builder.append(characterSet.charAt(randomIndex));
 		}
 
@@ -74,60 +87,44 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanCreateLargeEchoTaskRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
-		String additionalProps = "These are additional properties";
+		final UUID taskId = UUID.randomUUID();
+		final String additionalProps = "These are additional properties";
 
-		int STRING_LENGTH = 1048576;
+		final int STRING_LENGTH = 1048576;
 
-		byte[] input = ("{\"input\":\"" + generateRandomString(STRING_LENGTH) + "\"}").getBytes();
+		final byte[] input = ("{\"input\":\"" + generateRandomString(STRING_LENGTH) + "\"}").getBytes();
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript("/echo.py");
 		req.setInput(input);
 		req.setAdditionalProperties(additionalProps);
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
-
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-			Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
-		}
+		Assertions.assertEquals(taskId, resp.getId());
+		Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
 	}
 
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMModelCardRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		ClassPathResource resource = new ClassPathResource("gollm/test_input.json");
-		String content = new String(Files.readAllBytes(resource.getFile().toPath()));
+		final ClassPathResource resource = new ClassPathResource("gollm/test_input.json");
+		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript("gollm:model_card");
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM, 300);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM, 300);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-		}
-
-		log.info(new String(responses.get(responses.size() - 1).getOutput()));
-
-		Thread.sleep(10000);
+		log.info(new String(resp.getOutput()));
 	}
 
 	static class AdditionalProps {
@@ -139,158 +136,185 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMEmbeddingRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript("gollm:embedding");
 		req.setInput(
 				("{\"text\":\"What kind of dinosaur is the coolest?\",\"embedding_model\":\"text-embedding-ada-002\"}")
 						.getBytes());
 
-		AdditionalProps add = new AdditionalProps();
+		final AdditionalProps add = new AdditionalProps();
 		add.str = "this is my str";
 		add.num = 123;
 		req.setAdditionalProperties(add);
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
+		final AdditionalProps respAdd = resp.getAdditionalProperties(AdditionalProps.class);
+		Assertions.assertEquals(add.str, respAdd.str);
+		Assertions.assertEquals(add.num, respAdd.num);
 
-			AdditionalProps respAdd = resp.getAdditionalProperties(AdditionalProps.class);
-			Assertions.assertEquals(add.str, respAdd.str);
-			Assertions.assertEquals(add.num, respAdd.num);
-		}
+		log.info(new String(resp.getOutput()));
 	}
 
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraMDLToStockflowRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		ClassPathResource resource = new ClassPathResource("mira/IndiaNonSubscriptedPulsed.mdl");
-		String content = new String(Files.readAllBytes(resource.getFile().toPath()));
+		final ClassPathResource resource = new ClassPathResource("mira/IndiaNonSubscriptedPulsed.mdl");
+		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript(MiraController.MDL_TO_STOCKFLOW);
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.MIRA);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-		}
-
-		log.info(new String(responses.get(responses.size() - 1).getOutput()));
+		log.info(new String(resp.getOutput()));
 	}
 
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraStellaToStockflowRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		ClassPathResource resource = new ClassPathResource("mira/SIR.xmile");
-		String content = new String(Files.readAllBytes(resource.getFile().toPath()));
+		final ClassPathResource resource = new ClassPathResource("mira/SIR.xmile");
+		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript(MiraController.STELLA_TO_STOCKFLOW);
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.MIRA);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-		}
-
-		log.info(new String(responses.get(responses.size() - 1).getOutput()));
+		log.info(new String(resp.getOutput()));
 	}
 
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraSBMLToPetrinetRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		ClassPathResource resource = new ClassPathResource("mira/BIOMD0000000001.xml");
-		String content = new String(Files.readAllBytes(resource.getFile().toPath()));
+		final ClassPathResource resource = new ClassPathResource("mira/BIOMD0000000001.xml");
+		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript(MiraController.SBML_TO_PETRINET);
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.MIRA);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
-		}
-
-		log.info(new String(responses.get(responses.size() - 1).getOutput()));
+		log.info(new String(resp.getOutput()));
 	}
 
 	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMConfigFromDatasetRequest() throws Exception {
 
-		UUID taskId = UUID.randomUUID();
+		final UUID taskId = UUID.randomUUID();
 
-		ClassPathResource datasetResource1 = new ClassPathResource("gollm/Epi Sc 4 Interaction matrix.csv");
-		String dataset1 = new String(Files.readAllBytes(datasetResource1.getFile().toPath()));
-		ClassPathResource datasetResource2 = new ClassPathResource("gollm/other-dataset.csv");
-		String dataset2 = new String(Files.readAllBytes(datasetResource2.getFile().toPath()));
+		final ClassPathResource datasetResource1 = new ClassPathResource("gollm/Epi Sc 4 Interaction matrix.csv");
+		final String dataset1 = new String(Files.readAllBytes(datasetResource1.getFile().toPath()));
+		final ClassPathResource datasetResource2 = new ClassPathResource("gollm/other-dataset.csv");
+		final String dataset2 = new String(Files.readAllBytes(datasetResource2.getFile().toPath()));
 
-		ClassPathResource amrResource = new ClassPathResource("gollm/scenario4_4spec_regnet_empty.json");
-		String amr = new String(Files.readAllBytes(amrResource.getFile().toPath()));
-		JsonNode amrJson = new ObjectMapper().readTree(amr);
+		final ClassPathResource amrResource = new ClassPathResource("gollm/scenario4_4spec_regnet_empty.json");
+		final String amr = new String(Files.readAllBytes(amrResource.getFile().toPath()));
+		final JsonNode amrJson = new ObjectMapper().readTree(amr);
 
-		String content = "{\"datasets\": ["
+		final String content = "{\"datasets\": ["
 				+ "\"" + dataset1.replaceAll("(?<!\\\\)\\n", Matcher.quoteReplacement("\\\\n")) + "\","
 				+ "\"" + dataset2.replaceAll("(?<!\\\\)\\n", Matcher.quoteReplacement("\\\\n"))
 				+ "\"], \"amr\":"
 				+ amrJson.toString() + "}";
 
-		TaskRequest req = new TaskRequest();
+		final TaskRequest req = new TaskRequest();
 		req.setId(taskId);
 		req.setScript("gollm:dataset_configure");
 		req.setInput(content.getBytes());
 
-		List<TaskResponse> responses = taskService.runTaskBlocking(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
 
-		Assertions.assertEquals(3, responses.size());
-		Assertions.assertEquals(TaskStatus.QUEUED, responses.get(0).getStatus());
-		Assertions.assertEquals(TaskStatus.RUNNING, responses.get(1).getStatus());
-		Assertions.assertEquals(TaskStatus.SUCCESS, responses.get(2).getStatus());
+		Assertions.assertEquals(taskId, resp.getId());
 
-		for (TaskResponse resp : responses) {
-			Assertions.assertEquals(taskId, resp.getId());
+		log.info(new String(resp.getOutput()));
+	}
+
+	@Test
+	@WithUserDetails(MockUser.URSULA)
+	public void testItCanCacheWithConcurrency() throws Exception {
+
+		final int NUM_REQUESTS = 512;
+		final int NUM_UNIQUE_REQUESTS = 16;
+		final int NUM_THREADS = 12;
+		final int TIMEOUT_SECONDS = 20;
+
+		final List<byte[]> reqInput = new ArrayList<>();
+		for (int i = 0; i < NUM_UNIQUE_REQUESTS; i++) {
+			// success tasks
+			reqInput.add(("{\"input\":\"" + generateRandomString(1024) + "\"}").getBytes());
+		}
+		for (int i = 0; i < NUM_UNIQUE_REQUESTS; i++) {
+			// failure tasks
+			reqInput.add(("{\"input\":\"" + generateRandomString(1024) + "\", \"should_fail\": true}").getBytes());
 		}
 
-		log.info(new String(responses.get(responses.size() - 1).getOutput()));
+		final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+
+		final Set<UUID> successTaskIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+		// final Set<UUID> failedTaskIds = Collections.newSetFromMap(new
+		// ConcurrentHashMap<>());
+		final List<Future<?>> futures = new ArrayList<>();
+
+		final Random rand = new Random();
+
+		for (int i = 0; i < NUM_REQUESTS; i++) {
+			final Future<?> future = executor.submit(() -> {
+				try {
+					final TaskRequest req = new TaskRequest();
+					req.setScript("/echo.py");
+					req.setInput(reqInput.get(rand.nextInt(NUM_UNIQUE_REQUESTS)));
+
+					final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM, TIMEOUT_SECONDS);
+					successTaskIds.add(resp.getId());
+				} catch (final RuntimeException e) {
+					// expected in some cases
+
+				} catch (final Exception e) {
+					log.error("Error in test", e);
+				}
+			});
+			futures.add(future);
+		}
+
+		// wait for all the responses to be send
+		for (final Future<?> future : futures) {
+			future.get(TIMEOUT_SECONDS * 2, TimeUnit.SECONDS);
+		}
+
+		log.info("Sending {} requests, which resulted in {} unique dispatches", NUM_REQUESTS, successTaskIds.size());
+		for (final UUID taskId : successTaskIds) {
+			log.info("Task ID: {}", taskId.toString());
+		}
+		Assertions.assertTrue(successTaskIds.size() <= NUM_UNIQUE_REQUESTS);
+
 	}
 
 }

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
@@ -17,7 +17,6 @@ import java.util.regex.Matcher;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -31,8 +30,8 @@ import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
 import software.uncharted.terarium.hmiserver.configuration.MockUser;
 import software.uncharted.terarium.hmiserver.controller.mira.MiraController;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
+import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
-import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskType;
 
 @Slf4j
 public class TaskServiceTest extends TerariumApplicationTests {
@@ -53,20 +52,18 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanCreateEchoTaskRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
 		final String additionalProps = "These are additional properties";
 
 		final byte[] input = "{\"input\":\"This is my input string\"}".getBytes();
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.GOLLM);
 		req.setScript("/echo.py");
 		req.setInput(input);
 		req.setAdditionalProperties(additionalProps);
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req);
 
-		Assertions.assertEquals(taskId, resp.getId());
 		Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
 	}
 
@@ -87,7 +84,6 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanCreateLargeEchoTaskRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
 		final String additionalProps = "These are additional properties";
 
 		final int STRING_LENGTH = 1048576;
@@ -95,14 +91,13 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		final byte[] input = ("{\"input\":\"" + generateRandomString(STRING_LENGTH) + "\"}").getBytes();
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.GOLLM);
 		req.setScript("/echo.py");
 		req.setInput(input);
 		req.setAdditionalProperties(additionalProps);
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req);
 
-		Assertions.assertEquals(taskId, resp.getId());
 		Assertions.assertEquals(additionalProps, resp.getAdditionalProperties(String.class));
 	}
 
@@ -110,19 +105,15 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMModelCardRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
-
 		final ClassPathResource resource = new ClassPathResource("gollm/test_input.json");
 		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.GOLLM);
 		req.setScript("gollm:model_card");
 		req.setInput(content.getBytes());
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM, 300);
-
-		Assertions.assertEquals(taskId, resp.getId());
+		final TaskResponse resp = taskService.runTaskSync(req, 300);
 
 		log.info(new String(resp.getOutput()));
 	}
@@ -136,10 +127,8 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendGoLLMEmbeddingRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
-
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.GOLLM);
 		req.setScript("gollm:embedding");
 		req.setInput(
 				("{\"text\":\"What kind of dinosaur is the coolest?\",\"embedding_model\":\"text-embedding-ada-002\"}")
@@ -150,9 +139,7 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		add.num = 123;
 		req.setAdditionalProperties(add);
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
-
-		Assertions.assertEquals(taskId, resp.getId());
+		final TaskResponse resp = taskService.runTaskSync(req);
 
 		final AdditionalProps respAdd = resp.getAdditionalProperties(AdditionalProps.class);
 		Assertions.assertEquals(add.str, respAdd.str);
@@ -165,19 +152,15 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraMDLToStockflowRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
-
 		final ClassPathResource resource = new ClassPathResource("mira/IndiaNonSubscriptedPulsed.mdl");
 		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.MIRA);
 		req.setScript(MiraController.MDL_TO_STOCKFLOW);
 		req.setInput(content.getBytes());
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
-
-		Assertions.assertEquals(taskId, resp.getId());
+		final TaskResponse resp = taskService.runTaskSync(req);
 
 		log.info(new String(resp.getOutput()));
 	}
@@ -186,19 +169,15 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraStellaToStockflowRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
-
 		final ClassPathResource resource = new ClassPathResource("mira/SIR.xmile");
 		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.MIRA);
 		req.setScript(MiraController.STELLA_TO_STOCKFLOW);
 		req.setInput(content.getBytes());
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
-
-		Assertions.assertEquals(taskId, resp.getId());
+		final TaskResponse resp = taskService.runTaskSync(req);
 
 		log.info(new String(resp.getOutput()));
 	}
@@ -207,19 +186,15 @@ public class TaskServiceTest extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanSendMiraSBMLToPetrinetRequest() throws Exception {
 
-		final UUID taskId = UUID.randomUUID();
-
 		final ClassPathResource resource = new ClassPathResource("mira/BIOMD0000000001.xml");
 		final String content = new String(Files.readAllBytes(resource.getFile().toPath()));
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.MIRA);
 		req.setScript(MiraController.SBML_TO_PETRINET);
 		req.setInput(content.getBytes());
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.MIRA);
-
-		Assertions.assertEquals(taskId, resp.getId());
+		final TaskResponse resp = taskService.runTaskSync(req);
 
 		log.info(new String(resp.getOutput()));
 	}
@@ -246,24 +221,24 @@ public class TaskServiceTest extends TerariumApplicationTests {
 				+ amrJson.toString() + "}";
 
 		final TaskRequest req = new TaskRequest();
-		req.setId(taskId);
+		req.setType(TaskType.GOLLM);
 		req.setScript("gollm:dataset_configure");
 		req.setInput(content.getBytes());
 
-		final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM);
+		final TaskResponse resp = taskService.runTaskSync(req);
 
 		Assertions.assertEquals(taskId, resp.getId());
 
 		log.info(new String(resp.getOutput()));
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void testItCanCacheWithConcurrency() throws Exception {
 
-		final int NUM_REQUESTS = 512;
-		final int NUM_UNIQUE_REQUESTS = 16;
-		final int NUM_THREADS = 12;
+		final int NUM_REQUESTS = 1024;
+		final int NUM_UNIQUE_REQUESTS = 32;
+		final int NUM_THREADS = 24;
 		final int TIMEOUT_SECONDS = 20;
 
 		final List<byte[]> reqInput = new ArrayList<>();
@@ -279,8 +254,6 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		final ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
 
 		final Set<UUID> successTaskIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
-		// final Set<UUID> failedTaskIds = Collections.newSetFromMap(new
-		// ConcurrentHashMap<>());
 		final List<Future<?>> futures = new ArrayList<>();
 
 		final Random rand = new Random();
@@ -289,13 +262,14 @@ public class TaskServiceTest extends TerariumApplicationTests {
 			final Future<?> future = executor.submit(() -> {
 				try {
 					final TaskRequest req = new TaskRequest();
+					req.setType(TaskType.GOLLM);
 					req.setScript("/echo.py");
-					req.setInput(reqInput.get(rand.nextInt(NUM_UNIQUE_REQUESTS)));
+					req.setInput(reqInput.get(rand.nextInt(NUM_UNIQUE_REQUESTS * 2)));
 
-					final TaskResponse resp = taskService.runTaskSync(req, TaskType.GOLLM, TIMEOUT_SECONDS);
+					final TaskResponse resp = taskService.runTaskSync(req, TIMEOUT_SECONDS);
 					successTaskIds.add(resp.getId());
 				} catch (final RuntimeException e) {
-					// expected in some cases
+					// expected for purposely failed tasks
 
 				} catch (final Exception e) {
 					log.error("Error in test", e);
@@ -309,12 +283,10 @@ public class TaskServiceTest extends TerariumApplicationTests {
 			future.get(TIMEOUT_SECONDS * 2, TimeUnit.SECONDS);
 		}
 
-		log.info("Sending {} requests, which resulted in {} unique dispatches", NUM_REQUESTS, successTaskIds.size());
 		for (final UUID taskId : successTaskIds) {
 			log.info("Task ID: {}", taskId.toString());
 		}
 		Assertions.assertTrue(successTaskIds.size() <= NUM_UNIQUE_REQUESTS);
-
 	}
 
 }

--- a/packages/taskrunner/docker/Dockerfile.GoLLM
+++ b/packages/taskrunner/docker/Dockerfile.GoLLM
@@ -22,6 +22,9 @@ RUN apt-get update && \
 # Copy the Spring Boot fat JAR from the builder image
 COPY --from=taskrunner_builder /taskrunner/build/libs/*.jar /taskrunner.jar
 
+# Copy the echo script for testing
+COPY ./packages/taskrunner/src/test/resources/echo.py /echo.py
+
 # Install wget
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends wget && \

--- a/packages/taskrunner/docker/Dockerfile.Mira
+++ b/packages/taskrunner/docker/Dockerfile.Mira
@@ -23,6 +23,9 @@ RUN apt-get update && \
 # Copy the Spring Boot fat JAR from the builder image
 COPY --from=taskrunner_builder /taskrunner/build/libs/*.jar /taskrunner.jar
 
+# Copy the echo script for testing
+COPY ./packages/taskrunner/src/test/resources/echo.py /echo.py
+
 # Install Mira
 RUN echo "Cache bust so we can always pull latest Mira" $(date -u)
 RUN wget -O mira.tar.gz https://github.com/gyorilab/mira/archive/refs/heads/main.tar.gz && \

--- a/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/models/task/TaskRequest.java
+++ b/packages/taskrunner/src/main/java/software/uncharted/terarium/taskrunner/models/task/TaskRequest.java
@@ -3,6 +3,8 @@ package software.uncharted.terarium.taskrunner.models.task;
 import java.io.Serializable;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -10,6 +12,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 @NoArgsConstructor
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskRequest implements Serializable {
 	private UUID id;
 	private String script;
@@ -17,7 +20,7 @@ public class TaskRequest implements Serializable {
 	private int timeoutMinutes = 30;
 	private Object additionalProperties;
 
-	public TaskResponse createResponse(TaskStatus status) {
+	public TaskResponse createResponse(final TaskStatus status) {
 		return new TaskResponse()
 				.setId(id)
 				.setStatus(status)


### PR DESCRIPTION
This PR accomplishes two things:

- Task caching / sharing: using a SHA256 of the task, determine if it has already been sent, if it has and is still pending or has finished successfully, use the existing task.
- Client sent events are sent _after_ request handlers have resolved. Now when the browser gets a `SUCCESS` it knows that any and all server logic has completed for that task.

This code uses redis for caching and locking and is written to support caching across multiple instances of the hmi-server if we ever need to scale it that way.