### PR TITLE
fix funman contraint-group-key generation

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -98,7 +98,7 @@
 					<tera-compartment-constraint :variables="modelStates" :mass="mass" />
 					<tera-constraint-group-form
 						v-for="(cfg, index) in node.state.constraintGroups"
-						:key="index + Date.now()"
+						:key="selectedOutputId + ':' + index"
 						:config="cfg"
 						:index="index"
 						:model-states="modelStates"


### PR DESCRIPTION
### Summary
The constraint-group keys were too loosely generated that they refresh every time the underlying data changes, this hooks up a parent-surrogate key, so it will re-render when switching output, but not constantly refresh if values are changed.


### Testing
Within a funman-operator
- verify that you can enter the numeric constraints

Run a couple of scenarios with different constraints, verify you can switch between these and the UI is reflecting the changes.