### PR TITLE
fix(model-edit): executed code is saved properly

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -178,12 +178,12 @@ const executeResponse = ref({
 });
 
 const appendCode = (data: any, property: string) => {
-	const code = data.content[property] as string;
-	if (code) {
-		codeText.value = (codeText.value ?? defaultCodeText).concat(' \n', code);
+	const newCode = data.content[property] as string;
+	if (newCode) {
+		codeText.value = (codeText.value ?? defaultCodeText).concat(' \n', newCode);
 
 		if (property === 'executed_code') {
-			saveCodeToState(code, true);
+			saveCodeToState(codeText.value, true);
 		}
 	} else {
 		logger.error('No code to append');


### PR DESCRIPTION
The executed code saved in model edit wasn't saved entirely. The code to be appended to the notebook was being saved. Now the entire notebook is saved.
