### PR TITLE
correcting behaviour with key update

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
@@ -180,7 +180,7 @@
 						<Button outlined size="small" label="Add Intervention" @click="addIntervention" />
 						<tera-model-intervention
 							v-for="(intervention, idx) of knobs.transientModelConfig.interventions"
-							:key="intervention.name + intervention.timestep"
+							:key="intervention.name + intervention.timestep + intervention.value"
 							:intervention="intervention"
 							:parameter-options="Object.keys(mmt.parameters)"
 							@update-value="
@@ -838,7 +838,7 @@ const initialize = async () => {
 	}
 	// State already been set up use it instead:
 	else {
-		knobs.value.transientModelConfig = state.transientModelConfig;
+		knobs.value.transientModelConfig = cloneDeep(state.transientModelConfig);
 	}
 
 	// Ensure the parameters have constant and distributions for editing in children components
@@ -881,8 +881,7 @@ const initialize = async () => {
 
 const applyConfigValues = (config: ModelConfiguration) => {
 	const state = cloneDeep(props.node.state);
-
-	knobs.value.transientModelConfig = config;
+	knobs.value.transientModelConfig = cloneDeep(config);
 
 	// Update output port:
 	if (!config.id) {


### PR DESCRIPTION
# Description

Issue was previously that if the `value` and you swapped the configs then it would update the underlying object but not update the UI. A refresh would be required to see the `value` get updated correctly.

https://github.com/DARPA-ASKEM/terarium/assets/17088680/39f7d17c-50dd-48f2-88f8-1bdc56be4771

