### PR TITLE
Fix issue with stalled requests if shutdown

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
@@ -132,7 +132,7 @@ public class TaskService {
 
 	// TTL = Time to live, the maximum time a key will be in the cache before it is
 	// evicted, regardless of activity.
-	@Value("${terarium.taskrunner.response-cache-ttl-seconds:86400}") // 24 hours
+	@Value("${terarium.taskrunner.response-cache-ttl-seconds:43200}") // 12 hours
 	private long CACHE_TTL_SECONDS;
 
 	// Max idle = The maximum time a key can be idle in the cache before it is
@@ -143,7 +143,7 @@ public class TaskService {
 	// Always use a lease time for distributed locks to prevent application wide
 	// deadlocks. If for whatever reason the lock has not been released within a
 	// N seconds, it will automatically free itself.
-	@Value("${terarium.taskrunner.redis-lock-lease-seconds:30}") // 30 seconds
+	@Value("${terarium.taskrunner.redis-lock-lease-seconds:10}") // 10 seconds
 	private long REDIS_LOCK_LEASE_SECONDS;
 
 	private final RabbitTemplate rabbitTemplate;
@@ -463,15 +463,15 @@ public class TaskService {
 					// future already exists on this instance
 					return futures.get(existingId);
 				}
-				// otherwise dispatch it again
-				log.info("No viable cached response found for task id: {} for SHA: {}, creating new task", existingId,
-						hash);
-			}
 
-			// no cached request, create the response cache entry
-			final TaskResponse queuedResponse = req.createResponse(TaskStatus.QUEUED);
-			responseCache.put(req.getId(), queuedResponse, CACHE_TTL_SECONDS, TimeUnit.SECONDS, CACHE_MAX_IDLE_SECONDS,
-					TimeUnit.SECONDS);
+				// otherwise dispatch it again, and overwrite the id
+				log.info(
+						"No viable cached response found for task id: {} for SHA: {}, creating new task with id {}", existingId,
+						hash, req.getId());
+
+				taskIdCache.put(hash, req.getId(), CACHE_TTL_SECONDS, TimeUnit.SECONDS, CACHE_MAX_IDLE_SECONDS,
+						TimeUnit.SECONDS);
+			}
 
 			// now send request
 			final String requestQueue = String.format("%s-%s", TASK_RUNNER_REQUEST_QUEUE, req.getType().toString());
@@ -494,6 +494,13 @@ public class TaskService {
 				log.info("Dispatching request: {} for task id: {}", new String(req.getInput()), req.getId());
 				final String jsonStr = objectMapper.writeValueAsString(req);
 				rabbitTemplate.convertAndSend(requestQueue, jsonStr);
+
+				// put the response in redis after it is queued in the case the id is reserved
+				// but the server is shutdown before it dispatches the request, which would
+				// cause servers to wait on requests that were never sent.
+				final TaskResponse queuedResponse = req.createResponse(TaskStatus.QUEUED);
+				responseCache.put(req.getId(), queuedResponse, CACHE_TTL_SECONDS, TimeUnit.SECONDS, CACHE_MAX_IDLE_SECONDS,
+						TimeUnit.SECONDS);
 
 				// create and return the future
 				final CompletableTaskFuture future = new CompletableTaskFuture(req.getId(), queuedResponse);

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/tasks/TaskServiceTest.java
@@ -299,10 +299,37 @@ public class TaskServiceTest extends TerariumApplicationTests {
 		final TaskFuture future1 = taskService.runTaskAsync(req);
 		Assertions.assertEquals(TaskStatus.FAILED, future1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getStatus());
 
-		// next request should not pull the successful response from cache
+		// next request should not pull the failed response from cache
 		final TaskFuture future2 = taskService.runTaskAsync(req);
 		Assertions.assertEquals(TaskStatus.FAILED, future2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getStatus());
 		Assertions.assertNotEquals(future1.getId(), future2.getId());
+	}
+
+	// @Test
+	@WithUserDetails(MockUser.URSULA)
+	public void testItDoesNotCacheFailureButCacheSuccessAfter() throws Exception {
+		final int TIMEOUT_SECONDS = 20;
+
+		final byte[] input = "{\"input\":\"This is my input string\"}".getBytes();
+
+		final TaskRequest req = new TaskRequest();
+		req.setType(TaskType.GOLLM);
+		req.setScript("/echo.py");
+		req.setInput(input);
+
+		final TaskFuture future1 = taskService.runTaskAsync(req);
+		taskService.cancelTask(future1.getId());
+		Assertions.assertEquals(TaskStatus.CANCELLED, future1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getStatus());
+
+		// next request should not pull the cancelled response from cache
+		final TaskFuture future2 = taskService.runTaskAsync(req);
+		Assertions.assertEquals(TaskStatus.SUCCESS, future2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getStatus());
+		Assertions.assertNotEquals(future1.getId(), future2.getId());
+
+		// next request should pull the successful response from cache
+		final TaskFuture future3 = taskService.runTaskAsync(req);
+		Assertions.assertEquals(TaskStatus.SUCCESS, future3.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getStatus());
+		Assertions.assertEquals(future2.getId(), future3.getId());
 	}
 
 	// @Test


### PR DESCRIPTION
I believe this to be the cause of the stalled requests that @mwdchang experienced.

If the `hmi-server` was shutdown between writing the initial `TaskStatus.QUEUED` state of the task to redis but _before_ it actually sent the request to rabbitmq, then any subsequent request would simply wait for a non-existent task to finish. 

This is consistent with the logs as no request was sent, but it did timeout waiting for the response.

This switches the logic to write out the `TaskStatus.QUEUED` state _after_ it is dispatched. If the server is shutdown after it dispatches to redis but before that state is set, then the subsequent requests will simply re-send it.

Another small issue is that failed task id's were never re-written in the task SHA -> task id lookup. So after a task failed subsequent attempts, if successful, were not cached.