### PR TITLE
feat: improve bound range indicators

### DIFF
--- a/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/funman/tera-funman-output.vue
@@ -37,7 +37,7 @@
 	<div class="variables-table" v-if="selectedParam2 === ''">
 		<div class="variables-header">
 			<header
-				v-for="(title, index) in ['select', 'Parameter', 'Lower bound', 'Upper bound', '']"
+				v-for="(title, index) in ['select', 'Parameter', 'Lower bound', 'Upper bound', '', '']"
 				:key="index"
 			>
 				{{ title }}
@@ -48,20 +48,21 @@
 			<div class="variables-row" v-if="parameterOptions.includes(parameter)">
 				<RadioButton v-model="selectedParam" :value="parameter" />
 				<div>{{ parameter }}</div>
-				<div>
-					{{ selectedBoxId === '' ? bound.lb.toFixed(4) : selectedBox[parameter][0].toFixed(4) }}
-				</div>
-				<div>
-					{{ selectedBoxId === '' ? bound.ub.toFixed(4) : selectedBox[parameter][1].toFixed(4) }}
-				</div>
+				<div>{{ formatNumber(bound.lb) }}</div>
+				<div>{{ formatNumber(bound.ub) }}</div>
 				<tera-funman-boundary-chart
-					:processed-data="processedData as FunmanProcessedData"
+					v-if="processedData"
+					:processed-data="processedData"
 					:param1="selectedParam"
 					:param2="parameter"
 					:timestep="timestep"
 					:selectedBoxId="selectedBoxId"
 					@click="selectedParam2 = parameter"
 				/>
+				<div v-if="selectedBoxId !== ''">
+					{{ formatNumber(selectedBox[parameter][0]) }} :
+					{{ formatNumber(selectedBox[parameter][1]) }}
+				</div>
 			</div>
 		</div>
 	</div>
@@ -115,6 +116,14 @@ const drilldownChartOptions = ref<RenderOptions>({
 		}
 	}
 });
+
+// TODO: better range-bound logic
+const formatNumber = (v: number) => {
+	if (v.toString().includes('.')) {
+		return v.toFixed(4);
+	}
+	return v;
+};
 
 const initalizeParameters = async () => {
 	const funmanResult = await getQueries(props.funModelId);

--- a/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
+++ b/packages/client/hmi-client/src/workflow/ops/funman/funman-operation.ts
@@ -28,6 +28,7 @@ export interface FunmanOperationState extends BaseState {
 	currentTimespan: TimeSpan;
 	numSteps: number;
 	tolerance: number;
+	inProgressId: string;
 	useCompartmentalConstraint: boolean;
 	constraintGroups: ConstraintGroup[];
 	requestParameters: RequestParameter[];
@@ -48,7 +49,8 @@ export const FunmanOperation: Operation = {
 			tolerance: 0.2,
 			constraintGroups: [],
 			requestParameters: [],
-			useCompartmentalConstraint: true
+			useCompartmentalConstraint: true,
+			inProgressId: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman-node.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman-node.vue
@@ -10,16 +10,76 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
+import { watch, onUnmounted } from 'vue';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import { WorkflowNode } from '@/types/workflow';
-import { FunmanOperationState } from '@/workflow/ops/funman/funman-operation';
+import { FunmanOperationState, FunmanOperation } from '@/workflow/ops/funman/funman-operation';
 import Button from 'primevue/button';
+import { Poller, PollerState } from '@/api/api';
+import { getQueries } from '@/services/models/funman-service';
 
-const emit = defineEmits(['open-drilldown']);
+const emit = defineEmits(['open-drilldown', 'append-output', 'update-state']);
 
-defineProps<{
+const props = defineProps<{
 	node: WorkflowNode<FunmanOperationState>;
 }>();
+
+const poller = new Poller();
+
+const addOutputPorts = async (runId: string) => {
+	const portLabel = props.node.inputs[0].label;
+	emit('append-output', {
+		label: `${portLabel} Result ${props.node.outputs.length + 1}`,
+		type: FunmanOperation.outputs[0].type,
+		value: runId,
+		state: _.cloneDeep(props.node.state)
+	});
+};
+
+const getStatus = async (runId: string) => {
+	poller
+		.setInterval(5000)
+		.setThreshold(100)
+		.setPollAction(async () => {
+			const response = await getQueries(runId);
+			if (response.done && response.done === true) {
+				return { data: response } as any;
+			}
+			return { data: null } as any;
+		});
+	const pollerResults = await poller.start();
+
+	if (pollerResults.state === PollerState.Cancelled) {
+		return pollerResults;
+	}
+	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
+		// throw if there are any failed runs for now
+		console.error(`Funman: ${runId} has failed`);
+		throw Error('Failed Funman validation');
+	}
+	return pollerResults;
+};
+
+onUnmounted(() => {
+	poller.stop();
+});
+
+watch(
+	() => props.node.state.inProgressId,
+	async (id) => {
+		if (!id || id === '') return;
+
+		const response = await getStatus(id);
+		if (response.state === PollerState.Done) {
+			addOutputPorts(id);
+			const state = _.cloneDeep(props.node.state);
+			state.inProgressId = '';
+			emit('update-state', state);
+		}
+	},
+	{ immediate: true }
+);
 </script>
 
 <style scoped></style>

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -520,7 +520,7 @@ const onSelection = (id: string) => {
 watch(
 	() => props.node.state.inProgressId,
 	(id) => {
-		if (id === '') {
+		if (!id || id === '') {
 			showSpinner.value = false;
 		} else {
 			showSpinner.value = true;

--- a/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/workflow/ops/funman/tera-funman.vue
@@ -164,7 +164,7 @@
 
 <script setup lang="ts">
 import _, { floor } from 'lodash';
-import { computed, ref, watch, onUnmounted } from 'vue';
+import { computed, ref, watch } from 'vue';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
@@ -189,13 +189,12 @@ import type {
 	ModelConfiguration,
 	ModelParameter
 } from '@/types/Types';
-import { getQueries, makeQueries } from '@/services/models/funman-service';
+import { makeQueries } from '@/services/models/funman-service';
 import { WorkflowNode, WorkflowOutput } from '@/types/workflow';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { useToastService } from '@/services/toast';
-import { Poller, PollerState } from '@/api/api';
 import { pythonInstance } from '@/python/PyodideController';
-import { FunmanOperationState, ConstraintGroup, FunmanOperation } from './funman-operation';
+import { FunmanOperationState, ConstraintGroup } from './funman-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<FunmanOperationState>;
@@ -314,8 +313,6 @@ const outputs = computed(() => {
 
 const activeOutput = ref<WorkflowOutput<FunmanOperationState> | null>(null);
 
-const poller = new Poller();
-
 const toggleAdditonalOptions = () => {
 	showAdditionalOptions.value = !showAdditionalOptions.value;
 };
@@ -373,46 +370,11 @@ const runMakeQuery = async () => {
 		}
 	}
 	const response = await makeQueries(request);
-	getStatus(response.id);
-};
 
-const getStatus = async (runId: string) => {
-	showSpinner.value = true;
-
-	poller
-		.setInterval(5000)
-		.setThreshold(100)
-		.setPollAction(async () => {
-			const response = await getQueries(runId);
-			if (response.done && response.done === true) {
-				return { data: response } as any;
-			}
-			return { data: null } as any;
-		});
-	const pollerResults = await poller.start();
-
-	if (pollerResults.state === PollerState.Cancelled) {
-		showSpinner.value = false;
-		return;
-	}
-	if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
-		// throw if there are any failed runs for now
-		showSpinner.value = false;
-		console.error(`Funman: ${runId} has failed`);
-		throw Error('Failed Funman validation');
-	}
-	showSpinner.value = false;
-	addOutputPorts(runId);
-};
-
-const addOutputPorts = async (runId: string) => {
-	const portLabel = props.node.inputs[0].label;
-	emit('append-output', {
-		label: `${portLabel} Result ${props.node.outputs.length + 1}`,
-		type: FunmanOperation.outputs[0].type,
-		value: runId,
-		state: _.cloneDeep(props.node.state)
-	});
+	// Setup the in-progress id
+	const state = _.cloneDeep(props.node.state);
+	state.inProgressId = response.id;
+	emit('update-state', state);
 };
 
 const addConstraintForm = () => {
@@ -555,6 +517,18 @@ const onSelection = (id: string) => {
 	emit('select-output', id);
 };
 
+watch(
+	() => props.node.state.inProgressId,
+	(id) => {
+		if (id === '') {
+			showSpinner.value = false;
+		} else {
+			showSpinner.value = true;
+		}
+	},
+	{ immediate: true }
+);
+
 /* Check for simple parameter changes */
 watch(
 	() => knobs.value,
@@ -593,10 +567,6 @@ watch(
 	},
 	{ immediate: true }
 );
-
-onUnmounted(() => {
-	poller.stop();
-});
 </script>
 
 <style scoped>


### PR DESCRIPTION
### Summary
UI tweaks to show min/max and selected range from constraint bounds. So we have parameter min/max, and selected min/max. Note it is rather difficult to advance on this front for selected min/max, as it seems any non-compartmental constraints result in 504 errors timing out, though the job is still in-flight - basically it is hard currently to generate multiple boxes that would result in parameter and selected having different ranges. This will be done subsequently, and also to update it to be closer to the design sketches.

Made funman a little more resilient, in that you can close the drilldown and it will keep track of the validation in progress - similar to how the TAS3 operators are tracking the in-flight simulation runs.


<img width="1479" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/a1c69b61-7813-4ab7-bbb2-9537235d119a">



### Testing
In funman, start a validation process and leave the drilldown, You should be able to come back into the drilldown and, if the job is not finished, to continue to poll for result.