### PR TITLE
fix cases where 0 doesn't show up

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -88,7 +88,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed, watch } from 'vue';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNumber } from 'lodash';
 import { pythonInstance } from '@/python/PyodideController';
 import InputText from 'primevue/inputtext';
 import Dropdown from 'primevue/dropdown';
@@ -144,7 +144,11 @@ function onEnterValueCell(variableName: string, rowIdx: number, colIdx: number) 
 // See ES2_2a_start in "Eval do not touch"
 // Returns the presentation mathml
 async function getMatrixValue(variableName: string) {
-	const expressionBase = getVariable(props.mmt, variableName).value;
+	let expressionBase = getVariable(props.mmt, variableName).value;
+
+	if (isNumber(expressionBase) && +expressionBase === 0) {
+		expressionBase = '0.0'; // just to ensure we don't trigger falsy checks
+	}
 
 	if (props.shouldEval) {
 		const expressionEval = await pythonInstance.evaluateExpression(


### PR DESCRIPTION
### Summary
Matrix generation: adding a guard to prevent any falsy checks down the line from the expression being `0`

e.g. a_5 is 0 and will be evaluated as "0.0"

<img width="346" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/7bc100e3-8ae6-4fce-92ee-a5ab4331c3a7">
