### PR TITLE
flag workflow to be saved on remove-node and duplicate-branch

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -444,12 +444,14 @@ const closeDrilldown = async () => {
 
 const removeNode = (event) => {
 	workflowService.removeNode(wf.value, event);
+	workflowDirty = true;
 };
 
 const duplicateBranch = (id: string) => {
 	workflowService.branchWorkflow(wf.value, id);
 
 	cloneNoteBookSessions();
+	workflowDirty = true;
 };
 
 // We need to clone data-transform sessions, unlike other operators that are


### PR DESCRIPTION
### Summary
For some reason we forgot to flag workflow to be saved on 
- operator node removal
- branch workflow

### Testing
Remove a node in a workflow, then quick navigate away, and come back, note the removed node should not reappear.