### PR TITLE
Fix: regnet stratify dropdown options

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -348,7 +348,7 @@ const getStatesAndParameters = (amrModel: Model) => {
 		});
 	} else if (modelFramework === AMRSchemaNames.REGNET) {
 		model.vertices.forEach((v) => {
-			modelStates.push(v.id);
+			modelStates.push(v.name);
 		});
 		model.parameters.forEach((p) => {
 			modelParameters.push(p.id);


### PR DESCRIPTION
# Description
This dropdown for regnets should be based off of regnet's vertices's names not ids (or we can update MIRA which may take longer)

As of right now we are allowing user to select ID which will not stratify correctly

<img width="1444" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/17088680/7bade689-fa62-44c6-b8ee-1f603e141e22">

