### PR TITLE
darker text for the toast messages == easier to read

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/messages/_toast.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/messages/_toast.scss
@@ -28,7 +28,7 @@
 
             .p-toast-detail {
                 margin: $toastDetailMargin;
-                color: var(--text-color-secondary);
+                color: var(--text-color);
             }
         }
 


### PR DESCRIPTION
BEFORE
![Monosnap Terarium 2024-03-05 14-52-06](https://github.com/DARPA-ASKEM/terarium/assets/120480244/1ac935b2-b868-4ffb-8efa-839d27628a64)

AFTER
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/934a71c7-2466-4387-ab8d-033a11c78451)
