### PR TITLE
Llm stratify

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -192,7 +192,6 @@ const outputs = computed(() => {
 	return [];
 });
 
-const kernelReady = ref(false);
 const kernelManager = new KernelSessionManager();
 
 let editor: VAceEditorInstance['_editor'] | null;
@@ -375,7 +374,6 @@ const inputChangeHandler = async () => {
 		const jupyterContext = buildJupyterContext();
 		if (jupyterContext) {
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', buildJupyterContext());
-			kernelReady.value = true;
 		}
 	} catch (error) {
 		logger.error(`Error initializing Jupyter session: ${error}`);

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -43,6 +43,15 @@
 		<div :tabName="StratifyTabs.Notebook">
 			<tera-drilldown-section>
 				<p class="mt-3 ml-4">Code Editor - Python</p>
+				<Suspense>
+					<tera-notebook-jupyter-input
+						:kernel-manager="kernelManager"
+						:default-options="[]"
+						:context-language="'python3'"
+						@llm-output="(data: any) => console.log(data)"
+					/>
+				</Suspense>
+
 				<v-ace-editor
 					v-model:value="codeText"
 					@init="initialize"
@@ -123,6 +132,7 @@ import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeho
 import TeraModelSemanticTables from '@/components/model/tera-model-semantic-tables.vue';
 import TeraSaveModelModal from '@/page/project/components/tera-save-model-modal.vue';
 import TeraStratificationGroupForm from '@/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue';
+import TeraNotebookJupyterInput from '@/components/llm/tera-notebook-jupyter-input.vue';
 
 import { createModel, getModel } from '@/services/model';
 import { WorkflowNode, OperatorStatus } from '@/types/workflow';

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -41,16 +41,17 @@
 			</tera-drilldown-section>
 		</div>
 		<div :tabName="StratifyTabs.Notebook">
-			<tera-drilldown-section>
+			<tera-drilldown-section class="notebook-section">
+				<!--
 				<p class="mt-3 ml-4">Code Editor - Python</p>
-				<Suspense>
-					<tera-notebook-jupyter-input
-						:kernel-manager="kernelManager"
-						:default-options="[]"
-						:context-language="'python3'"
-						@llm-output="(data: any) => console.log(data)"
-					/>
-				</Suspense>
+				-->
+				{{ kernelReady }}
+				<tera-notebook-jupyter-input
+					:kernel-manager="kernelManager"
+					:default-options="[]"
+					:context-language="'python3'"
+					@llm-output="(data: any) => console.log(data)"
+				/>
 
 				<v-ace-editor
 					v-model:value="codeText"
@@ -195,6 +196,7 @@ const outputs = computed(() => {
 	return [];
 });
 
+const kernelReady = ref(false);
 const kernelManager = new KernelSessionManager();
 
 let editor: VAceEditorInstance['_editor'] | null;
@@ -372,6 +374,7 @@ const inputChangeHandler = async () => {
 		const jupyterContext = buildJupyterContext();
 		if (jupyterContext) {
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', buildJupyterContext());
+			kernelReady.value = true;
 		}
 	} catch (error) {
 		logger.error(`Error initializing Jupyter session: ${error}`);
@@ -493,6 +496,16 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.notebook-section:deep(main .notebook-toolbar),
+.notebook-section:deep(main .ai-assistant) {
+	padding-left: var(--gap-medium);
+}
+
+.notebook-section:deep(main) {
+	gap: var(--gap-small);
+	position: relative;
+}
+
 .code-executed-warning {
 	background-color: #ffe6e6;
 	color: #cc0000;

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -42,15 +42,11 @@
 		</div>
 		<div :tabName="StratifyTabs.Notebook">
 			<tera-drilldown-section class="notebook-section">
-				<!--
-				<p class="mt-3 ml-4">Code Editor - Python</p>
-				-->
-				{{ kernelReady }}
 				<tera-notebook-jupyter-input
 					:kernel-manager="kernelManager"
 					:default-options="[]"
 					:context-language="'python3'"
-					@llm-output="(data: any) => console.log(data)"
+					@llm-output="(data: any) => processLLMOutput(data)"
 				/>
 
 				<v-ace-editor
@@ -210,6 +206,11 @@ const updateStratifyGroupForm = (config: StratifyGroup) => {
 
 const stratifyModel = () => {
 	stratifyRequest();
+};
+
+const processLLMOutput = (data: any) => {
+	codeText.value = data.content.code;
+	saveCodeToState(data.content.code, false);
 };
 
 const resetModel = () => {


### PR DESCRIPTION
### Summary
Add llm toolbar to stratify operator for code generation

Note:
- Not all prompts work, however this template of `show me code to stratify model abc by region named xyz and zzz` had worked more consistently
- The code generated is not precisely correct, it should be "model = stratify(..." instead of "stratified_model = stratify(...". However this is outside of the scope of this PR to address.


<img width="1198" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/50ec90f4-0df8-4317-ad02-96b5be390402">
