### PR TITLE
Ts/3067 calibrate ensemble

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -11,7 +11,6 @@ export interface EnsembleCalibrateExtraCiemss {
 }
 
 export interface CalibrateEnsembleCiemssOperationState {
-	modelConfigIds: string[];
 	chartConfigs: ChartConfig[];
 	mapping: EnsembleModelConfigs[];
 	extra: EnsembleCalibrateExtraCiemss;
@@ -37,7 +36,6 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 
 	initState: () => {
 		const init: CalibrateEnsembleCiemssOperationState = {
-			modelConfigIds: [],
 			chartConfigs: [],
 			mapping: [],
 			extra: {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -22,17 +22,11 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 	displayName: 'Calibrate ensemble',
 	description: '',
 	inputs: [
-		{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: true },
-		{ type: 'datasetId', label: 'Dataset' }
+		{ type: 'datasetId', label: 'Dataset' },
+		{ type: 'modelConfigId', label: 'Model configuration', acceptMultiple: false }
 	],
 	outputs: [{ type: 'simulationId' }],
 	isRunnable: true,
-
-	// TODO: Figure out mapping
-	// Calls API, returns results.
-	action: async (): Promise<void> => {
-		console.log('test');
-	},
 
 	initState: () => {
 		const init: CalibrateEnsembleCiemssOperationState = {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -240,7 +240,7 @@ const currentDatasetFileName = ref<string>();
 const datasetColumnNames = ref<string[]>();
 
 const listModelLabels = ref<string[]>([]);
-const ensembleWeightMode = ref<string>(EnsembleWeightMode.EQUALWEIGHTS);
+const ensembleWeightMode = ref(EnsembleWeightMode.EQUALWEIGHTS);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
 // List of each observible + state for each model.
 const allModelOptions = ref<string[][]>([]);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -410,7 +410,7 @@ onMounted(async () => {
 
 	const state = _.cloneDeep(props.node.state);
 	if (state.mapping && state.mapping.length === 0) {
-		// TOM Fix this so checks lengths of this is length of input - 1?
+		// TOM Fix this. This should check that the length of ensemble is = port length - 1
 		for (let i = 0; i < allModelConfigurations.value.length; i++) {
 			ensembleConfigs.value.push({
 				id: allModelConfigurations.value[i].id as string,

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -86,7 +86,8 @@
 											<th>Weight</th>
 										</thead>
 										<tbody class="p-datatable-tbody">
-											<tr v-for="(id, i) in listModelIds" :key="i">
+											<!-- Index matching listModelLabels and ensembleConfigs-->
+											<tr v-for="(id, i) in listModelLabels" :key="i">
 												<td>
 													{{ id }}
 												</td>
@@ -109,8 +110,9 @@
 								<table>
 									<tr>
 										<th>Ensemble Variables</th>
-										<th v-for="(element, i) in ensembleConfigs" :key="i">
-											{{ element.id }}
+										<!-- Index matching listModelLabels and ensembleConfigs-->
+										<th v-for="(element, i) in listModelLabels" :key="i">
+											{{ element }}
 										</th>
 									</tr>
 									<tr>
@@ -255,7 +257,6 @@ const runResults = ref<RunResults>({});
 
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
-// Tom TODO: Make this generic... its copy paste from node.
 const chartConfigurationChange = (index: number, config: ChartConfig) => {
 	const state = _.cloneDeep(props.node.state);
 	state.chartConfigs[index] = config;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -65,15 +65,6 @@
 										<input
 											type="radio"
 											v-model="ensembleCalibrationMode"
-											:value="EnsembleCalibrationMode.CALIBRATIONWEIGHTS"
-											:disabled="disabledCalibrationWeights"
-										/>
-										{{ EnsembleCalibrationMode.CALIBRATIONWEIGHTS }}
-									</label>
-									<label>
-										<input
-											type="radio"
-											v-model="ensembleCalibrationMode"
 											:value="EnsembleCalibrationMode.CUSTOM"
 										/>
 										{{ EnsembleCalibrationMode.CUSTOM }}
@@ -82,10 +73,7 @@
 								<!-- Turn this into a horizontal bar chart -->
 								<section class="ensemble-calibration-graph">
 									<Chart
-										v-if="
-											ensembleCalibrationMode === EnsembleCalibrationMode.CALIBRATIONWEIGHTS ||
-											ensembleCalibrationMode === EnsembleCalibrationMode.EQUALWEIGHTS
-										"
+										v-if="ensembleCalibrationMode === EnsembleCalibrationMode.EQUALWEIGHTS"
 										type="bar"
 										:height="200"
 										:data="setBarChartData()"
@@ -102,10 +90,7 @@
 												<td>
 													{{ id }}
 												</td>
-												<td v-if="customWeights === false">
-													{{ ensembleConfigs[i].weight }}
-												</td>
-												<td v-else>
+												<td>
 													<InputNumber
 														mode="decimal"
 														:min-fraction-digits="0"
@@ -233,7 +218,6 @@ enum CalibrateView {
 }
 enum EnsembleCalibrationMode {
 	EQUALWEIGHTS = 'equalWeights',
-	CALIBRATIONWEIGHTS = 'calibrationWeights',
 	CUSTOM = 'custom'
 }
 
@@ -266,9 +250,6 @@ const completedRunId = computed<string>(
 	() => props?.node?.outputs?.[0]?.value?.[0].runId as string
 );
 
-const customWeights = ref<boolean>(false);
-// TODO: Does AMR contain weights? Can i check all inputs have the weights parameter filled in or the calibration boolean checked off?
-const disabledCalibrationWeights = computed(() => true);
 const newSolutionMappingKey = ref<string>('');
 const runResults = ref<RunResults>({});
 
@@ -285,17 +266,10 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 const calculateWeights = () => {
 	if (!ensembleConfigs.value) return;
 	if (ensembleCalibrationMode.value === EnsembleCalibrationMode.EQUALWEIGHTS) {
-		customWeights.value = false;
 		const percent = 1 / ensembleConfigs.value.length;
 		for (let i = 0; i < ensembleConfigs.value.length; i++) {
 			ensembleConfigs.value[i].weight = percent;
 		}
-	}
-	if (ensembleCalibrationMode.value === EnsembleCalibrationMode.CUSTOM) {
-		customWeights.value = true;
-	} else if (ensembleCalibrationMode.value === EnsembleCalibrationMode.CALIBRATIONWEIGHTS) {
-		customWeights.value = false;
-		// TODO: Get weights from AMR
 	}
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -248,7 +248,7 @@ const viewOptions = ref([
 	{ value: CalibrateView.Input, icon: 'pi pi-sign-in' },
 	{ value: CalibrateView.Output, icon: 'pi pi-sign-out' }
 ]);
-const listModelIds = computed<string[]>(() => props.node.state.modelConfigIds);
+const listModelIds = computed<string[]>(() => props.node.inputs[0].value as string[]);
 const datasetId = computed(() => props.node.inputs[1].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
 const datasetColumnNames = ref<string[]>();

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -56,24 +56,24 @@
 									<label>
 										<input
 											type="radio"
-											v-model="ensembleCalibrationMode"
-											:value="EnsembleCalibrationMode.EQUALWEIGHTS"
+											v-model="ensembleWeightMode"
+											:value="EnsembleWeightMode.EQUALWEIGHTS"
 										/>
-										{{ EnsembleCalibrationMode.EQUALWEIGHTS }}
+										{{ EnsembleWeightMode.EQUALWEIGHTS }}
 									</label>
 									<label>
 										<input
 											type="radio"
-											v-model="ensembleCalibrationMode"
-											:value="EnsembleCalibrationMode.CUSTOM"
+											v-model="ensembleWeightMode"
+											:value="EnsembleWeightMode.CUSTOM"
 										/>
-										{{ EnsembleCalibrationMode.CUSTOM }}
+										{{ EnsembleWeightMode.CUSTOM }}
 									</label>
 								</section>
 								<!-- Turn this into a horizontal bar chart -->
 								<section class="ensemble-calibration-graph">
 									<Chart
-										v-if="ensembleCalibrationMode === EnsembleCalibrationMode.EQUALWEIGHTS"
+										v-if="ensembleWeightMode === EnsembleWeightMode.EQUALWEIGHTS"
 										type="bar"
 										:height="200"
 										:data="setBarChartData()"
@@ -216,7 +216,7 @@ enum CalibrateView {
 	Input = 'Input',
 	Output = 'Output'
 }
-enum EnsembleCalibrationMode {
+enum EnsembleWeightMode {
 	EQUALWEIGHTS = 'equalWeights',
 	CUSTOM = 'custom'
 }
@@ -238,7 +238,7 @@ const currentDatasetFileName = ref<string>();
 const datasetColumnNames = ref<string[]>();
 
 const listModelLabels = ref<string[]>([]);
-const ensembleCalibrationMode = ref<string>(EnsembleCalibrationMode.EQUALWEIGHTS);
+const ensembleWeightMode = ref<string>(EnsembleWeightMode.EQUALWEIGHTS);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
 // List of each observible + state for each model.
 const allModelOptions = ref<string[][]>([]);
@@ -265,7 +265,7 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 
 const calculateWeights = () => {
 	if (!ensembleConfigs.value) return;
-	if (ensembleCalibrationMode.value === EnsembleCalibrationMode.EQUALWEIGHTS) {
+	if (ensembleWeightMode.value === EnsembleWeightMode.EQUALWEIGHTS) {
 		const percent = 1 / ensembleConfigs.value.length;
 		for (let i = 0; i < ensembleConfigs.value.length; i++) {
 			ensembleConfigs.value[i].weight = percent;
@@ -371,7 +371,7 @@ watch(
 watch(() => completedRunId.value, watchCompletedRunList, { immediate: true });
 
 watch(
-	[() => ensembleCalibrationMode.value, listModelIds.value],
+	[() => ensembleWeightMode.value, listModelIds.value],
 	async () => {
 		calculateWeights();
 	},

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -228,7 +228,6 @@ watch(
 			}
 
 			const state = _.cloneDeep(props.node.state);
-			state.modelConfigIds = modelConfigIds.value;
 			state.mapping = mapping;
 			emit('update-state', state);
 		}


### PR DESCRIPTION
# Description

- input ports now only take 1 value. append when all model config ports are full.
- remove CALIBRATIONWEIGHTS -> AMRs do not have weights to pull from.
- rename ensembleCalibrationMode and the enum for readability
- use model labels in display rather than IDs for user readability

<img width="542" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/1a0d5fa4-9aee-4c86-bb62-f81ac841daab">

<img width="940" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/550828c6-e283-484b-bda6-b6b093e2691a">


Resolves #(issue)
