### PR TITLE
Small fix for missing datatype after Enrich Dataset

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-overview-table.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-overview-table.vue
@@ -126,7 +126,7 @@ function formatData(data: DatasetColumn[]) {
 		description: col.description,
 		concept: col.metadata?.groundings?.identifiers,
 		unit: col.metadata?.unit,
-		dataType: col.dataType,
+		dataType: col.metadata?.column_stats?.type,
 		stats: col.metadata?.column_stats,
 		column: col
 	}));

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -71,7 +71,6 @@ export const profileDataset = async (
 	} else {
 		response = await API.post(`/knowledge/profile-dataset/${datasetId}`);
 	}
-	console.log('data profile response', response.data);
 	return response.data.id;
 };
 


### PR DESCRIPTION
# Description

Adding back value for missing datatype. The missing concept value will need a backend change in another ticket

![image](https://github.com/DARPA-ASKEM/terarium/assets/95376249/f7a5fdce-7353-41cd-ab4e-88d0a3a0268a)

Resolves #(issue)
