### PR TITLE
Open rename workflow text field in focus mode

### DIFF
--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -17,14 +17,19 @@
 		<template #foreground>
 			<div class="toolbar glass">
 				<div class="button-group w-full">
-					<InputText
-						v-if="isRenamingWorkflow"
-						class="p-inputtext w-full mr-8"
-						v-model.lazy="newWorkflowName"
-						placeholder="Workflow name"
-						@keyup.enter="updateWorkflowName"
-						@keyup.esc="updateWorkflowName"
-					/>
+					<div v-if="isRenamingWorkflow" class="rename-workflow w-full">
+						<InputText
+							class="p-inputtext w-full"
+							v-model.lazy="newWorkflowName"
+							placeholder="Workflow name"
+							@keyup.enter="updateWorkflowName"
+							@keyup.esc="updateWorkflowName"
+							v-focus
+						/>
+						<div class="flex flex-nowrap ml-1 mr-3">
+							<Button icon="pi pi-check" rounded text @click="updateWorkflowName" />
+						</div>
+					</div>
 					<h4 v-else>{{ wf.name }}</h4>
 					<Button
 						v-if="!isRenamingWorkflow"
@@ -901,5 +906,11 @@ function resetZoom() {
 	align-items: center;
 	flex-direction: row;
 	gap: var(--gap-small);
+}
+
+.rename-workflow {
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
 }
 </style>


### PR DESCRIPTION
BEFORE
After selecting 'Rename' you need to click in the input box before you begin typing. And it's not clear how to submit -- you can press enter or escape, but there's no signifier.
![Open notes in focus mode - BEFORE](https://github.com/DARPA-ASKEM/terarium/assets/120480244/24254dc9-caaf-4310-915f-46f11c1bca39)



AFTER
Now we open the input box in focus mode. I also added a check mark that you can click, which runs the same 'updateWorkflowName' function as the enter and escape keys do. 
![open rename workflow in focus mode - COMPLETE](https://github.com/DARPA-ASKEM/terarium/assets/120480244/e098584c-bcc2-4eeb-b0c2-f37ea0b7a215)
