### PR TITLE
ensemble cleanups 2

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -2,7 +2,6 @@ import { Operation, WorkflowOperationTypes } from '@/types/workflow';
 import type { EnsembleModelConfigs, TimeSpan } from '@/types/Types';
 
 export interface SimulateEnsembleCiemssOperationState {
-	modelConfigIds: string[];
 	chartConfigs: string[][];
 	mapping: EnsembleModelConfigs[];
 	timeSpan: TimeSpan;
@@ -26,7 +25,6 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 
 	initState: () => {
 		const init: SimulateEnsembleCiemssOperationState = {
-			modelConfigIds: [],
 			chartConfigs: [],
 			mapping: [],
 			timeSpan: { start: 0, end: 40 },

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -43,7 +43,7 @@
 									<th>Weight</th>
 								</thead>
 								<tbody class="p-datatable-tbody">
-									<tr v-for="(id, i) in listModelIds" :key="i">
+									<tr v-for="(id, i) in ensembleConfigs.map((ele) => ele.id)" :key="i">
 										<td>
 											{{ id }}
 										</td>
@@ -204,7 +204,6 @@ const MINBARLENGTH = 1;
 
 const showSpinner = ref(false);
 
-const listModelIds = computed<string[]>(() => props.node.state.modelConfigIds);
 const listModelLabels = ref<string[]>([]);
 const ensembleCalibrationMode = ref<string>(EnsembleCalibrationMode.EQUALWEIGHTS);
 
@@ -402,9 +401,12 @@ watch(
 	{ immediate: true }
 );
 
-watch([() => ensembleCalibrationMode.value, listModelIds.value], () => {
-	calculateWeights();
-});
+watch(
+	() => ensembleCalibrationMode.value,
+	() => {
+		calculateWeights();
+	}
+);
 
 watch(
 	() => [timeSpan.value, numSamples.value],

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -359,7 +359,6 @@ onMounted(async () => {
 	listModelLabels.value = allModelConfigurations.map((ele) => ele.name);
 
 	const state = _.cloneDeep(props.node.state);
-	state.modelConfigIds = modelConfigurationIds;
 
 	if (state.mapping && state.mapping.length === 0) {
 		for (let i = 0; i < allModelConfigurations.length; i++) {


### PR DESCRIPTION
# Description
Removing `modelConfigIds` from state. 
These are already stored in the input ports and there is no need to also store them in the state. 
Removing `listModelIds` as it is an additional variable that is just adding noise to this file. 

Will be updating line 46 next PR to have labels instead of IDs
<img width="923" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/db669460-256e-4bdd-b5c1-38e36beb6657">

