### PR TITLE
Model config apply config also appends to node

### DIFF
--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -70,7 +70,7 @@
 										<Button
 											class="use-button"
 											label="Apply configuration values"
-											@click="useSuggestedConfig(data)"
+											@click="applyConfigValues(data)"
 											text
 										/>
 									</template>
@@ -873,7 +873,8 @@ const initialize = async () => {
 	}
 };
 
-const useSuggestedConfig = (config: ModelConfiguration) => {
+const applyConfigValues = (config: ModelConfiguration) => {
+	const state = cloneDeep(props.node.state);
 	const amr = config.configuration;
 
 	knobs.value.name = config.name;
@@ -887,6 +888,23 @@ const useSuggestedConfig = (config: ModelConfiguration) => {
 	knobs.value.timeseries = amr.metadata?.timeseries ?? {};
 	knobs.value.initialsMetadata = amr.metadata?.initials ?? {};
 	knobs.value.parametersMetadata = amr.metadata?.parameters ?? {};
+
+	// Append this config to the output.
+	state.name = knobs.value.name;
+	state.description = knobs.value.description;
+	state.initials = knobs.value.initials;
+	state.parameters = knobs.value.parameters;
+	state.timeseries = knobs.value.timeseries;
+	state.initialsMetadata = knobs.value.initialsMetadata;
+	state.parametersMetadata = knobs.value.parametersMetadata;
+	state.tempConfigId = knobs.value.tempConfigId;
+	emit('append-output', {
+		type: ModelConfigOperation.outputs[0].type,
+		label: config.name,
+		value: config.id,
+		isSelected: false,
+		state
+	});
 	logger.success(`Configuration applied ${config.name}`);
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -889,22 +889,33 @@ const applyConfigValues = (config: ModelConfiguration) => {
 	knobs.value.initialsMetadata = amr.metadata?.initials ?? {};
 	knobs.value.parametersMetadata = amr.metadata?.parameters ?? {};
 
-	// Append this config to the output.
-	state.name = knobs.value.name;
-	state.description = knobs.value.description;
-	state.initials = knobs.value.initials;
-	state.parameters = knobs.value.parameters;
-	state.timeseries = knobs.value.timeseries;
-	state.initialsMetadata = knobs.value.initialsMetadata;
-	state.parametersMetadata = knobs.value.parametersMetadata;
-	state.tempConfigId = knobs.value.tempConfigId;
-	emit('append-output', {
-		type: ModelConfigOperation.outputs[0].type,
-		label: config.name,
-		value: config.id,
-		isSelected: false,
-		state
-	});
+	// Update output port:
+	const listOfConfigIds: string[] = props.node.outputs.map((output) => output.value?.[0]);
+	// Check if this output already exists
+	if (config.id && listOfConfigIds.includes(config.id)) {
+		// Select the existing output
+		const output = props.node.outputs.find((ele) => ele.value?.[0] === config.id);
+		emit('select-output', output?.id);
+	}
+	// If the output does not already exist
+	if (config.id && !listOfConfigIds.includes(config.id)) {
+		// Append this config to the output.
+		state.name = knobs.value.name;
+		state.description = knobs.value.description;
+		state.initials = knobs.value.initials;
+		state.parameters = knobs.value.parameters;
+		state.timeseries = knobs.value.timeseries;
+		state.initialsMetadata = knobs.value.initialsMetadata;
+		state.parametersMetadata = knobs.value.parametersMetadata;
+		state.tempConfigId = knobs.value.tempConfigId;
+		emit('append-output', {
+			type: ModelConfigOperation.outputs[0].type,
+			label: config.name,
+			value: config.id,
+			isSelected: false,
+			state
+		});
+	}
 	logger.success(`Configuration applied ${config.name}`);
 };
 

--- a/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/workflow/ops/model-config/tera-model-config.vue
@@ -890,15 +890,19 @@ const applyConfigValues = (config: ModelConfiguration) => {
 	knobs.value.parametersMetadata = amr.metadata?.parameters ?? {};
 
 	// Update output port:
+	if (!config.id) {
+		logger.error('Model configuration not found');
+		return;
+	}
 	const listOfConfigIds: string[] = props.node.outputs.map((output) => output.value?.[0]);
 	// Check if this output already exists
-	if (config.id && listOfConfigIds.includes(config.id)) {
+	if (listOfConfigIds.includes(config.id)) {
 		// Select the existing output
 		const output = props.node.outputs.find((ele) => ele.value?.[0] === config.id);
 		emit('select-output', output?.id);
 	}
 	// If the output does not already exist
-	if (config.id && !listOfConfigIds.includes(config.id)) {
+	else {
 		// Append this config to the output.
 		state.name = knobs.value.name;
 		state.description = knobs.value.description;


### PR DESCRIPTION
# Description

- Rename a function to something a bit more accurate
- Apply a model config will now also append it to the output so user does not need to hit run and create a new config 

# Testing:
Making a few distinct configs where changes can be easily seen.
Checking that the state is being properly updated when changing between outputs and is saved
Checking that output that is appended is updated correctly

https://github.com/DARPA-ASKEM/terarium/assets/17088680/a4b9c60d-c50f-4838-98d5-3cc781afcf78

