### PR TITLE
chore: operator chart clean up

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -111,7 +111,10 @@
 				<div ref="drilldownLossPlot"></div>
 				<div v-if="!showSpinner" class="form-section">
 					<h4>Variables</h4>
-					<section v-if="modelConfig && node.state.chartConfigs.length && csvAsset">
+					<section
+						v-if="modelConfig && node.state.chartConfigs.length && csvAsset"
+						ref="outputPanel"
+					>
 						<tera-simulate-chart
 							v-for="(config, index) of node.state.chartConfigs"
 							:key="index"
@@ -124,7 +127,7 @@
 							:mapping="mapping"
 							has-mean-line
 							@configuration-change="chartProxy.configurationChange(index, $event)"
-							:size="{ width: previewChartWidth, height: 140 }"
+							:size="chartSize"
 						/>
 						<Button
 							class="add-chart"
@@ -188,7 +191,7 @@ import {
 	ModelConfiguration,
 	State
 } from '@/types/Types';
-import { getTimespan, chartActionsProxy } from '@/workflow/util';
+import { getTimespan, chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 import { useToastService } from '@/services/toast';
 import { autoCalibrationMapping } from '@/services/concept';
 import {
@@ -259,6 +262,9 @@ const outputs = computed(() => {
 	}
 	return [];
 });
+
+const outputPanel = ref(null);
+const chartSize = computed(() => drilldownChartSize(outputPanel.value));
 
 const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateCiemss) => {
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -260,7 +260,7 @@ const outputs = computed(() => {
 	return [];
 });
 
-const chartProxy = chartActionsProxy(props.node.state, (state: CalibrationOperationStateCiemss) => {
+const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateCiemss) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -73,7 +73,7 @@ const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const areInputsFilled = computed(() => props.node.inputs[0].value && props.node.inputs[1].value);
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 
-const chartProxy = chartActionsProxy(props.node.state, (state: CalibrationOperationStateCiemss) => {
+const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateCiemss) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -150,7 +150,7 @@
 				<div class="form-section">
 					<h4>Variables</h4>
 					<div>
-						<template v-if="selectedRunId && runResults[selectedRunId]">
+						<section v-if="selectedRunId && runResults[selectedRunId]" ref="outputPanel">
 							<tera-simulate-chart
 								v-for="(cfg, index) of node.state.chartConfigs"
 								:key="index"
@@ -160,8 +160,9 @@
 								:run-type="RunType.Julia"
 								:chartConfig="{ selectedRun: selectedRunId, selectedVariable: cfg }"
 								@configuration-change="chartProxy.configurationChange(index, $event)"
+								:size="chartSize"
 							/>
-						</template>
+						</section>
 						<Button
 							class="p-button-sm p-button-text"
 							@click="chartProxy.addChart"
@@ -227,7 +228,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
-import { getTimespan, chartActionsProxy } from '@/workflow/util';
+import { getTimespan, chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 import { useToastService } from '@/services/toast';
 import {
 	CalibrateExtraJulia,
@@ -283,6 +284,9 @@ const parameterResult = ref<{ [index: string]: any }>();
 
 const runResults = ref<RunResults>({});
 const runResultParams = ref<Record<string, Record<string, number>>>({});
+
+const outputPanel = ref(null);
+const chartSize = computed(() => drilldownChartSize(outputPanel.value));
 
 const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateJulia) => {
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -284,7 +284,7 @@ const parameterResult = ref<{ [index: string]: any }>();
 const runResults = ref<RunResults>({});
 const runResultParams = ref<Record<string, Record<string, number>>>({});
 
-const chartProxy = chartActionsProxy(props.node.state, (state: CalibrationOperationStateJulia) => {
+const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateJulia) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
@@ -66,7 +66,7 @@ const inProgressSimulationId = computed(() => props.node.state.inProgressSimulat
 
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
-const chartProxy = chartActionsProxy(props.node.state, (state: CalibrationOperationStateJulia) => {
+const chartProxy = chartActionsProxy(props.node, (state: CalibrationOperationStateJulia) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -217,7 +217,7 @@ const chartSize = computed(() => {
 	return { width: parentContainerWidth, height: 270 };
 });
 
-const chartProxy = chartActionsProxy(props.node.state, (state: SimulateCiemssOperationState) => {
+const chartProxy = chartActionsProxy(props.node, (state: SimulateCiemssOperationState) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -146,7 +146,7 @@ import {
 	makeForecastJobCiemss as makeForecastJob
 } from '@/services/models/simulation-service';
 import { createCsvAssetFromRunResults } from '@/services/dataset';
-import { chartActionsProxy } from '@/workflow/util';
+import { chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraDatasetDatatable from '@/components/dataset/tera-dataset-datatable.vue';
@@ -161,7 +161,7 @@ import { SimulateCiemssOperationState } from './simulate-ciemss-operation';
 const props = defineProps<{
 	node: WorkflowNode<SimulateCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
+const emit = defineEmits(['update-state', 'select-output', 'close']);
 
 const inferredParameters = computed(() => props.node.inputs[1].value);
 
@@ -210,12 +210,7 @@ const selectedRunId = computed(
 );
 
 const outputPanel = ref(null);
-const chartSize = computed(() => {
-	if (!outputPanel.value) return { width: 100, height: 270 };
-
-	const parentContainerWidth = (outputPanel.value as HTMLElement).clientWidth - 48;
-	return { width: parentContainerWidth, height: 270 };
-});
+const chartSize = computed(() => drilldownChartSize(outputPanel.value));
 
 const chartProxy = chartActionsProxy(props.node, (state: SimulateCiemssOperationState) => {
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -85,7 +85,7 @@ const pollResult = async (runId: string) => {
 	return pollerResults;
 };
 
-const chartProxy = chartActionsProxy(props.node.state, (state: SimulateCiemssOperationState) => {
+const chartProxy = chartActionsProxy(props.node, (state: SimulateCiemssOperationState) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -232,12 +232,9 @@ const outputs = computed(() => {
 const selectedOutputId = ref<string>();
 const selectedRunId = ref<string>('');
 
-const chartProxy = chartActionsProxy(
-	props.node.state,
-	(state: SimulateEnsembleCiemssOperationState) => {
-		emit('update-state', state);
-	}
-);
+const chartProxy = chartActionsProxy(props.node, (state: SimulateEnsembleCiemssOperationState) => {
+	emit('update-state', state);
+});
 
 const onSelection = (id: string) => {
 	emit('select-output', id);

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -58,12 +58,9 @@ const runResults = ref<{ [runId: string]: RunResults }>({});
 const inProgressSimulationId = computed(() => props.node.state.inProgressSimulationId);
 const selectedRunId = ref<string>('');
 
-const chartProxy = chartActionsProxy(
-	props.node.state,
-	(state: SimulateEnsembleCiemssOperationState) => {
-		emit('update-state', state);
-	}
-);
+const chartProxy = chartActionsProxy(props.node, (state: SimulateEnsembleCiemssOperationState) => {
+	emit('update-state', state);
+});
 
 const poller = new Poller();
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -59,7 +59,7 @@
 					</template>
 				</SelectButton>
 				<template v-if="runResults[selectedRunId]">
-					<div v-if="view === OutputView.Charts">
+					<div v-if="view === OutputView.Charts" ref="outputPanel">
 						<tera-simulate-chart
 							v-for="(cfg, idx) in node.state.chartConfigs"
 							:key="idx"
@@ -169,7 +169,7 @@ const selectedRunId = computed(
 	() => props.node.outputs.find((o) => o.id === selectedOutputId.value)?.value?.[0]
 );
 
-const chartProxy = chartActionsProxy(props.node.state, (state: SimulateJuliaOperationState) => {
+const chartProxy = chartActionsProxy(props.node, (state: SimulateJuliaOperationState) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -66,6 +66,7 @@
 							:run-results="{ [selectedRunId]: runResults[selectedRunId] }"
 							:chartConfig="{ selectedRun: selectedRunId, selectedVariable: cfg }"
 							@configuration-change="chartProxy.configurationChange(idx, $event)"
+							:size="chartSize"
 							color-by-run
 						/>
 						<Button
@@ -112,7 +113,7 @@ import { getModelConfigurationById } from '@/services/model-configurations';
 import { getRunResult, makeForecastJob } from '@/services/models/simulation-service';
 import { createCsvAssetFromRunResults } from '@/services/dataset';
 import { csvParse } from 'd3';
-import { chartActionsProxy } from '@/workflow/util';
+import { chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 import { useProjects } from '@/composables/project';
 
 import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
@@ -168,6 +169,9 @@ const selectedOutputId = ref<string>();
 const selectedRunId = computed(
 	() => props.node.outputs.find((o) => o.id === selectedOutputId.value)?.value?.[0]
 );
+
+const outputPanel = ref(null);
+const chartSize = computed(() => drilldownChartSize(outputPanel.value));
 
 const chartProxy = chartActionsProxy(props.node, (state: SimulateJuliaOperationState) => {
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -74,7 +74,7 @@ const pollResult = async (runId: string) => {
 	return pollerResults;
 };
 
-const chartProxy = chartActionsProxy(props.node.state, (state: SimulateJuliaOperationState) => {
+const chartProxy = chartActionsProxy(props.node, (state: SimulateJuliaOperationState) => {
 	emit('update-state', state);
 });
 

--- a/packages/client/hmi-client/src/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/workflow/tera-simulate-chart.vue
@@ -299,12 +299,14 @@ onMounted(() => {
 </script>
 
 <style scoped>
+/*
 .custom-chip {
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius-bigger);
 	padding: var(--gap-xsmall) var(--gap);
 	color: var(--surface-0);
 }
+*/
 .simulate-chart {
 	background-color: var(--surface-0);
 	border: 1px solid var(--surface-border-light);

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -3,6 +3,16 @@ import { DataseriesConfig, RunType, ChartConfig } from '@/types/SimulateConfig';
 import type { CsvAsset, TimeSpan } from '@/types/Types';
 import type { WorkflowNode } from '@/types/workflow';
 
+// export const previewChartSize= (element: HTMLElement) => {
+// }
+
+export const drilldownChartSize = (element: HTMLElement | null) => {
+	if (!element) return { width: 100, height: 270 };
+
+	const parentContainerWidth = (element as HTMLElement).clientWidth - 48;
+	return { width: parentContainerWidth, height: 270 };
+};
+
 /**
  * Function generator for common TA3-operator operations, such add, update, and delete charts
  * The idea is to have a single place to do data manipulations but let the caller retain control

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -1,29 +1,30 @@
 import _ from 'lodash';
 import { DataseriesConfig, RunType, ChartConfig } from '@/types/SimulateConfig';
 import type { CsvAsset, TimeSpan } from '@/types/Types';
+import type { WorkflowNode } from '@/types/workflow';
 
 /**
  * Function generator for common TA3-operator operations, such add, update, and delete charts
  * The idea is to have a single place to do data manipulations but let the caller retain control
  * via the callback function
  * */
-export const chartActionsProxy = (state: any, updateStateCallback: Function) => {
-	if (!state.chartConfigs) throw new Error('Cannot find chartConfigs in state object');
+export const chartActionsProxy = (node: WorkflowNode<any>, updateStateCallback: Function) => {
+	if (!node.state.chartConfigs) throw new Error('Cannot find chartConfigs in state object');
 
 	const addChart = () => {
-		const copy = _.cloneDeep(state);
+		const copy = _.cloneDeep(node.state);
 		copy.chartConfigs.push([]);
 		updateStateCallback(copy);
 	};
 
 	const removeChart = (index: number) => {
-		const copy = _.cloneDeep(state);
+		const copy = _.cloneDeep(node.state);
 		copy.chartConfigs.splice(index, 1);
 		updateStateCallback(copy);
 	};
 
 	const configurationChange = (index: number, config: ChartConfig) => {
-		const copy = _.cloneDeep(state);
+		const copy = _.cloneDeep(node.state);
 		copy.chartConfigs[index] = config.selectedVariable;
 		updateStateCallback(copy);
 	};


### PR DESCRIPTION
### Summary
Cleaning up chart related matters, this goes over all TA3 operators with the exception of 
- ensemble-simulate
- ensemble-calibrate
- optmize
which are still under construction to adopt new designs and communication paradigm.

This PR does several things
- Resize charts across drilldowns and previews
- Fix problem with state-references in chartProxy
- Remove pills the chart variable selector