### PR TITLE
fix[hmi-client]: Configuration column in parameter table

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-table.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-table.vue
@@ -316,6 +316,11 @@
 						</span>
 					</template>
 				</Column>
+				<Column header="Configuration">
+					<template #body="{ data }">
+						{{ data.configuration?.name }}
+					</template>
+				</Column>
 				<Column header="Value type">
 					<template #body="{ data }">
 						{{ typeOptions[getParamType(data.parameter, data.configuration.configuration)].label }}


### PR DESCRIPTION
Show the configuration column in the tera-parameter-table.vue

Resolves #3243
