### PR TITLE
fix(model-diagram): check if transition node is stratified

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
@@ -191,18 +191,18 @@ async function renderGraph() {
 	}
 
 	renderer.on('node-click', (_eventName, _event, selection) => {
-		const { id, data, matrixRows } = selection.datum();
+		const { id, data } = selection.datum();
 		// If there are matrixRows then it is stratified
-		if (data.type === NodeType.Transition && matrixRows) {
+		if (data.type === NodeType.Transition && data.isStratified) {
 			selectedTransitionId.value = id;
 			openValueConfig.value = true;
 		}
 	});
 
 	renderer.on('node-mouse-enter', async (_eventName, _event, selection) => {
-		const { id, data, matrixRows } = selection.datum();
+		const { id, data } = selection.datum();
 
-		if (data.type === NodeType.Transition && matrixRows) {
+		if (data.type === NodeType.Transition && data.isStratified) {
 			hoveredTransitionId.value = id;
 
 			const diagramBounds = renderer?.svgEl?.getBoundingClientRect();
@@ -231,8 +231,8 @@ async function renderGraph() {
 	});
 
 	renderer.on('node-mouse-leave', (_eventName, _event, selection) => {
-		const { data, matrixRows } = selection.datum();
-		if (data.type === NodeType.Transition && matrixRows) hoveredTransitionId.value = '';
+		const { data } = selection.datum();
+		if (data.type === NodeType.Transition && data.isStratified) hoveredTransitionId.value = '';
 	});
 
 	// Render graph

--- a/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
@@ -192,7 +192,6 @@ async function renderGraph() {
 
 	renderer.on('node-click', (_eventName, _event, selection) => {
 		const { id, data } = selection.datum();
-		// If there are matrixRows then it is stratified
 		if (data.type === NodeType.Transition && data.isStratified) {
 			selectedTransitionId.value = id;
 			openValueConfig.value = true;

--- a/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-diagrams/tera-model-diagram.vue
@@ -190,15 +190,15 @@ async function renderGraph() {
 		graphLegendColors.value = renderer.depthColorList;
 	}
 
-	renderer.on('node-click', (_eventName, _event, selection) => {
-		const { id, data } = selection.datum();
-		if (data.type === NodeType.Transition) {
-			selectedTransitionId.value = id;
-			openValueConfig.value = true;
-		}
-	});
-
 	if (isStratified.value) {
+		renderer.on('node-click', (_eventName, _event, selection) => {
+			const { id, data } = selection.datum();
+			if (data.type === NodeType.Transition) {
+				selectedTransitionId.value = id;
+				openValueConfig.value = true;
+			}
+		});
+
 		renderer.on('node-mouse-enter', async (_eventName, _event, selection) => {
 			const { id, data } = selection.datum();
 

--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -2,8 +2,11 @@ import { select } from 'd3';
 import { D3SelectionINode, Options } from '@graph-scaffolder/types';
 import { useNodeTypeColorPalette, useNestedTypeColorPalette } from '@/utils/petrinet-color-palette';
 
-import { NodeType, PetrinetRenderer } from '@/model-representation/petrinet/petrinet-renderer';
-import { NodeData } from '@/model-representation/petrinet/petrinet-service';
+import {
+	NodeType,
+	PetrinetRenderer,
+	NodeData
+} from '@/model-representation/petrinet/petrinet-renderer';
 
 // packing data sourced from https://hydra.nat.uni-magdeburg.de/packing/cci for up to n=200
 import CIRCLE_PACKING_CHILD_NORMALIZED_VECTORS from '@/model-representation/petrinet/circle-packing-vectors.json';
@@ -54,19 +57,14 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 	}
 
 	renderNodes(selection: D3SelectionINode<NodeData>) {
-		const species = selection.filter((d) => d.data.type === NodeType.State);
-		const transitions = selection.filter((d) => d.data.type === NodeType.Transition);
-
 		const strataTypes: string[] = [];
 		selection.each((d) => {
 			const strataType = d.data.strataType;
 			if (strataType && !strataTypes.includes(strataType)) {
 				strataTypes.push(strataType as string);
 			}
-		});
 
-		// Calculate aspect ratio for each node based on the transition matrix
-		selection.each((d) => {
+			// Calculate aspect ratio for each node based on the transition matrix
 			const BASE_SIZE = 50;
 
 			const transitionMatrix = this.transitionMatrices?.[d.id] ?? [];
@@ -75,6 +73,9 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 
 			d.matrixRows = matrixRowLen;
 			d.matrixCols = matrixColLen;
+
+			// FIXME: Consider rendering 1x1 matrices as a regular transition instead
+			d.data.isStratified = true;
 
 			// Initialize aspectRatio to 1 in case the matrix is square or empty
 			d.aspectRatio = 1;
@@ -96,6 +97,9 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 				d.height = BASE_SIZE;
 			}
 		});
+
+		const species = selection.filter((d) => d.data.type === NodeType.State);
+		const transitions = selection.filter((d) => d.data.type === NodeType.Transition);
 
 		// transitions
 		transitions

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -8,6 +8,7 @@ export interface NodeData {
 	type: string;
 	expression?: string;
 	strataType?: string;
+	isStratified?: boolean;
 }
 
 export interface EdgeData {

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-service.ts
@@ -1,21 +1,6 @@
 import { updateModelConfiguration } from '@/services/model-configurations';
 import { Model, ModelConfiguration } from '@/types/Types';
 
-export interface NodeData {
-	type: string;
-	strataType?: string;
-	expression?: string;
-}
-
-export interface EdgeData {
-	numEdges: number;
-}
-
-export enum StratifiedModel {
-	Mira = 'mira',
-	Catlab = 'catlab'
-}
-
 const replaceExactString = (str: string, wordToReplace: string, replacementWord: string): string =>
 	str.trim() === wordToReplace.trim() ? str.replace(wordToReplace, replacementWord) : str;
 


### PR DESCRIPTION
# Description

Clicking on a regular transition triggered opening a stratified transition matrix which threw an error. 

Now I make sure to check if the transition being hovered on is stratified. This is more accurate than checking if the model is stratified since there could be some transitions that are regular and some that are stratified in the same model.
