### PR TITLE
Ts/update stratify beaker context

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
@@ -58,7 +58,7 @@ const props = defineProps<{
 	contextLanguage: string;
 }>();
 
-const emit = defineEmits(['llm-output', 'llm-thought-output']);
+const emit = defineEmits(['question-asked', 'llm-output', 'llm-thought-output']);
 
 const questionString = ref('');
 const kernelStatus = ref<string>('');
@@ -73,6 +73,7 @@ const submitQuestion = () => {
 	const message = props.kernelManager.sendMessage('llm_request', {
 		request: questionString.value
 	});
+	emit('question-asked');
 	// May prefer to use a manual status rather than following this. TBD. Both options work for now
 	message.register('status', (data) => {
 		kernelStatus.value = data.content.execution_state;
@@ -81,6 +82,10 @@ const submitQuestion = () => {
 		emit('llm-output', data);
 	});
 	message.register('llm_thought', (data) => {
+		thoughts.value = data;
+		emit('llm-thought-output', data);
+	});
+	message.register('llm_response', (data) => {
 		thoughts.value = data;
 		emit('llm-thought-output', data);
 	});

--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-thought-output.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-thought-output.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch, ref, computed } from 'vue';
+import { ref, computed } from 'vue';
 import Button from 'primevue/button';
 
 const props = defineProps<{
@@ -26,15 +26,6 @@ const thought = computed(() => {
 	});
 	return aString;
 });
-
-// Set model, modelNodeOptions
-watch(
-	() => props.llmThoughts,
-	async () => {
-		console.log(props.llmThoughts);
-	},
-	{ immediate: true }
-);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-thought-output.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-thought-output.vue
@@ -11,18 +11,35 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { watch, ref, computed } from 'vue';
 import Button from 'primevue/button';
 
 const props = defineProps<{
-	llmThought?: any;
+	llmThoughts: any[];
 }>();
 const showThoughts = ref(false);
-const thought = computed(() => props?.llmThought?.content?.thought ?? '');
+const thought = computed(() => {
+	let aString = '';
+	props.llmThoughts.forEach((ele) => {
+		const llmResponse = ele.content?.thought ?? ele.content?.text ?? '';
+		aString = aString.concat(llmResponse, '\n \n');
+	});
+	return aString;
+});
+
+// Set model, modelNodeOptions
+watch(
+	() => props.llmThoughts,
+	async () => {
+		console.log(props.llmThoughts);
+	},
+	{ immediate: true }
+);
 </script>
 
 <style scoped>
 .thought-bubble {
+	white-space: pre-line;
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius);
 	padding: var(--gap-small);

--- a/packages/client/hmi-client/src/components/workflow/ops/decapodes/tera-decapodes-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/decapodes/tera-decapodes-drilldown.vue
@@ -31,10 +31,11 @@
 						:defaultOptions="sampleAgentQuestions"
 						:context-language="contextLanguage"
 						@llm-output="(data: any) => appendCode(data, 'code')"
-						@llm-thought-output="(data: any) => (llmThought = data)"
+						@llm-thought-output="(data: any) => llmThoughts.push(data)"
+						@question-asked="llmThoughts = []"
 					/>
 				</Suspense>
-				<tera-notebook-jupyter-thought-output :llm-thought="llmThought" />
+				<tera-notebook-jupyter-thought-output :llm-thoughts="llmThoughts" />
 				<v-ace-editor
 					v-model:value="codeText"
 					@init="initializeEditor"
@@ -118,7 +119,7 @@ const initializeEditor = (editorInstance: any) => {
 	editor = editorInstance;
 };
 const codeText = ref();
-const llmThought = ref();
+const llmThoughts = ref<any[]>([]);
 
 const buildJupyterContext = () => ({
 	context: 'decapodes',

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -86,10 +86,11 @@
 						:kernelManager="kernelManager"
 						:defaultOptions="sampleAgentQuestions"
 						@llm-output="appendCode"
-						@llm-thought-output="(data: any) => (llmThought = data)"
+						@llm-thought-output="(data: any) => llmThoughts.push(data)"
+						@question-asked="llmThoughts = []"
 						:context-language="contextLanguage"
 					/>
-					<tera-notebook-jupyter-thought-output :llm-thought="llmThought" />
+					<tera-notebook-jupyter-thought-output :llm-thoughts="llmThoughts" />
 				</div>
 				<v-ace-editor
 					v-model:value="code"
@@ -191,7 +192,7 @@ const isLoadingStructuralComparisons = ref(false);
 const structuralComparisons = ref<string[]>([]);
 const llmAnswer = ref('');
 const code = ref(props.node.state.notebookHistory?.[0]?.code ?? '');
-const llmThought = ref();
+const llmThoughts = ref<any[]>([]);
 const isKernelReady = ref(false);
 const modelsToCompare = ref<Model[]>([]);
 const contextLanguage = ref<string>('python3');

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
@@ -240,10 +240,11 @@
 							:defaultOptions="sampleAgentQuestions"
 							:context-language="contextLanguage"
 							@llm-output="(data: any) => appendCode(data, 'code')"
-							@llm-thought-output="(data: any) => (llmThought = data)"
+							@llm-thought-output="(data: any) => llmThoughts.push(data)"
+							@question-asked="llmThoughts = []"
 						/>
 					</Suspense>
-					<tera-notebook-jupyter-thought-output :llm-thought="llmThought" />
+					<tera-notebook-jupyter-thought-output :llm-thoughts="llmThoughts" />
 				</div>
 				<v-ace-editor
 					v-model:value="codeText"
@@ -442,7 +443,7 @@ const buildJupyterContext = () => {
 const codeText = ref(
 	'# This environment contains the variable "model_config" to be read and updated'
 );
-const llmThought = ref();
+const llmThoughts = ref<any[]>([]);
 const notebookResponse = ref();
 const executeResponse = ref({
 	status: OperatorStatus.DEFAULT,

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -165,7 +165,8 @@ const sampleAgentQuestions = [
 	'Add a new transition from S (to nowhere) with a rate constant of v with unit Days. The Rate depends on R',
 	'Add an observable titled sample with the expression A * B  * p.',
 	'Rename the state S to Susceptible in the infection transition.',
-	'Rename the transition infection to inf.'
+	'Rename the transition infection to inf.',
+	'Change rate law of inf to S * I * z.'
 ];
 
 const contextLanguage = ref<string>('python3');

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -33,10 +33,11 @@
 							:default-options="sampleAgentQuestions"
 							:context-language="contextLanguage"
 							@llm-output="(data: any) => appendCode(data, 'code')"
-							@llm-thought-output="(data: any) => (llmThought = data)"
+							@llm-thought-output="(data: any) => llmThoughts.push(data)"
+							@question-asked="llmThoughts = []"
 						/>
 					</Suspense>
-					<tera-notebook-jupyter-thought-output :llm-thought="llmThought" />
+					<tera-notebook-jupyter-thought-output :llm-thoughts="llmThoughts" />
 				</div>
 				<v-ace-editor
 					v-model:value="codeText"
@@ -174,7 +175,7 @@ const contextLanguage = ref<string>('python3');
 const defaultCodeText =
 	'# This environment contains the variable "model" \n# which is displayed on the right';
 const codeText = ref(defaultCodeText);
-const llmThought = ref();
+const llmThoughts = ref<any[]>([]);
 
 const executeResponse = ref({
 	status: OperatorStatus.DEFAULT,

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -311,7 +311,7 @@ const buildJupyterContext = () => {
 	}
 
 	return {
-		context: 'mira_model',
+		context: 'mira_model_edit',
 		language: 'python3',
 		context_info: {
 			id: amr.value.id

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -48,9 +48,10 @@
 						:default-options="[]"
 						:context-language="'python3'"
 						@llm-output="(data: any) => processLLMOutput(data)"
-						@llm-thought-output="(data: any) => (llmThought = data)"
+						@llm-thought-output="(data: any) => llmThoughts.push(data)"
+						@question-asked="llmThoughts = []"
 					/>
-					<tera-notebook-jupyter-thought-output :llm-thought="llmThought" />
+					<tera-notebook-jupyter-thought-output :llm-thoughts="llmThoughts" />
 				</div>
 				<v-ace-editor
 					v-model:value="codeText"
@@ -200,7 +201,7 @@ const kernelManager = new KernelSessionManager();
 
 let editor: VAceEditorInstance['_editor'] | null;
 const codeText = ref('');
-const llmThought = ref();
+const llmThoughts = ref<any[]>([]);
 
 const updateStratifyGroupForm = (config: StratifyGroup) => {
 	const state = _.cloneDeep(props.node.state);

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -45,7 +45,7 @@
 				<div class="toolbar">
 					<tera-notebook-jupyter-input
 						:kernel-manager="kernelManager"
-						:default-options="[]"
+						:default-options="sampleAgentQuestions"
 						:context-language="'python3'"
 						@llm-output="(data: any) => processLLMOutput(data)"
 						@llm-thought-output="(data: any) => llmThoughts.push(data)"
@@ -202,6 +202,12 @@ const kernelManager = new KernelSessionManager();
 let editor: VAceEditorInstance['_editor'] | null;
 const codeText = ref('');
 const llmThoughts = ref<any[]>([]);
+
+const sampleAgentQuestions = [
+	'Stratify my model by the ages young and old',
+	'Stratify my model by the locations Toronto and Montreal where Toronto and Montreal cannot interact',
+	'What is cartesian_control in stratify?'
+];
 
 const updateStratifyGroupForm = (config: StratifyGroup) => {
 	const state = _.cloneDeep(props.node.state);

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -260,16 +260,13 @@ const stratifyRequest = () => {
 	});
 
 	const messageContent = {
-		stratify_args: {
-			key: strataOption.name,
-			strata: strataOption.groupLabels.split(',').map((d) => d.trim()),
-			concepts_to_stratify: conceptsToStratify,
-			params_to_stratify: parametersToStratify,
-			cartesian_control: strataOption.cartesianProduct,
-			structure: strataOption.useStructure === true ? null : []
-		}
+		key: strataOption.name,
+		strata: strataOption.groupLabels.split(',').map((d) => d.trim()),
+		concepts_to_stratify: conceptsToStratify,
+		params_to_stratify: parametersToStratify,
+		cartesian_control: strataOption.cartesianProduct,
+		structure: strataOption.useStructure === true ? null : []
 	};
-
 	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		kernelManager
 			.sendMessage('stratify_request', messageContent)

--- a/testing/Stratify-LLM-Tests.md
+++ b/testing/Stratify-LLM-Tests.md
@@ -1,0 +1,101 @@
+## [Name of the Test Scenario]
+Please go through __every__ step of the test scenario.\
+When blocked, an error, or a UI/UX anomaly occurs, please report which scenario and step to [\#askem-testing](https://unchartedsoftware.slack.com/archives/C06FGLXB2CE).
+
+### 1. Begin test
+1. Login to https://app.staging.terarium.ai using the test account
+    ```
+    email: qa@test.io
+    password: askem-quality-assurance
+    ```
+2. Create, or open, project named `Q&A [Your Name] [YYMMDD]`
+
+### 2. Test Stratify LLM Responses
+1. Make sure you have a model in your project.
+2. Create a workflow
+    Drop in your model in the workflow
+    Create a Stratify node
+    Connect the model to the stratify node
+3. Drill down into the Stratify node and go to the notebook section.
+
+Ask the follow questions one at a time, wait for the response, check the response matches
+reset the code block move on to the next.
+
+Q) "Stratify my model by the ages young and old",
+A) 
+model = stratify(
+    template_model=model,
+    key= "Age",
+    strata=['young', 'old'],
+    structure= [],
+    directed=False,
+    cartesian_control=False,
+    modify_names=True
+)
+
+Q) Stratify my model by the ages young and old where young can transition to old
+A) 
+model = stratify(
+    template_model=model,
+    key= "Age",
+    strata=['young', 'old'],
+    structure= [['young', 'old']],
+    directed=True,
+    cartesian_control=False,
+    modify_names=True
+)
+
+Q) Stratify my model by the ages young and old where young and old can become old, but old cannot become young
+A) 
+model = stratify(
+    template_model=model,
+    key= "Age",
+    strata=['young', 'old'],
+    structure= [['young', 'old']],
+    directed=False,
+    cartesian_control=False,
+    modify_names=True
+)
+
+Q) Stratify my model by the locations Toronto and Montreal where Toronto and Montreal cannot interact
+A) 
+model = stratify(
+    template_model=model,
+    key= "Location",
+    strata=['Toronto', 'Montreal'],
+    structure= [],
+    directed=False,
+    cartesian_control=False,
+    modify_names=True
+)
+
+Q) Stratify my model by the locations Toronto and Montreal where Toronto and Montreal can interact
+A) 
+model = stratify(
+    template_model=model,
+    key= "Location",
+    strata=['Toronto', 'Montreal'],
+    structure= [['Toronto', 'Montreal'], ['Montreal', 'Toronto']],
+    directed=False,
+    cartesian_control=True,
+    modify_names=True
+)
+
+OR
+model = stratify(
+    template_model=model,
+    key= "Location",
+    strata=['Toronto', 'Montreal'],
+    structure= [['Toronto', 'Montreal']],
+    directed=True,
+    cartesian_control=True,
+    modify_names=True
+)
+
+Q) What is cartesian_control in stratify?
+A)
+No code response, instead just a message in the thought section.
+
+
+### 4. End test
+1. logout of the application 


### PR DESCRIPTION
# Whats changed?
- Moving stratify context to the `mira_model_edit` context where a stratify procedure exists (https://github.com/DARPA-ASKEM/beaker-kernel/pull/130)
- Reset thoughts on asking a question
- append thoughts instead of replacing
- append llm_responses as well (this is when a user asks for documentation for eg)
- Update stratify default Q's

# Note: 
below the code screenshots have a bunch of comments above the stratify code. This is a beaker change in another branch that will not be keeping the comments.

# Pictures 
<img width="1412" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/3a18a173-d4c1-4898-851d-ed9c6919e1da">

<img width="729" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/b9ba5671-1451-4639-9f9a-36660cc4789d">


