### PR TITLE
Jamie fix calibrate ensemble mapping columns

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -12,7 +12,7 @@
 					<AccordionTab header="Model weights">
 						<div class="model-weights">
 							<!-- Turn this into a horizontal bar chart -->
-							<section class="ensemble-calibration-graph">
+							<section>
 								<table class="p-datatable-table">
 									<thead class="p-datatable-thead">
 										<th>Model config ID</th>
@@ -48,15 +48,14 @@
 					<AccordionTab header="Mapping">
 						<label> Dataset timestamp column </label>
 						<Dropdown
-							style="width: 50%"
 							v-model="knobs.timestampColName"
 							:options="datasetColumnNames"
 							placeholder="Timestamp column"
 						/>
 						<template v-if="knobs.ensembleConfigs.length > 0">
-							<table>
+							<table class="w-full mt-3">
 								<tr>
-									<th>Ensemble variables</th>
+									<th class="w-4">Ensemble variables</th>
 									<!-- Index matching listModelLabels and ensembleConfigs-->
 									<th v-for="(element, i) in listModelLabels" :key="i">
 										{{ element }}
@@ -79,6 +78,7 @@
 											<Dropdown
 												v-model="knobs.ensembleConfigs[i - 1].solutionMappings[element]"
 												:options="allModelOptions[i - 1]?.map((ele) => ele.id)"
+												class="w-full mb-2 mt-2"
 											/>
 										</template>
 									</td>
@@ -86,7 +86,7 @@
 							</table>
 						</template>
 						<Dropdown
-							style="width: 50%"
+							class="mr-2"
 							v-model="newSolutionMappingKey"
 							:options="datasetColumnNames"
 							placeholder="Variable name"

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -51,6 +51,7 @@
 							v-model="knobs.timestampColName"
 							:options="datasetColumnNames"
 							placeholder="Timestamp column"
+							class="ml-2"
 						/>
 						<template v-if="knobs.ensembleConfigs.length > 0">
 							<table class="w-full mt-3">
@@ -418,12 +419,6 @@ watch(
 	z-index: 1;
 }
 
-.ensemble-calibration-graph {
-	/* margin-left: 1rem; */
-	height: 200px;
-	/* width: 80%; */
-}
-
 .model-weights {
 	display: flex;
 }
@@ -439,7 +434,7 @@ th {
 
 th,
 td {
-	padding-left: 15px;
+	padding-left: 0px;
 }
 
 .ensemble-header-label {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -434,7 +434,7 @@ th {
 
 th,
 td {
-	padding-left: 0px;
+	padding-left: 0;
 }
 
 .ensemble-header-label {


### PR DESCRIPTION
I made this prettier. Heads up, the code is pretty hacky. It's an HTML table that is only one row, with loops generating multiple elements within each <td>. I didn't change anything... just aligned stuff better.

**BEFORE**
![image](https://github.com/DARPA-ASKEM/terarium/assets/120480244/1717a825-a059-4239-812e-8feb3ef04f5e)


**AFTER**
![Monosnap Terarium 2024-03-27 14-54-14](https://github.com/DARPA-ASKEM/terarium/assets/120480244/c0481585-d583-4b4b-baf0-425c87c3c755)
