### PR TITLE
Feat: Add optimize_result.json to the output panel

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -27,6 +27,7 @@ export interface OptimizeCiemssOperationState {
 	chartConfigs: string[][];
 	simulationsInProgress: string[];
 	simulationRunId: string;
+	optimzationRunId: string;
 	modelConfigName: string;
 	modelConfigDesc: string;
 }
@@ -64,6 +65,7 @@ export const OptimizeCiemssOperation: Operation = {
 			chartConfigs: [],
 			simulationsInProgress: [],
 			simulationRunId: '',
+			optimzationRunId: '',
 			modelConfigName: '',
 			modelConfigDesc: ''
 		};


### PR DESCRIPTION
# Description
I have thrown the result.dill file to result.json for us to work with on the frontend.
This saves the optimize run Id + gets the result file to utilize in the output panel.

# Blocked
Waiting on further design:
<img width="703" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/7b9d968c-40d4-4b68-8d07-73452656d8cc">


Resolves #(issue)
