### PR TITLE
fix(model-edit): code is saved properly in output state

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -112,7 +112,13 @@ import { ModelEditOperationState } from './model-edit-operation';
 const props = defineProps<{
 	node: WorkflowNode<ModelEditOperationState>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output']);
+const emit = defineEmits([
+	'append-output',
+	'update-state',
+	'close',
+	'select-output',
+	'update-output-port'
+]);
 
 enum ModelEditTabs {
 	Wizard = 'Wizard',
@@ -292,6 +298,13 @@ function updateCodeState(code: string = codeText.value, hasCodeRun: boolean = tr
 // Called when the selected output is changed, component unmounts or before the window is closed
 function updateOutputModel() {
 	if (readyToSaveOutputModel.value && amr.value) {
+		// Save notebook code to output state
+		if (activeOutput.value) {
+			const updatedOutputPort = cloneDeep(activeOutput.value);
+			updatedOutputPort.state = cloneDeep(props.node.state);
+			emit('update-output-port', updatedOutputPort);
+		}
+		// Save model in backend
 		updateModel(amr.value);
 		readyToSaveOutputModel.value = false;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -293,6 +293,8 @@ function updateCodeState(code: string = codeText.value, hasCodeRun: boolean = tr
 	emit('update-state', state);
 }
 
+// FIXME: Output port should not be updated as outputs are read only, this is a temporary fix so that code and model are in sync
+// FIXME: We should create the output once a Save button is clicked, any edits made on an output would be saved as a draft
 // Saves the output model in the backend
 // Not called after every little model edit to avoid too many requests
 // Called when the selected output is changed, component unmounts or before the window is closed


### PR DESCRIPTION
# Description

The notebook code was only saved once the new output model was created. Any edits after that were not saved.

Now the code is saved properly.

BEFORE:

https://github.com/DARPA-ASKEM/terarium/assets/28237258/59439e70-ba39-49f3-ba77-e161f3c772ea

AFTER:

https://github.com/DARPA-ASKEM/terarium/assets/28237258/eace54c6-33c2-4638-ae15-b64dcd00f1c6

