### PR TITLE
only add interventions when provided.

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -143,7 +143,7 @@ const startForecast = async (simulationInterventions) => {
 		},
 		engine: 'ciemss'
 	};
-	if (_.isEmpty(simulationInterventions)) {
+	if (!_.isEmpty(simulationInterventions)) {
 		simulationPayload.interventions = simulationInterventions;
 	}
 	return makeForecastJobCiemss(simulationPayload);

--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -137,13 +137,15 @@ const startForecast = async (simulationIntervetions) => {
 			start: 0,
 			end: props.node.state.endTime
 		},
-		interventions: simulationIntervetions,
 		extra: {
 			num_samples: props.node.state.numSamples,
 			method: props.node.state.solverMethod
 		},
 		engine: 'ciemss'
 	};
+	if (simulationIntervetions.length > 0) {
+		simulationPayload.interventions = simulationIntervetions;
+	}
 	return makeForecastJobCiemss(simulationPayload);
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -115,21 +115,21 @@ const getSimulationInterventions = async (id) => {
 		startTime.push(ele.startTime);
 	});
 
-	const simulationIntervetions: SimulationIntervention[] = [];
+	const simulationInterventions: SimulationIntervention[] = [];
 	// This is all index matching for optimizeInterventions.paramNames, optimizeInterventions.startTimes, and policyResult
 	for (let i = 0; i < paramNames.length; i++) {
 		if (policyResult?.at(i) && startTime?.[i]) {
-			simulationIntervetions.push({
+			simulationInterventions.push({
 				name: paramNames[i],
 				timestep: startTime[i],
 				value: policyResult[i]
 			});
 		}
 	}
-	return simulationIntervetions;
+	return simulationInterventions;
 };
 
-const startForecast = async (simulationIntervetions) => {
+const startForecast = async (simulationInterventions) => {
 	const simulationPayload: SimulationRequest = {
 		projectId: '',
 		modelConfigId: modelConfigId.value as string,
@@ -143,8 +143,8 @@ const startForecast = async (simulationIntervetions) => {
 		},
 		engine: 'ciemss'
 	};
-	if (simulationIntervetions.length > 0) {
-		simulationPayload.interventions = simulationIntervetions;
+	if (_.isEmpty(simulationInterventions)) {
+		simulationPayload.interventions = simulationInterventions;
 	}
 	return makeForecastJobCiemss(simulationPayload);
 };
@@ -157,8 +157,8 @@ watch(
 		const response = await pollResult(id);
 		if (response.state === PollerState.Done) {
 			// Start 2nd simulation to get sample simulation from dill
-			const simulationIntervetions = await getSimulationInterventions(id);
-			const forecastResponse = await startForecast(simulationIntervetions);
+			const simulationInterventions = await getSimulationInterventions(id);
+			const forecastResponse = await startForecast(simulationInterventions);
 			const forecastId = forecastResponse.id;
 
 			const state = _.cloneDeep(props.node.state);


### PR DESCRIPTION
# Description
Only add interventions from `policy.json` when they exist.
Do not include `interventions: []` into the payload as that will impact how we are doing the check 

Post this week's eval I will need to look into how we are handling interventions much cleaner and we can talk about this:
https://github.com/DARPA-ASKEM/terarium/pull/2990

https://github.com/DARPA-ASKEM/terarium/blob/main/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java#L121

