### PR TITLE
fix: once a new output is generated update the selected output to it

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
@@ -29,16 +29,29 @@
 </template>
 
 <script setup lang="ts">
+import { watch } from 'vue';
+import { isEmpty } from 'lodash';
 import { WorkflowOutput, WorkflowPortStatus } from '@/types/workflow';
 import Dropdown from 'primevue/dropdown';
 
-defineProps<{
+const props = defineProps<{
 	options: WorkflowOutput<any>[] | { label: string; items: WorkflowOutput<any>[] }[];
 	output: WorkflowOutput<any>['id'];
 	isLoading?: boolean;
 }>();
 
 const emit = defineEmits(['update:selection']);
+
+// When a new output is added to the list choose it by default
+watch(
+	() => props.options,
+	(newOptions) => {
+		if (!isEmpty(newOptions)) {
+			const { items } = newOptions[0];
+			emit('update:selection', items[items.length - 1].id);
+		}
+	}
+);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
@@ -29,29 +29,16 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from 'vue';
-import { isEmpty } from 'lodash';
 import { WorkflowOutput, WorkflowPortStatus } from '@/types/workflow';
 import Dropdown from 'primevue/dropdown';
 
-const props = defineProps<{
+defineProps<{
 	options: WorkflowOutput<any>[] | { label: string; items: WorkflowOutput<any>[] }[];
 	output: WorkflowOutput<any>['id'];
 	isLoading?: boolean;
 }>();
 
 const emit = defineEmits(['update:selection']);
-
-// When a new output is added to the list choose it by default
-watch(
-	() => props.options,
-	(newOptions) => {
-		if (!isEmpty(newOptions)) {
-			const { items } = newOptions[0];
-			emit('update:selection', items[items.length - 1].id);
-		}
-	}
-);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -367,6 +367,8 @@ function appendOutput(
 	node.outputs.push(outputPort);
 	node.active = uuid;
 
+	selectOutput(node, uuid);
+
 	workflowDirty = true;
 }
 

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -358,11 +358,6 @@ function appendOutput(
 		timestamp: new Date()
 	};
 
-	// Revert
-	node.outputs.forEach((o) => {
-		o.isSelected = false;
-	});
-
 	// Append and set active
 	node.outputs.push(outputPort);
 	node.active = uuid;


### PR DESCRIPTION
# Description

Before when a new output was generated it appeared to be the chosen one once the output list was updated. In reality it was just a side effect of the list changing. I now select the new output after a new one is added (within `appendOutput()`)

In the old version the new output looked like it was the selected one after a Run. However it was missing the connected label that should have been beside it. 

https://github.com/DARPA-ASKEM/terarium/assets/28237258/388c6f29-895c-4e24-ae54-1c94ff67fa70


