### PR TITLE
clone dataset-transform session on branching action

### DIFF
--- a/packages/client/hmi-client/src/services/notebook-session.ts
+++ b/packages/client/hmi-client/src/services/notebook-session.ts
@@ -36,3 +36,8 @@ export const deleteNotebookSession = async (notebook_id: string) => {
 	const response = await API.delete(`/sessions/${notebook_id}`);
 	return response?.data ?? null;
 };
+
+export const cloneNoteBookSession = async (notebookId: string) => {
+	const response = await API.post(`/sessions/${notebookId}/clone`);
+	return response?.data ?? null;
+};

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -158,6 +158,7 @@ public class NotebookSessionController {
 	@Operation(summary = "Clone a session")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "NotebookSession cloned.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = NotebookSession.class))),
+			@ApiResponse(responseCode = "500", description = "There was an issue cloning the session", content = @Content)
 	})
 	ResponseEntity<NotebookSession> cloneNotebookSession(
 			@PathVariable("id") final UUID id) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -153,6 +153,27 @@ public class NotebookSessionController {
 		}
 	}
 
+	@PostMapping("/{id}/clone")
+	@Secured(Roles.USER)
+	@Operation(summary = "Clone a session")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "NotebookSession cloned.", content = @Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = NotebookSession.class))),
+	})
+	ResponseEntity<NotebookSession> cloneNotebookSession(
+			@PathVariable("id") final UUID id) {
+		try {
+			final NotebookSession clone = sessionService.cloneAsset(id);
+			return ResponseEntity.status(HttpStatus.CREATED).body(clone);
+		} catch (final IOException e) {
+			final String error = "Unable to clone notebook session";
+			log.error(error, e);
+			throw new ResponseStatusException(
+					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+					error);
+		}
+	}
+
+
 	/**
 	 * Deletes and session
 	 *

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetService.java
@@ -163,4 +163,16 @@ public abstract class TerariumAssetService<T extends TerariumAsset> {
 		elasticService.index(getAssetIndex(), asset.getId().toString(), asset);
 		return Optional.of(asset);
 	}
+
+	/**
+	 * Clone asset on ES, retrieve and save document with a different id
+	 */
+	public T cloneAsset(final UUID id) throws IOException, IllegalArgumentException {
+		final Optional<T> targetAsset = getAsset(id);
+		if (targetAsset.isEmpty()) {
+			throw new IllegalArgumentException("Cannot clone non-existent asset: " + id.toString());
+		}
+		return createAsset(targetAsset.get());
+	}
+
 }


### PR DESCRIPTION
### Summary
DataTransform has a `state.notebookSessionId` field that links to an ES document representing the notebook session, this means when we branch, subsequent modifications are written into the same doc from multiple sources creating weird inconsistencies. 

This PR breaks this by adding a "clone" method, when branching happens DataTransform sessions are cloned are reassigned new ids.


### Testing
- Add a dataset to the workflow
- Attach the dataset to a data-transform node
- Branch the data-transform node
- Do something, e.g. adding a column in one of the data-transform node
- The two data-transforms should be separate entities and showing different data