### PR TITLE
reorg sciml simulate

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/simulate-julia-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/simulate-julia-operation.ts
@@ -7,7 +7,9 @@ export interface SimulateJuliaOperationState {
 
 	// state specific to individual simulate runs
 	currentTimespan: TimeSpan;
-	simulationsInProgress: string[];
+
+	// In progress
+	inProgressSimulationId: string;
 }
 
 export const SimulateJuliaOperation: Operation = {
@@ -22,7 +24,7 @@ export const SimulateJuliaOperation: Operation = {
 		const init: SimulateJuliaOperationState = {
 			chartConfigs: [],
 			currentTimespan: { start: 1, end: 100 },
-			simulationsInProgress: []
+			inProgressSimulationId: ''
 		};
 		return init;
 	},

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -169,7 +169,6 @@ const updateState = () => {
 
 // Main entry point
 const run = async () => {
-	console.log('making request');
 	const simulationId = await makeForecastRequest();
 
 	const state = _.cloneDeep(props.node.state);
@@ -244,14 +243,12 @@ watch(
 
 watch(
 	() => props.node.active,
-	async (n, o) => {
-		if (!props.node.active || n === o) return;
+	async (newValue, oldValue) => {
+		if (!props.node.active || newValue === oldValue) return;
 		selectedOutputId.value = props.node.active;
 
 		// Update Wizard form fields with current selected output state timespan
 		timespan.value = props.node.state.currentTimespan;
-
-		console.log('hihihi', selectedRunId.value);
 
 		// Resume or fetch result
 		const simulationId = selectedRunId.value;

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -117,7 +117,7 @@
 
 <script setup lang="ts">
 import _ from 'lodash';
-import { computed, ref, shallowRef, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import Button from 'primevue/button';
 import InputNumber from 'primevue/inputnumber';
 import type { CsvAsset, SimulationRequest, TimeSpan } from '@/types/Types';
@@ -169,8 +169,8 @@ const showSpinner = ref(false);
 const showSaveInput = ref(<boolean>false);
 const saveAsName = ref(<string | null>'');
 
-const runResults = shallowRef<RunResults>({});
-const rawContent = shallowRef<{ [runId: string]: CsvAsset | null }>({});
+const runResults = ref<RunResults>({});
+const rawContent = ref<{ [runId: string]: CsvAsset | null }>({});
 
 const outputs = computed(() => {
 	if (!_.isEmpty(props.node.outputs)) {
@@ -287,6 +287,8 @@ watch(
 
 		// Update Wizard form fields with current selected output state timespan
 		timespan.value = props.node.state.currentTimespan;
+
+		console.log('hihihi', selectedRunId.value);
 
 		// Resume or fetch result
 		const simulationId = selectedRunId.value;

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -97,8 +97,8 @@ watch(
 	async (id) => {
 		if (!id || id === '') return;
 
-		const r = await pollResult(id);
-		if (r.state === PollerState.Done) {
+		const response = await pollResult(id);
+		if (response.state === PollerState.Done) {
 			processResult(id);
 		}
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -24,27 +24,92 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import { ref, computed, watch } from 'vue';
 import Button from 'primevue/button';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import { WorkflowNode } from '@/types/workflow';
 import { RunResults } from '@/types/SimulateConfig';
-import { getRunResult } from '@/services/models/simulation-service';
+import { getRunResult, pollAction } from '@/services/models/simulation-service';
 import { csvParse } from 'd3';
-import { SimulateJuliaOperationState } from './simulate-julia-operation';
+import { Poller, PollerState } from '@/api/api';
+import { logger } from '@/utils/logger';
+import { SimulateJuliaOperation, SimulateJuliaOperationState } from './simulate-julia-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<SimulateJuliaOperationState>;
 }>();
 
-const emit = defineEmits(['open-drilldown']);
+const emit = defineEmits(['open-drilldown', 'append-output', 'update-state']);
 const runResults = ref<RunResults>({});
 const hasData = ref(false);
 
 const areInputsFilled = computed(() => props.node.inputs[0].value);
 
 const selectedRunId = ref<any>(null);
+
+const poller = new Poller();
+const pollResult = async (runId: string) => {
+	poller
+		.setInterval(3000)
+		.setThreshold(300)
+		.setPollAction(async () => pollAction(runId));
+	const pollerResults = await poller.start();
+
+	if (pollerResults.state === PollerState.Cancelled) {
+		return pollerResults;
+	}
+	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
+		// throw if there are any failed runs for now
+		logger.error(`Simulate: ${runId} has failed`, {
+			toastTitle: 'Error - Sciml'
+		});
+		throw Error('Failed Runs');
+	}
+	return pollerResults;
+};
+
+const processResult = async (runId: string) => {
+	const state = _.cloneDeep(props.node.state);
+	if (state.chartConfigs.length === 0) {
+		addChart();
+	}
+
+	emit('append-output', {
+		type: SimulateJuliaOperation.outputs[0].type,
+		label: `Output - ${props.node.outputs.length + 1}`,
+		value: runId,
+		state: {
+			currentTimespan: state.currentTimespan
+		},
+		isSelected: false
+	});
+};
+
+const addChart = () => {
+	const state = _.cloneDeep(props.node.state);
+	state.chartConfigs.push([]);
+	emit('update-state', state);
+};
+
+watch(
+	() => props.node.state.inProgressSimulationId,
+	async (id) => {
+		if (!id || id === '') return;
+		console.log('gotta start polling.....');
+
+		const r = await pollResult(id);
+		if (r.state === PollerState.Done) {
+			processResult(id);
+		}
+
+		const state = _.cloneDeep(props.node.state);
+		state.inProgressSimulationId = '';
+		emit('update-state', state);
+	},
+	{ immediate: true }
+);
 
 watch(
 	() => props.node.active,

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -1,7 +1,7 @@
 <template>
 	<main>
 		<tera-simulate-chart
-			v-if="hasData"
+			v-if="runResults[selectedRunId]"
 			:run-results="{ [selectedRunId]: runResults[selectedRunId] }"
 			:chartConfig="{
 				selectedRun: selectedRunId,
@@ -43,7 +43,6 @@ const props = defineProps<{
 
 const emit = defineEmits(['open-drilldown', 'append-output', 'update-state']);
 const runResults = ref<RunResults>({});
-const hasData = ref(false);
 
 const areInputsFilled = computed(() => props.node.inputs[0].value);
 
@@ -97,7 +96,6 @@ watch(
 	() => props.node.state.inProgressSimulationId,
 	async (id) => {
 		if (!id || id === '') return;
-		console.log('gotta start polling.....');
 
 		const r = await pollResult(id);
 		if (r.state === PollerState.Done) {
@@ -114,6 +112,8 @@ watch(
 watch(
 	() => props.node.active,
 	async () => {
+		if (!props.node.active) return;
+
 		const active = props.node.active;
 		if (!active) return;
 
@@ -123,7 +123,6 @@ watch(
 		const resultCsv = await getRunResult(selectedRunId.value, 'result.csv');
 		const csvData = csvParse(resultCsv);
 		runResults.value[selectedRunId.value] = csvData as any;
-		hasData.value = true;
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
### Summary
This covers the Simulate operators, Calibrate and Ensemble will be dealt with in different PRs.

There are two themes to the PR here
- Reorganization and simplification of the operator logic, we no longer need to support multiple concurrent simulations within the same operator, and this means we can simplify state management and remove logic that never quite worked completely. 
- Enable a preview on the workflow within the operator node, the nodes will poll and update in a similar manner as the drilldown.