### PR TITLE
regnets stratify based off of name not id

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -344,7 +344,7 @@ const getStatesAndParameters = (amrModel: Model) => {
 		});
 	} else if (modelFramework === AMRSchemaNames.REGNET) {
 		model.vertices.forEach((v) => {
-			modelStates.push(v.id);
+			modelStates.push(v.name);
 		});
 		model.parameters.forEach((p) => {
 			modelParameters.push(p.id);


### PR DESCRIPTION
# Description
This dropdown for regnets should be based off of regnet's vertices's names not ids (or we can update MIRA which may take longer)

As of right now we are allowing user to select ID which will not stratify correctly
![image](https://github.com/DARPA-ASKEM/terarium/assets/17088680/552c75e7-9748-4b08-b8a5-6ab4aee671e0)
