### PR TITLE
3555 bug unable to enrich dataset with a text extraction only contains an abstract

### DIFF
--- a/packages/client/hmi-client/src/components/documents/tera-text-editor.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-text-editor.vue
@@ -1,5 +1,5 @@
 <template>
-	<QuillEditor theme="snow" v-model:content="text" contentType="html" />
+	<QuillEditor theme="snow" v-model:content="text" contentType="text" />
 </template>
 
 <script setup lang="ts">

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -598,7 +598,7 @@ public class DatasetController {
 			final String csvString = new String(csvBytes);
 			final String[] csvRows = csvString.split("\\R");
 			final String[] headers = csvRows[0].split(",");
-			for(int i = 0; i <headers.length; i++){
+			for (int i = 0; i < headers.length; i++) {
 				// this is very ugly but we're removing opening and closing "'s around these strings.
 				headers[i] = headers[i].replaceAll("^\"|\"$", "");
 			}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -598,6 +598,10 @@ public class DatasetController {
 			final String csvString = new String(csvBytes);
 			final String[] csvRows = csvString.split("\\R");
 			final String[] headers = csvRows[0].split(",");
+			for(int i = 0; i <headers.length; i++){
+				// this is very ugly but we're removing opening and closing "'s around these strings.
+				headers[i] = headers[i].replaceAll("^\"|\"$", "");
+			}
 			return uploadCSVAndUpdateColumns(datasetId, filename, csvEntity, headers);
 		} catch (final IOException e) {
 			final String error = "Unable to upload csv dataset";


### PR DESCRIPTION
# Description

Two issues at play here.  Firstly, the front end treated text as HTML and broke when there was `<` `>` characters in the body. Secondly, quotes weren't being stripped from headers.  WE SHOULD REALLY NOT BE CONSUMING CSVS LIKE THIS... but that may be for another issue...

Resolves #3555
