### PR TITLE
accommodate mixed types

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
@@ -68,7 +68,6 @@ export const extractSubjectOutcomeMatrix = (
 	if (rowNames.length === 0 || colNames.length === 0) {
 		return { rowNames, colNames, matrix: [] };
 	}
-
 	const matrix = emptyMatrix(rowNames, colNames);
 
 	for (let i = 0; i < paramNames.length; i++) {
@@ -80,6 +79,8 @@ export const extractSubjectOutcomeMatrix = (
 		paramLocations.forEach((location) => {
 			const rowIdx = rowNames.indexOf(location.subject);
 			const colIdx = colNames.indexOf(location.outcome);
+
+			if (rowIdx === -1 || colIdx === -1) return;
 
 			matrix[rowIdx][colIdx].rowCriteria = location.subject;
 			matrix[rowIdx][colIdx].colCriteria = location.outcome;
@@ -117,6 +118,8 @@ export const extractSubjectControllersMatrix = (
 			const rowIdx = rowNames.indexOf(location.subject);
 			const colIdx = colNames.indexOf(location.controllers.join('-'));
 
+			if (rowIdx === -1 || colIdx === -1) return;
+
 			matrix[rowIdx][colIdx].rowCriteria = location.subject;
 			matrix[rowIdx][colIdx].colCriteria = location.controllers.join('-');
 			matrix[rowIdx][colIdx].content = {
@@ -152,6 +155,8 @@ export const extractOutcomeControllersMatrix = (
 		paramLocations.forEach((location) => {
 			const rowIdx = rowNames.indexOf(location.outcome);
 			const colIdx = colNames.indexOf(location.controllers.join('-'));
+
+			if (rowIdx === -1 || colIdx === -1) return;
 
 			matrix[rowIdx][colIdx].rowCriteria = location.outcome;
 			matrix[rowIdx][colIdx].colCriteria = location.controllers.join('-');


### PR DESCRIPTION
### Summary
We have assumed that the children-parameters of some parameter beta: beta_0, beta_1, beta_2 ... etc can all be slotted into a singular type of matrix out of the three we have
- subject-outcome
- subject-controller
- outcome-controller

That isn't exactly always the case, it may be that beta_1 is subject-outcome and beta_2 is none of those 3. It could be that our 3-matrix approach is not exactly right when it comes to bio-models, or that someone had manually adjusted model. Anyway this PR adds escape hatches to the generation process so we don't error out when this scenario happens.