### PR TITLE
NPE accessing a document assets "optional" Metadata

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
@@ -134,6 +134,9 @@ public class ModelController {
 						final Optional<DocumentAsset> document = documentAssetService
 							.getAsset(UUID.fromString(documentId));
 						if (document.isPresent()) {
+							if (document.get().getMetadata() == null) {
+								document.get().setMetadata(new HashMap<>());
+							}
 							final List<JsonNode> extractions = objectMapper.convertValue(
 								document.get().getMetadata().get("attributes"), new TypeReference<>() {
 								});

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -500,6 +500,9 @@ public class ExtractionService {
 
 				final String modelString = objectMapper.writeValueAsString(model);
 
+				if (document.getMetadata() == null) {
+					document.setMetadata(new HashMap<>());
+				}
 				if (document.getMetadata().get("attributes") == null) {
 					throw new RuntimeException("No attributes found in document");
 				}


### PR DESCRIPTION
wish we used proper constructors and not hope developers know how to use objects

# Description

POJOs "constructed" with `@Data` and 100% the most garbage of annotations `@Accessors(chain = true)` which should never be used unless one can produce a 50 page documenting why it is better than a proper constructor... .

Resolves #(issue)
