### PR TITLE
Added an edit icon to the annotation note to indicate that it's editable

### DIFF
--- a/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
@@ -17,7 +17,7 @@
 			</div>
 		</template>
 		<div v-else-if="!isEmpty(annotation)" class="annotation">
-			<p @click="isEditing = true">{{ annotation }}</p>
+			<p @click="isEditing = true">{{ annotation }}<span class="pi pi-pencil ml-2 text-xs" /></p>
 		</div>
 	</section>
 	<Button


### PR DESCRIPTION
**BEFORE**
![Monosnap Terarium 2024-03-26 15-49-25](https://github.com/DARPA-ASKEM/terarium/assets/120480244/c4cd6f89-aab5-4378-9316-8cf45dd82125)
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/ab3abfb9-4bcc-4abc-aa41-bb7ff45f5e2b)


**AFTER**
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/dda21541-f6e8-4458-9ac3-8c0e61889f59)
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/19707ce3-5ee4-4765-b1fa-2f657d5c49e0)
