### PR TITLE
fix broken PDF viewer in workflow document drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-pdf-embed.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-pdf-embed.vue
@@ -53,7 +53,13 @@ watch(isAdobePdfApiReady, () => {
 					},
 					metaData: { fileName: props.title }
 				},
-				{ embedMode: 'IN_LINE', showPrintPDF: true, showDownloadPDF: true }
+				{
+					embedMode: 'FULL_WINDOW',
+					showPrintPDF: true,
+					showDownloadPDF: true,
+					showAnnotationTools: false,
+					viewMode: 'FIT_WIDTH'
+				}
 			);
 		} else if (props.filePromise) {
 			adobeDCView.value.previewFile(
@@ -63,7 +69,13 @@ watch(isAdobePdfApiReady, () => {
 					},
 					metaData: { fileName: props.title }
 				},
-				{ embedMode: 'IN_LINE', showPrintPDF: true, showDownloadPDF: true }
+				{
+					embedMode: 'FULL_WINDOW',
+					showPrintPDF: true,
+					showDownloadPDF: true,
+					showAnnotationTools: false,
+					viewMode: 'FIT_WIDTH'
+				}
 			);
 		}
 	}


### PR DESCRIPTION
BEFORE
You can't scroll in the workflow document drilldown
![PDF viewer - can't scroll](https://github.com/DARPA-ASKEM/terarium/assets/120480244/e9ff7f1c-0b51-4181-9153-406eb866dcf3)


AFTER
Now you can... though I can only test it for about a second on my local host... should work fine on staging/prod
![PDF viewer - fixed](https://github.com/DARPA-ASKEM/terarium/assets/120480244/a662d831-3b4a-436e-8ec6-6b4a586887bf)


