### PR TITLE
Small document asset fixes

### DIFF
--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -280,12 +280,22 @@ watch(
 			const filename = document.value?.fileNames?.[0];
 
 			if (filename?.endsWith('.pdf')) {
-				pdfLink.value = await downloadDocumentAsset(props.assetId, filename); // Generate PDF download link on (doi change)
+				// Generate PDF download link on assetId change
+				downloadDocumentAsset(props.assetId, filename).then((pdfLinkResponse) => {
+					if (pdfLinkResponse) {
+						pdfLink.value = pdfLinkResponse;
+					}
+				});
+			} else if (filename && document.value?.id) {
+				if (document.value?.text) {
+					docText.value = document.value.text;
+				} else {
+					getDocumentFileAsText(document.value.id, filename).then((text) => {
+						docText.value = text;
+					});
+				}
 			} else {
-				docText.value =
-					filename && document.value?.id
-						? document.value?.text ?? (await getDocumentFileAsText(document.value.id, filename))
-						: document.value?.text ?? null;
+				docText.value = document.value?.text ?? null;
 			}
 
 			documentLoading.value = false;

--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -2,8 +2,8 @@
 <template>
 	<tera-asset
 		:feature-config="featureConfig"
-		:name="highlightSearchTerms(document?.name)"
-		:overline="highlightSearchTerms(document?.source)"
+		:name="document?.name ?? ''"
+		:overline="document?.source ?? ''"
 		@close-preview="emit('close-preview')"
 		:hide-intro="view === DocumentView.PDF"
 		:stretch-content="view === DocumentView.PDF"
@@ -62,7 +62,7 @@
 						<tera-show-more-text
 							v-if="ex.metadata?.content"
 							class="extracted-caption col-7"
-							:text="highlightSearchTerms(ex.metadata?.content ?? '')"
+							:text="ex.metadata?.content ?? ''"
 							:lines="previewLineLimit"
 						/>
 						<div v-else class="no-extracted-text">No extracted text</div>
@@ -89,7 +89,7 @@
 						<tera-show-more-text
 							v-if="ex.metadata?.content"
 							class="extracted-caption col-7"
-							:text="highlightSearchTerms(ex.metadata?.content ?? '')"
+							:text="ex.metadata?.content ?? ''"
 							:lines="previewLineLimit"
 						/>
 						<div v-else class="no-extracted-text">No extracted text</div>
@@ -116,7 +116,7 @@
 						<tera-show-more-text
 							v-if="ex.metadata?.content"
 							class="extracted-caption col-7"
-							:text="highlightSearchTerms(ex.metadata?.content ?? '')"
+							:text="ex.metadata?.content ?? ''"
 							:lines="previewLineLimit"
 						/>
 						<div v-else class="no-extracted-text">No extracted text</div>
@@ -154,7 +154,6 @@ import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import { FeatureConfig } from '@/types/common';
 import TeraPdfEmbed from '@/components/widgets/tera-pdf-embed.vue';
-import * as textUtil from '@/utils/text';
 import TeraAsset from '@/components/asset/tera-asset.vue';
 import type { DocumentAsset } from '@/types/Types';
 import { AssetType, ExtractionAssetType } from '@/types/Types';
@@ -181,7 +180,6 @@ enum DocumentView {
 }
 const props = defineProps<{
 	assetId: string;
-	highlight?: string;
 	previewLineLimit: number;
 	featureConfig?: FeatureConfig;
 }>();
@@ -258,14 +256,6 @@ const optionsMenuItems = ref([
 const toggleOptionsMenu = (event) => {
 	optionsMenu.value.toggle(event);
 };
-
-// Highlight strings based on props.highlight
-function highlightSearchTerms(text: string | undefined): string {
-	if (!!props.highlight && !!text) {
-		return textUtil.highlight(text, props.highlight);
-	}
-	return text ?? '';
-}
 
 /* TODO: When fetching a document by id, its id and fileNames don't get returned.
  Once they do see about adjusting the conditionals */

--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -1,4 +1,7 @@
-<!-- This template is a copy of tera-external-publication with some elements stripped out.  TODO: merge the concept of external publication and document asset -->
+<!--
+  -- This template is a copy of tera-external-publication with some elements stripped out.
+  -- TODO: merge the concept of external publication and document asset.
+  -->
 <template>
 	<tera-asset
 		:feature-config="featureConfig"
@@ -127,7 +130,10 @@
 			</AccordionTab>
 		</Accordion>
 
-		<!-- Adding this here for now...we will need a way to listen to the extraction job since this takes some time in the background when uploading a doucment-->
+		<!--
+		  -- Adding this here for now...
+		  -- until we implement the process manager
+		  -->
 		<p
 			class="pl-3"
 			v-if="
@@ -197,13 +203,12 @@ const notFoundOption = { value: DocumentView.NOT_FOUND, icon: 'pi pi-file', disa
 
 const viewOptions = computed(() => {
 	const options: { value: DocumentView; icon: string; disabled?: boolean }[] = [extractionsOption];
-	const filename = document.value?.fileNames?.[0];
-	const isPdf = filename?.endsWith('.pdf');
+	const isPdf = document.value?.fileNames?.some((file) => file.endsWith('.pdf')) ?? false;
 
 	if (isPdf) {
-		options.push(pdfOption);
+		options.push({ ...pdfOption, disabled: documentLoading.value });
 	} else if (docText.value) {
-		options.push(txtOption);
+		options.push({ ...txtOption, disabled: documentLoading.value });
 	} else {
 		options.push(notFoundOption);
 	}

--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -281,13 +281,11 @@ watch(
 
 			if (filename?.endsWith('.pdf')) {
 				pdfLink.value = await downloadDocumentAsset(props.assetId, filename); // Generate PDF download link on (doi change)
-				view.value = DocumentView.PDF;
 			} else {
 				docText.value =
 					filename && document.value?.id
 						? document.value?.text ?? (await getDocumentFileAsText(document.value.id, filename))
 						: document.value?.text ?? null;
-				if (docText.value !== null) view.value = DocumentView.TXT;
 			}
 
 			documentLoading.value = false;
@@ -307,11 +305,6 @@ onUpdated(() => {
 });
 </script>
 <style scoped>
-.container {
-	margin-left: 1rem;
-	margin-right: 1rem;
-}
-
 .extracted-item {
 	display: flex;
 	flex-direction: row;

--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -95,6 +95,18 @@ export function useProjects() {
 	}
 
 	/**
+	 * Get the name of an asset from the active project.
+	 * @param {ProjectAsset['assetId]} assetId
+	 * @returns {ProjectAsset['assetName']}
+	 */
+	function getAssetName(assetId: ProjectAsset['assetId']): ProjectAsset['assetName'] {
+		const asset = activeProject.value?.projectAssets.find(
+			(projectAsset) => projectAsset.assetId === assetId
+		);
+		return asset?.assetName ?? '';
+	}
+
+	/**
 	 * If `projectId` is defined, delete an asset from that project.
 	 * Otherwise, delete an asset from the active project and refresh it.
 	 *
@@ -248,6 +260,7 @@ export function useProjects() {
 		getAll,
 		getActiveProjectAssets,
 		addAsset,
+		getAssetName,
 		deleteAsset,
 		create,
 		update,

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -18,7 +18,6 @@
 			<tera-document-asset
 				v-else-if="previewItemResourceType === ResourceType.XDD && source === 'Terarium'"
 				:asset-id="previewItemId"
-				:highlight="searchTerm"
 				:previewLineLimit="10"
 				:feature-config="{ isPreview: true }"
 				@close-preview="closePreview"

--- a/packages/client/hmi-client/src/services/document-assets.ts
+++ b/packages/client/hmi-client/src/services/document-assets.ts
@@ -144,7 +144,7 @@ async function addFileToDocumentAsset(
 	return response && response.status < 400;
 }
 
-async function downloadDocumentAsset(documentId: string, fileName: string): Promise<any> {
+async function downloadDocumentAsset(documentId: string, fileName: string): Promise<string | null> {
 	try {
 		const response = await API.get(
 			`document-asset/${documentId}/download-document?filename=${fileName}`,
@@ -154,7 +154,7 @@ async function downloadDocumentAsset(documentId: string, fileName: string): Prom
 		const pdfLink = window.URL.createObjectURL(blob);
 		return pdfLink ?? null;
 	} catch (error) {
-		logger.error(`Error: Unable to download pdf for document asset ${documentId}: ${error}`);
+		logger.error(`Unable to download PDF file for document asset ${documentId}: ${error}`);
 		return null;
 	}
 }


### PR DESCRIPTION
# Description

* Do not open on the PDF tab right away
* Remove blocking file download to open the asset
* Remove highlight search

