### PR TITLE
calibrate ensemble 2

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -5,8 +5,8 @@ import { ChartConfig } from '@/types/SimulateConfig';
 import type { EnsembleModelConfigs } from '@/types/Types';
 
 export interface EnsembleCalibrateExtraCiemss {
-	numSamples: number;
-	totalPopulation: number;
+	solverMethod: string;
+	numParticles: number;
 	numIterations: number;
 }
 
@@ -33,9 +33,9 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 			chartConfigs: [],
 			mapping: [],
 			extra: {
-				numSamples: 50,
-				totalPopulation: 1000,
-				numIterations: 10
+				solverMethod: 'dopri5',
+				numParticles: 1000,
+				numIterations: 1000
 			},
 			simulationsInProgress: []
 		};

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -34,8 +34,8 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 			mapping: [],
 			extra: {
 				solverMethod: 'dopri5',
-				numParticles: 1000,
-				numIterations: 1000
+				numParticles: 10,
+				numIterations: 100
 			},
 			simulationsInProgress: []
 		};

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -6,7 +6,7 @@ import type { EnsembleModelConfigs } from '@/types/Types';
 
 export interface EnsembleCalibrateExtraCiemss {
 	solverMethod: string;
-	numParticles: number;
+	numParticles: number; // The number of particles to use for the inference algorithm. https://github.com/ciemss/pyciemss/blob/1fc62b0d4b0870ca992514ad7a9b7a09a175ce44/pyciemss/interfaces.py#L225
 	numIterations: number;
 }
 

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -6,164 +6,188 @@
 				@update-state="(state: any) => emit('update-state', state)"
 			/>
 		</template>
-		<section>
-			<section class="tera-ensemble">
-				<SelectButton
-					:model-value="view"
-					@change="if ($event.value) view = $event.value;"
-					:options="viewOptions"
-					option-value="value"
-				>
-					<template #option="{ option }">
-						<i :class="`${option.icon} p-button-icon-left`" />
-						<span class="p-button-label">{{ option.value }}</span>
-					</template>
-				</SelectButton>
-				<div v-if="view === CalibrateView.Output && runResults" class="simulate-container">
-					<tera-simulate-chart
-						v-for="(cfg, index) of node.state.chartConfigs"
-						:key="index"
-						:run-results="runResults"
-						:initial-data="csvAsset"
-						:chartConfig="cfg"
-						has-mean-line
-						@configuration-change="chartConfigurationChange(index, $event)"
-					/>
-					<Button
-						class="add-chart"
-						text
-						:outlined="true"
-						@click="addChart"
-						label="Add chart"
-						icon="pi pi-plus"
-					/>
-					<Button
-						class="add-chart"
-						title="Saves the current version of the model as a new Terarium asset"
-						@click="showSaveInput = !showSaveInput"
-					>
-						<span class="pi pi-save p-button-icon p-button-icon-left"></span>
-						<span class="p-button-text">Save as</span>
-					</Button>
-					<tera-save-dataset-from-simulation :simulation-run-id="completedRunId" />
-				</div>
-
-				<div v-else-if="view === CalibrateView.Input && node" class="simulate-container">
-					<Accordion :multiple="true" :active-index="[0, 1, 2]">
-						<AccordionTab header="Model weights">
-							<div class="model-weights">
-								<!-- Turn this into a horizontal bar chart -->
-								<section class="ensemble-calibration-graph">
-									<table class="p-datatable-table">
-										<thead class="p-datatable-thead">
-											<th>Model Config ID</th>
-											<th>Weight</th>
-										</thead>
-										<tbody class="p-datatable-tbody">
-											<!-- Index matching listModelLabels and ensembleConfigs-->
-											<tr v-for="(id, i) in listModelLabels" :key="i">
-												<td>
-													{{ id }}
-												</td>
-												<td>
-													<InputNumber
-														mode="decimal"
-														:min-fraction-digits="0"
-														:max-fraction-digits="7"
-														v-model="ensembleConfigs[i].weight"
-													/>
-												</td>
-											</tr>
-										</tbody>
-									</table>
-									<Button
-										label="Set weights to be equal"
-										class="p-button-sm p-button-outlined ml-2 mt-2"
-										outlined
-										severity="secondary"
-										@click="calculateEvenWeights()"
-									/>
-								</section>
-							</div>
-						</AccordionTab>
-						<AccordionTab header="Mapping">
-							<template v-if="ensembleConfigs.length > 0">
-								<table>
-									<tr>
-										<th>Ensemble Variables</th>
+		<section :tabName="CalibrateEnsembleTabs.Wizard">
+			<tera-drilldown-section>
+				<Accordion :multiple="true" :active-index="[0, 1, 2]">
+					<AccordionTab header="Model weights">
+						<div class="model-weights">
+							<!-- Turn this into a horizontal bar chart -->
+							<section class="ensemble-calibration-graph">
+								<table class="p-datatable-table">
+									<thead class="p-datatable-thead">
+										<th>Model Config ID</th>
+										<th>Weight</th>
+									</thead>
+									<tbody class="p-datatable-tbody">
 										<!-- Index matching listModelLabels and ensembleConfigs-->
-										<th v-for="(element, i) in listModelLabels" :key="i">
-											{{ element }}
-										</th>
-									</tr>
-									<tr>
-										<div class="row-header">
-											<td
-												v-for="(element, i) in Object.keys(ensembleConfigs[0].solutionMappings)"
-												:key="i"
-											>
-												{{ element }}
+										<tr v-for="(id, i) in listModelLabels" :key="i">
+											<td>
+												{{ id }}
 											</td>
-										</div>
-										<td v-for="i in ensembleConfigs.length" :key="i">
-											<template
-												v-for="element in Object.keys(ensembleConfigs[i - 1].solutionMappings)"
-												:key="element"
-											>
-												<Dropdown
-													v-model="ensembleConfigs[i - 1].solutionMappings[element]"
-													:options="allModelOptions[i - 1]"
+											<td>
+												<InputNumber
+													mode="decimal"
+													:min-fraction-digits="0"
+													:max-fraction-digits="7"
+													v-model="knobs.ensembleConfigs[i].weight"
 												/>
-											</template>
-										</td>
-									</tr>
+											</td>
+										</tr>
+									</tbody>
 								</table>
-							</template>
-
-							<Dropdown
-								style="width: 50%"
-								v-model="newSolutionMappingKey"
-								:options="datasetColumnNames"
-								placeholder="Variable Name"
-							/>
-							<Button
-								class="p-button-sm p-button-outlined"
-								icon="pi pi-plus"
-								label="Add mapping"
-								@click="addMapping"
-							/>
-						</AccordionTab>
-						<AccordionTab header="Additional fields">
+								<Button
+									label="Set weights to be equal"
+									class="p-button-sm p-button-outlined ml-2 mt-2"
+									outlined
+									severity="secondary"
+									@click="calculateEvenWeights()"
+								/>
+							</section>
+						</div>
+					</AccordionTab>
+					<AccordionTab header="Mapping">
+						<template v-if="knobs.ensembleConfigs.length > 0">
 							<table>
-								<thead class="p-datatable-thead">
-									<th>Units</th>
-									<th>Number of particles</th>
-									<th>Number of iterations</th>
-									<th>Solver Method</th>
-								</thead>
-								<tbody class="p-datatable-tbody">
-									<td>Steps</td>
-									<td>
-										<InputNumber v-model="extra.numParticles" />
+								<tr>
+									<th>Ensemble Variables</th>
+									<!-- Index matching listModelLabels and ensembleConfigs-->
+									<th v-for="(element, i) in listModelLabels" :key="i">
+										{{ element }}
+									</th>
+								</tr>
+								<tr>
+									<div class="row-header">
+										<td
+											v-for="(element, i) in Object.keys(knobs.ensembleConfigs[0].solutionMappings)"
+											:key="i"
+										>
+											{{ element }}
+										</td>
+									</div>
+									<td v-for="i in knobs.ensembleConfigs.length" :key="i">
+										<template
+											v-for="element in Object.keys(knobs.ensembleConfigs[i - 1].solutionMappings)"
+											:key="element"
+										>
+											<Dropdown
+												v-model="knobs.ensembleConfigs[i - 1].solutionMappings[element]"
+												:options="allModelOptions[i - 1]"
+											/>
+										</template>
 									</td>
-									<td>
-										<InputNumber v-model="extra.numIterations" />
-									</td>
-									<td>
-										<Dropdown
-											class="p-inputtext-sm"
-											:options="['dopri5', 'euler']"
-											v-model="extra.solverMethod"
-											placeholder="Select"
-										/>
-									</td>
-								</tbody>
+								</tr>
 							</table>
-						</AccordionTab>
-					</Accordion>
-				</div>
-			</section>
+						</template>
+
+						<Dropdown
+							style="width: 50%"
+							v-model="newSolutionMappingKey"
+							:options="datasetColumnNames"
+							placeholder="Variable Name"
+						/>
+						<Button
+							class="p-button-sm p-button-outlined"
+							icon="pi pi-plus"
+							label="Add mapping"
+							@click="addMapping"
+						/>
+					</AccordionTab>
+					<AccordionTab header="Additional fields">
+						<table>
+							<thead class="p-datatable-thead">
+								<th>Units</th>
+								<th>Number of particles</th>
+								<th>Number of iterations</th>
+								<th>Solver Method</th>
+							</thead>
+							<tbody class="p-datatable-tbody">
+								<td>Steps</td>
+								<td>
+									<InputNumber v-model="knobs.extra.numParticles" />
+								</td>
+								<td>
+									<InputNumber v-model="knobs.extra.numIterations" />
+								</td>
+								<td>
+									<Dropdown
+										class="p-inputtext-sm"
+										:options="['dopri5', 'euler']"
+										v-model="knobs.extra.solverMethod"
+										placeholder="Select"
+									/>
+								</td>
+							</tbody>
+						</table>
+					</AccordionTab>
+				</Accordion>
+			</tera-drilldown-section>
 		</section>
+		<section :tabName="CalibrateEnsembleTabs.Notebook">
+			<h4>Notebook</h4>
+		</section>
+		<template #preview>
+			<tera-drilldown-preview
+				title="Calibrate ensemble"
+				:options="outputs"
+				v-model:output="selectedOutputId"
+				@update:selection="onSelection"
+				:is-loading="showSpinner"
+				is-selectable
+			>
+				<tera-simulate-chart
+					v-for="(cfg, index) of node.state.chartConfigs"
+					:key="index"
+					:run-results="runResults"
+					:initial-data="csvAsset"
+					:chartConfig="cfg"
+					has-mean-line
+					@configuration-change="chartConfigurationChange(index, $event)"
+				/>
+				<Button
+					class="add-chart"
+					text
+					:outlined="true"
+					@click="addChart"
+					label="Add chart"
+					icon="pi pi-plus"
+				/>
+				<Button
+					class="add-chart"
+					title="Saves the current version of the model as a new Terarium asset"
+					@click="showSaveInput = !showSaveInput"
+				>
+					<span class="pi pi-save p-button-icon p-button-icon-left"></span>
+					<span class="p-button-text">Save as</span>
+				</Button>
+				<tera-save-dataset-from-simulation :simulation-run-id="completedRunId" />
+			</tera-drilldown-preview>
+		</template>
+		<!-- <template #footer>
+			<Button
+				:disabled="isRunDisabled"
+				outlined
+				:style="{ marginRight: 'auto' }"
+				label="Run"
+				icon="pi pi-play"
+				@click="runOptimize"
+			/>
+			<div class="label-and-input">
+				<label> Model Config Name</label>
+				<InputText v-model="knobs.modelConfigName" />
+			</div>
+			<div class="label-and-input">
+				<label> Model Config Description</label>
+				<InputText v-model="knobs.modelConfigDesc" />
+			</div>
+			<Button
+				:disabled="knobs.modelConfigName === ''"
+				outlined
+				label="Save as a new model configuration"
+				@click="saveModelConfiguration"
+			/>
+			<tera-save-dataset-from-simulation :simulation-run-id="knobs.forecastRunId" />
+			<Button label="Close" @click="emit('close')" />
+		</template> -->
 	</tera-drilldown>
 </template>
 
@@ -182,8 +206,9 @@ import Dropdown from 'primevue/dropdown';
 import { ChartConfig, RunResults } from '@/types/SimulateConfig';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
 import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
-import SelectButton from 'primevue/selectbutton';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
+import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
+import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import teraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
 import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
 import {
@@ -194,20 +219,39 @@ import {
 const props = defineProps<{
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'close']);
+const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output']);
 
-enum CalibrateView {
-	Input = 'Input',
-	Output = 'Output'
+enum CalibrateEnsembleTabs {
+	Wizard = 'Wizard',
+	Notebook = 'Notebook'
 }
+
+interface BasicKnobs {
+	ensembleConfigs: EnsembleModelConfigs[];
+	extra: EnsembleCalibrateExtraCiemss;
+}
+
+const knobs = ref<BasicKnobs>({
+	ensembleConfigs: props.node.state.mapping ?? [],
+	extra: props.node.state.extra ?? {}
+});
+
+const outputs = computed(() => {
+	if (!_.isEmpty(props.node.outputs)) {
+		return [
+			{
+				label: 'Select outputs to display in operator',
+				items: props.node.outputs
+			}
+		];
+	}
+	return [];
+});
+const selectedOutputId = ref<string>();
+const showSpinner = ref(false);
 
 const showSaveInput = ref(<boolean>false);
 
-const view = ref(CalibrateView.Input);
-const viewOptions = ref([
-	{ value: CalibrateView.Input, icon: 'pi pi-sign-in' },
-	{ value: CalibrateView.Output, icon: 'pi pi-sign-out' }
-]);
 const datasetId = computed(() => props.node.inputs[0].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
 const datasetColumnNames = ref<string[]>();
@@ -216,9 +260,6 @@ const listModelLabels = ref<string[]>([]);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
 // List of each observible + state for each model.
 const allModelOptions = ref<string[][]>([]);
-const ensembleConfigs = ref<EnsembleModelConfigs[]>(props.node.state.mapping);
-
-const extra = ref<EnsembleCalibrateExtraCiemss>(props.node.state.extra);
 
 const completedRunId = computed<string>(
 	() => props?.node?.outputs?.[0]?.value?.[0].runId as string
@@ -237,20 +278,24 @@ const chartConfigurationChange = (index: number, config: ChartConfig) => {
 };
 
 const calculateEvenWeights = () => {
-	if (!ensembleConfigs.value) return;
-	const percent = 1 / ensembleConfigs.value.length;
-	for (let i = 0; i < ensembleConfigs.value.length; i++) {
-		ensembleConfigs.value[i].weight = percent;
+	if (!knobs.value.ensembleConfigs) return;
+	const percent = 1 / knobs.value.ensembleConfigs.length;
+	for (let i = 0; i < knobs.value.ensembleConfigs.length; i++) {
+		knobs.value.ensembleConfigs[i].weight = percent;
 	}
 };
 
+const onSelection = (id: string) => {
+	emit('select-output', id);
+};
+
 function addMapping() {
-	for (let i = 0; i < ensembleConfigs.value.length; i++) {
-		ensembleConfigs.value[i].solutionMappings[newSolutionMappingKey.value] = '';
+	for (let i = 0; i < knobs.value.ensembleConfigs.length; i++) {
+		knobs.value.ensembleConfigs[i].solutionMappings[newSolutionMappingKey.value] = '';
 	}
 
 	const state = _.cloneDeep(props.node.state);
-	state.mapping = ensembleConfigs.value;
+	state.mapping = knobs.value.ensembleConfigs;
 
 	emit('update-state', state);
 }
@@ -316,15 +361,15 @@ onMounted(async () => {
 	if (state.mapping && state.mapping.length === 0) {
 		// TOM Fix this. This should check that the length of ensemble is = port length - 1
 		for (let i = 0; i < allModelConfigurations.value.length; i++) {
-			ensembleConfigs.value.push({
+			knobs.value.ensembleConfigs.push({
 				id: allModelConfigurations.value[i].id as string,
 				solutionMappings: {},
 				weight: 0
 			});
 		}
 	}
-	state.mapping = ensembleConfigs.value;
-	if (ensembleConfigs.value.some((ele) => ele.weight === 0)) {
+	state.mapping = knobs.value.ensembleConfigs;
+	if (knobs.value.ensembleConfigs.some((ele) => ele.weight === 0)) {
 		calculateEvenWeights();
 	}
 
@@ -332,10 +377,10 @@ onMounted(async () => {
 });
 
 watch(
-	() => extra.value,
+	() => knobs.value.extra,
 	async () => {
 		const state = _.cloneDeep(props.node.state);
-		state.extra = extra.value;
+		state.extra = knobs.value.extra;
 
 		emit('update-state', state);
 	},

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -134,26 +134,26 @@
 				:is-loading="showSpinner"
 				is-selectable
 			>
-				<tera-simulate-chart
-					v-for="(cfg, index) of node.state.chartConfigs"
-					:key="index"
-					:run-results="runResults"
-					:chartConfig="cfg"
-					has-mean-line
-					@configuration-change="chartProxy.configurationChange(index, $event)"
-					:size="chartSize"
-					class="mb-2"
-				/>
+				<div ref="outputPanel">
+					<tera-simulate-chart
+						v-for="(cfg, index) of node.state.chartConfigs"
+						:key="index"
+						:run-results="runResults"
+						:chartConfig="cfg"
+						has-mean-line
+						@configuration-change="chartProxy.configurationChange(index, $event)"
+						:size="chartSize"
+						class="mb-2"
+					/>
+					<Button
+						class="p-button-sm p-button-text"
+						@click="chartProxy.addChart()"
+						label="Add chart"
+						icon="pi pi-plus"
+					/>
+				</div>
 				<Button
-					class="add-chart"
-					text
-					:outlined="true"
-					@click="chartProxy.addChart()"
-					label="Add chart"
-					icon="pi pi-plus"
-				/>
-				<Button
-					class="add-chart"
+					class="p-button-sm p-button-text"
 					title="Saves the current version of the model as a new Terarium asset"
 					@click="showSaveInput = !showSaveInput"
 				>
@@ -383,12 +383,6 @@ watch(
 </script>
 
 <style scoped>
-.add-chart {
-	width: 9em;
-	margin: 0em 1em;
-	margin-bottom: 1em;
-}
-
 .row-header {
 	display: flex;
 	flex-direction: column;
@@ -433,26 +427,6 @@ td {
 	margin: 0 1em;
 	font-weight: 700;
 	font-size: 1.75em;
-}
-
-.simulate-container {
-	overflow-y: scroll;
-}
-
-.simulate-chart {
-	margin: 2em 1em;
-}
-
-.sim-tspan-container {
-	display: flex;
-	gap: 1em;
-}
-
-.sim-tspan-group {
-	display: flex;
-	flex-direction: column;
-	flex-grow: 1;
-	flex-basis: 0;
 }
 
 :deep(.p-inputnumber-input, .p-inputwrapper) {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -133,24 +133,29 @@
 								@click="addMapping"
 							/>
 						</AccordionTab>
-						<AccordionTab header="Time span">
+						<AccordionTab header="Additional fields">
 							<table>
 								<thead class="p-datatable-thead">
 									<th>Units</th>
-									<th>Number of Samples</th>
+									<th>Number of particles</th>
 									<th>Number of iterations</th>
-									<th>Total Population</th>
+									<th>Solver Method</th>
 								</thead>
 								<tbody class="p-datatable-tbody">
 									<td>Steps</td>
 									<td>
-										<InputNumber v-model="extra.numSamples" />
+										<InputNumber v-model="extra.numParticles" />
 									</td>
 									<td>
 										<InputNumber v-model="extra.numIterations" />
 									</td>
 									<td>
-										<InputNumber v-model="extra.totalPopulation" />
+										<Dropdown
+											class="p-inputtext-sm"
+											:options="['dopri5', 'euler']"
+											v-model="extra.solverMethod"
+											placeholder="Select"
+										/>
 									</td>
 								</tbody>
 							</table>

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -149,9 +149,9 @@ const runEnsemble = async () => {
 		},
 		engine: 'ciemss',
 		extra: {
-			num_samples: extra.value.numSamples,
+			num_particles: extra.value.numParticles,
 			num_iterations: extra.value.numIterations,
-			total_population: extra.value.totalPopulation
+			solver_method: extra.value.solverMethod
 		}
 	};
 	const response = await makeEnsembleCiemssCalibration(params);


### PR DESCRIPTION
# Description
-Proxy chart 
-drilldown components
-start looking to see if knobs object can help add a bit organization to this mess
-update extras object to be in line with pyciemss-service interface

 # Note
-Sorry for the long PR but I promise a lot of it is just the reformatting for drilldown components
-This should be considered a WIP I will have more follow up PRs to move the run button to the footer of drill down and reorg to new paradigm just trying to keep PRs relatively focused

<img width="1450" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/3e35a7fd-1b28-438c-b8a9-84cd9fb0c6db">


