### PR TITLE
fix[hmi-server]: Allowing errors to pass

### DIFF
--- a/packages/client/hmi-client/src/api/api.ts
+++ b/packages/client/hmi-client/src/api/api.ts
@@ -45,7 +45,7 @@ API.interceptors.response.use(
 				// If not, check the 'trace' property and extract the error from that.
 				// It will be the substring between the first set of quotations marks.
 				if (responseError.message) {
-					message = `${responseError.message} ${responseError?.path}`;
+					message = `${responseError.message}`;
 				} else if (responseError.trace) {
 					// extract the substring between the first set of quotation marks and use that
 					const start = responseError.trace.indexOf('"');

--- a/packages/server/src/main/resources/application.properties
+++ b/packages/server/src/main/resources/application.properties
@@ -108,6 +108,9 @@ springdoc.swagger-ui.path=/swagger-ui
 
 #File upload/download
 spring.mvc.async.request-timeout=-1
+#Pass error message in response
+server.error.include-message=always
+server.error.include-stacktrace=never
 
 
 ########################################################################################################################


### PR DESCRIPTION
# Description
Allow error messages to pass (without their stack traces). Also removing the path from the errors because it feels like too much/not safe
