### PR TITLE
Removed corner radius from overview text edit toolbar, removed bottom border from banner

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/input/_editor.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/input/_editor.scss
@@ -1,8 +1,8 @@
 .p-editor-container {
     .p-editor-toolbar {
         background: $editorToolbarBg;
-        border-top-right-radius: $borderRadius;
-        border-top-left-radius: $borderRadius;
+        // border-top-right-radius: $borderRadius;
+        // border-top-left-radius: $borderRadius;
 
         &.ql-snow {
             border: $editorToolbarBorder;
@@ -10,11 +10,11 @@
             .ql-stroke {
                 stroke: $editorToolbarIconColor;
             }
-    
+
             .ql-fill {
                 fill: $editorToolbarIconColor;
             }
-    
+
             .ql-picker {
                 .ql-picker-label {
                     border: 0 none;
@@ -26,7 +26,7 @@
                         .ql-stroke {
                             stroke: $editorToolbarIconHoverColor;
                         }
-                
+
                         .ql-fill {
                             fill: $editorToolbarIconHoverColor;
                         }
@@ -40,7 +40,7 @@
                         .ql-stroke {
                             stroke: $editorToolbarIconHoverColor;
                         }
-                
+
                         .ql-fill {
                             fill: $editorToolbarIconHoverColor;
                         }
@@ -55,7 +55,7 @@
 
                         .ql-picker-item {
                             color: $inputListItemTextColor;
-                            
+
                             &:hover {
                                 color: $inputListItemTextHoverColor;
                                 background: $inputListItemHoverBg;

--- a/packages/client/hmi-client/src/assets/css/theme/designer/components/input/_editor.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/designer/components/input/_editor.scss
@@ -1,8 +1,6 @@
 .p-editor-container {
     .p-editor-toolbar {
         background: $editorToolbarBg;
-        // border-top-right-radius: $borderRadius;
-        // border-top-left-radius: $borderRadius;
 
         &.ql-snow {
             border: $editorToolbarBorder;

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -209,7 +209,6 @@ header {
 	display: flex;
 	gap: var(--gap);
 	align-items: center;
-	border-bottom: 1px solid var(--surface-border-light);
 	background: var(--surface-ground);
 }
 

--- a/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-project-overview.vue
@@ -13,7 +13,7 @@
 		</template>
 		<template #overview-summary>
 			<!-- Description & Contributors -->
-			<p class="mt-1 mb-1">
+			<p class="overview-description">
 				{{ useProjects().activeProject.value?.description }}
 			</p>
 		</template>
@@ -33,3 +33,9 @@ import teraProjectOverviewEditor from '@/components/home/tera-project-overview-e
 
 const isRenamingProject = ref(false);
 </script>
+<style scoped>
+.overview-description {
+	margin-bottom: var(--gap-xsmall);
+	color: var(--text-color-primary);
+}
+</style>


### PR DESCRIPTION
Removed top left and right corner radius from text editor toolbar and removed bottom border from banner (not needed, looked weird).

**BEFORE**
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/0d9d8b66-d559-4746-8e9a-ac0fbc9fdd1a)
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/44dac068-80d6-4e04-81ca-42d6d16c26f8)

**AFTER**
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/5f17e644-8137-4ea1-b159-ff1eb754c7f9)
