### PR TITLE
handled error when doc is still processing

### DIFF
--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -36,13 +36,17 @@ export const equationsToAMR = async (
  */
 export const profileModel = async (modelId: Model['id'], documentId: string | null = null) => {
 	let response: any;
-	if (documentId && modelId) {
-		response = await API.post(`/knowledge/profile-model/${modelId}?document-id=${documentId}`);
-	} else {
-		response = await API.post(`/knowledge/profile-model/${modelId}`);
+	try {
+		if (documentId && modelId) {
+			response = await API.post(`/knowledge/profile-model/${modelId}?document-id=${documentId}`);
+		} else {
+			response = await API.post(`/knowledge/profile-model/${modelId}`);
+		}
+		return response.data.id;
+	} catch (error: unknown) {
+		logger.error(error, { showToast: false });
+		return null;
 	}
-	console.log('model profile response', response.data);
-	return response.data.id;
 };
 
 export const alignModel = async (

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -443,8 +443,16 @@ public class KnowledgeController {
 					final int MAX_CHAR_LIMIT = 9000;
 
 					final DocumentAsset document = documentOptional.get();
-					documentText = document.getText()
-							.substring(0, Math.min(document.getText().length(), MAX_CHAR_LIMIT));
+
+					try {
+						final int documentTextLength = document.getText().length();
+						documentText = document.getText()
+							.substring(0, Math.min(documentTextLength, MAX_CHAR_LIMIT));
+					} catch (NullPointerException e) {
+						throw new ResponseStatusException(
+							HttpStatus.BAD_REQUEST,
+							"Supplied document is still in the extraction process. Please try again later...");
+					}
 
 					try {
 						final Provenance provenancePayload = new Provenance(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -446,12 +446,11 @@ public class KnowledgeController {
 
 					try {
 						final int documentTextLength = document.getText().length();
-						documentText = document.getText()
-							.substring(0, Math.min(documentTextLength, MAX_CHAR_LIMIT));
+						documentText = document.getText().substring(0, Math.min(documentTextLength, MAX_CHAR_LIMIT));
 					} catch (NullPointerException e) {
 						throw new ResponseStatusException(
-							HttpStatus.BAD_REQUEST,
-							"Supplied document is still in the extraction process. Please try again later...");
+								HttpStatus.BAD_REQUEST,
+								"Supplied document is still in the extraction process. Please try again later...");
 					}
 
 					try {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -445,7 +445,8 @@ public class KnowledgeController {
 					final DocumentAsset document = documentOptional.get();
 
 					if (document.getText() != null) {
-						documentText = document.getText().substring(0, Math.min(document.getText().length(), MAX_CHAR_LIMIT));
+						documentText = document.getText()
+								.substring(0, Math.min(document.getText().length(), MAX_CHAR_LIMIT));
 					} else {
 						throw new ResponseStatusException(
 								HttpStatus.BAD_REQUEST,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -444,10 +444,9 @@ public class KnowledgeController {
 
 					final DocumentAsset document = documentOptional.get();
 
-					try {
-						final int documentTextLength = document.getText().length();
-						documentText = document.getText().substring(0, Math.min(documentTextLength, MAX_CHAR_LIMIT));
-					} catch (NullPointerException e) {
+					if (document.getText() != null) {
+						documentText = document.getText().substring(0, Math.min(document.getText().length(), MAX_CHAR_LIMIT));
+					} else {
 						throw new ResponseStatusException(
 								HttpStatus.BAD_REQUEST,
 								"Supplied document is still in the extraction process. Please try again later...");


### PR DESCRIPTION
# Description

When the user tries to enrich a document in a model. If the document is still being processed, an null error would appear.

Resolves #(issue)
