### PR TITLE
fix ciemss calibrate output switching

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -156,7 +156,6 @@ watch(
 		const response = await pollResult(id);
 		if (response.state === PollerState.Done) {
 			const state = _.cloneDeep(props.node.state);
-
 			state.chartConfigs = [[]];
 			state.inProgressForecastId = '';
 			state.forecastId = id;
@@ -166,7 +165,13 @@ watch(
 			emit('append-output', {
 				type: 'calibrateSimulationId',
 				label: `${portLabel} Result`,
-				value: [state.calibrationId]
+				value: [state.calibrationId],
+				state: {
+					calibrationId: state.calibrationId,
+					forecastId: state.forecastId,
+					numIterations: state.numIterations,
+					numSamples: state.numSamples
+				}
 			});
 		}
 	},


### PR DESCRIPTION
### Summary
Fix problem where the chart is stuck when switching output in ciemss-calibrate, this is because the state is not written to the output properly.