### PR TITLE
Fix Align AMR

### DIFF
--- a/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
@@ -75,15 +75,17 @@
 							v-model="evaluationScenario"
 							:options="evalScenarios.scenarios"
 							optionLabel="name"
+							placeholder="Select a Scenario"
 							@change="onScenarioChange"
 						/>
 
 						<label class="text-sm" for="evaluation-scenario-task">Task</label>
 						<Dropdown
 							id="evaluation-scenario-task"
-							:options="evaluationScenario.questions"
+							:options="evaluationScenario?.questions ?? []"
 							v-model="evaluationScenarioTask"
 							optionLabel="task"
+							placeholder="Select a Task"
 							@change="onTaskChange"
 						/>
 
@@ -346,21 +348,22 @@ const refreshEvaluationScenario = async () => {
 };
 
 const loadEvaluationScenario = async () => {
-	const scenarioName: string | null = window.localStorage.getItem('evaluationScenarioName');
-	const scenarioIndex: number = scenarioName
+	const scenarioName = window.localStorage.getItem('evaluationScenarioName');
+	const scenarioIndex = scenarioName
 		? evalScenarios.value.scenarios.findIndex((s) => s.name === scenarioName)
 		: 0;
 	evaluationScenario.value = evalScenarios.value.scenarios[scenarioIndex];
 
-	const taskName: string | null = window.localStorage.getItem('evaluationScenarioTask');
-	const taskIndex: number = taskName
-		? evaluationScenario.value?.questions.findIndex((q) => q.task === taskName)
-		: 0;
-	evaluationScenarioTask.value = evaluationScenario.value.questions[taskIndex];
+	const taskName = window.localStorage.getItem('evaluationScenarioTask');
+
+	let taskIndex: number = 0;
+	if (taskName && evaluationScenario.value?.questions) {
+		taskIndex = evaluationScenario.value.questions.findIndex((q) => q.task === taskName);
+		evaluationScenarioTask.value = evaluationScenario.value.questions[taskIndex];
+	}
+
 	evaluationScenarioDescription.value = evaluationScenarioTask.value.description;
-
 	evaluationScenarioNotes.value = window.localStorage.getItem('evaluationScenarioNotes') || '';
-
 	evaluationScenarioMultipleUsers.value =
 		window.localStorage.getItem('evaluationScenarioMultipleUsers') !== 'false';
 

--- a/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
@@ -213,32 +213,29 @@ const sendForExtractions = async () => {
 	await getRelatedDocuments();
 };
 
+function getRelatedDocuments() {
+	if (!props.assetType) return;
+
+	const provenanceType = mapAssetTypeToProvenanceType(props.assetType);
+	if (!provenanceType) return;
+
+	getRelatedArtifacts(props.assetId, provenanceType, [ProvenanceType.Document]).then((nodes) => {
+		const provenanceNodes = nodes ?? [];
+		relatedDocuments.value =
+			(provenanceNodes.filter((node) => isDocumentAsset(node)) as DocumentAsset[]).map(
+				({ id, name }) => ({ id: id ?? '', name: name ?? '' })
+			) ?? [];
+	});
+}
+
 onMounted(() => {
 	getRelatedDocuments();
 });
 
 watch(
 	() => props.assetId,
-	() => {
-		getRelatedDocuments();
-	}
+	() => getRelatedDocuments()
 );
-
-async function getRelatedDocuments() {
-	if (!props.assetType) return;
-
-	const provenanceType = mapAssetTypeToProvenanceType(props.assetType);
-	if (!provenanceType) return;
-
-	const provenanceNodes = await getRelatedArtifacts(props.assetId, provenanceType, [
-		ProvenanceType.Document
-	]);
-
-	relatedDocuments.value =
-		(provenanceNodes.filter((node) => isDocumentAsset(node)) as DocumentAsset[]).map(
-			({ id, name }) => ({ id: id ?? '', name: name ?? '' })
-		) ?? [];
-}
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
@@ -185,7 +185,7 @@ const sendForEnrichment = async () => {
 
 	isLoading.value = false;
 	emit('enriched');
-	getRelatedDocuments();
+	await getRelatedDocuments();
 };
 
 const sendForExtractions = async () => {
@@ -220,22 +220,24 @@ const sendForExtractions = async () => {
 	}
 
 	isLoading.value = false;
-	getRelatedDocuments();
+	await getRelatedDocuments();
 };
 
-function getRelatedDocuments() {
+async function getRelatedDocuments() {
 	if (!props.assetType) return;
 
 	const provenanceType = mapAssetTypeToProvenanceType(props.assetType);
 	if (!provenanceType) return;
 
-	getRelatedArtifacts(props.assetId, provenanceType, [ProvenanceType.Document]).then((nodes) => {
-		const provenanceNodes = nodes ?? [];
-		relatedDocuments.value =
-			(provenanceNodes.filter((node) => isDocumentAsset(node)) as DocumentAsset[]).map(
-				({ id, name }) => ({ id: id ?? '', name: name ?? '' })
-			) ?? [];
-	});
+	await getRelatedArtifacts(props.assetId, provenanceType, [ProvenanceType.Document]).then(
+		(nodes) => {
+			const provenanceNodes = nodes ?? [];
+			relatedDocuments.value =
+				(provenanceNodes.filter((node) => isDocumentAsset(node)) as DocumentAsset[]).map(
+					({ id, name }) => ({ id: id ?? '', name: name ?? '' })
+				) ?? [];
+		}
+	);
 }
 
 onMounted(() => {

--- a/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-related-documents.vue
@@ -205,7 +205,6 @@ const sendForExtractions = async () => {
 
 		logger.info('Provenance created after extraction', { showToast: false });
 		emit('extracted');
-		getRelatedDocuments();
 	}
 
 	// Model extraction
@@ -221,6 +220,7 @@ const sendForExtractions = async () => {
 	}
 
 	isLoading.value = false;
+	getRelatedDocuments();
 };
 
 function getRelatedDocuments() {

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -7,7 +7,6 @@ import { AxiosResponse } from 'axios';
 
 /**
  * Transform a list of LaTeX or mathml strings to an AMR
- * @param format string - the type of equations used to define an AMR ('mathml' or 'latex')
  * @param equations string[] - list of LaTeX or mathml strings representing a model
  * @param framework string= - the framework to use for the extraction, default to 'petrinet'
  * @param modelId string= - the model id to use for the extraction
@@ -36,7 +35,7 @@ export const equationsToAMR = async (
  * Returns a runId used to poll for result
  */
 export const profileModel = async (modelId: Model['id'], documentId: string | null = null) => {
-	let response: any = null;
+	let response: any;
 	if (documentId && modelId) {
 		response = await API.post(`/knowledge/profile-model/${modelId}?document-id=${documentId}`);
 	} else {
@@ -48,12 +47,14 @@ export const profileModel = async (modelId: Model['id'], documentId: string | nu
 
 export const alignModel = async (
 	modelId: Model['id'],
-	documentId: string
-): Promise<Model | null> => {
-	const response = await API.post(
-		`/knowledge/link-amr?document-id=${documentId}&model-id=${modelId}`
-	);
-	return response.data ?? null;
+	documentId: DocumentAsset['id']
+): Promise<boolean> => {
+	if (!modelId || !documentId) {
+		return false;
+	}
+	const url = `/knowledge/align-model?document-id=${documentId}&model-id=${modelId}`;
+	const response = await API.post(url);
+	return response?.status === 200;
 };
 
 /**
@@ -64,7 +65,7 @@ export const profileDataset = async (
 	datasetId: Dataset['id'],
 	documentId: string | null = null
 ) => {
-	let response: any = null;
+	let response: any;
 	if (documentId && datasetId) {
 		response = await API.post(`/knowledge/profile-dataset/${datasetId}?document-id=${documentId}`);
 	} else {

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -54,7 +54,7 @@ export const alignModel = async (
 	}
 	const url = `/knowledge/align-model?document-id=${documentId}&model-id=${modelId}`;
 	const response = await API.post(url);
-	return response?.status === 200;
+	return response?.status === 204;
 };
 
 /**

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -97,9 +97,13 @@ export const extractVariables = async (
 ) => {
 	console.group('SKEMA Variable extraction');
 	if (documentId) {
-		await API.post(
-			`/knowledge/variable-extractions?document-id=${documentId}&model-ids=${modelIds}`
-		);
+		const url = `/knowledge/variable-extractions?document-id=${documentId}&model-ids=${modelIds}`;
+		const response = await API.post(url);
+		if (response?.status === 202) {
+			await subscribe(ClientEventType.Extraction, extractionStatusUpdateHandler);
+		} else {
+			console.debug('Failed — ', response);
+		}
 	} else {
 		console.debug('Failed — No documentId provided for variable extraction.');
 	}

--- a/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-node.vue
@@ -113,7 +113,7 @@ watch(
 			if (!props.node.outputs.find((port) => port.type === 'documentId')) {
 				emit('append-output', {
 					type: 'documentId',
-					label: `document`,
+					label: documentName.value,
 					value: [
 						{
 							documentId: document.value.id,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/GlobalExceptionControllerAdvice.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/GlobalExceptionControllerAdvice.java
@@ -2,12 +2,14 @@ package software.uncharted.terarium.hmiserver.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.messaging.handler.invocation.MethodArgumentResolutionException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,7 +22,10 @@ public class GlobalExceptionControllerAdvice {
 			MethodArgumentNotValidException.class,
 			HttpMessageConversionException.class,
 			HttpRequestMethodNotSupportedException.class,
-			ServletRequestBindingException.class })
+			ServletRequestBindingException.class,
+			MethodArgumentResolutionException.class,
+			NoHandlerFoundException.class
+	})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public void handleBadRequest(final Exception ex) {
 		log.error("HTTP Status Code: 400", ex);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
@@ -101,8 +101,6 @@ public class DocumentController {
 
 	final ObjectMapper objectMapper;
 	final ExtractionService extractionService;
-	private final CurrentUserService currentUserService;
-	private final XDDDocumentController xDDDocumentController;
 
 	@Value("${xdd.api-key}")
 	String apikey;
@@ -675,8 +673,6 @@ public class DocumentController {
 		try (final CloseableHttpClient httpclient = HttpClients.custom()
 				.disableRedirectHandling()
 				.build()) {
-			final String currentUserId = currentUserService.get().getId();
-
 			final byte[] fileAsBytes = DownloadService.getPDF("https://unpaywall.org/" + doi);
 
 			// if this service fails, return ok with errors
@@ -699,7 +695,7 @@ public class DocumentController {
 			}
 
 			// fire and forgot pdf extractions
-			extractionService.extractPDF(docId, currentUserId, domain);
+			extractionService.extractPDF(docId, domain);
 		} catch (final ResponseStatusException e) {
 			log.error("Unable to upload PDF document then extract", e);
 			throw e;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -697,8 +697,7 @@ public class KnowledgeController {
 	public ResponseEntity<Void> postPDFToCosmos(
 			@RequestParam("document-id") final UUID documentId,
 			@RequestParam(name = "domain", defaultValue = "epi") final String domain) {
-		final String currentUserId = currentUserService.get().getId();
-		extractionService.extractPDF(documentId, currentUserId, domain);
+		extractionService.extractPDF(documentId, domain);
 		return ResponseEntity.accepted().build();
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -34,7 +34,6 @@ import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.Model
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata.Card;
 import software.uncharted.terarium.hmiserver.models.dataservice.provenance.Provenance;
-import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceQueryParam;
 import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceRelationType;
 import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceType;
 import software.uncharted.terarium.hmiserver.models.extractionservice.ExtractionResponse;
@@ -398,30 +397,6 @@ public class KnowledgeController {
 		}
 
 		try {
-			final ProvenanceQueryParam payload = new ProvenanceQueryParam();
-			payload.setRootId(modelId);
-			payload.setRootType(ProvenanceType.MODEL);
-
-			final Set<String> codeIds = provenanceSearchService.modelsFromCode(payload);
-
-			String codeContentString = "";
-			if (codeIds.size() > 0) {
-				final UUID codeId = UUID.fromString(codeIds.iterator().next());
-
-				final Code code = codeService.getAsset(codeId).orElseThrow();
-
-				final Map<String, String> codeContent = new HashMap<>();
-
-				for (final Entry<String, CodeFile> file : code.getFiles().entrySet()) {
-
-					final String name = file.getKey();
-					final String content = codeService.fetchFileAsString(codeId, file.getKey()).orElseThrow();
-
-					codeContent.put(name, content);
-				}
-				codeContentString = mapper.writeValueAsString(codeContent);
-			}
-
 			final Optional<DocumentAsset> documentOptional = documentService.getAsset(documentId);
 			String documentText = "";
 			if (documentOptional.isPresent()) {
@@ -435,7 +410,7 @@ public class KnowledgeController {
 
 			final StringMultipartFile textFile = new StringMultipartFile(documentText, "document.txt",
 					"application/text");
-			final StringMultipartFile codeFile = new StringMultipartFile(codeContentString, "code.txt",
+			final StringMultipartFile codeFile = new StringMultipartFile("", "code.txt",
 					"application/text");
 
 			final ResponseEntity<JsonNode> resp = mitProxy.modelCard(MIT_OPENAI_API_KEY, textFile, codeFile);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -666,8 +666,6 @@ public class KnowledgeController {
 	 *
 	 * @param documentId (String): The ID of the document to profile
 	 * @param modelIds   (List<String>): The IDs of the models to use for extraction
-	 * @param annotateSkema (Boolean): Whether to annotate with SKEMA
-	 * @param annotateMIT (Boolean): Whether to annotate with MIT
 	 * @param domain (String): The domain of the document
 	 * @return an accepted response, the request being handled asynchronously
 	 */
@@ -675,10 +673,8 @@ public class KnowledgeController {
 	public ResponseEntity<DocumentAsset> postPdfExtractions(
 			@RequestParam("document-id") final UUID documentId,
 			@RequestParam(name = "model-ids", defaultValue = "[]") final List<UUID> modelIds,
-			@RequestParam(name = "annotate-skema", defaultValue = "true") final Boolean annotateSkema,
-			@RequestParam(name = "annotate-mit", defaultValue = "true") final Boolean annotateMIT,
 			@RequestParam(name = "domain", defaultValue = "epi") final String domain) {
-		extractionService.extractVariables(documentId, modelIds, annotateSkema, annotateMIT, domain);
+		extractionService.extractVariables(documentId, modelIds, domain);
 		return ResponseEntity.accepted().build();
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -601,6 +601,10 @@ public class KnowledgeController {
 
 	@PostMapping("/link-amr")
 	@Secured(Roles.USER)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "204", description = "Model as been align with document", content = @Content),
+		@ApiResponse(responseCode = "500", description = "Error aligning model with variable extracted from document", content = @Content)
+	})
 	public ResponseEntity<Model> postLinkAmr(
 			@RequestParam("document-id") final UUID documentId,
 			@RequestParam("model-id") final UUID modelId) {
@@ -650,7 +654,7 @@ public class KnowledgeController {
 					documentId, ProvenanceType.DOCUMENT);
 			provenanceService.createProvenance(provenance);
 
-			return ResponseEntity.ok(model);
+			return ResponseEntity.noContent().build();
 
 		} catch (final IOException e) {
 			final String error = "Unable to get link amr";

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -612,7 +612,7 @@ public class KnowledgeController {
 
 			final String modelString = mapper.writeValueAsString(model);
 			final String extractionsString = mapper
-					.writeValueAsString(document.getMetadata() != null ? document.getMetadata() : new HashMap<>());
+					.writeValueAsString(document.getMetadata().get("attributes") != null ? document.getMetadata().get("attributes") : new HashMap<>());
 
 			final StringMultipartFile amrFile = new StringMultipartFile(modelString, "amr.json",
 					"application/json");

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -661,6 +661,16 @@ public class KnowledgeController {
 		}
 	}
 
+	/**
+	 * Variables Extractions from Document with SKEMA
+	 *
+	 * @param documentId (String): The ID of the document to profile
+	 * @param modelIds   (List<String>): The IDs of the models to use for extraction
+	 * @param annotateSkema (Boolean): Whether to annotate with SKEMA
+	 * @param annotateMIT (Boolean): Whether to annotate with MIT
+	 * @param domain (String): The domain of the document
+	 * @return an accepted response, the request being handled asynchronously
+	 */
 	@PostMapping("/variable-extractions")
 	public ResponseEntity<DocumentAsset> postPdfExtractions(
 			@RequestParam("document-id") final UUID documentId,
@@ -668,24 +678,15 @@ public class KnowledgeController {
 			@RequestParam(name = "annotate-skema", defaultValue = "true") final Boolean annotateSkema,
 			@RequestParam(name = "annotate-mit", defaultValue = "true") final Boolean annotateMIT,
 			@RequestParam(name = "domain", defaultValue = "epi") final String domain) {
-
-		try {
-			return ResponseEntity
-					.ok(extractionService.extractVariables(documentId, modelIds, annotateSkema, annotateMIT, domain));
-		} catch (final IOException e) {
-			final String error = "Unable to get required assets";
-			log.error(error, e);
-			throw new ResponseStatusException(
-					org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-					error + ": " + e.getMessage());
-		}
+		extractionService.extractVariables(documentId, modelIds, annotateSkema, annotateMIT, domain);
+		return ResponseEntity.accepted().build();
 	}
 
 	/**
 	 * Document Extractions
 	 *
 	 * @param documentId (String): The ID of the document to profile
-	 * @return the profiled document
+	 * @return an accepted response, the request being handled asynchronously
 	 */
 	@PostMapping("/pdf-extractions")
 	@Secured(Roles.USER)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -599,7 +599,7 @@ public class KnowledgeController {
 		}
 	}
 
-	@PostMapping("/link-amr")
+	@PostMapping("/align-model")
 	@Secured(Roles.USER)
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "Model as been align with document", content = @Content),

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -638,7 +638,7 @@ public class KnowledgeController {
 
 			final JsonNode modelJson = mapper.valueToTree(model);
 
-			// ovewrite all updated fields
+			// overwrite all updated fields
 			JsonUtil.recursiveSetAll((ObjectNode) modelJson, res.getBody());
 
 			// update the model

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaUnifiedProxy.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/proxies/skema/SkemaUnifiedProxy.java
@@ -57,7 +57,7 @@ public interface SkemaUnifiedProxy {
 			@RequestPart("text_extractions_file") MultipartFile extractionsFile);
 
 	@Data
-	public static class IntegratedTextExtractionsBody {
+    class IntegratedTextExtractionsBody {
 
 		public IntegratedTextExtractionsBody(final String text) {
 			this.texts = Arrays.asList(text);
@@ -85,8 +85,5 @@ public interface SkemaUnifiedProxy {
 
 	@PostMapping("/text-reading/integrated-text-extractions")
 	ResponseEntity<JsonNode> integratedTextExtractions(
-			@RequestParam(value = "annotate_mit", defaultValue = "true") Boolean annotateMit,
-			@RequestParam(value = "annotate_skema", defaultValue = "true") Boolean annotateSkema,
-			@RequestBody IntegratedTextExtractionsBody body);
-
+		@RequestBody IntegratedTextExtractionsBody body);
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -364,8 +364,13 @@ public class ExtractionService {
 
 	public DocumentAsset extractVariables(final UUID documentId, final List<UUID> modelIds, final Boolean annotateSkema,
 			final Boolean annotateMIT,
-			final String domain) throws IOException {
+			final String domain) {
 
+		final String userId = currentUserService.get().getId();
+		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
+			HALFTIME_SECONDS);
+
+		/*
 		DocumentAsset document = documentService.getAsset(documentId).orElseThrow();
 
 		if (document.getText() == null || document.getText().isEmpty()) {
@@ -501,6 +506,7 @@ public class ExtractionService {
 		document = documentService.updateAsset(document).orElseThrow();
 
 		return document;
+		 */
 	}
 
 	public static HttpEntity zipEntryToHttpEntity(final ZipInputStream zipInputStream) throws IOException {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -362,10 +362,9 @@ public class ExtractionService {
 		});
 	}
 
-	public void extractVariables(final UUID documentId, final List<UUID> modelIds, final Boolean annotateSkema,
-			final Boolean annotateMIT,
-			final String domain) {
+	public void extractVariables(final UUID documentId, final List<UUID> modelIds, final String domain) {
 
+		// Set up the client interface
 		final String userId = currentUserService.get().getId();
 		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
 			HALFTIME_SECONDS);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -1,10 +1,19 @@
 package software.uncharted.terarium.hmiserver.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.FeignException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
@@ -13,12 +22,23 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.models.ClientEvent;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentExtraction;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.ExtractionAssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
+import software.uncharted.terarium.hmiserver.models.dataservice.provenance.Provenance;
+import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceRelationType;
+import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceType;
 import software.uncharted.terarium.hmiserver.models.extractionservice.ExtractionStatusUpdate;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
@@ -29,32 +49,26 @@ import software.uncharted.terarium.hmiserver.proxies.skema.SkemaUnifiedProxy;
 import software.uncharted.terarium.hmiserver.proxies.skema.SkemaUnifiedProxy.IntegratedTextExtractionsBody;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
+import software.uncharted.terarium.hmiserver.service.data.ProvenanceService;
 import software.uncharted.terarium.hmiserver.service.tasks.ModelCardResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
 import software.uncharted.terarium.hmiserver.utils.ByteMultipartFile;
+import software.uncharted.terarium.hmiserver.utils.JsonUtil;
 import software.uncharted.terarium.hmiserver.utils.StringMultipartFile;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ExtractionService {
-	final DocumentAssetService documentService;
-	final ModelService modelService;
-	final ExtractionProxy extractionProxy;
-	final SkemaUnifiedProxy skemaUnifiedProxy;
-	final MitProxy mitProxy;
-	final ObjectMapper objectMapper;
-	final ClientEventService clientEventService;
-	final TaskService taskService;
+	private final DocumentAssetService documentService;
+	private final ModelService modelService;
+	private final ExtractionProxy extractionProxy;
+	private final SkemaUnifiedProxy skemaUnifiedProxy;
+	private final MitProxy mitProxy;
+	private final ObjectMapper objectMapper;
+	private final ClientEventService clientEventService;
+	private final TaskService taskService;
+	private final ProvenanceService provenanceService;
 	private final CurrentUserService currentUserService;
 
 	// time the progress takes to reach each subsequent half
@@ -94,6 +108,7 @@ public class ExtractionService {
 				final String userId) {
 
 			log.info("t: {}, {}", t, message);
+
 			final ExtractionStatusUpdate update = new ExtractionStatusUpdate(documentId, t, message, error);
 			final ClientEvent<ExtractionStatusUpdate> status = ClientEvent.<ExtractionStatusUpdate>builder()
 					.type(ClientEventType.EXTRACTION).data(update).build();
@@ -122,320 +137,432 @@ public class ExtractionService {
 		return filename;
 	}
 
-	public void extractPDF(final UUID documentId, final String domain) {
+	public Future<DocumentAsset> extractPDF(final UUID documentId, final String domain) {
 
 		final String userId = currentUserService.get().getId();
 		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
 				HALFTIME_SECONDS);
 
-		executor.execute(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					clientInterface.sendMessage("Starting extraction...");
+		return executor.submit(() -> {
+			try {
+				clientInterface.sendMessage("Starting extraction...");
 
-					DocumentAsset document = documentService.getAsset(documentId).get();
-					clientInterface.sendMessage("Document found, fetching file...");
+				DocumentAsset document = documentService.getAsset(documentId).get();
+				clientInterface.sendMessage("Document found, fetching file...");
 
-					if (document.getFileNames().isEmpty()) {
-						final String errorMsg = "No files found on document";
-						clientInterface.sendError(errorMsg);
-						throw new RuntimeException(errorMsg);
-					}
-
-					final String filename = document.getFileNames().get(0);
-
-					final byte[] documentContents = documentService.fetchFileAsBytes(documentId, filename).get();
-					clientInterface.sendMessage("File fetched, processing PDF extraction...");
-
-					final ByteMultipartFile documentFile = new ByteMultipartFile(documentContents, filename,
-							"application/pdf");
-
-					final boolean compressImages = false;
-					final boolean useCache = false;
-					final ResponseEntity<JsonNode> extractionResp = extractionProxy.processPdfExtraction(compressImages,
-							useCache, documentFile);
-
-					final JsonNode body = extractionResp.getBody();
-					final UUID jobId = UUID.fromString(body.get("job_id").asText());
-
-					final int POLLING_INTERVAL_SECONDS = 5;
-					final int MAX_EXECUTION_TIME_SECONDS = 600;
-					final int MAX_ITERATIONS = MAX_EXECUTION_TIME_SECONDS / POLLING_INTERVAL_SECONDS;
-
-					boolean jobDone = false;
-					clientInterface.sendMessage("COSMOS extraction in progress...");
-
-					for (int i = 0; i < MAX_ITERATIONS; i++) {
-
-						final ResponseEntity<JsonNode> statusResp = extractionProxy.status(jobId);
-						if (!statusResp.getStatusCode().is2xxSuccessful()) {
-							final String errorMsg = "Unable to poll status endpoint";
-							clientInterface.sendError(errorMsg);
-							throw new RuntimeException(errorMsg);
-						}
-
-						final JsonNode statusData = statusResp.getBody();
-						if (!statusData.get("error").isNull()) {
-							final String errorMsg = "Extraction job failed: " + statusData.has("error");
-							clientInterface.sendError(errorMsg);
-							throw new RuntimeException(errorMsg);
-						}
-
-						log.info("Polled status endpoint {} times:\n{}", i + 1, statusData);
-						jobDone = statusData.get("error").asBoolean() || statusData.get("job_completed").asBoolean();
-						if (jobDone) {
-							clientInterface.sendMessage("COSMOS extraction complete; processing results...");
-							break;
-						}
-						Thread.sleep(POLLING_INTERVAL_SECONDS * 1000);
-					}
-
-					if (!jobDone) {
-						final String errorMsg = "Extraction job did not complete within the expected time";
-						clientInterface.sendError(errorMsg);
-						throw new RuntimeException(errorMsg);
-					}
-
-					final ResponseEntity<byte[]> zipFileResp = extractionProxy.result(jobId);
-					if (!zipFileResp.getStatusCode().is2xxSuccessful()) {
-						final String errorMsg = "Unable to fetch the extraction result";
-						clientInterface.sendError(errorMsg);
-						throw new RuntimeException(errorMsg);
-					}
-
-					clientInterface.sendMessage("Uploading COSMOS extraction results...");
-					final String zipFileName = documentId + "_cosmos.zip";
-					documentService.uploadFile(documentId, zipFileName, new ByteArrayEntity(zipFileResp.getBody()),
-							ContentType.APPLICATION_OCTET_STREAM);
-
-					document.getFileNames().add(zipFileName);
-
-					// Open the zipfile and extract the contents
-					clientInterface.sendMessage("Extracting COSMOS extraction results...");
-					final Map<String, HttpEntity> fileMap = new HashMap<>();
-					try {
-						final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
-								zipFileResp.getBody());
-						final ZipInputStream zipInputStream = new ZipInputStream(byteArrayInputStream);
-
-						ZipEntry entry = zipInputStream.getNextEntry();
-						while (entry != null) {
-							log.info("Adding {} to filemap", entry.getName());
-							final String filenameNoExt = removeFileExtension(entry.getName());
-							fileMap.put(filenameNoExt, zipEntryToHttpEntity(zipInputStream));
-							entry = zipInputStream.getNextEntry();
-						}
-
-						zipInputStream.closeEntry();
-						zipInputStream.close();
-					} catch (final IOException e) {
-						final String errorMsg = "Unable to extract the contents of the zip file";
-						clientInterface.sendError(errorMsg);
-						throw new RuntimeException(errorMsg, e);
-					}
-
-					final ResponseEntity<JsonNode> textResp = extractionProxy.text(jobId);
-					if (!textResp.getStatusCode().is2xxSuccessful()) {
-						final String errorMsg = "Unable to fetch the text extractions";
-						clientInterface.sendError(errorMsg);
-						throw new RuntimeException(errorMsg);
-					}
-
-					// clear existing assets
-					document.setAssets(new ArrayList<>());
-					clientInterface.sendMessage("Uploading COSMOS extraction assets...");
-
-					int totalUploads = 0;
-
-					for (final ExtractionAssetType extractionType : ExtractionAssetType.values()) {
-						final ResponseEntity<JsonNode> response = extractionProxy.extraction(jobId,
-								extractionType.toStringPlural());
-						log.info("Extraction type {} response status: {}", extractionType, response.getStatusCode());
-						if (!response.getStatusCode().is2xxSuccessful()) {
-							log.warn("Unable to fetch the {} extractions", extractionType);
-							continue;
-						}
-
-						for (final JsonNode record : response.getBody()) {
-
-							String assetFileName = "";
-							if (record.has("img_pth")) {
-
-								final String path = record.get("img_pth").asText();
-								assetFileName = path.substring(path.lastIndexOf("/") + 1);
-								final String assetFilenameNoExt = removeFileExtension(assetFileName);
-								if (!fileMap.containsKey(assetFilenameNoExt)) {
-									log.warn("Unable to find file {} in zipfile", assetFileName);
-								}
-								final HttpEntity file = fileMap.get(assetFilenameNoExt);
-								if (file == null) {
-									throw new RuntimeException("Unable to find file " + assetFileName + " in zipfile");
-								}
-								documentService.uploadFile(documentId, assetFileName, file, ContentType.IMAGE_JPEG);
-								totalUploads++;
-
-							} else {
-								log.warn("No img_pth found in record: {}", record);
-							}
-
-							final DocumentExtraction extraction = new DocumentExtraction();
-							extraction.setFileName(assetFileName);
-							extraction.setAssetType(extractionType);
-							extraction.setMetadata(objectMapper.convertValue(record, Map.class));
-
-							document.getAssets().add(extraction);
-							clientInterface
-									.sendMessage(
-											String.format("Add COSMOS extraction %s to Document...", assetFileName));
-						}
-					}
-
-					log.info("Uploaded a total of {} files", totalUploads);
-
-					String responseText = "";
-					for (final JsonNode record : textResp.getBody()) {
-						if (record.has("content")) {
-							responseText += record.get("content").asText() + "\n";
-							document.setText(responseText);
-						} else {
-							log.warn("No content found in record: {}", record);
-						}
-					}
-
-					// update the document
-					document = documentService.updateAsset(document).get();
-
-					// if there is text, run variable extraction
-					if (!responseText.isEmpty()) {
-
-						// run variable extraction (disabled currently due to timeouts...)
-						// clientInterface.sendMessage("Dispatching variable extraction request...");
-						// document = extractVariables(documentId, true, true, domain);
-						// clientInterface.sendMessage("Variable extraction completed");
-
-						// check for input length
-						if (document.getText().length() > ModelCardResponseHandler.MAX_TEXT_SIZE) {
-							log.warn("Document {} text too long for GoLLM model card task, not sendingh request",
-									documentId);
-						} else {
-							// dispatch GoLLM model card request
-							final ModelCardResponseHandler.Input input = new ModelCardResponseHandler.Input();
-							input.setResearchPaper(document.getText());
-
-							// Create the task
-							final TaskRequest req = new TaskRequest();
-							req.setType(TaskRequest.TaskType.GOLLM);
-							req.setScript(ModelCardResponseHandler.NAME);
-							req.setInput(objectMapper.writeValueAsBytes(input));
-
-							final ModelCardResponseHandler.Properties props = new ModelCardResponseHandler.Properties();
-							props.setDocumentId(documentId);
-							req.setAdditionalProperties(props);
-
-							clientInterface.sendMessage("Sending GoLLM model card request");
-							final TaskResponse resp = taskService.runTaskSync(req);
-							if (resp.getStatus() != TaskStatus.SUCCESS) {
-								final String errorMsg = "GoLLM model card task failed";
-								clientInterface.sendError(errorMsg);
-								throw new RuntimeException(errorMsg);
-							}
-							clientInterface.sendMessage("Model Card created");
-						}
-					}
-
-					clientInterface.sendFinalMessage("Extraction complete");
-				} catch (final FeignException e) {
-					final String error = "Transitive service failure";
-					throw new ResponseStatusException(
-							HttpStatus.valueOf(e.status()),
-							error + ": " + e.getMessage());
-				} catch (final Exception e) {
-					final String error = "Unable to extract pdf";
-					log.error(error, e);
-					clientInterface.sendError("Extraction failed, unexpected error.");
-					throw new ResponseStatusException(
-							org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-							error);
+				if (document.getFileNames().isEmpty()) {
+					final String errorMsg = "No files found on document";
+					clientInterface.sendError(errorMsg);
+					throw new RuntimeException(errorMsg);
 				}
+
+				final String filename = document.getFileNames().get(0);
+
+				final byte[] documentContents = documentService.fetchFileAsBytes(documentId, filename).get();
+				clientInterface.sendMessage("File fetched, processing PDF extraction...");
+
+				final ByteMultipartFile documentFile = new ByteMultipartFile(documentContents, filename,
+						"application/pdf");
+
+				final boolean compressImages = false;
+				final boolean useCache = false;
+				final ResponseEntity<JsonNode> extractionResp = extractionProxy.processPdfExtraction(compressImages,
+						useCache, documentFile);
+
+				final JsonNode body = extractionResp.getBody();
+				final UUID jobId = UUID.fromString(body.get("job_id").asText());
+
+				final int POLLING_INTERVAL_SECONDS = 5;
+				final int MAX_EXECUTION_TIME_SECONDS = 600;
+				final int MAX_ITERATIONS = MAX_EXECUTION_TIME_SECONDS / POLLING_INTERVAL_SECONDS;
+
+				boolean jobDone = false;
+				clientInterface.sendMessage("COSMOS extraction in progress...");
+
+				for (int i = 0; i < MAX_ITERATIONS; i++) {
+
+					final ResponseEntity<JsonNode> statusResp = extractionProxy.status(jobId);
+					if (!statusResp.getStatusCode().is2xxSuccessful()) {
+						final String errorMsg = "Unable to poll status endpoint";
+						clientInterface.sendError(errorMsg);
+						throw new RuntimeException(errorMsg);
+					}
+
+					final JsonNode statusData = statusResp.getBody();
+					if (!statusData.get("error").isNull()) {
+						final String errorMsg = "Extraction job failed: " + statusData.has("error");
+						clientInterface.sendError(errorMsg);
+						throw new RuntimeException(errorMsg);
+					}
+
+					log.info("Polled status endpoint {} times:\n{}", i + 1, statusData);
+					jobDone = statusData.get("error").asBoolean() || statusData.get("job_completed").asBoolean();
+					if (jobDone) {
+						clientInterface.sendMessage("COSMOS extraction complete; processing results...");
+						break;
+					}
+					Thread.sleep(POLLING_INTERVAL_SECONDS * 1000);
+				}
+
+				if (!jobDone) {
+					final String errorMsg = "Extraction job did not complete within the expected time";
+					clientInterface.sendError(errorMsg);
+					throw new RuntimeException(errorMsg);
+				}
+
+				final ResponseEntity<byte[]> zipFileResp = extractionProxy.result(jobId);
+				if (!zipFileResp.getStatusCode().is2xxSuccessful()) {
+					final String errorMsg = "Unable to fetch the extraction result";
+					clientInterface.sendError(errorMsg);
+					throw new RuntimeException(errorMsg);
+				}
+
+				clientInterface.sendMessage("Uploading COSMOS extraction results...");
+				final String zipFileName = documentId + "_cosmos.zip";
+				documentService.uploadFile(documentId, zipFileName, new ByteArrayEntity(zipFileResp.getBody()),
+						ContentType.APPLICATION_OCTET_STREAM);
+
+				document.getFileNames().add(zipFileName);
+
+				// Open the zipfile and extract the contents
+				clientInterface.sendMessage("Extracting COSMOS extraction results...");
+				final Map<String, HttpEntity> fileMap = new HashMap<>();
+				try {
+					final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+							zipFileResp.getBody());
+					final ZipInputStream zipInputStream = new ZipInputStream(byteArrayInputStream);
+
+					ZipEntry entry = zipInputStream.getNextEntry();
+					while (entry != null) {
+						log.info("Adding {} to filemap", entry.getName());
+						final String filenameNoExt = removeFileExtension(entry.getName());
+						fileMap.put(filenameNoExt, zipEntryToHttpEntity(zipInputStream));
+						entry = zipInputStream.getNextEntry();
+					}
+
+					zipInputStream.closeEntry();
+					zipInputStream.close();
+				} catch (final IOException e) {
+					final String errorMsg = "Unable to extract the contents of the zip file";
+					clientInterface.sendError(errorMsg);
+					throw new RuntimeException(errorMsg, e);
+				}
+
+				final ResponseEntity<JsonNode> textResp = extractionProxy.text(jobId);
+				if (!textResp.getStatusCode().is2xxSuccessful()) {
+					final String errorMsg = "Unable to fetch the text extractions";
+					clientInterface.sendError(errorMsg);
+					throw new RuntimeException(errorMsg);
+				}
+
+				// clear existing assets
+				document.setAssets(new ArrayList<>());
+				clientInterface.sendMessage("Uploading COSMOS extraction assets...");
+
+				int totalUploads = 0;
+
+				for (final ExtractionAssetType extractionType : ExtractionAssetType.values()) {
+					final ResponseEntity<JsonNode> response = extractionProxy.extraction(jobId,
+							extractionType.toStringPlural());
+					log.info("Extraction type {} response status: {}", extractionType, response.getStatusCode());
+					if (!response.getStatusCode().is2xxSuccessful()) {
+						log.warn("Unable to fetch the {} extractions", extractionType);
+						continue;
+					}
+
+					for (final JsonNode record : response.getBody()) {
+
+						String assetFileName = "";
+						if (record.has("img_pth")) {
+
+							final String path = record.get("img_pth").asText();
+							assetFileName = path.substring(path.lastIndexOf("/") + 1);
+							final String assetFilenameNoExt = removeFileExtension(assetFileName);
+							if (!fileMap.containsKey(assetFilenameNoExt)) {
+								log.warn("Unable to find file {} in zipfile", assetFileName);
+							}
+							final HttpEntity file = fileMap.get(assetFilenameNoExt);
+							if (file == null) {
+								throw new RuntimeException("Unable to find file " + assetFileName + " in zipfile");
+							}
+							documentService.uploadFile(documentId, assetFileName, file, ContentType.IMAGE_JPEG);
+							totalUploads++;
+
+						} else {
+							log.warn("No img_pth found in record: {}", record);
+						}
+
+						final DocumentExtraction extraction = new DocumentExtraction();
+						extraction.setFileName(assetFileName);
+						extraction.setAssetType(extractionType);
+						extraction.setMetadata(objectMapper.convertValue(record, Map.class));
+
+						document.getAssets().add(extraction);
+						clientInterface
+								.sendMessage(
+										String.format("Add COSMOS extraction %s to Document...", assetFileName));
+					}
+				}
+
+				log.info("Uploaded a total of {} files", totalUploads);
+
+				String responseText = "";
+				for (final JsonNode record : textResp.getBody()) {
+					if (record.has("content")) {
+						responseText += record.get("content").asText() + "\n";
+						document.setText(responseText);
+					} else {
+						log.warn("No content found in record: {}", record);
+					}
+				}
+
+				// update the document
+				document = documentService.updateAsset(document).get();
+
+				// if there is text, run variable extraction
+				if (!responseText.isEmpty()) {
+
+					// run variable extraction
+					try {
+						clientInterface.sendMessage("Dispatching variable extraction request...");
+						document = extractVariables(documentId, new ArrayList<>(), domain).get();
+						clientInterface.sendMessage("Variable extraction completed");
+					} catch (final Exception e) {
+						clientInterface.sendMessage("Variable extraction failed, continuing");
+					}
+
+					// check for input length
+					if (document.getText().length() > ModelCardResponseHandler.MAX_TEXT_SIZE) {
+						log.warn("Document {} text too long for GoLLM model card task, not sendingh request",
+								documentId);
+					} else {
+						// dispatch GoLLM model card request
+						final ModelCardResponseHandler.Input input = new ModelCardResponseHandler.Input();
+						input.setResearchPaper(document.getText());
+
+						// Create the task
+						final TaskRequest req = new TaskRequest();
+						req.setType(TaskRequest.TaskType.GOLLM);
+						req.setScript(ModelCardResponseHandler.NAME);
+						req.setInput(objectMapper.writeValueAsBytes(input));
+
+						final ModelCardResponseHandler.Properties props = new ModelCardResponseHandler.Properties();
+						props.setDocumentId(documentId);
+						req.setAdditionalProperties(props);
+
+						clientInterface.sendMessage("Sending GoLLM model card request");
+						final TaskResponse resp = taskService.runTaskSync(req);
+						if (resp.getStatus() != TaskStatus.SUCCESS) {
+							final String errorMsg = "GoLLM model card task failed";
+							clientInterface.sendError(errorMsg);
+							throw new RuntimeException(errorMsg);
+						}
+						clientInterface.sendMessage("Model Card created");
+					}
+				}
+
+				clientInterface.sendFinalMessage("Extraction complete");
+
+				// return the final document
+				return documentService.updateAsset(document).orElseThrow();
+
+			} catch (final FeignException e) {
+				final String error = "Transitive service failure";
+				log.error(error, e.contentUTF8(), e);
+				throw new ResponseStatusException(
+						e.status() < 100 ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.valueOf(e.status()),
+						error + ": " + e.getMessage());
+			} catch (final Exception e) {
+				final String error = "Unable to extract pdf";
+				log.error(error, e);
+				clientInterface.sendError("Extraction failed, unexpected error.");
+				throw new ResponseStatusException(
+						org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+						error);
 			}
 		});
 	}
 
-	public void extractVariables(final UUID documentId, final List<UUID> modelIds, final String domain) {
+	public Future<DocumentAsset> extractVariables(final UUID documentId, final List<UUID> modelIds,
+			final String domain) {
 
 		// Set up the client interface
 		final String userId = currentUserService.get().getId();
 		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
-			HALFTIME_SECONDS);
+				HALFTIME_SECONDS);
 
-		executor.execute(new Runnable() {
-			 @Override
-			 public void run() {
+		return executor.submit(() -> {
 
-				 clientInterface.sendMessage("Starting variable extraction.");
-				 try {
-					 // Fetch the text from the document
-					 DocumentAsset document = documentService.getAsset(documentId).orElseThrow();
-					 clientInterface.sendMessage("Document found, fetching text.");
-					 if (document.getText() == null || document.getText().isEmpty()) {
-						 throw new RuntimeException("No text found in paper document");
-					 }
+			clientInterface.sendMessage("Starting variable extraction.");
+			try {
+				// Fetch the text from the document
+				final DocumentAsset document = documentService.getAsset(documentId).orElseThrow();
+				clientInterface.sendMessage("Document found, fetching text.");
+				if (document.getText() == null || document.getText().isEmpty()) {
+					throw new RuntimeException("No text found in paper document");
+				}
 
-					 // add optional models
-					 final List<Model> models = new ArrayList<>();
-					 for (final UUID modelId : modelIds) {
-						 models.add(modelService.getAsset(modelId).orElseThrow());
-					 }
-					 clientInterface.sendMessage("Model(s) found, added to extraction request.");
+				// add optional models
+				final List<Model> models = new ArrayList<>();
+				for (final UUID modelId : modelIds) {
+					models.add(modelService.getAsset(modelId).orElseThrow());
+				}
+				clientInterface.sendMessage("Model(s) found, added to extraction request.");
 
-					 // Create a collection to hold the variable extractions
-					 JsonNode collection = null;
+				// Create a collection to hold the variable extractions
+				JsonNode collection = null;
 
-					 clientInterface.sendMessage("Sending request to be processes by SKEMA and MIT.");
-					 final IntegratedTextExtractionsBody body = new IntegratedTextExtractionsBody(document.getText(), models);
-					 final ResponseEntity<JsonNode> resp = skemaUnifiedProxy.integratedTextExtractions(body);
+				clientInterface.sendMessage("Sending request to be processes by SKEMA and MIT.");
 
-					 clientInterface.sendMessage("Response received.");
-					 if (resp.getStatusCode().is2xxSuccessful()) {
-						 for (final JsonNode output : resp.getBody().get("outputs")) {
-							 if (!output.has("errors") || output.get("errors").isEmpty()) {
-								 collection = output.get("data");
-								 break;
-							 }
-						 }
-					 } else {
-						 throw new RuntimeException("non successful response.");
-					 }
+				final IntegratedTextExtractionsBody body = new IntegratedTextExtractionsBody(
+						document.getText(),
+						models);
 
-					 if (collection == null) {
-						 throw new RuntimeException("No variables extractions returned");
-					 }
+				log.info("Sending variable extraction request to SKEMA");
+				final ResponseEntity<JsonNode> resp = skemaUnifiedProxy.integratedTextExtractions(true, true, body);
 
-					 clientInterface.sendMessage("Organizing and saving the extractions.");
-					 final List<JsonNode> attributes = new ArrayList<>();
-					 for (final JsonNode attribute : collection.get("attributes")) {
-						 attributes.add(attribute);
-					 }
+				clientInterface.sendMessage("Response received.");
+				if (resp.getStatusCode().is2xxSuccessful()) {
+					for (final JsonNode output : resp.getBody().get("outputs")) {
+						if (!output.has("errors") || output.get("errors").isEmpty()) {
+							collection = output.get("data");
+							break;
+						}
+					}
+				} else {
+					throw new RuntimeException("non successful response.");
+				}
 
-					 // add the attributes to the metadata
-					 if (document.getMetadata() == null) {
-						 document.setMetadata(new HashMap<>());
-					 }
-					 document.getMetadata().put("attributes", attributes);
+				if (collection == null) {
+					throw new RuntimeException("No variables extractions returned");
+				}
 
-					 // update the document
-					 documentService.updateAsset(document).orElseThrow();
+				clientInterface.sendMessage("Organizing and saving the extractions.");
+				final List<JsonNode> attributes = new ArrayList<>();
+				for (final JsonNode attribute : collection.get("attributes")) {
+					attributes.add(attribute);
+				}
 
-				 } catch (final Exception e) {
-					 final String error = "SKEMA unified integrated-text-extractions request from document: " + documentId + " failed.";
-					 log.error(error, e); // FIXME - Is this handle by the clientInterface.sendError?
-					 clientInterface.sendError(error + " — " + e.getMessage());
-					 throw new ResponseStatusException(
-						 org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-						 error);
-				 }
-		}
+				// add the attributes to the metadata
+				if (document.getMetadata() == null) {
+					document.setMetadata(new HashMap<>());
+				}
+				document.getMetadata().put("attributes", attributes);
+
+				if (modelIds.size() > 0) {
+					for (final UUID modelId : modelIds) {
+						clientInterface.sendMessage("Attempting to align models for model: " + modelId);
+						try {
+							alignAMR(documentId, modelId).get();
+							clientInterface.sendMessage("Model " + modelId + " aligned successfully");
+						} catch (final Exception e) {
+							clientInterface.sendMessage("Failed to align model: " + modelId + ", continuing...");
+						}
+					}
+				}
+
+				clientInterface.sendFinalMessage("Extraction complete");
+
+				// update the document
+				return documentService.updateAsset(document).orElseThrow();
+
+			} catch (final FeignException e) {
+				final String error = "Transitive service failure";
+				log.error(error, e.contentUTF8(), e);
+				throw new ResponseStatusException(
+						e.status() < 100 ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.valueOf(e.status()),
+						error + ": " + e.getMessage());
+			} catch (final Exception e) {
+				final String error = "SKEMA unified integrated-text-extractions request from document: "
+						+ documentId + " failed.";
+				log.error(error, e);
+				clientInterface.sendError(error + " — " + e.getMessage());
+				throw new ResponseStatusException(
+						org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+						error);
+			}
+		});
+	}
+
+	public Future<Model> alignAMR(final UUID documentId, final UUID modelId) {
+
+		final String userId = currentUserService.get().getId();
+		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
+				HALFTIME_SECONDS);
+
+		return executor.submit(() -> {
+			try {
+				clientInterface.sendMessage("Starting model alignment...");
+
+				final DocumentAsset document = documentService.getAsset(documentId).orElseThrow();
+
+				final Model model = modelService.getAsset(modelId).orElseThrow();
+
+				final String modelString = objectMapper.writeValueAsString(model);
+				final String extractionsString = objectMapper.writeValueAsString(document.getMetadata());
+
+				// final String extractionsString = objectMapper
+				// .writeValueAsString(
+				// document.getMetadata().get("attributes") != null
+				// ? document.getMetadata().get("attributes")
+				// : new HashMap<>());
+
+				final StringMultipartFile amrFile = new StringMultipartFile(
+						modelString,
+						"amr.json",
+						"application/json");
+				final StringMultipartFile extractionFile = new StringMultipartFile(
+						extractionsString,
+						"extractions.json",
+						"application/json");
+
+				final ResponseEntity<JsonNode> res;
+				try {
+					res = skemaUnifiedProxy.linkAMRFile(amrFile, extractionFile);
+				} catch (final FeignException e) {
+					final String error = "Transitive service failure";
+					log.error(error, e.contentUTF8(), e);
+					throw new ResponseStatusException(
+							e.status() < 100 ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.valueOf(e.status()),
+							error + ": " + e.getMessage());
+				}
+				if (!res.getStatusCode().is2xxSuccessful()) {
+					throw new ResponseStatusException(
+							res.getStatusCode(),
+							"Unable to link AMR file");
+				}
+
+				final JsonNode modelJson = objectMapper.valueToTree(model);
+
+				// overwrite all updated fields
+				JsonUtil.recursiveSetAll((ObjectNode) modelJson, res.getBody());
+
+				// update the model
+				modelService.updateAsset(model);
+
+				// create provenance
+				final Provenance provenance = new Provenance(ProvenanceRelationType.EXTRACTED_FROM, modelId,
+						ProvenanceType.MODEL,
+						documentId, ProvenanceType.DOCUMENT);
+				provenanceService.createProvenance(provenance);
+
+				return model;
+
+			} catch (final FeignException e) {
+				final String error = "Transitive service failure";
+				log.error(error, e.contentUTF8(), e);
+				throw new ResponseStatusException(
+						e.status() < 100 ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.valueOf(e.status()),
+						error + ": " + e.getMessage());
+			} catch (final Exception e) {
+				final String error = "SKEMA link_amr request from document: "
+						+ documentId + " failed.";
+				log.error(error, e);
+				clientInterface.sendError(error + " — " + e.getMessage());
+				throw new ResponseStatusException(
+						org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+						error);
+			}
 		});
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -499,13 +499,17 @@ public class ExtractionService {
 				final Model model = modelService.getAsset(modelId).orElseThrow();
 
 				final String modelString = objectMapper.writeValueAsString(model);
-				final String extractionsString = objectMapper.writeValueAsString(document.getMetadata());
 
-				// final String extractionsString = objectMapper
-				// .writeValueAsString(
-				// document.getMetadata().get("attributes") != null
-				// ? document.getMetadata().get("attributes")
-				// : new HashMap<>());
+				if (document.getMetadata().get("attributes") == null) {
+					throw new RuntimeException("No attributes found in document");
+				}
+
+				final JsonNode attributes = objectMapper.valueToTree(document.getMetadata().get("attributes"));
+
+				final ObjectNode extractions = objectMapper.createObjectNode();
+				extractions.set("attributes", attributes);
+
+				final String extractionsString = objectMapper.writeValueAsString(extractions);
 
 				final StringMultipartFile amrFile = new StringMultipartFile(
 						modelString,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -362,13 +362,19 @@ public class ExtractionService {
 		});
 	}
 
-	public DocumentAsset extractVariables(final UUID documentId, final List<UUID> modelIds, final Boolean annotateSkema,
+	public void extractVariables(final UUID documentId, final List<UUID> modelIds, final Boolean annotateSkema,
 			final Boolean annotateMIT,
 			final String domain) {
 
 		final String userId = currentUserService.get().getId();
 		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
 			HALFTIME_SECONDS);
+
+		executor.execute(new Runnable() {
+			 @Override
+			 public void run() {
+			 }
+		});
 
 		/*
 		DocumentAsset document = documentService.getAsset(documentId).orElseThrow();

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -55,6 +55,10 @@ public class ExtractionService {
 	final ObjectMapper objectMapper;
 	final ClientEventService clientEventService;
 	final TaskService taskService;
+	private final CurrentUserService currentUserService;
+
+	// time the progress takes to reach each subsequent half
+	final Double HALFTIME_SECONDS = 2.0;
 
 	@Value("${mit-openai-api-key:}")
 	String MIT_OPENAI_API_KEY;
@@ -118,11 +122,9 @@ public class ExtractionService {
 		return filename;
 	}
 
-	public void extractPDF(final UUID documentId, final String userId, final String domain) {
+	public void extractPDF(final UUID documentId, final String domain) {
 
-		// time the progress takes to reach each subsequent half
-		final Double HALFTIME_SECONDS = 2.0;
-
+		final String userId = currentUserService.get().getId();
 		final ClientEventInterface clientInterface = new ClientEventInterface(clientEventService, documentId, userId,
 				HALFTIME_SECONDS);
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeControllerTests.java
@@ -18,7 +18,6 @@ import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -82,7 +81,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		elasticService.deleteIndex(elasticConfig.getDocumentIndex());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void equationsToModelRegNet() throws Exception {
 
@@ -135,7 +134,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		log.info(regnetModelId.toString());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void equationsToModelPetrinet() throws Exception {
 
@@ -188,7 +187,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		log.info(petrinetModelId.toString());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void base64EquationsToAMRTests() throws Exception {
 
@@ -220,7 +219,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		log.info(amr.toString());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void base64EquationsToLatexTests() throws Exception {
 
@@ -252,7 +251,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		log.info(latex);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void variableExtractionTests() throws Exception {
 
@@ -271,7 +270,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 				.andExpect(status().isAccepted());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void variableExtractionWithModelTests() throws Exception {
 
@@ -297,7 +296,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 				.andExpect(status().isAccepted());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void linkAmrTests() throws Exception {
 
@@ -330,7 +329,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		Assertions.assertTrue(model != null);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void cosmosPdfExtraction() throws Exception {
 
@@ -356,7 +355,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 				.andExpect(status().isAccepted());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void profileModel() throws Exception {
 
@@ -404,7 +403,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		Assertions.assertTrue(model.getMetadata().getCard() != null);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void profileDataset() throws Exception {
 
@@ -474,7 +473,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		Assertions.assertTrue(dataset.getMetadata().get("dataCard") != null);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void codeToAmrTest() throws Exception {
 
@@ -508,7 +507,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		Assertions.assertTrue(model != null);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void codeToAmrTestLLM() throws Exception {
 
@@ -543,7 +542,7 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 		Assertions.assertTrue(model != null);
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void codeToAmrTestDynamicsOnly() throws Exception {
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/ExtractionServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/ExtractionServiceTests.java
@@ -10,7 +10,6 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.test.context.support.WithUserDetails;
@@ -58,7 +57,7 @@ public class ExtractionServiceTests extends TerariumApplicationTests {
 		elasticService.deleteIndex(elasticConfig.getDocumentIndex());
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void variableExtractionTests() throws Exception {
 
@@ -72,7 +71,7 @@ public class ExtractionServiceTests extends TerariumApplicationTests {
 		documentAsset = extractionService.extractVariables(documentAsset.getId(), new ArrayList<>(), "epi").get();
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void variableExtractionWithModelTests() throws Exception {
 
@@ -93,7 +92,7 @@ public class ExtractionServiceTests extends TerariumApplicationTests {
 				.get();
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void linkAmrTests() throws Exception {
 
@@ -115,7 +114,7 @@ public class ExtractionServiceTests extends TerariumApplicationTests {
 		model = extractionService.alignAMR(documentAsset.getId(), model.getId()).get();
 	}
 
-	@Test
+	// @Test
 	@WithUserDetails(MockUser.URSULA)
 	public void cosmosPdfExtraction() throws Exception {
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/ExtractionServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/ExtractionServiceTests.java
@@ -1,0 +1,140 @@
+package software.uncharted.terarium.hmiserver.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.test.context.support.WithUserDetails;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
+import software.uncharted.terarium.hmiserver.configuration.ElasticsearchConfiguration;
+import software.uncharted.terarium.hmiserver.configuration.MockUser;
+import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
+import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
+import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
+import software.uncharted.terarium.hmiserver.service.data.ModelService;
+import software.uncharted.terarium.hmiserver.service.elasticsearch.ElasticsearchService;
+
+@Slf4j
+public class ExtractionServiceTests extends TerariumApplicationTests {
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private DocumentAssetService documentAssetService;
+
+	@Autowired
+	private ModelService modelService;
+
+	@Autowired
+	private ElasticsearchService elasticService;
+
+	@Autowired
+	private ExtractionService extractionService;
+
+	@Autowired
+	private ElasticsearchConfiguration elasticConfig;
+
+	@BeforeEach
+	public void setup() throws IOException {
+		elasticService.createOrEnsureIndexIsEmpty(elasticConfig.getDocumentIndex());
+	}
+
+	@AfterEach
+	public void teardown() throws IOException {
+		elasticService.deleteIndex(elasticConfig.getDocumentIndex());
+	}
+
+	@Test
+	@WithUserDetails(MockUser.URSULA)
+	public void variableExtractionTests() throws Exception {
+
+		DocumentAsset documentAsset = new DocumentAsset()
+				.setName("test-document-name")
+				.setDescription("my description")
+				.setText("x = 0. y = 1. I = Infected population.");
+
+		documentAsset = documentAssetService.createAsset(documentAsset);
+
+		documentAsset = extractionService.extractVariables(documentAsset.getId(), new ArrayList<>(), "epi").get();
+	}
+
+	@Test
+	@WithUserDetails(MockUser.URSULA)
+	public void variableExtractionWithModelTests() throws Exception {
+
+		DocumentAsset documentAsset = new DocumentAsset()
+				.setName("test-document-name")
+				.setDescription("my description")
+				.setText("x = 0. y = 1. I = Infected population.");
+
+		documentAsset = documentAssetService.createAsset(documentAsset);
+
+		final ClassPathResource resource = new ClassPathResource("knowledge/sir.json");
+		final byte[] content = Files.readAllBytes(resource.getFile().toPath());
+		Model model = objectMapper.readValue(content, Model.class);
+
+		model = modelService.createAsset(model);
+
+		documentAsset = extractionService.extractVariables(documentAsset.getId(), List.of(model.getId()), "epi")
+				.get();
+	}
+
+	@Test
+	@WithUserDetails(MockUser.URSULA)
+	public void linkAmrTests() throws Exception {
+
+		DocumentAsset documentAsset = new DocumentAsset()
+				.setName("test-document-name")
+				.setDescription("my description")
+				.setText("x = 0. y = 1. I = Infected population.");
+
+		documentAsset = documentAssetService.createAsset(documentAsset);
+
+		documentAsset = extractionService.extractVariables(documentAsset.getId(), new ArrayList<>(), "epi").get();
+
+		final ClassPathResource resource = new ClassPathResource("knowledge/sir.json");
+		final byte[] content = Files.readAllBytes(resource.getFile().toPath());
+		Model model = objectMapper.readValue(content, Model.class);
+
+		model = modelService.createAsset(model);
+
+		model = extractionService.alignAMR(documentAsset.getId(), model.getId()).get();
+	}
+
+	@Test
+	@WithUserDetails(MockUser.URSULA)
+	public void cosmosPdfExtraction() throws Exception {
+
+		final ClassPathResource resource = new ClassPathResource("knowledge/paper.pdf");
+		final byte[] content = Files.readAllBytes(resource.getFile().toPath());
+
+		final HttpEntity pdfFileEntity = new ByteArrayEntity(content, ContentType.create("application/pdf"));
+
+		DocumentAsset documentAsset = new DocumentAsset()
+				.setName("test-pdf-name")
+				.setDescription("my description")
+				.setFileNames(List.of("paper.pdf"));
+
+		documentAsset = documentAssetService.createAsset(documentAsset);
+
+		documentAssetService.uploadFile(documentAsset.getId(), "paper.pdf", pdfFileEntity,
+				ContentType.create("application/pdf"));
+
+		documentAsset = extractionService.extractPDF(documentAsset.getId(), "epi").get();
+	}
+
+}


### PR DESCRIPTION
# Description

* Clean up some issue with the scenario form
* Update how we call the knowledgeController
* Move the extraction call into a runnable like PDF extraction
* Remove the optionals `annotateSkema` and `annotateMit` as Skema unified has them on by default.
* Remove the call to MIT as this is handle by the Skeme unified endpoint
* TODO - Move the align AMR into the extractionService
* TODO - Call align AMR after variable extraction if a model was provided
* TODO - Getting 500 when calling  SKEMA unified`link_amr`
