### PR TITLE
Darkened operator annotation text, removed indent

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
@@ -75,7 +75,7 @@ header > * {
 header .tabs-row {
 	justify-content: space-between;
 	align-items: end;
-	gap: var(--gap-small);
+	gap: var(--gap);
 }
 
 header .tabs-row:deep(.p-tabview .p-tabview-panels) {

--- a/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
@@ -98,7 +98,7 @@ section {
 		justify-content: space-between;
 		width: 100%;
 		font-size: var(--font-caption);
-		color: var(--text-color-subdued);
+		color: var(--text-color-primary);
 		cursor: text;
 	}
 
@@ -119,7 +119,6 @@ section {
 	/* In drilldown */
 	&:not(.in-node) {
 		padding-bottom: var(--gap-small);
-		padding-left: var(--gap-small);
 		border-radius: var(--border-radius);
 		gap: var(--gap-small);
 		& > textarea {


### PR DESCRIPTION
Operator node and drill-down header annotation text has been darkened (changed from subdued to primary). Removed the unwanted indentation on a drill-down header annotation when there are no tabs in the header. 

**BEFORE**
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/2670f8fe-1c2a-4003-a5c9-017781b0ad82)
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/057b95eb-225d-46d3-a017-70e052ba5fc1)


**AFTER**
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/41d4b0a8-69e8-423c-bba6-21586da58973)
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/12ee0a6a-1eca-4526-9ccd-69ceae45a0f6)
![image](https://github.com/DARPA-ASKEM/terarium/assets/141876103/64d1a077-bf39-41b8-8603-06285f57e9dc)


