### PR TITLE
fix[hmi-server]: Download netcdf assets

### DIFF
--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-search-results-list.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-search-results-list.vue
@@ -89,7 +89,7 @@ import { logger } from '@/utils/logger';
 import { isEmpty } from 'lodash';
 import { computed, PropType, Ref, ref } from 'vue';
 import { Vue3Lottie } from 'vue3-lottie';
-import { createDataset } from '@/services/dataset';
+import { createDataset, getClimateDataset } from '@/services/dataset';
 import TeraSearchItem from './tera-search-item.vue';
 
 const { searchByExampleItem } = useSearchByExampleOptions();
@@ -151,9 +151,15 @@ const projectOptions = computed(() => [
 						let datasetId = selectedAsset.value.id;
 
 						if (!datasetId && selectedAsset.value.esgfId) {
-							const dataset: Dataset | null = await createDataset(selectedAsset.value);
-							if (dataset) {
-								datasetId = dataset.id;
+							// The selectedAsset is a light asset for front end and we need the whole thing.
+							const climateDataset: Dataset | null = await getClimateDataset(
+								selectedAsset.value.esgfId
+							);
+							if (climateDataset) {
+								const dataset: Dataset | null = await createDataset(climateDataset);
+								if (dataset) {
+									datasetId = dataset.id;
+								}
 							}
 						}
 

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -160,6 +160,7 @@ export interface Dataset extends TerariumAsset {
     dataSourceDate?: Date;
     fileNames?: string[];
     datasetUrl?: string;
+    datasetUrls?: string[];
     columns?: DatasetColumn[];
     metadata?: any;
     source?: string;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/dataset/Dataset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/dataset/Dataset.java
@@ -1,10 +1,5 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.dataset;
 
-import java.io.Serial;
-import java.sql.Timestamp;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
@@ -14,6 +9,10 @@ import software.uncharted.terarium.hmiserver.annotations.TSModel;
 import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 import software.uncharted.terarium.hmiserver.models.TerariumAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.Grounding;
+
+import java.io.Serial;
+import java.sql.Timestamp;
+import java.util.List;
 
 /**
  * Represents a dataset document from TDS
@@ -65,10 +64,17 @@ public class Dataset extends TerariumAsset {
 
 	/**
 	 * (Optional) Url from which the dataset can be downloaded/fetched
+	 * TODO: IS THIS NEEDED? IS THIS FROM OLD TDS? https://github.com/DARPA-ASKEM/terarium/issues/3194
 	 **/
 	@TSOptional
 	@JsonAlias("dataset_url")
 	private String datasetUrl;
+
+	/**
+	 *  (Optional) List of urls from which the dataset can be downloaded/fetched. Used for ESGF datasets
+	 */
+	@TSOptional
+	private List<String> datasetUrls;
 
 	/**
 	 * Information regarding the columns that make up the dataset


### PR DESCRIPTION
# Description
Adding support for downloading the original netcdf files from the source service. If there are download urls set this will take precidence over s3 stored assets, but we _should_ never have both set as subset datasets are new datasets without the dataset urls field set.


Resolves #3206