### PR TITLE
fix: rename reserved keywords

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -432,14 +432,20 @@ const initialize = async () => {
 const setModelOptions = async () => {
 	if (!model.value) return;
 
+	const renameReserved = (v: string) => {
+		const reserved = ['lambda'];
+		if (reserved.includes(v)) return `${v}_`;
+		return v;
+	};
+
 	// Calculate mass
 	const semantics = model.value.semantics;
 	const modelInitials = semantics?.ode.initials;
-	const modelMassExpression = modelInitials?.map((d) => d.expression).join(' + ');
+	const modelMassExpression = modelInitials?.map((d) => renameReserved(d.expression)).join(' + ');
 
 	const parametersMap = {};
 	semantics?.ode.parameters?.forEach((d) => {
-		parametersMap[d.id] = d.value;
+		parametersMap[renameReserved(d.id)] = d.value;
 	});
 
 	const massValue = await pythonInstance.evaluateExpression(


### PR DESCRIPTION
### Summary
We cannot use reserved keywords as left-hand-side assignments, such as lambda. This is a problem because we are building a symbolics lookup table: `{ v1 => 321, v2 => 123 ... }` and the key cannot be reserved keyword in the language such as "lambda".

This PR works around the issue of mass evaluation by appending an underscore suffix.


<img width="740" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/dafda3ca-01df-4824-823f-857d2e45b466">


### Testing
Models with "lambda" in one or more of its expressions will not error out in the Funman operator.