### PR TITLE
refactor: operator annotation in drilldown component instead of within every operator

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -7,9 +7,14 @@
 				:tooltip="tooltip"
 				@tab-change="handleTabChange"
 				@close="emit('on-close-clicked')"
-				>{{ props.title }}
+			>
+				{{ title ?? node.displayName }}
 				<template #actions>
 					<slot name="header-actions" />
+					<tera-operator-annotation
+						:state="node.state"
+						@update-state="(state: any) => emit('update-state', state)"
+					/>
 				</template>
 			</tera-drilldown-header>
 			<tera-columnar-panel>
@@ -38,9 +43,12 @@ import TeraDrilldownHeader from '@/components/drilldown/tera-drilldown-header.vu
 import { TabViewChangeEvent } from 'primevue/tabview';
 import { computed, ref, useSlots } from 'vue';
 import TeraColumnarPanel from '@/components/widgets/tera-columnar-panel.vue';
+import { WorkflowNode } from '@/types/workflow';
+import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
 
 const props = defineProps<{
-	title: string;
+	node: WorkflowNode;
+	title?: string;
 	tooltip?: string;
 	popover?: boolean;
 }>();

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -47,13 +47,13 @@ import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
 
 const props = defineProps<{
-	node: WorkflowNode;
+	node: WorkflowNode<any>;
 	title?: string;
 	tooltip?: string;
 	popover?: boolean;
 }>();
 
-const emit = defineEmits(['on-close-clicked']);
+const emit = defineEmits(['on-close-clicked', 'update-state']);
 const slots = useSlots();
 
 /**

--- a/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/page/project/components/tera-resource-sidebar.vue
@@ -60,30 +60,14 @@
 						<!-- New asset buttons for some types -->
 						<Button
 							class="new-button"
-							v-if="type === AssetType.Model"
+							v-if="
+								type === AssetType.Model || type === AssetType.Code || type === AssetType.Workflow
+							"
 							icon="pi pi-plus"
 							label="New"
 							text
 							size="small"
-							@click.stop="emit('open-new-asset', AssetType.Model)"
-						/>
-						<Button
-							class="new-button"
-							v-if="type === AssetType.Code"
-							icon="pi pi-plus"
-							label="New"
-							text
-							size="small"
-							@click.stop="emit('open-new-asset', AssetType.Code)"
-						/>
-						<Button
-							class="new-button"
-							v-if="type === AssetType.Workflow"
-							icon="pi pi-plus"
-							label="New"
-							text
-							size="small"
-							@click.stop="emit('open-new-asset', AssetType.Workflow)"
+							@click.stop="emit('open-new-asset', type)"
 						/>
 					</div>
 				</template>
@@ -294,14 +278,15 @@ header {
 }
 
 .new-button {
-	width: 6rem;
-	padding: 0rem 0.25rem 0 0.25rem !important;
-	margin-right: -0.75rem;
+	&:deep() {
+		padding: 0 var(--gap-xsmall);
+	}
+
+	&:deep(.pi-plus) {
+		font-size: 0.75rem;
+	}
 }
 
-.new-button:deep(.p-button-icon) {
-	margin-right: -0.5rem !important;
-}
 .dragged-asset {
 	background-color: var(--surface-highlight);
 	border-radius: var(--border-radius);
@@ -397,10 +382,6 @@ header {
 	margin-right: 0.5rem;
 }
 
-:deep(.pi-plus) {
-	font-size: 0.75rem !important;
-	padding-top: 2px;
-}
 .skeleton-container {
 	display: flex;
 	flex-direction: column;

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -94,7 +94,7 @@ export interface WorkflowOutput<S> extends WorkflowPort {
 
 // Common state properties for all operators
 export interface BaseState {
-	annotation: string;
+	annotation?: string;
 }
 
 // Node definition in the workflow

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -92,6 +92,11 @@ export interface WorkflowOutput<S> extends WorkflowPort {
 	timestamp?: Date;
 }
 
+// Common state properties for all operators
+export interface BaseState {
+	annotation: string;
+}
+
 // Node definition in the workflow
 // This is the graphical operation of the operation defined in operationType
 export interface WorkflowNode<S> {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -1,7 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import { CalibrateMap } from '@/services/calibrate-workflow';
 
-export interface CalibrationOperationStateCiemss {
+export interface CalibrationOperationStateCiemss extends BaseState {
 	chartConfigs: string[][];
 	mapping: CalibrateMap[];
 	simulationsInProgress: string[];

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="CalibrateTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<div class="form-section">
@@ -188,7 +186,7 @@ import TeraSimulateChart from '@/workflow/tera-simulate-chart.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import type { EnsembleModelConfigs } from '@/types/Types';
 
 export interface EnsembleCalibrateExtraCiemss {
@@ -7,7 +7,7 @@ export interface EnsembleCalibrateExtraCiemss {
 	numIterations: number;
 }
 
-export interface CalibrateEnsembleCiemssOperationState {
+export interface CalibrateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
 	ensembleConfigs: EnsembleModelConfigs[];
 	timestampColName: string;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="CalibrateEnsembleTabs.Wizard">
 			<tera-drilldown-section class="ml-3 mr-2 pt-2">
 				<Accordion :multiple="true" :active-index="[0, 1, 2]">
@@ -204,7 +202,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { chartActionsProxy, drilldownChartSize, getTimespan } from '@/workflow/util';
 import type {
 	CsvAsset,

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/calibrate-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
 export interface CalibrateMap {
 	modelVariable: string;
@@ -18,7 +18,7 @@ export enum CalibrateMethodOptions {
 	GLOBAL = 'global'
 }
 
-export interface CalibrationOperationStateJulia {
+export interface CalibrationOperationStateJulia extends BaseState {
 	// state shared across all runs
 	chartConfigs: string[][];
 	mapping: CalibrateMap[];

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="CalibrateTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<div class="form-section">
@@ -228,7 +226,7 @@ import { csvParse } from 'd3';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { getTimespan, chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 import { useToastService } from '@/services/toast';
 import {

--- a/packages/client/hmi-client/src/workflow/ops/code-asset/code-asset-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/code-asset-operation.ts
@@ -1,6 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { WorkflowOperationTypes } from '@/types/workflow';
+import type { Operation, BaseState } from '@/types/workflow';
 
-export interface CodeAssetState {
+export interface CodeAssetState extends BaseState {
 	codeAssetId: string | null;
 }
 

--- a/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-wrapper.vue
+++ b/packages/client/hmi-client/src/workflow/ops/code-asset/tera-code-asset-wrapper.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section>
 			<tera-code
 				:asset-id="node.state?.codeAssetId ?? ''"
@@ -23,7 +21,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import { cloneDeep } from 'lodash';
 import type { Code } from '@/types/Types';
 import { getCodeBlocks } from '@/utils/code-asset';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { CodeAssetState } from './code-asset-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/dataset-transformer/dataset-transformer-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/dataset-transformer/dataset-transformer-operation.ts
@@ -1,6 +1,6 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface DatasetTransformerState {
+export interface DatasetTransformerState extends BaseState {
 	datasetId: string | null;
 	notebookSessionId?: string;
 }

--- a/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div class="background">
 			<Suspense>
 				<tera-dataset-jupyter-panel
@@ -31,7 +29,7 @@ import type { NotebookSession } from '@/types/Types';
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { DatasetTransformerState } from './dataset-transformer-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/dataset/dataset-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/dataset-operation.ts
@@ -1,6 +1,6 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface DatasetOperationState {
+export interface DatasetOperationState extends BaseState {
 	datasetId: string | null;
 }
 

--- a/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/dataset/tera-dataset-drilldown.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section tabName="Description" class="ml-3 mr-3">
 			<tera-drilldown-section :is-loading="fetchingDataset" class="pt-2">
 				<tera-dataset-description :dataset="dataset" :raw-content="rawContent" :image="image" />
@@ -31,7 +29,7 @@ import TeraDatasetDescription from '@/components/dataset/tera-dataset-descriptio
 import { downloadRawFile, getClimateDatasetPreview, getDataset } from '@/services/dataset';
 import { enrichDataset } from '@/components/dataset/utils';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { DatasetOperationState } from './dataset-operation';
 
 const dataset = ref<Dataset | null>(null);

--- a/packages/client/hmi-client/src/workflow/ops/decapodes/decapodes-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/decapodes/decapodes-operation.ts
@@ -1,10 +1,10 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
 export interface CodeHistory {
 	code: string;
 	timestamp: number;
 }
-export interface DecapodesOperationState {
+export interface DecapodesOperationState extends BaseState {
 	codeHistory: CodeHistory[];
 }
 

--- a/packages/client/hmi-client/src/workflow/ops/decapodes/tera-decapodes-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/decapodes/tera-decapodes-drilldown.vue
@@ -1,6 +1,10 @@
 <!-- FIXME: decapodes with LLM isnt entirely functional, this is more of a placeholder at the moment -->
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<template #header-actions>
 			<tera-output-dropdown
 				@click.stop

--- a/packages/client/hmi-client/src/workflow/ops/document/document-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/document/document-operation.ts
@@ -1,7 +1,8 @@
 import type { DocumentExtraction } from '@/types/Types';
-import { Operation, AssetBlock, WorkflowOperationTypes } from '@/types/workflow';
+import type { AssetBlock, Operation, BaseState } from '@/types/workflow';
+import { WorkflowOperationTypes } from '@/types/workflow';
 
-export interface DocumentOperationState {
+export interface DocumentOperationState extends BaseState {
 	documentId: string | null;
 	equations: AssetBlock<DocumentExtraction>[];
 	tables: AssetBlock<DocumentExtraction>[];

--- a/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/document/tera-document-operation-drilldown.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div>
 			<tera-drilldown-section :is-loading="isFetchingPDF">
 				<tera-pdf-embed v-if="pdfLink" :pdf-link="pdfLink" :title="document?.name || ''" />
@@ -99,7 +97,7 @@ import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
 import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { DocumentOperationState } from './document-operation';
 
 const emit = defineEmits(['close', 'update-state', 'update-output-port']);

--- a/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import type { FunmanInterval, TimeSpan } from '@/types/Types';
 
 export interface ConstraintGroup {
@@ -24,7 +24,7 @@ export interface RequestParameter {
 	label: string;
 }
 
-export interface FunmanOperationState {
+export interface FunmanOperationState extends BaseState {
 	currentTimespan: TimeSpan;
 	numSteps: number;
 	tolerance: number;

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="FunmanTabs.Wizard" class="ml-4 mr-2 mt-3">
 			<tera-drilldown-section>
 				<main>
@@ -159,7 +157,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 
 import type {

--- a/packages/client/hmi-client/src/workflow/ops/model-comparison/model-comparison-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-comparison/model-comparison-operation.ts
@@ -1,7 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import { NotebookHistory } from '@/services/notebook';
 
-export interface ModelComparisonOperationState {
+export interface ModelComparisonOperationState extends BaseState {
 	notebookHistory: NotebookHistory[];
 	hasCodeRun: boolean;
 	comparisonImageIds: string[];

--- a/packages/client/hmi-client/src/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="Tabs.Wizard">
 			<tera-drilldown-section class="ml-4 mr-4 pt-3">
 				<!-- LLM generated overview -->
@@ -156,7 +154,7 @@ import Button from 'primevue/button';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
 import { VAceEditorInstance } from 'vue3-ace-editor/types';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraNotebookJupyterInput from '@/components/llm/tera-notebook-jupyter-input.vue';
 import Image from 'primevue/image';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';

--- a/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/model-config-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import type { Initial, ModelParameter } from '@/types/Types';
 
 export const name = 'ModelConfigOperation';
@@ -8,7 +8,7 @@ export interface ModelEditCode {
 	timestamp: number;
 }
 
-export interface ModelConfigOperationState {
+export interface ModelConfigOperationState extends BaseState {
 	name: string;
 	description: string;
 	initials: Initial[];

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -253,6 +253,7 @@
 	<tera-drilldown
 		v-if="suggestedConfirgurationContext.isOpen"
 		:title="suggestedConfirgurationContext.modelConfiguration?.name ?? 'Model Configuration'"
+		:node="node"
 		@on-close-clicked="suggestedConfirgurationContext.isOpen = false"
 		popover
 	>

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -1,5 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<template #header-actions>
 			<tera-operator-annotation
 				:state="node.state"
@@ -312,7 +316,7 @@ import TeraOutputDropdown from '@/components/drilldown/tera-output-dropdown.vue'
 import TeraNotebookJupyterInput from '@/components/llm/tera-notebook-jupyter-input.vue';
 import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-model-diagram.vue';
 import TeraModelSemanticTables from '@/components/model/tera-model-semantic-tables.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraModal from '@/components/widgets/tera-modal.vue';
 
 import { FatalError } from '@/api/api';

--- a/packages/client/hmi-client/src/workflow/ops/model-coupling/model-coupling-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-coupling/model-coupling-operation.ts
@@ -1,6 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import type { Operation, BaseState } from '@/types/workflow';
+import { WorkflowOperationTypes } from '@/types/workflow';
 
-export interface ModelCouplingState {}
+export interface ModelCouplingState extends BaseState {}
 
 export const ModelCouplingOperation: Operation = {
 	name: WorkflowOperationTypes.MODEL_COUPLING,

--- a/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-coupling/tera-model-coupling.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="ModelCouplingTabgs.Wizard">
 			<tera-drilldown-section class="ml-4 mr-2 mt-3"
 				>Coming soon. Use the notebook tab for now.</tera-drilldown-section
@@ -112,7 +110,6 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import Dropdown from 'primevue/dropdown';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
 
 /* Jupyter imports */
 import { KernelSessionManager } from '@/services/jupyter';

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/model-edit-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/model-edit-operation.ts
@@ -1,11 +1,11 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
 export interface ModelEditCode {
 	code: string;
 	timestamp: number;
 }
 
-export interface ModelEditOperationState {
+export interface ModelEditOperationState extends BaseState {
 	modelEditCodeHistory: ModelEditCode[];
 	hasCodeBeenRun: boolean;
 }
@@ -21,7 +21,8 @@ export const ModelEditOperation: Operation = {
 	initState: () => {
 		const init: ModelEditOperationState = {
 			modelEditCodeHistory: [],
-			hasCodeBeenRun: false
+			hasCodeBeenRun: false,
+			annotation: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/model-edit-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/model-edit-operation.ts
@@ -21,8 +21,7 @@ export const ModelEditOperation: Operation = {
 	initState: () => {
 		const init: ModelEditOperationState = {
 			modelEditCodeHistory: [],
-			hasCodeBeenRun: false,
-			annotation: ''
+			hasCodeBeenRun: false
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -374,6 +374,7 @@ watch(
 );
 
 onMounted(async () => {
+	console.log(props.node);
 	await inputChangeHandler();
 });
 

--- a/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-edit/tera-model-edit.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="ModelEditTabs.Wizard">
 			<tera-model-template-editor
 				v-if="amr && isKernelReady"
@@ -116,7 +114,7 @@ import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraModelTemplateEditor from '@/components/model-template/tera-model-template-editor.vue';
 import TeraNotebookJupyterInput from '@/components/llm/tera-notebook-jupyter-input.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { KernelSessionManager } from '@/services/jupyter';
 import { ModelEditOperationState } from './model-edit-operation';
 

--- a/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-code/tera-model-from-code.vue
@@ -1,5 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<template #header-actions>
 			<tera-operator-annotation
 				:state="node.state"
@@ -148,7 +152,7 @@ import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraOutputDropdown from '@/components/drilldown/tera-output-dropdown.vue';
 import TeraModelDescription from '@/components/model/petrinet/tera-model-description.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
 import { useProjects } from '@/composables/project';

--- a/packages/client/hmi-client/src/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -1,5 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<template #header-actions>
 			<tera-operator-annotation
 				:state="node.state"
@@ -138,7 +142,7 @@ import TeraModelModal from '@/page/project/components/tera-model-modal.vue';
 import { ModelServiceType } from '@/types/common';
 import TeraOutputDropdown from '@/components/drilldown/tera-output-dropdown.vue';
 import TeraModelDescription from '@/components/model/petrinet/tera-model-description.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import * as textUtils from '@/utils/text';
 import {
 	EquationBlock,

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/model-transformer-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/model-transformer-operation.ts
@@ -1,6 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { WorkflowOperationTypes } from '@/types/workflow';
+import type { Operation, BaseState } from '@/types/workflow';
 
-export interface ModelTransformerState {
+export interface ModelTransformerState extends BaseState {
 	modelId: string | null;
 	modelConfigurationIds: string[];
 	notebookSessionId?: string;

--- a/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-transformer/tera-model-transformer.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div class="background">
 			<Suspense>
 				<tera-model-jupyter-panel
@@ -34,7 +32,7 @@ import { cloneDeep } from 'lodash';
 import { getModel } from '@/services/model';
 import { addDefaultConfiguration } from '@/services/model-configurations';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { ModelTransformerState } from './model-transformer-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/model/model-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/model/model-operation.ts
@@ -1,6 +1,6 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface ModelOperationState {
+export interface ModelOperationState extends BaseState {
 	modelId: string | null;
 	modelConfigurationIds: string[];
 }

--- a/packages/client/hmi-client/src/workflow/ops/model/tera-model-workflow-wrapper.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model/tera-model-workflow-wrapper.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section>
 			<tera-model
 				:asset-id="props.node.state.modelId as string"
@@ -23,7 +21,7 @@ import { WorkflowNode } from '@/types/workflow';
 import TeraModel from '@/components/model/tera-model.vue';
 // import { workflowEventBus } from '@/services/workflow';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { ModelOperationState } from './model-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
 export enum InterventionTypes {
 	paramValue = 'param_value',
@@ -17,7 +17,7 @@ export interface InterventionPolicyGroup {
 	paramValue: number;
 }
 
-export interface OptimizeCiemssOperationState {
+export interface OptimizeCiemssOperationState extends BaseState {
 	// Settings
 	endTime: number;
 	numSamples: number;

--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="OptimizeTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<div class="form-section">
@@ -324,7 +322,7 @@ import { logger } from '@/utils/logger';
 import { chartActionsProxy, drilldownChartSize } from '@/workflow/util';
 import { RunResults as SimulationRunResults } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import {
 	OptimizeCiemssOperationState,

--- a/packages/client/hmi-client/src/workflow/ops/regridding/regridding-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/regridding/regridding-operation.ts
@@ -1,6 +1,6 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface RegriddingState {
+export interface RegriddingOperationState extends BaseState {
 	datasetId: string | null;
 	notebookSessionId?: string;
 }
@@ -15,7 +15,7 @@ export const RegriddingOperation: Operation = {
 	action: () => {},
 
 	initState: () => {
-		const init: RegriddingState = {
+		const init: RegriddingOperationState = {
 			datasetId: null
 		};
 		return init;

--- a/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding-node.vue
@@ -12,12 +12,12 @@ import { watch } from 'vue';
 import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import Button from 'primevue/button';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
-import { RegriddingState } from './regridding-operation';
+import type { RegriddingOperationState } from './regridding-operation';
 
 const emit = defineEmits(['append-input-port', 'open-drilldown']);
 
 const props = defineProps<{
-	node: WorkflowNode<RegriddingState>;
+	node: WorkflowNode<RegriddingOperationState>;
 }>();
 
 watch(

--- a/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding.vue
+++ b/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding.vue
@@ -30,11 +30,10 @@ import type { NotebookSession, Dataset } from '@/types/Types';
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-
-import { RegriddingState } from './regridding-operation';
+import type { RegriddingOperationState } from './regridding-operation';
 
 const props = defineProps<{
-	node: WorkflowNode<RegriddingState>;
+	node: WorkflowNode<RegriddingOperationState>;
 }>();
 const emit = defineEmits(['append-output', 'update-state', 'close']);
 

--- a/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding.vue
+++ b/packages/client/hmi-client/src/workflow/ops/regridding/tera-regridding.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div class="background">
 			<Suspense>
 				<tera-dataset-jupyter-regridding-panel
@@ -32,7 +30,7 @@ import type { NotebookSession, Dataset } from '@/types/Types';
 import { cloneDeep } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { RegriddingState } from './regridding-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
@@ -1,7 +1,7 @@
 import type { TimeSpan } from '@/types/Types';
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface SimulateCiemssOperationState {
+export interface SimulateCiemssOperationState extends BaseState {
 	// state shared across all runs
 	chartConfigs: string[][];
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="SimulateTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<div class="form-section">
@@ -156,7 +154,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { SimulateCiemssOperationState } from './simulate-ciemss-operation';
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -1,7 +1,7 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import type { EnsembleModelConfigs, TimeSpan } from '@/types/Types';
 
-export interface SimulateEnsembleCiemssOperationState {
+export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
 	mapping: EnsembleModelConfigs[];
 	timeSpan: TimeSpan;

--- a/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="Tabs.Wizard" class="ml-3 mr-2 pt-3">
 			<Accordion :multiple="true" :active-index="[0, 1, 2]">
 				<!-- Model weights -->
@@ -233,7 +231,7 @@ import type {
 	EnsembleSimulationCiemssRequest
 } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { SimulateEnsembleCiemssOperationState } from './simulate-ensemble-ciemss-operation';
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/simulate-julia-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/simulate-julia-operation.ts
@@ -1,7 +1,7 @@
 import type { TimeSpan } from '@/types/Types';
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface SimulateJuliaOperationState {
+export interface SimulateJuliaOperationState extends BaseState {
 	// state shared across all runs
 	chartConfigs: string[][];
 

--- a/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<section :tabName="SimulateTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<div class="form-section">
@@ -124,7 +122,7 @@ import SelectButton from 'primevue/selectbutton';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import { SimulateJuliaOperationState } from './simulate-julia-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -1,4 +1,5 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import type { Operation, BaseState } from '@/types/workflow';
+import { WorkflowOperationTypes } from '@/types/workflow';
 
 export interface StratifyGroup {
 	borderColour: string;
@@ -18,7 +19,7 @@ export interface StratifyCode {
 	timestamp: number;
 }
 
-export interface StratifyOperationStateMira {
+export interface StratifyOperationStateMira extends BaseState {
 	strataGroup: StratifyGroup;
 	strataCodeHistory: StratifyCode[];
 	hasCodeBeenRun: boolean;

--- a/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -1,11 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
-		<template #header-actions>
-			<tera-operator-annotation
-				:state="node.state"
-				@update-state="(state: any) => emit('update-state', state)"
-			/>
-		</template>
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="StratifyTabs.Wizard">
 			<tera-drilldown-section class="pl-4 pt-3">
 				<div class="form-section">
@@ -141,7 +139,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-model-diagram.vue';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraModelSemanticTables from '@/components/model/tera-model-semantic-tables.vue';
-import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotation.vue';
+
 import TeraStratificationGroupForm from '@/components/stratification/tera-stratification-group-form.vue';
 import TeraModal from '@/components/widgets/tera-modal.vue';
 import { useProjects } from '@/composables/project';

--- a/packages/client/hmi-client/src/workflow/ops/subset-data/subset-data-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/subset-data/subset-data-operation.ts
@@ -1,6 +1,6 @@
-import { Operation, WorkflowOperationTypes } from '@/types/workflow';
+import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
-export interface SubsetDataOperationState {
+export interface SubsetDataOperationState extends BaseState {
 	datasetId: string | null;
 	fromDate: Date;
 	toDate: Date;

--- a/packages/client/hmi-client/src/workflow/ops/subset-data/tera-subset-data.vue
+++ b/packages/client/hmi-client/src/workflow/ops/subset-data/tera-subset-data.vue
@@ -1,5 +1,9 @@
 <template>
-	<tera-drilldown :title="node.displayName" @on-close-clicked="emit('close')">
+	<tera-drilldown
+		:node="node"
+		@on-close-clicked="emit('close')"
+		@update-state="(state: any) => emit('update-state', state)"
+	>
 		<div :tabName="SubsetDataTabs.Wizard" class="ml-4 mr-2 pt-3">
 			<tera-drilldown-section>
 				<!-- Geo boundaries -->

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -387,6 +387,7 @@ function appendOutput(
 
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
+	console.log(5);
 	workflowService.updateNodeState(wf.value, node.id, state);
 	workflowDirty = true;
 }

--- a/packages/client/hmi-client/src/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/workflow/tera-workflow.vue
@@ -387,7 +387,6 @@ function appendOutput(
 
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
-	console.log(5);
 	workflowService.updateNodeState(wf.value, node.id, state);
 	workflowDirty = true;
 }


### PR DESCRIPTION
# Description

- `tera-operator-annotation` is in `tera-drilldown` instead of in every operator
- `tera-drilldown` now accepts a node for reading state (later inputs)
- operator states now extend `BaseState` which holds `annotation: string`
