### PR TITLE
Unnecessary and Incorrect Permission check

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -178,8 +178,6 @@ public class ProjectController {
 					AssetType.DATASET, AssetType.MODEL, AssetType.DOCUMENT, AssetType.WORKFLOW, AssetType.PUBLICATION);
 
 			final RebacProject rebacProject = new RebacProject(project.getId(), reBACService);
-			final Schema.Permission permission = projectService.checkPermissionCanWrite(
-					currentUserService.get().getId(), project.getId());
 
 			// Set the user permission for the project. If we are unable to get the user permission, we remove the
 			// project.


### PR DESCRIPTION
The initial fetch of projectIds ensures the user has READ permission for all projects, there is no need to check again (let alone incorrectly check that they have WRITE permissions - mistake).  Yes there is a potential race condition that a project between initial ids and population could change permission, but the same can be said whilst they sit on the projects page, it is a moot issue.