### PR TITLE
remember selected traj-state in funman output

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/funman-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/funman-operation.ts
@@ -34,6 +34,9 @@ export interface FunmanOperationState extends BaseState {
 	useCompartmentalConstraint: boolean;
 	constraintGroups: ConstraintGroup[];
 	requestParameters: RequestParameter[];
+
+	// selected state in ouptut
+	trajectoryState?: string;
 }
 
 export const FunmanOperation: Operation = {

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-output.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-output.vue
@@ -1,7 +1,12 @@
 <template>
 	<div class="section-row">
 		<label>Trajectory State</label>
-		<Dropdown v-model="selectedTrajState" :options="modelStates"> </Dropdown>
+		<Dropdown
+			v-model="selectedTrajState"
+			:options="modelStates"
+			@update:model-value="emit('update:trajectoryState', $event)"
+		>
+		</Dropdown>
 	</div>
 	<div ref="trajRef"></div>
 
@@ -85,7 +90,10 @@ import TeraFunmanBoundaryChart from './tera-funman-boundary-chart.vue';
 
 const props = defineProps<{
 	funModelId: string;
+	trajectoryState?: string;
 }>();
+
+const emit = defineEmits(['update:trajectoryState']);
 
 const parameterOptions = ref<string[]>([]);
 const selectedParam = ref<string>('');
@@ -147,7 +155,8 @@ const initalizeParameters = async () => {
 	funmanResult.model.petrinet.model.states.forEach((element) => {
 		modelStates.value.push(element.id);
 	});
-	selectedTrajState.value = modelStates.value[0];
+
+	selectedTrajState.value = props.trajectoryState || modelStates.value[0];
 
 	lastTrueBox.value = funmanResult.parameter_space.true_boxes?.at(-1);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -139,7 +139,12 @@
 					<tera-progress-spinner :font-size="2" is-centered style="height: 100%" />
 				</template>
 				<template v-else>
-					<tera-funman-output v-if="activeOutput" :fun-model-id="activeOutput.value?.[0]" />
+					<tera-funman-output
+						v-if="activeOutput"
+						:fun-model-id="activeOutput.value?.[0]"
+						:trajectoryState="node.state.trajectoryState"
+						@update:trajectoryState="updateTrajectorystate"
+					/>
 					<div v-else class="flex flex-column h-full justify-content-center">
 						<tera-operator-placeholder :operation-type="node.operationType" />
 					</div>
@@ -511,6 +516,12 @@ const setRequestParameters = (modelParameters: ModelParameter[]) => {
 		}
 		return param;
 	});
+};
+
+const updateTrajectorystate = (s: string) => {
+	const state = _.cloneDeep(props.node.state);
+	state.trajectoryState = s;
+	emit('update-state', state);
 };
 
 const onSelection = (id: string) => {


### PR DESCRIPTION
### Summary
Remember the selected trajectory-state in funman output, this will be saved to the operator's state, and shared across the operator's output.

<img width="1209" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/c84c3458-8ecc-45f6-b707-b74456aee65e">



### Test
In funman operator with several outputs
- change the shown trajectory state
- switch to different output, verify trajectory state did not change
- exit the operator and come back, verify trajectory state is restored