### PR TITLE
fix[hmi-server]: Improving xDD errors

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/RelatedController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/RelatedController.java
@@ -1,14 +1,17 @@
 package software.uncharted.terarium.hmiserver.controller.documentservice;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.server.ResponseStatusException;
 import software.uncharted.terarium.hmiserver.models.documentservice.responses.XDDRelatedDocumentsResponse;
 import software.uncharted.terarium.hmiserver.models.documentservice.responses.XDDRelatedWordsResponse;
 import software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy;
@@ -17,45 +20,51 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 @RequestMapping("/document/related")
 @RestController
 @Slf4j
+@RequiredArgsConstructor
 public class RelatedController {
 
-	@Autowired
-	DocumentProxy proxy;
+	final DocumentProxy proxy;
 
 	@GetMapping("/document")
 	@Secured(Roles.USER)
 	public ResponseEntity<XDDRelatedDocumentsResponse> getRelatedDocuments(
-			@RequestParam("set") String set,
-			@RequestParam("docid") String docid) {
+			@RequestParam("set") final String set,
+			@RequestParam("docid") final String docid) {
 		try {
-			XDDRelatedDocumentsResponse response = proxy.getRelatedDocuments(set, docid);
+			final XDDRelatedDocumentsResponse response = proxy.getRelatedDocuments(set, docid);
 			if (response.getData() == null || response.getData().isEmpty())
 				return ResponseEntity.noContent().build();
 
 			return ResponseEntity.ok(response);
 
-		} catch (RuntimeException e) {
-			log.error("There was an error finding related documents", e);
-			return ResponseEntity.internalServerError().build();
+		} catch (final FeignException e) {
+			log.error("xDD returned an exception for related document search:", e);
+			throw new ResponseStatusException(HttpStatusCode.valueOf(e.status()), "There was an issue with the related request to xDD");
+		} catch (final Exception e) {
+			log.error("Unable to find related documents, an error occurred", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to find related documents, an error occurred");
 		}
 	}
 
 	@GetMapping("/word")
 	@Secured(Roles.USER)
 	public ResponseEntity<XDDRelatedWordsResponse> getRelatedWords(
-			@RequestParam("set") String set,
-			@RequestParam("word") String word) {
+			@RequestParam("set") final String set,
+			@RequestParam("word") final String word) {
 		try {
-			XDDRelatedWordsResponse response = proxy.getRelatedWords(set, word);
+			final XDDRelatedWordsResponse response = proxy.getRelatedWords(set, word);
 			if (response.getData() == null || response.getData().isEmpty()) {
 				return ResponseEntity.noContent().build();
 			}
 
 			return ResponseEntity.ok(response);
 
-		} catch (RuntimeException e) {
-			log.error("An error occurred finding related words", e);
-			return ResponseEntity.internalServerError().build();
+		} catch (final FeignException e) {
+			log.error("xDD returned an exception for related word search:", e);
+			throw new ResponseStatusException(HttpStatusCode.valueOf(e.status()), "There was an issue with the related word request to xDD");
+		} catch (final Exception e) {
+			log.error("Unable to find related words, an error occurred", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to find related words, an error occurred");
 		}
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/SetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/documentservice/SetController.java
@@ -1,13 +1,17 @@
 package software.uncharted.terarium.hmiserver.controller.documentservice;
 
 
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import software.uncharted.terarium.hmiserver.models.documentservice.responses.XDDSetsResponse;
 import software.uncharted.terarium.hmiserver.proxies.documentservice.DocumentProxy;
 import software.uncharted.terarium.hmiserver.security.Roles;
@@ -15,26 +19,29 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 @RequestMapping("/document")
 @RestController
 @Slf4j
+@RequiredArgsConstructor
 public class SetController {
 
-	@Autowired
-	DocumentProxy proxy;
+	final DocumentProxy proxy;
 
 	@GetMapping("/sets")
 	@Secured(Roles.USER)
 	public ResponseEntity<XDDSetsResponse> getAvailableSets() {
 
 		try {
-			XDDSetsResponse response = proxy.getAvailableSets();
+			final XDDSetsResponse response = proxy.getAvailableSets();
 
 			if (response.getAvailableSets() == null || response.getAvailableSets().isEmpty())
 				return ResponseEntity.noContent().build();
 
 			return ResponseEntity.ok(response);
 
-		} catch (RuntimeException e) {
-			log.error("There was an error finding available sets", e);
-			return ResponseEntity.internalServerError().build();
+		} catch (final FeignException e) {
+			log.error("xDD returned an exception for set search:", e);
+			throw new ResponseStatusException(HttpStatusCode.valueOf(e.status()), "There was an issue with the request to xDD");
+		} catch (final Exception e) {
+			log.error("Unable to find sets, an error occurred", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to find documents, an error occurred");
 		}
 	}
 


### PR DESCRIPTION
# Description

Improving the errors from xdd document and extraction search. If xDD gives us an exception we return that status code to the front end with an error message. In all other cases it's a server error, so we return 500
