### PR TITLE
calibrate ensemble mapping

### DIFF
--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -23,7 +23,7 @@ export const setupModelInput = async (modelConfigId: string | undefined) => {
 			});
 		}
 
-		modelOptions.push({ id: 'timestamp' });
+		modelOptions.push({ id: 'Timestamp' });
 		return { modelConfiguration, modelOptions };
 	}
 	return {};

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -23,7 +23,7 @@ export const setupModelInput = async (modelConfigId: string | undefined) => {
 			});
 		}
 
-		modelOptions.push({ id: 'Timestamp' });
+		modelOptions.push({ id: 'timestamp' });
 		return { modelConfiguration, modelOptions };
 	}
 	return {};

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss.vue
@@ -316,7 +316,7 @@ const runCalibrate = async () => {
 		extra: {
 			num_iterations: knobs.value.numIterations
 		},
-		timespan: getTimespan(csvAsset.value, mapping.value),
+		timespan: getTimespan({ dataset: csvAsset.value, mapping: mapping.value }),
 		engine: 'ciemss'
 	};
 	const response = await makeCalibrateJobCiemss(calibrationRequest);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -36,7 +36,7 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 			timestampColName: '',
 			extra: {
 				solverMethod: 'dopri5',
-				numParticles: 10,
+				numParticles: 1,
 				numIterations: 100
 			},
 			inProgressCalibrationId: '',

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -307,7 +307,7 @@ function addMapping() {
 const runEnsemble = async () => {
 	if (!datasetId.value || !currentDatasetFileName.value) return;
 	const datasetMapping: { [index: string]: string } = {};
-	datasetMapping[knobs.value.timestampColName] = 'Timestamp';
+	datasetMapping[knobs.value.timestampColName] = 'timestamp';
 	// Each key used in the ensemble configs is a dataset column.
 	// add these columns used to the datasetMapping
 	Object.keys(knobs.value.ensembleConfigs[0].solutionMappings).forEach((key) => {
@@ -316,7 +316,10 @@ const runEnsemble = async () => {
 
 	const calibratePayload: EnsembleCalibrationCiemssRequest = {
 		modelConfigs: knobs.value.ensembleConfigs,
-		timespan: getTimespan(csvAsset.value),
+		timespan: getTimespan({
+			dataset: csvAsset.value,
+			timestampColName: knobs.value.timestampColName
+		}),
 		dataset: {
 			id: datasetId.value,
 			filename: currentDatasetFileName.value,
@@ -340,6 +343,7 @@ const runEnsemble = async () => {
 };
 
 onMounted(async () => {
+	console.log(props.node.state);
 	allModelConfigurations.value = [];
 	const modelConfigurationIds: string[] = [];
 	props.node.inputs.forEach((ele) => {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -306,16 +306,16 @@ function addMapping() {
 
 const runEnsemble = async () => {
 	if (!datasetId.value || !currentDatasetFileName.value) return;
-	const mapping = _.cloneDeep(knobs.value.ensembleConfigs[0].solutionMappings);
-	mapping[knobs.value.timestampColName] = 'Timestamp';
+	const datasetMapping: { [index: string]: string } = {};
+	datasetMapping[knobs.value.timestampColName] = 'Timestamp';
 
-	const params: EnsembleCalibrationCiemssRequest = {
+	const calibratePayload: EnsembleCalibrationCiemssRequest = {
 		modelConfigs: knobs.value.ensembleConfigs,
 		timespan: getTimespan(csvAsset.value),
 		dataset: {
 			id: datasetId.value,
 			filename: currentDatasetFileName.value,
-			mappings: mapping
+			mappings: datasetMapping
 		},
 		engine: 'ciemss',
 		extra: {
@@ -324,7 +324,7 @@ const runEnsemble = async () => {
 			solver_method: knobs.value.extra.solverMethod
 		}
 	};
-	const response = await makeEnsembleCiemssCalibration(params);
+	const response = await makeEnsembleCiemssCalibration(calibratePayload);
 	if (response?.simulationId) {
 		const state = _.cloneDeep(props.node.state);
 		state.inProgressCalibrationId = response?.simulationId;

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -343,7 +343,6 @@ const runEnsemble = async () => {
 };
 
 onMounted(async () => {
-	console.log(props.node.state);
 	allModelConfigurations.value = [];
 	const modelConfigurationIds: string[] = [];
 	props.node.inputs.forEach((ele) => {

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -329,7 +329,6 @@ const runEnsemble = async () => {
 			solver_method: knobs.value.extra.solverMethod
 		}
 	};
-	console.log(calibratePayload);
 	const response = await makeEnsembleCiemssCalibration(calibratePayload);
 	if (response?.simulationId) {
 		const state = _.cloneDeep(props.node.state);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -308,6 +308,11 @@ const runEnsemble = async () => {
 	if (!datasetId.value || !currentDatasetFileName.value) return;
 	const datasetMapping: { [index: string]: string } = {};
 	datasetMapping[knobs.value.timestampColName] = 'Timestamp';
+	// Each key used in the ensemble configs is a dataset column.
+	// add these columns used to the datasetMapping
+	Object.keys(knobs.value.ensembleConfigs[0].solutionMappings).forEach((key) => {
+		datasetMapping[key] = key;
+	});
 
 	const calibratePayload: EnsembleCalibrationCiemssRequest = {
 		modelConfigs: knobs.value.ensembleConfigs,
@@ -324,6 +329,7 @@ const runEnsemble = async () => {
 			solver_method: knobs.value.extra.solverMethod
 		}
 	};
+	console.log(calibratePayload);
 	const response = await makeEnsembleCiemssCalibration(calibratePayload);
 	if (response?.simulationId) {
 		const state = _.cloneDeep(props.node.state);

--- a/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
+++ b/packages/client/hmi-client/src/workflow/ops/calibrate-julia/tera-calibrate-julia.vue
@@ -356,7 +356,7 @@ const makeCalibrateRequest = async () => {
 		},
 		extra: extra.value,
 		engine: 'sciml',
-		timespan: getTimespan(csvAsset.value, mapping.value)
+		timespan: getTimespan({ dataset: csvAsset.value, mapping: mapping.value })
 	};
 	const response = await makeCalibrateJobJulia(calibrationRequest);
 	return response.simulationId;

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -53,7 +53,7 @@ export interface GetTimespanParams {
 	timestampColName?: string;
 }
 
-export const getTimespan = (params: GetTimespanParams): TimeSpan => {
+export function getTimespan(params: GetTimespanParams): TimeSpan {
 	let start = 0;
 	let end = 90;
 	// If we have the min/max timestamp available from the csv asset use it

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -75,7 +75,7 @@ export function getTimespan(params: GetTimespanParams): TimeSpan {
 		end = params.dataset.stats?.[tIndex].maxValue!;
 	}
 	return { start, end };
-};
+}
 
 export const getGraphDataFromDatasetCSV = (
 	dataset: CsvAsset,

--- a/packages/client/hmi-client/src/workflow/util.ts
+++ b/packages/client/hmi-client/src/workflow/util.ts
@@ -47,26 +47,32 @@ export const chartActionsProxy = (node: WorkflowNode<any>, updateStateCallback: 
 	};
 };
 
-export const getTimespan = (dataset?: CsvAsset, mapping?: CalibrateMap[]): TimeSpan => {
+export interface GetTimespanParams {
+	dataset?: CsvAsset;
+	mapping?: CalibrateMap[];
+	timestampColName?: string;
+}
+
+export const getTimespan = (params: GetTimespanParams): TimeSpan => {
 	let start = 0;
 	let end = 90;
 	// If we have the min/max timestamp available from the csv asset use it
-	if (dataset) {
-		let tVar = 'timestamp';
-		if (mapping) {
+	if (params.dataset) {
+		let tVar = params.timestampColName ?? 'timestamp';
+		if (params.mapping && !params.timestampColName) {
 			// if there's a mapping for timestamp, then the model variable is guaranteed to be 'timestamp'
-			const tMap = mapping.find((m) => m.modelVariable === 'timestamp');
+			const tMap = params.mapping.find((m) => m.modelVariable === 'timestamp');
 			if (tMap) {
 				tVar = tMap.datasetVariable;
 			}
 		}
-		let tIndex = dataset.headers.indexOf(tVar);
+		let tIndex = params.dataset.headers.indexOf(tVar);
 		// if the timestamp column is not found, default to 0 as this is what is assumed to be the default
 		// timestamp column in the pyciemss backend
 		tIndex = tIndex === -1 ? 0 : tIndex;
 
-		start = dataset.stats?.[tIndex].minValue!;
-		end = dataset.stats?.[tIndex].maxValue!;
+		start = params.dataset.stats?.[tIndex].minValue!;
+		end = params.dataset.stats?.[tIndex].maxValue!;
 	}
 	return { start, end };
 };


### PR DESCRIPTION
# Description

- Updating mapping provided to ensemble calibrate
- Correcting `timespan` value in ensemble calibrate
- Adding optional input to `getTimespan` and using an interface for easier use of optional params.
- Updating default num particles to 1

# Testing
Running a regular calibrate to ensure the timespan changes are not breaking anything unexpectedly
Running ensemble calibrate with two different models with no indexes being titled the same

# Mapping Details
Pyciemss-service wants the dataset mapping as follows
{dataset timestamp col name}: "timestamp",
{X dataset column used}: {X dataset column used},
...


Example:
```
{
    "time": "timestamp",
    "S": "S",
    "I": "I"
}
```
