### PR TITLE
fix cache not refresh upper and lower bound on upstream change

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -491,10 +491,10 @@ const setModelOptions = async () => {
 // eslint-disable-next-line
 const setRequestParameters = (modelParameters: ModelParameter[]) => {
 	const previous = props.node.state.requestParameters;
-	if (previous && previous.length > 0) {
-		requestParameters.value = _.cloneDeep(props.node.state.requestParameters);
-		return;
-	}
+	const labelMap = new Map<string, string>();
+	previous.forEach((p) => {
+		labelMap.set(p.name, p.label);
+	});
 
 	requestParameters.value = modelParameters.map((ele) => {
 		let interval = { lb: ele.value, ub: ele.value };
@@ -504,11 +504,12 @@ const setRequestParameters = (modelParameters: ModelParameter[]) => {
 				ub: ele.distribution.parameters.maximum
 			};
 		}
-		return {
-			name: ele.id,
-			interval,
-			label: 'any'
-		};
+
+		const param = { name: ele.id, interval, label: 'any' };
+		if (labelMap.has(param.name)) {
+			param.label = labelMap.get(param.name) as string;
+		}
+		return param;
 	});
 };
 


### PR DESCRIPTION
### Summary
`requestParameter` is saved into the operator state, but when upstream configuration changes it needs to be refreshed.


### Testing
- Create a simple funman workflow, e.g. `SIR => model-config => funman`
- Select beta/gamma are parameters of interest under "additional options"
- Run funman
- Goto model-config operator, change beta/gamma upper/lower ranges
- Goto funman operator, run funman
- Compare the two results, verify that they have different output ranges based on the model configuration settings.

![image](https://github.com/DARPA-ASKEM/terarium/assets/1220927/8d576793-7f17-4b72-907b-280748bf0981)
