### PR TITLE
do not drag operators when clicking on the input or output ports

### DIFF
--- a/packages/client/hmi-client/src/components/operator/tera-operator-inputs.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-inputs.vue
@@ -10,6 +10,7 @@
 			@click.stop="emit('port-selected', input, WorkflowDirection.FROM_INPUT)"
 			@focus="() => {}"
 			@focusout="() => {}"
+			@mousedown.stop
 		>
 			<section>
 				<div class="port-container">

--- a/packages/client/hmi-client/src/components/operator/tera-operator-outputs.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-outputs.vue
@@ -10,6 +10,7 @@
 			@click.stop="emit('port-selected', output, WorkflowDirection.FROM_OUTPUT)"
 			@focus="() => {}"
 			@focusout="() => {}"
+			@mousedown.stop
 		>
 			<section>
 				<div class="port-container">


### PR DESCRIPTION
# Description

* A small fix to address the bug where dragging an operator from a label will cause wonky arrows to appear.  Now you cannot drag when clicking a label (see attached bug ticket from additional details)

