### PR TITLE
Client events allow multiple tabs

### DIFF
--- a/packages/client/hmi-client/src/services/ClientEventService.ts
+++ b/packages/client/hmi-client/src/services/ClientEventService.ts
@@ -83,13 +83,13 @@ export async function init(): Promise<void> {
  */
 setInterval(async () => {
 	if (!reconnecting) {
+		reconnecting = true;
 		const config = await getConfiguration();
 		const heartbeatIntervalMillis = config?.sseHeartbeatIntervalMillis ?? 10000;
 		if (new Date().valueOf() - lastHeartbeat > heartbeatIntervalMillis) {
-			reconnecting = true;
 			await init();
-			reconnecting = false;
 		}
+		reconnecting = false;
 	}
 }, 1000);
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -8,7 +8,9 @@ import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,7 +49,7 @@ public class ClientEventService {
 	@Value("${terarium.client-all-user-event-queue}")
 	private String CLIENT_ALL_USERS_EVENT_QUEUE;
 
-	final Map<String, SseEmitter> userIdToEmitter = new ConcurrentHashMap<>();
+	final Map<String, List<SseEmitter>> userIdToEmitter = new ConcurrentHashMap<>();
 
 	Queue allUsersQueue;
 	Queue userQueue;
@@ -80,13 +82,10 @@ public class ClientEventService {
 	 */
 	public SseEmitter connect(final User user) {
 		final SseEmitter emitter = new SseEmitter();
-		if (userIdToEmitter.containsKey(user.getId())) {
-			try {
-				userIdToEmitter.get(user.getId()).complete();
-			} catch (final IllegalStateException ignored) {
-			}
+		if (!userIdToEmitter.containsKey(user.getId())) {
+			userIdToEmitter.put(user.getId(), new ArrayList<>());
 		}
-		userIdToEmitter.put(user.getId(), emitter);
+		userIdToEmitter.get(user.getId()).add(emitter);
 		return emitter;
 	}
 
@@ -138,15 +137,17 @@ public class ClientEventService {
 		synchronized (userIdToEmitter) {
 			// Send the message to each user connected and remove disconnected users
 			final Set<String> userIdsToRemove = new HashSet<>();
-			userIdToEmitter.forEach((userId, emitter) -> {
-				try {
-					emitter.send(messageJson);
-				} catch (final IllegalStateException | ClientAbortException e) {
-					log.warn("Error sending all users message to user {}. User likely disconnected", userId);
-					userIdsToRemove.add(userId);
-				} catch (final IOException e) {
-					log.error("Error sending all users message to user {}", userId, e);
-				}
+			userIdToEmitter.forEach((userId, emitterList) -> {
+				emitterList.forEach((emitter) -> {
+					try {
+						emitter.send(messageJson);
+					} catch (final IllegalStateException | ClientAbortException e) {
+						log.warn("Error sending all users message to user {}. User likely disconnected", userId);
+						userIdsToRemove.add(userId);
+					} catch (final IOException e) {
+						log.error("Error sending all users message to user {}", userId, e);
+					}
+				});
 			});
 
 			// Clean up and remove disconnected users
@@ -170,19 +171,27 @@ public class ClientEventService {
 		if (messageJson == null) {
 			return;
 		}
-		final SseEmitter emitter = userIdToEmitter.get(messageJson.at("/userId").asText());
+		final List<SseEmitter> emitterList =
+				userIdToEmitter.get(messageJson.at("/userId").asText());
 		synchronized (userIdToEmitter) {
-			if (emitter != null) {
-				final String userId = messageJson.at("/userId").asText();
-				try {
-					emitter.send(messageJson.at("/event"));
-				} catch (final IllegalStateException | ClientAbortException e) {
-					log.warn("Error sending user message to user {}. User likely disconnected", userId);
-					userIdToEmitter.remove(userId);
-				} catch (final IOException e) {
-					log.error("Error sending user message to user {}", userId, e);
+			emitterList.forEach((emitter) -> {
+				if (emitter != null) {
+					final String userId = messageJson.at("/userId").asText();
+					try {
+						emitter.send(messageJson.at("/event"));
+					} catch (final IllegalStateException | ClientAbortException e) {
+						// Remove emitter from the server, if the client is still running it will fail to get a
+						// heartbeat and reconnect
+						log.warn("Error sending user message to user {}. User likely disconnected", userId);
+						userIdToEmitter.get(userId).remove(emitter);
+						if (userIdToEmitter.get(userId).size() == 0) {
+							userIdToEmitter.remove(userId);
+						}
+					} catch (final IOException e) {
+						log.error("Error sending user message to user {}", userId, e);
+					}
 				}
-			}
+			});
 		}
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -83,10 +83,8 @@ public class ClientEventService {
 	public SseEmitter connect(final User user) {
 		final SseEmitter emitter = new SseEmitter();
 		if (!userIdToEmitter.containsKey(user.getId())) {
-			System.out.println("New user connected creating new Arraylist");
 			userIdToEmitter.put(user.getId(), new ArrayList<>());
 		}
-		System.out.println("Adding new emitter to ArrayList");
 		userIdToEmitter.get(user.getId()).add(emitter);
 		return emitter;
 	}
@@ -136,7 +134,6 @@ public class ClientEventService {
 		if (messageJson == null) {
 			return;
 		}
-		System.out.println("Sending an event to all users - locking HashMap");
 		synchronized (userIdToEmitter) {
 			// Send the message to each user connected and remove disconnected users
 			final Set<String> userIdsToRemove = new HashSet<>();
@@ -156,7 +153,6 @@ public class ClientEventService {
 		List<SseEmitter> emittersToRemove = new ArrayList<>();
 		emitterList.forEach((emitter) -> {
 			try {
-				System.out.println("Sending an event to user:" + userId + " for an emitter");
 				emitter.send(message);
 			} catch (final IllegalStateException | ClientAbortException e) {
 				log.warn("Error sending all users message to user {}. User likely disconnected", userId);
@@ -186,7 +182,6 @@ public class ClientEventService {
 		}
 		final String userId = messageJson.at("/userId").asText();
 		final List<SseEmitter> emitterList = userIdToEmitter.get(userId);
-		System.out.println("Sending an event to one user - locking HashMap");
 		synchronized (userIdToEmitter) {
 			List<SseEmitter> emittersToRemove = send(messageJson.at("/event"), emitterList, userId);
 			emittersToRemove.forEach((emitter) -> {


### PR DESCRIPTION
Two issues were at work here, the `hmi-server` would only allow one sseEmitter per user therefore when a second tab/page was opened by the user they would constantly disconnect each other.  Secondly, the client did not block the heartbeat check well enough.