### PR TITLE
Put the toast in the center and wider

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -1,9 +1,10 @@
+3
 <template>
 	<!-- Sets the Toast notification groups and their respective levels-->
-	<Toast position="top-right" group="error" />
-	<Toast position="top-right" group="warn" />
-	<Toast position="top-right" group="info" />
-	<Toast position="top-right" group="success" />
+	<Toast position="top-center" group="error" />
+	<Toast position="top-center" group="warn" />
+	<Toast position="top-center" group="info" />
+	<Toast position="top-center" group="success" />
 	<header>
 		<tera-navbar :active="displayNavBar" />
 	</header>
@@ -22,7 +23,7 @@
 import { computed, onMounted, watch } from 'vue';
 import Toast from 'primevue/toast';
 
-import { ToastSummaries, ToastSeverity, useToastService } from '@/services/toast';
+import { ToastSeverity, ToastSummaries, useToastService } from '@/services/toast';
 import { useRoute, useRouter } from 'vue-router';
 import API from '@/api/api';
 import TeraNavbar from '@/components/navbar/tera-navbar.vue';

--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -1,4 +1,3 @@
-3
 <template>
 	<!-- Sets the Toast notification groups and their respective levels-->
 	<Toast position="top-center" group="error" />

--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/messages/_toast.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/messages/_toast.scss
@@ -1,5 +1,6 @@
 .p-toast {
     opacity: $toastOpacity;
+    width: 40rem;
 
     .p-toast-message {
         margin: $toastMargin;

--- a/packages/client/hmi-client/src/services/toast.ts
+++ b/packages/client/hmi-client/src/services/toast.ts
@@ -5,9 +5,7 @@ const DEFAULT_DURATION = 3000; // 3 seconds
 // TODO: Define more.
 export enum ToastSummaries {
 	NETWORK_ERROR = 'Network Error',
-	UNKNOWN_ERROR = 'Unknown Error',
 	SERVICE_UNAVAILABLE = 'Service Unavailable',
-	ATTENTION = 'Attention',
 	INFO = 'Info',
 	WARNING = 'Warning',
 	ERROR = 'Error',


### PR DESCRIPTION
# Description

* Display the toast in the center to avoid blocking actions button from the UI (i.e. drilldowns close button)
* Make the toast slightly wider.
![Screenshot 2024-03-10 at 06 24 07](https://github.com/DARPA-ASKEM/terarium/assets/636801/a3997a22-a8f9-4596-b446-a8cbaafa4a48)

