### PR TITLE
fix: remove auto run in model edit notebook

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -360,10 +360,10 @@ watch(
 		if (props.node.active) {
 			activeOutput.value = props.node.outputs.find((d) => d.id === props.node.active) as any;
 			selectedOutputId.value = props.node.active;
-
 			await inputChangeHandler();
 		}
-	}
+	},
+	{ immediate: true }
 );
 
 onMounted(async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -311,10 +311,6 @@ const inputChangeHandler = async () => {
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', buildJupyterContext());
 			isKernelReady.value = true;
 		}
-
-		if (codeText.value && codeText.value.length > 0) {
-			runFromCodeWrapper();
-		}
 	} catch (error) {
 		logger.error(`Error initializing Jupyter session: ${error}`);
 	}
@@ -367,8 +363,7 @@ watch(
 
 			await inputChangeHandler();
 		}
-	},
-	{ immediate: true }
+	}
 );
 
 onMounted(async () => {


### PR DESCRIPTION
# Description

* Don't auto run notebook code (this was only happening when the Notebook tab was opened as soon as the model edit drilldown is opened)
