### PR TITLE
Feat: simulate ensemble appending ports

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -15,7 +15,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 	name: WorkflowOperationTypes.SIMULATE_ENSEMBLE_CIEMSS,
 	displayName: 'Simulate ensemble',
 	description: '',
-	inputs: [{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: true }],
+	inputs: [{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: false }],
 	outputs: [{ type: 'simulationId' }],
 	isRunnable: true,
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -344,7 +344,10 @@ const runEnsemble = async () => {
 
 onMounted(async () => {
 	// FIXME: probably switch to multiport instead of multivalue
-	const modelConfigurationIds = props.node.inputs[0]?.value;
+	const modelConfigurationIds: string[] = [];
+	props.node.inputs.forEach((ele) => {
+		if (ele.value) modelConfigurationIds.push(ele.value[0]);
+	});
 	if (!modelConfigurationIds) return;
 
 	const allModelConfigurations = await Promise.all(

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -343,7 +343,6 @@ const runEnsemble = async () => {
 };
 
 onMounted(async () => {
-	// FIXME: probably switch to multiport instead of multivalue
 	const modelConfigurationIds: string[] = [];
 	props.node.inputs.forEach((ele) => {
 		if (ele.value) modelConfigurationIds.push(ele.value[0]);

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -33,7 +33,7 @@
 <script setup lang="ts">
 import _ from 'lodash';
 import { ref, computed, watch } from 'vue';
-import { WorkflowNode } from '@/types/workflow';
+import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import { getRunResultCiemss, pollAction } from '@/services/models/simulation-service';
 import Button from 'primevue/button';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
@@ -50,7 +50,7 @@ import {
 const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'update-state', 'open-drilldown', 'append-input-port']);
 
 // const runResults = ref<RunResults>({});
 const runResults = ref<{ [runId: string]: RunResults }>({});
@@ -104,6 +104,16 @@ const processResult = async (simulationId: string) => {
 		isSelected: false
 	});
 };
+
+watch(
+	() => props.node.inputs,
+	() => {
+		if (props.node.inputs.every((input) => input.status === WorkflowPortStatus.CONNECTED)) {
+			emit('append-input-port', { type: 'modelConfigId', label: 'Model configuration' });
+		}
+	},
+	{ deep: true }
+);
 
 watch(
 	() => props.node.state.inProgressSimulationId,


### PR DESCRIPTION
# Description
Rather than 1 port that accepts multiple inputs, update the design for simulate ensemble to have appending ports

<img width="317" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/92da494d-9c4e-44c6-af12-ce4b33d603cc">


