### PR TITLE
Remove knowledge-middleware container from local docker-compose

### DIFF
--- a/containers/docker-compose-actions.yml
+++ b/containers/docker-compose-actions.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 include:
   - scripts/docker-compose-common.yml
   - scripts/docker-compose-keycloak.yml

--- a/containers/docker-compose-full.yml
+++ b/containers/docker-compose-full.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.9'
-
 include:
   - scripts/docker-compose-common.yml
   - scripts/docker-compose-taskrunner.yml

--- a/containers/docker-compose-lean.yml
+++ b/containers/docker-compose-lean.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 include:
   - scripts/docker-compose-common.yml
   - scripts/docker-compose-keycloak.yml

--- a/containers/docker-compose-local-lean.yml
+++ b/containers/docker-compose-local-lean.yml
@@ -1,5 +1,3 @@
 ---
-version: '3.9'
-
 include:
   - scripts/docker-compose-common.yml

--- a/containers/docker-compose-local.yml
+++ b/containers/docker-compose-local.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.9'
-
 include:
   - scripts/docker-compose-common.yml
   - scripts/docker-compose-taskrunner.yml

--- a/containers/scripts/docker-compose-common.yml
+++ b/containers/scripts/docker-compose-common.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   redis:
     image: redis:7-alpine

--- a/containers/scripts/docker-compose-data-services.yml
+++ b/containers/scripts/docker-compose-data-services.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   beaker:
     container_name: beaker
@@ -19,50 +17,5 @@ services:
       AUTH_USERNAME: "${secret_service_account_username}"
       AUTH_PASSWORD: "${secret_service_account_password}"
       OPENAI_API_KEY: "${secret_mit_openai_key}"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
-  knowledge-middleware-api:
-    container_name: knowledge-middleware-api
-    image: ghcr.io/darpa-askem/knowledge-middleware-api:latest
-    networks:
-      - terarium
-    ports:
-      - "3060:8000"
-    environment:
-      MIT_TR_URL: "http://54.227.237.7"
-      OPENAI_API_KEY: "${secret_mit_openai_key}"
-      REDIS_HOST: "redis"
-      REDIS_PORT: "6379"
-      SKEMA_RS_URL: "https://skema-rs.staging.terarium.ai"
-      SKEMA_TR_URL: "https://skema-tr.staging.terarium.ai"
-      TA1_UNIFIED_URL: "https://api.askem.lum.ai"
-      TDS_URL: "http://${local_host_name}:3000"
-      TDS_USER: "${secret_service_account_username}"
-      TDS_PASSWORD: "${secret_service_account_password}"
-      LOG_LEVEL: "DEBUG"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
-  knowledge-middleware-worker:
-    container_name: knowledge-middleware-worker
-    image: ghcr.io/darpa-askem/knowledge-middleware-worker:latest
-    networks:
-      - terarium
-    environment:
-      MIT_TR_URL: "http://54.227.237.7"
-      OPENAI_API_KEY: "${secret_mit_openai_key}"
-      REDIS_HOST: "redis"
-      REDIS_PORT: "6379"
-      SKEMA_RS_URL: "https://skema-rs.staging.terarium.ai"
-      SKEMA_TR_URL: "https://skema-tr.staging.terarium.ai"
-      TA1_UNIFIED_URL: "https://api.askem.lum.ai"
-      TDS_URL: "http://${local_host_name}:3000"
-      TDS_USER: "${secret_service_account_username}"
-      TDS_PASSWORD: "${secret_service_account_password}"
-      LOG_LEVEL: "DEBUG"
-    depends_on:
-      redis:
-        condition: service_started
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/containers/scripts/docker-compose-hmi.yml
+++ b/containers/scripts/docker-compose-hmi.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   hmi-server:
     image: ghcr.io/darpa-askem/hmi-server:latest

--- a/containers/scripts/docker-compose-keycloak.yml
+++ b/containers/scripts/docker-compose-keycloak.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   keycloak:
     container_name: keycloak

--- a/containers/scripts/docker-compose-local-keycloak.yml
+++ b/containers/scripts/docker-compose-local-keycloak.yml
@@ -1,8 +1,5 @@
 ---
-version: "3.9"
-
 services:
-
   keycloak:
     image: ghcr.io/unchartedsoftware/keycloak:22.0.4.0
     networks:

--- a/containers/scripts/docker-compose-sim-services.yml
+++ b/containers/scripts/docker-compose-sim-services.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   sciml-service:
     container_name: sciml-service

--- a/containers/scripts/docker-compose-taskrunner.yml
+++ b/containers/scripts/docker-compose-taskrunner.yml
@@ -1,36 +1,34 @@
 ---
-version: "3.9"
-
 services:
-    gollm-taskrunner:
-        container_name: gollm-taskrunner
-        image: ghcr.io/darpa-askem/gollm-taskrunner:latest
-        networks:
-            - terarium
-        environment:
-            TERARIUM_MQ-ADDRESSES: "amqp://rabbitmq:5672"
-            TERARIUM_MQ-PASSWORD: "terarium123"
-            TERARIUM_MQ-USERNAME: "terarium"
-            TERARIUM_TASKRUNNER_REQUEST-TYPE: "gollm"
-            OPENAI_API_KEY: "${secret_gollm_openai_key}"
-        depends_on:
-            rabbitmq:
-                condition: service_healthy
-        extra_hosts:
-            - "host.docker.internal:host-gateway"
+  gollm-taskrunner:
+    container_name: gollm-taskrunner
+    image: ghcr.io/darpa-askem/gollm-taskrunner:latest
+    networks:
+      - terarium
+    environment:
+      TERARIUM_MQ-ADDRESSES: "amqp://rabbitmq:5672"
+      TERARIUM_MQ-PASSWORD: "terarium123"
+      TERARIUM_MQ-USERNAME: "terarium"
+      TERARIUM_TASKRUNNER_REQUEST-TYPE: "gollm"
+      OPENAI_API_KEY: "${secret_gollm_openai_key}"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
-    mira-taskrunner:
-        container_name: mira-taskrunner
-        image: ghcr.io/darpa-askem/mira-taskrunner:latest
-        networks:
-            - terarium
-        environment:
-            TERARIUM_MQ-ADDRESSES: "amqp://rabbitmq:5672"
-            TERARIUM_MQ-PASSWORD: "terarium123"
-            TERARIUM_MQ-USERNAME: "terarium"
-            TERARIUM_TASKRUNNER_REQUEST-TYPE: "mira"
-        depends_on:
-            rabbitmq:
-                condition: service_healthy
-        extra_hosts:
-            - "host.docker.internal:host-gateway"
+  mira-taskrunner:
+    container_name: mira-taskrunner
+    image: ghcr.io/darpa-askem/mira-taskrunner:latest
+    networks:
+      - terarium
+    environment:
+      TERARIUM_MQ-ADDRESSES: "amqp://rabbitmq:5672"
+      TERARIUM_MQ-PASSWORD: "terarium123"
+      TERARIUM_MQ-USERNAME: "terarium"
+      TERARIUM_TASKRUNNER_REQUEST-TYPE: "mira"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Also remove `version` tag that causes warnings:

```
WARN[0000] /home/user/workspace/terarium/containers/scripts/docker-compose-common.yml: `version` is obsolete 
WARN[0000] /home/user/workspace/terarium/containers/scripts/docker-compose-taskrunner.yml: `version` is obsolete 
WARN[0000] /home/user/workspace/terarium/containers/scripts/docker-compose-data-services.yml: `version` is obsolete 
WARN[0000] /home/user/workspace/terarium/containers/scripts/docker-compose-sim-services.yml: `version` is obsolete 
WARN[0000] /home/user/workspace/terarium/containers/docker-compose-local.yml: `version` is obsolete 
```