### PR TITLE
Subset output top corner radius removed (below tabs)

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/subset-data/tera-subset-data.vue
+++ b/packages/client/hmi-client/src/workflow/ops/subset-data/tera-subset-data.vue
@@ -540,7 +540,8 @@ code {
 	&:deep(.p-tabview-panels) {
 		flex: 1;
 		border: 1px solid var(--surface-border);
-		border-radius: var(--border-radius);
+		border-bottom-left-radius: var(--border-radius);
+		border-bottom-right-radius: var(--border-radius);
 		background-color: var(--surface-ground);
 	}
 }


### PR DESCRIPTION
The top left and right corner radius has been removed from the Output panel, so that it better aligns with the tabs anchored to the top of the panel.

**BEFORE**
<img width="1107" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/141876103/bd5dddc0-0152-4f25-a1f3-f03c4cf4acf4">

**AFTER**
<img width="635" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/141876103/86d0c87f-5449-45cf-92f9-f05021f393ef">
