### PR TITLE
Update to more generic progress

### DIFF
--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -84,20 +84,16 @@ export const profileDataset = async (
 /** Handle messages received from the extraction client-event */
 const messageHandler = async (event: ClientEvent<ExtractionStatusUpdate>) => {
 	if (event.data.error) {
-		logger.error(
-			`Extraction client-event: ERROR [${event.data.step}/${event.data.totalSteps}]: ${event.data.error}`
-		);
+		logger.error(`Extraction client-event: ERROR [${event.data.t}]: ${event.data.error}`);
 		await unsubscribe(ClientEventType.Extraction, messageHandler);
 		return;
 	}
 	if (event.data.message) {
-		console.debug(
-			`Extraction client-event: [${event.data.step}/${event.data.totalSteps}]: ${event.data.message}`
-		);
+		console.debug(`Extraction client-event: [${event.data.t}]: ${event.data.message}`);
 	} else {
-		logger.success(`Extraction client-event: [${event.data.step}/${event.data.totalSteps}]`);
+		logger.success(`Extraction client-event: [${event.data.t}]`);
 	}
-	if (event.data.step === event.data.totalSteps) {
+	if (event.data.t >= 1.0) {
 		await unsubscribe(ClientEventType.Extraction, messageHandler);
 	}
 };

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -620,8 +620,7 @@ export interface ExtractionResponseResult {
 
 export interface ExtractionStatusUpdate {
     documentId: string;
-    step: number;
-    totalSteps: number;
+    t: number;
     message: string;
     error: string;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extractionservice/ExtractionStatusUpdate.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extractionservice/ExtractionStatusUpdate.java
@@ -1,24 +1,22 @@
 package software.uncharted.terarium.hmiserver.models.extractionservice;
 
+import java.util.UUID;
+
 import lombok.Data;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
-
-import java.util.UUID;
 
 @Data
 @TSModel
 public class ExtractionStatusUpdate {
-    private UUID documentId;
-    private Integer step;
-    private Integer totalSteps;
-    private String message;
-    private String error;
+	private UUID documentId;
+	private Double t;
+	private String message;
+	private String error;
 
-    public ExtractionStatusUpdate(UUID documentId, Integer step, Integer totalSteps, String message, String error) {
-        this.documentId = documentId;
-        this.step = step;
-        this.totalSteps = totalSteps;
-        this.message = message;
-        this.error = error;
-    }
+	public ExtractionStatusUpdate(final UUID documentId, final Double t, final String message, final String error) {
+		this.documentId = documentId;
+		this.t = t;
+		this.message = message;
+		this.error = error;
+	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -1,15 +1,29 @@
 package software.uncharted.terarium.hmiserver.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.models.ClientEvent;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
@@ -22,19 +36,6 @@ import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.tasks.ModelCardResponseHandler;
 import software.uncharted.terarium.hmiserver.utils.ByteMultipartFile;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.function.BiConsumer;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -44,41 +45,91 @@ public class ExtractionService {
 	final ObjectMapper objectMapper;
 	final ClientEventService clientEventService;
 
-	private ExecutorService executor = Executors.newFixedThreadPool(1);
+	private final ExecutorService executor = Executors.newFixedThreadPool(1);
 
-	private static final Integer TOTAL_EXTRACTION_STEPS = 14;
+	private static class ClientEventInterface {
 
-	public void extractPDF(UUID documentId, String userId) {
-		final BiConsumer<Integer, String> messageClient = createMessageClient(documentId, userId);
-		final BiConsumer<Integer, String> errorClient = createErrorClient(documentId, userId);
+		private Double halfTimeSeconds = 2.0;
+		private Double startSeconds = 0.0;
+		private final UUID documentId;
+		private final String userId;
+		final ClientEventService clientEventService;
+
+		ClientEventInterface(final ClientEventService clientEventService, final UUID documentId, final String userId,
+				final Double halfTimeSeconds) {
+			this.clientEventService = clientEventService;
+			this.documentId = documentId;
+			this.userId = userId;
+			this.halfTimeSeconds = halfTimeSeconds;
+			this.startSeconds = System.currentTimeMillis() / 1000.0;
+		}
+
+		private Double estimateT() {
+			return 1.0f - Math.pow(0.5, (getElapsedSeconds() / halfTimeSeconds));
+		}
+
+		private Double getElapsedSeconds() {
+			return (System.currentTimeMillis() / 1000.0) - startSeconds;
+		}
+
+		private void updateClient(final UUID documentId, final Double t, final String message, final String error,
+				final String userId) {
+			final ExtractionStatusUpdate update = new ExtractionStatusUpdate(documentId, t, message, error);
+			final ClientEvent<ExtractionStatusUpdate> status = ClientEvent.<ExtractionStatusUpdate>builder()
+					.type(ClientEventType.EXTRACTION).data(update).build();
+			clientEventService.sendToUser(status, userId);
+		}
+
+		public void sendMessage(final String msg) {
+			updateClient(documentId, estimateT(), msg, null, userId);
+		}
+
+		public void sendFinalMessage(final String msg) {
+			updateClient(documentId, 1.0, msg, null, userId);
+		}
+
+		public void sendError(final String msg) {
+			updateClient(documentId, estimateT(), null, msg, userId);
+		}
+
+	}
+
+	public void extractPDF(final UUID documentId, final String userId) {
+
+		// time the progress takes to reach each subsequent half
+		final Double HALFTIME_SECONDS = 2.0;
+
+		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
+				HALFTIME_SECONDS);
 
 		executor.execute(new Runnable() {
 			@Override
 			public void run() {
 				try {
-					messageClient.accept(0, "Starting extraction...");
+					clientInterface.sendMessage("Starting extraction...");
+
 					DocumentAsset document = documentService.getAsset(documentId).get();
-					messageClient.accept(1, "Document found, fetching file...");
+					clientInterface.sendMessage("Document found, fetching file...");
 
 					if (document.getFileNames().isEmpty()) {
-						String errorMsg = "No files found on document";
-						errorClient.accept(1, errorMsg);
+						final String errorMsg = "No files found on document";
+						clientInterface.sendError(errorMsg);
 						throw new RuntimeException(errorMsg);
 					}
 
 					final String filename = document.getFileNames().get(0);
 
 					final byte[] documentContents = documentService.fetchFileAsBytes(documentId, filename).get();
-					messageClient.accept(2, "File fetched, processing PDF extraction...");
+					clientInterface.sendMessage("File fetched, processing PDF extraction...");
 
 					final ByteMultipartFile documentFile = new ByteMultipartFile(documentContents, filename,
-						"application/pdf");
+							"application/pdf");
 
 					final boolean compressImages = false;
 					final boolean useCache = false;
 					final ResponseEntity<JsonNode> extractionResp = extractionProxy.processPdfExtraction(compressImages,
-						useCache,
-						documentFile);
+							useCache,
+							documentFile);
 
 					final JsonNode body = extractionResp.getBody();
 					final UUID jobId = UUID.fromString(body.get("job_id").asText());
@@ -88,54 +139,54 @@ public class ExtractionService {
 					final int MAX_ITERATIONS = MAX_EXECUTION_TIME_SECONDS / POLLING_INTERVAL_SECONDS;
 
 					boolean jobDone = false;
-					messageClient.accept(3, "COSMOS extraction in progress...");
+					clientInterface.sendMessage("COSMOS extraction in progress...");
 
 					for (int i = 0; i < MAX_ITERATIONS; i++) {
 
 						final ResponseEntity<JsonNode> statusResp = extractionProxy.status(jobId);
 						if (!statusResp.getStatusCode().is2xxSuccessful()) {
-							String errorMsg = "Unable to poll status endpoint";
-							errorClient.accept(3, errorMsg);
+							final String errorMsg = "Unable to poll status endpoint";
+							clientInterface.sendError(errorMsg);
 							throw new RuntimeException(errorMsg);
 						}
 
 						final JsonNode statusData = statusResp.getBody();
 						if (!statusData.get("error").isNull()) {
-							String errorMsg = "Extraction job failed: " + statusData.has("error");
-							errorClient.accept(3, errorMsg);
+							final String errorMsg = "Extraction job failed: " + statusData.has("error");
+							clientInterface.sendError(errorMsg);
 							throw new RuntimeException(errorMsg);
 						}
 
 						log.info("Polled status endpoint {} times:\n{}", i + 1, statusData);
 						jobDone = statusData.get("error").asBoolean() || statusData.get("job_completed").asBoolean();
 						if (jobDone) {
-							messageClient.accept(4, "COSMOS extraction complete; processing results...");
+							clientInterface.sendMessage("COSMOS extraction complete; processing results...");
 							break;
 						}
 						Thread.sleep(POLLING_INTERVAL_SECONDS * 1000);
 					}
 
 					if (!jobDone) {
-						String errorMsg = "Extraction job did not complete within the expected time";
-						errorClient.accept(5, errorMsg);
+						final String errorMsg = "Extraction job did not complete within the expected time";
+						clientInterface.sendError(errorMsg);
 						throw new RuntimeException(errorMsg);
 					}
 
 					final ResponseEntity<byte[]> zipFileResp = extractionProxy.result(jobId);
 					if (!zipFileResp.getStatusCode().is2xxSuccessful()) {
-						String errorMsg = "Unable to fetch the extraction result";
-						errorClient.accept(6, errorMsg);
+						final String errorMsg = "Unable to fetch the extraction result";
+						clientInterface.sendError(errorMsg);
 						throw new RuntimeException(errorMsg);
 					}
 
-					messageClient.accept(7, "Uploading COSMOS extraction results...");
+					clientInterface.sendMessage("Uploading COSMOS extraction results...");
 					final String zipFileName = documentId + "_cosmos.zip";
 					documentService.uploadFile(documentId, zipFileName, new ByteArrayEntity(zipFileResp.getBody()));
 
 					document.getFileNames().add(zipFileName);
 
 					// Open the zipfile and extract the contents
-					messageClient.accept(8, "Extracting COSMOS extraction results...");
+					clientInterface.sendMessage("Extracting COSMOS extraction results...");
 					final Map<String, HttpEntity> fileMap = new HashMap<>();
 					try {
 						final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(zipFileResp.getBody());
@@ -150,25 +201,25 @@ public class ExtractionService {
 						zipInputStream.closeEntry();
 						zipInputStream.close();
 					} catch (final IOException e) {
-						String errorMsg = "Unable to extract the contents of the zip file";
-						errorClient.accept(8, errorMsg);
+						final String errorMsg = "Unable to extract the contents of the zip file";
+						clientInterface.sendError(errorMsg);
 						throw new RuntimeException(errorMsg, e);
 					}
 
 					final ResponseEntity<JsonNode> textResp = extractionProxy.text(jobId);
 					if (!textResp.getStatusCode().is2xxSuccessful()) {
-						String errorMsg = "Unable to fetch the text extractions";
-						errorClient.accept(9, errorMsg);
+						final String errorMsg = "Unable to fetch the text extractions";
+						clientInterface.sendError(errorMsg);
 						throw new RuntimeException(errorMsg);
 					}
 
 					// clear existing assets
 					document.setAssets(new ArrayList<>());
-					messageClient.accept(10, "Uploading COSMOS extraction assets...");
+					clientInterface.sendMessage("Uploading COSMOS extraction assets...");
 
 					for (final ExtractionAssetType extractionType : ExtractionAssetType.values()) {
 						final ResponseEntity<JsonNode> response = extractionProxy.extraction(jobId,
-							extractionType.toStringPlural());
+								extractionType.toStringPlural());
 						log.info(" {} response status: {}", extractionType, response.getStatusCode());
 						if (!response.getStatusCode().is2xxSuccessful()) {
 							log.warn("Unable to fetch the {} extractions", extractionType);
@@ -200,7 +251,7 @@ public class ExtractionService {
 							extraction.setMetadata(objectMapper.convertValue(record, Map.class));
 
 							document.getAssets().add(extraction);
-							messageClient.accept(11, String.format("Add COSMOS extraction %s to Document...", filename));
+							clientInterface.sendMessage(String.format("Add COSMOS extraction %s to Document...", filename));
 						}
 					}
 
@@ -217,18 +268,18 @@ public class ExtractionService {
 
 					// update the document
 					document = documentService.updateAsset(document).get();
-					messageClient.accept(12, "Document updated");
+					clientInterface.sendMessage("Document updated");
 
 					if (document.getText() == null || document.getText().isEmpty()) {
 						log.warn("Document {} has no text to send", documentId);
-						errorClient.accept(13, "Model Card not created: document has no text");
+						clientInterface.sendError("Model Card not created: document has no text");
 						throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Document has no text");
 					}
 
 					// check for input length
 					if (document.getText().length() > 600000) {
 						log.warn("Document {} text too long for GoLLM model card task", documentId);
-						errorClient.accept(13, "Model Card not created: document text is too long");
+						clientInterface.sendError("Model Card not created: document text is too long");
 						throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Document text is too long");
 					}
 
@@ -244,38 +295,17 @@ public class ExtractionService {
 					final ModelCardResponseHandler.Properties props = new ModelCardResponseHandler.Properties();
 					props.setDocumentId(documentId);
 					req.setAdditionalProperties(props);
-					messageClient.accept(14, "Model Card task created");
+					clientInterface.sendFinalMessage("Model Card task created");
 				} catch (final Exception e) {
 					final String error = "Unable to extract pdf";
 					log.error(error, e);
-					errorClient.accept(14, "Extraction failed, unexpected error.");
+					clientInterface.sendError("Extraction failed, unexpected error.");
 					throw new ResponseStatusException(
-						org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-						error);
+							org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+							error);
 				}
 			}
 		});
-	}
-
-	/**
-	 * Notify, via ClientEvent, of progress
-	 */
-	public BiConsumer<Integer, String> createMessageClient(UUID documentId, String userId) {
-		return (step, message) -> updateClient(documentId, step, TOTAL_EXTRACTION_STEPS, message, null, userId);
-	}
-
-	/**
-	 * Notify, via ClientEvent, of an error
-	 */
-	public BiConsumer<Integer, String> createErrorClient(UUID documentId, String userId) {
-		return (step, message) -> updateClient(documentId, step, TOTAL_EXTRACTION_STEPS, null, message, userId);
-	}
-
-	private void updateClient(UUID documentId, Integer step, Integer totalSteps, String message, String error, String userId) {
-		ExtractionStatusUpdate update = new ExtractionStatusUpdate(documentId, step, totalSteps, message, error);
-		ClientEvent<ExtractionStatusUpdate> status =
-			ClientEvent.<ExtractionStatusUpdate>builder().type(ClientEventType.EXTRACTION).data(update).build();
-		clientEventService.sendToUser(status, userId);
 	}
 
 	public HttpEntity zipEntryToHttpEntity(final ZipInputStream zipInputStream) throws IOException {


### PR DESCRIPTION
Optional PR that modifies the extraction progress to be even more generic, and created an `estimated` progress value of t using a logarithmic easing function so that the first 50% takes n seconds, the next 25% takes n, next 12.5% takes n... etc.

Coupled with a css transition it behaves really nicely:

https://jsfiddle.net/hwpdb6yv/1/

 The main motivation for this is that it is less error prone since it doesn't rely on hardcoding exactly how many updates will be sent, and can be used in cases where that number isn't known ahead of time.