### PR TITLE
reorganize ciemss calibrate

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -1,7 +1,4 @@
-import { WorkflowPort, Operation, WorkflowOperationTypes } from '@/types/workflow';
-// import type { CalibrationRequest } from '@/types/Types';
-// import { makeCalibrateJob } from '@/services/models/simulation-service';
-import { getModel } from '@/services/model';
+import { Operation, WorkflowOperationTypes } from '@/types/workflow';
 import { ChartConfig } from '@/types/SimulateConfig';
 import { CalibrateMap } from '@/services/calibrate-workflow';
 
@@ -10,13 +7,16 @@ export interface CalibrationOperationStateCiemss {
 	mapping: CalibrateMap[];
 	simulationsInProgress: string[];
 
+	inProgressCalibrationId: string;
+	inProgressForecastId: string;
+
 	calibrationId: string;
-	simulationId: string;
+	forecastId: string;
 }
 
 export const CalibrationOperationCiemss: Operation = {
 	name: WorkflowOperationTypes.CALIBRATION_CIEMSS,
-	displayName: 'Calibrate & Simulate (probabilistic)',
+	displayName: 'Calibrate & Simulate',
 	description:
 		'given a model id, a dataset id, and optionally a configuration. calibrate the models initial values and rates',
 	inputs: [
@@ -26,36 +26,17 @@ export const CalibrationOperationCiemss: Operation = {
 	outputs: [{ type: 'simulationId' }],
 	isRunnable: true,
 
-	// TODO: Figure out mapping
-	// Calls API, returns results.
-	action: async (v: WorkflowPort[]) => {
-		// TODO Add more safety checks.
-		if (v.length) {
-			// TODO: The mapping is not 0 -> modelId as i am assuming here for testing
-			const modelId = v[0].value?.[0];
-			// let datasetId = v[1].value;
-			// let configuration = v[2].value; //TODO Not sure if this is a required input
-
-			// Get the model:
-			const model = await getModel(modelId);
-			if (model) {
-				// Make calibration job.
-				// const calibrationParam: CalibrationRequest = calibrationParamExample;
-				// const result = makeCalibrateJob(calibrationParam);
-				// return [{ type: 'number', result }];
-				return [{ type: null, value: null }];
-			}
-		}
-		return [{ type: null, value: null }];
-	},
+	action: async () => {},
 
 	initState: () => {
 		const init: CalibrationOperationStateCiemss = {
 			chartConfigs: [],
 			mapping: [{ modelVariable: '', datasetVariable: '' }],
 			simulationsInProgress: [],
+			inProgressCalibrationId: '',
+			inProgressForecastId: '',
 			calibrationId: '',
-			simulationId: ''
+			forecastId: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -166,10 +166,6 @@ import Column from 'primevue/column';
 import {
 	getRunResultCiemss,
 	makeCalibrateJobCiemss,
-	simulationPollAction,
-	querySimulationInProgress,
-	getCalibrateBlobURL,
-	makeForecastJobCiemss,
 	subscribeToUpdateMessages,
 	unsubscribeToUpdateMessages
 } from '@/services/models/simulation-service';
@@ -198,9 +194,7 @@ import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
-import { Poller, PollerState } from '@/api/api';
 import { getTimespan } from '@/workflow/util';
-import { logger } from '@/utils/logger';
 import { useToastService } from '@/services/toast';
 import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
 import { CalibrationOperationStateCiemss } from './calibrate-operation';
@@ -235,7 +229,7 @@ const previewChartWidth = ref(120);
 
 const showSpinner = ref(false);
 const progress = ref({ status: ProgressState.Retrieving, value: 0 });
-let lossValues: { [key: string]: number }[] = [];
+const lossValues: { [key: string]: number }[] = [];
 
 const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
 
@@ -247,15 +241,8 @@ const method = ref('dopri5');
 const ciemssMethodOptions = ref(['dopri5', 'euler']);
 */
 
-const poller = new Poller();
-
 const disableRunButton = computed(
-	() =>
-		!currentDatasetFileName.value ||
-		!modelConfig.value ||
-		!csvAsset.value ||
-		!modelConfigId.value ||
-		!datasetId.value
+	() => !currentDatasetFileName.value || !csvAsset.value || !modelConfigId.value || !datasetId.value
 );
 
 const selectedOutputId = ref<string>();
@@ -272,13 +259,7 @@ const outputs = computed(() => {
 });
 
 const runCalibrate = async () => {
-	if (
-		!modelConfigId.value ||
-		!datasetId.value ||
-		!currentDatasetFileName.value ||
-		!modelConfig.value
-	)
-		return;
+	if (!modelConfigId.value || !datasetId.value || !currentDatasetFileName.value) return;
 
 	const formattedMap: { [index: string]: string } = {};
 	// If the user has done any mapping populate formattedMap
@@ -310,11 +291,15 @@ const runCalibrate = async () => {
 	const response = await makeCalibrateJobCiemss(calibrationRequest);
 
 	if (response?.simulationId) {
-		getCalibrateStatus(response.simulationId);
+		const state = _.cloneDeep(props.node.state);
+		state.inProgressCalibrationId = response?.simulationId;
+		state.inProgressForecastId = '';
+
+		emit('update-state', state);
 	}
 };
 
-const getMessageHandler = (event: ClientEvent<any>) => {
+const messageHandler = (event: ClientEvent<any>) => {
 	console.log('msg', event.data);
 	lossValues.push({ iter: lossValues.length, loss: event.data.loss });
 
@@ -324,128 +309,6 @@ const getMessageHandler = (event: ClientEvent<any>) => {
 			height: 120
 		});
 	}
-};
-
-/**
- * This is a two step process
- * - Polling loop for calibration to finish, plot the loss values
- * - Polling loop for a sampmle simulation, plot the result against input dataset
- * */
-const getCalibrateStatus = async (simulationId: string) => {
-	showSpinner.value = true;
-	if (!simulationId) {
-		console.log('No sim id');
-		return;
-	}
-	const runIds = [simulationId];
-	lossValues = [];
-
-	// open a connection for each run id and handle the messages
-	await subscribeToUpdateMessages(
-		[simulationId],
-		ClientEventType.SimulationPyciemss,
-		getMessageHandler
-	);
-
-	poller
-		.setInterval(3000)
-		.setThreshold(300)
-		.setPollAction(async () => simulationPollAction(runIds, props.node, progress, emit));
-
-	const pollerResults = await poller.start();
-
-	// closing event source connections
-	await unsubscribeToUpdateMessages(
-		[simulationId],
-		ClientEventType.SimulationPyciemss,
-		getMessageHandler
-	);
-
-	if (pollerResults.state === PollerState.Cancelled) {
-		return;
-	}
-	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
-		// throw if there are any failed runs for now
-		showSpinner.value = false;
-		logger.error(`Calibrate: ${simulationId} has failed`, {
-			toastTitle: 'Error - Pyciemss'
-		});
-		throw Error('Failed Runs');
-	}
-
-	// Start 2nd simulation to get sample simulation from dill
-	const dillURL = await getCalibrateBlobURL(simulationId);
-	console.log('dill URL is', dillURL);
-
-	const resp = await makeForecastJobCiemss({
-		projectId: '',
-		modelConfigId: modelConfigId.value as string,
-		timespan: {
-			start: 0,
-			end: 100
-			// start: state.currentTimespan.start,
-			// end: state.currentTimespan.end
-		},
-		extra: {
-			num_samples: 5,
-			method: 'dopri5',
-			inferred_parameters: simulationId
-		},
-		engine: 'ciemss'
-	});
-
-	const sampleSimulateId = resp.id;
-
-	poller.stop();
-	poller
-		.setInterval(3000)
-		.setThreshold(500)
-		.setPollAction(async () =>
-			simulationPollAction([sampleSimulateId], props.node, progress, emit)
-		);
-	const sampleSimulateResults = await poller.start();
-
-	if (sampleSimulateResults.state === PollerState.Cancelled) {
-		showSpinner.value = false;
-		return;
-	}
-	if (sampleSimulateResults.state !== PollerState.Done || !sampleSimulateResults.data) {
-		// throw if there are any failed runs for now
-		showSpinner.value = false;
-		logger.error(`Simulation: ${sampleSimulateId} has failed`, {
-			toastTitle: 'Error - Pyciemss'
-		});
-		throw Error('Failed Runs');
-	}
-
-	const output = await getRunResultCiemss(sampleSimulateId, 'result.csv');
-	runResults.value = output.runResults;
-
-	appendOutput(simulationId, sampleSimulateId);
-	showSpinner.value = false;
-};
-
-const appendOutput = async (calibrationId: string, simulationId: string) => {
-	const portLabel = props.node.inputs[0].label;
-	const state = _.cloneDeep(props.node.state);
-
-	state.chartConfigs = [
-		{
-			selectedRun: simulationId,
-			selectedVariable: []
-		}
-	];
-
-	state.calibrationId = calibrationId;
-	state.simulationId = simulationId;
-
-	emit('update-state', state);
-
-	emit('append-output', {
-		type: 'calibrateSimulationId',
-		label: `${portLabel} Result`,
-		value: [calibrationId]
-	});
 };
 
 const chartConfigurationChange = (index: number, config: ChartConfig) => {
@@ -515,8 +378,6 @@ async function getAutoMapping() {
 }
 
 onMounted(async () => {
-	const runIds = querySimulationInProgress(props.node);
-
 	// Get sizing
 	if (drilldownLossPlot.value) {
 		previewChartWidth.value = drilldownLossPlot.value.offsetWidth;
@@ -532,16 +393,20 @@ onMounted(async () => {
 	currentDatasetFileName.value = filename;
 	csvAsset.value = csv;
 	datasetColumns.value = datasetOptions;
+});
 
-	// currently in progress
-	if (runIds.length > 0) {
-		getCalibrateStatus(runIds[0]);
+onUnmounted(() => {});
+
+watch(
+	() => props.node.state.inProgressCalibrationId,
+	(id) => {
+		if (id === '') {
+			unsubscribeToUpdateMessages([id], ClientEventType.SimulationSciml, messageHandler);
+		} else {
+			subscribeToUpdateMessages([id], ClientEventType.SimulationSciml, messageHandler);
+		}
 	}
-});
-
-onUnmounted(() => {
-	poller.stop();
-});
+);
 
 watch(
 	() => props.node.active,
@@ -552,7 +417,7 @@ watch(
 
 			// FIXME: could still be running
 			const state = props.node.state;
-			const output = await getRunResultCiemss(state.simulationId, 'result.csv');
+			const output = await getRunResultCiemss(state.forecastId, 'result.csv');
 			runResults.value = output.runResults;
 		}
 	},

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -158,7 +158,7 @@
 
 <script setup lang="ts">
 import _ from 'lodash';
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch } from 'vue';
+import { computed, onMounted, ref, shallowRef, watch } from 'vue';
 import Button from 'primevue/button';
 import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
@@ -394,8 +394,6 @@ onMounted(async () => {
 	datasetColumns.value = datasetOptions;
 });
 
-onUnmounted(() => {});
-
 watch(
 	() => props.node.state.inProgressCalibrationId,
 	(id) => {
@@ -417,7 +415,6 @@ watch(
 		if (props.node.active) {
 			selectedOutputId.value = props.node.active;
 
-			// FIXME: could still be running
 			const state = props.node.state;
 			const output = await getRunResultCiemss(state.forecastId, 'result.csv');
 			runResults.value = output.runResults;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -138,7 +138,7 @@
 					</section>
 				</div>
 				<section v-else>
-					<tera-progress-bar :value="progress.value" :status="progress.status" />
+					<tera-progress-spinner :font-size="2" is-centered style="height: 100%" />
 				</section>
 			</tera-drilldown-preview>
 		</template>
@@ -163,22 +163,6 @@ import Button from 'primevue/button';
 import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
 import Column from 'primevue/column';
-import {
-	getRunResultCiemss,
-	makeCalibrateJobCiemss,
-	subscribeToUpdateMessages,
-	unsubscribeToUpdateMessages
-} from '@/services/models/simulation-service';
-import {
-	CalibrationRequestCiemss,
-	ClientEvent,
-	ClientEventType,
-	CsvAsset,
-	DatasetColumn,
-	ModelConfiguration,
-	ProgressState,
-	State
-} from '@/types/Types';
 // import InputNumber from 'primevue/inputnumber';
 import {
 	CalibrateMap,
@@ -186,18 +170,34 @@ import {
 	setupDatasetInput,
 	setupModelInput
 } from '@/services/calibrate-workflow';
-import { autoCalibrationMapping } from '@/services/concept';
-import { ChartConfig, RunResults } from '@/types/SimulateConfig';
-import { WorkflowNode } from '@/types/workflow';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
-import TeraProgressBar from '@/workflow/tera-progress-bar.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
+import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
+import {
+	CalibrationRequestCiemss,
+	ClientEvent,
+	ClientEventType,
+	CsvAsset,
+	DatasetColumn,
+	ModelConfiguration,
+	State
+} from '@/types/Types';
 import { getTimespan } from '@/workflow/util';
 import { useToastService } from '@/services/toast';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
-import { CalibrationOperationStateCiemss } from './calibrate-operation';
+import { autoCalibrationMapping } from '@/services/concept';
+import {
+	getRunResultCiemss,
+	makeCalibrateJobCiemss,
+	subscribeToUpdateMessages,
+	unsubscribeToUpdateMessages
+} from '@/services/models/simulation-service';
+
+import type { ChartConfig, RunResults } from '@/types/SimulateConfig';
+import type { WorkflowNode } from '@/types/workflow';
+import type { CalibrationOperationStateCiemss } from './calibrate-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
@@ -228,7 +228,6 @@ const runResults = ref<RunResults>({});
 const previewChartWidth = ref(120);
 
 const showSpinner = ref(false);
-const progress = ref({ status: ProgressState.Retrieving, value: 0 });
 const lossValues: { [key: string]: number }[] = [];
 
 const mapping = ref<CalibrateMap[]>(props.node.state.mapping);
@@ -401,11 +400,14 @@ watch(
 	() => props.node.state.inProgressCalibrationId,
 	(id) => {
 		if (id === '') {
-			unsubscribeToUpdateMessages([id], ClientEventType.SimulationSciml, messageHandler);
+			showSpinner.value = false;
+			unsubscribeToUpdateMessages([id], ClientEventType.SimulationPyciemss, messageHandler);
 		} else {
-			subscribeToUpdateMessages([id], ClientEventType.SimulationSciml, messageHandler);
+			showSpinner.value = true;
+			subscribeToUpdateMessages([id], ClientEventType.SimulationPyciemss, messageHandler);
 		}
-	}
+	},
+	{ immediate: true }
 );
 
 watch(

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -24,27 +24,128 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import { computed, watch, ref, shallowRef } from 'vue';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import { WorkflowNode } from '@/types/workflow';
 import Button from 'primevue/button';
-import { getRunResultCiemss } from '@/services/models/simulation-service';
+import {
+	getRunResultCiemss,
+	pollAction,
+	getCalibrateBlobURL,
+	makeForecastJobCiemss
+} from '@/services/models/simulation-service';
 import { RunResults } from '@/types/SimulateConfig';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
 import type { CsvAsset } from '@/types/Types';
+import { Poller, PollerState } from '@/api/api';
+import { logger } from '@/utils/logger';
 import { CalibrationOperationStateCiemss } from './calibrate-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
 }>();
 
+const modelConfigId = computed<string | undefined>(() => props.node.inputs[0]?.value?.[0]);
+
 const runResults = ref<RunResults>({});
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
 const areInputsFilled = computed(() => props.node.inputs[0].value && props.node.inputs[1].value);
 
-const emit = defineEmits(['open-drilldown']);
+const emit = defineEmits(['open-drilldown', 'update-state', 'append-output']);
+
+const poller = new Poller();
+const pollResult = async (runId: string) => {
+	poller
+		.setInterval(3000)
+		.setThreshold(300)
+		.setPollAction(async () => pollAction(runId));
+	const pollerResults = await poller.start();
+
+	if (pollerResults.state === PollerState.Cancelled) {
+		return pollerResults;
+	}
+	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
+		// throw if there are any failed runs for now
+		logger.error(`Calibration: ${runId} has failed`, {
+			toastTitle: 'Error - Pyciemss'
+		});
+		throw Error('Failed Runs');
+	}
+	return pollerResults;
+};
+
+watch(
+	() => props.node.state.inProgressCalibrationId,
+	async (id) => {
+		if (!id || id === '') return;
+
+		const response = await pollResult(id);
+		if (response.state === PollerState.Done) {
+			// Start 2nd simulation to get sample simulation from dill
+			const dillURL = await getCalibrateBlobURL(id);
+			console.log('dill URL is', dillURL);
+
+			// FIXME: should proably align with time-span in dataset
+			const forecastResponse = await makeForecastJobCiemss({
+				projectId: '',
+				modelConfigId: modelConfigId.value as string,
+				timespan: {
+					start: 0,
+					end: 100
+					// start: state.currentTimespan.start,
+					// end: state.currentTimespan.end
+				},
+				extra: {
+					num_samples: 5,
+					method: 'dopri5',
+					inferred_parameters: id
+				},
+				engine: 'ciemss'
+			});
+			const forecastId = forecastResponse.id;
+
+			const state = _.cloneDeep(props.node.state);
+			state.inProgressCalibrationId = '';
+			state.calibrationId = id;
+			state.inProgressForecastId = forecastId;
+			emit('update-state', state);
+		}
+	},
+	{ immediate: true }
+);
+
+watch(
+	() => props.node.state.inProgressForecastId,
+	async (id) => {
+		if (!id || id === '') return;
+
+		const response = await pollResult(id);
+		if (response.state === PollerState.Done) {
+			const state = _.cloneDeep(props.node.state);
+
+			state.chartConfigs = [
+				{
+					selectedRun: id,
+					selectedVariable: []
+				}
+			];
+			state.inProgressForecastId = '';
+			state.forecastId = id;
+			emit('update-state', state);
+
+			const portLabel = props.node.inputs[0].label;
+			emit('append-output', {
+				type: 'calibrateSimulationId',
+				label: `${portLabel} Result`,
+				value: [state.calibrationId]
+			});
+		}
+	},
+	{ immediate: true }
+);
 
 watch(
 	() => props.node.active,
@@ -52,12 +153,12 @@ watch(
 		const active = props.node.active;
 		const state = props.node.state;
 		if (!active) return;
-		if (!state.simulationId) return;
+		if (!state.forecastId) return;
 
-		const simulationId = state.simulationId;
+		const forecastId = state.forecastId;
 
 		// Simulate
-		const result = await getRunResultCiemss(simulationId, 'result.csv');
+		const result = await getRunResultCiemss(forecastId, 'result.csv');
 		runResults.value = result.runResults;
 
 		// Dataset used to calibrate

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -1,13 +1,20 @@
 <template>
 	<main>
 		<tera-simulate-chart
-			v-if="runResults && csvAsset"
+			v-if="!inProgressCalibrationId && runResults && csvAsset"
 			:run-results="runResults"
 			:chartConfig="props.node.state.chartConfigs[0]"
 			:mapping="props.node.state.mapping as any"
 			:initial-data="csvAsset"
 			:size="{ width: 190, height: 120 }"
 			has-mean-line
+		/>
+
+		<tera-progress-spinner
+			v-if="inProgressCalibrationId"
+			:font-size="2"
+			is-centered
+			style="height: 100%"
 		/>
 
 		<Button
@@ -26,22 +33,24 @@
 <script setup lang="ts">
 import _ from 'lodash';
 import { computed, watch, ref, shallowRef } from 'vue';
+import Button from 'primevue/button';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
-import { WorkflowNode } from '@/types/workflow';
-import Button from 'primevue/button';
+import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import {
 	getRunResultCiemss,
 	pollAction,
 	getCalibrateBlobURL,
 	makeForecastJobCiemss
 } from '@/services/models/simulation-service';
-import { RunResults } from '@/types/SimulateConfig';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
-import type { CsvAsset } from '@/types/Types';
 import { Poller, PollerState } from '@/api/api';
 import { logger } from '@/utils/logger';
-import { CalibrationOperationStateCiemss } from './calibrate-operation';
+
+import type { WorkflowNode } from '@/types/workflow';
+import type { CsvAsset } from '@/types/Types';
+import type { RunResults } from '@/types/SimulateConfig';
+import type { CalibrationOperationStateCiemss } from './calibrate-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<CalibrationOperationStateCiemss>;
@@ -53,6 +62,7 @@ const runResults = ref<RunResults>({});
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
 const areInputsFilled = computed(() => props.node.inputs[0].value && props.node.inputs[1].value);
+const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 
 const emit = defineEmits(['open-drilldown', 'update-state', 'append-output']);
 

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -35,8 +35,8 @@ export const getGraphDataFromDatasetCSV = (
 	runType?: RunType
 ): DataseriesConfig | null => {
 	// TA3 quirks, adjust variable names - FIXME
-	const selectedVariableLookup =
-		runType === RunType.Julia ? columnVar.slice(0, -3) : columnVar.slice(0, -6);
+	const selectedVariableLookup = runType === RunType.Julia ? columnVar.slice(0, -3) : columnVar;
+	// runType === RunType.Julia ? columnVar.slice(0, -3) : columnVar.slice(0, -6);
 	const timeVariableLookup = 'timestamp';
 
 	// Default


### PR DESCRIPTION
### Summary
- Sync ciemss-calibrate drilldown/node interactions and add in resuming logic for long running calibrations
- Tidy up code

Note unlike other operators, ciemss-calibrate is a two-stage process, so we need to track extra data, namely
- inProgressCalibrateId, which points to the dill file, and
- inProgressForecastId, which points to the simulation result


TODO in other PR(s)
- better handling of loss values and chart's variable selections, there seemed to be a few bugs 
- figure out what is going on with the state names coming back, we used to parse for `_state` but they don't seem to be there anymore, however @Tom-Szendrey is reporting parsing for `_state` in his optimization changes, so there may be some inconsistent naming issues we need to report.
