### PR TITLE
fix link

### DIFF
--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -38,7 +38,7 @@
 				<!-- Video container -->
 				<section v-else class="col-3 flex justify-content-end">
 					<video controls ref="introVideo" class="video-container" height="200px">
-						<source src="http://videos.terarium.ai/terarium.mp4" type="video/mp4" />
+						<source src="https://videos.terarium.ai/terarium.mp4" type="video/mp4" />
 						<track src="" kind="captions" srclang="en" label="English" />
 						Your browser does not support the video tag.
 					</video>


### PR DESCRIPTION
**ISSUE**
Video played fine on my local, but not on staging.
<img width="1575" alt="Monosnap Terarium 2024-03-20 13-12-50" src="https://github.com/DARPA-ASKEM/terarium/assets/120480244/de491fc4-2c4e-4e46-9de8-062700a80cb1">

**SOLUTION**
- Changed http:// to https:// in the video player
- Asked Nishant to change the video link as well
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/b13b4a51-d907-4dff-b366-13c2b864880b)
