### PR TITLE
Dataset filenames repeating

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -775,7 +775,7 @@ public class DatasetController {
 				// add the filename to existing file names
 				if (updatedDataset.get().getFileNames() == null) {
 					updatedDataset.get().setFileNames(new ArrayList<>(List.of(filename)));
-				} else {
+				} else if (!updatedDataset.get().getFileNames().contains(filename)) {
 					updatedDataset.get().getFileNames().add(filename);
 				}
 


### PR DESCRIPTION
# Description

Small fix to stop filenames from duplicating

![image](https://github.com/DARPA-ASKEM/terarium/assets/95376249/8203817d-06d7-4403-a73a-9ea71220ae4e)

![image](https://github.com/DARPA-ASKEM/terarium/assets/95376249/d2990ad2-338f-4293-aafe-5661c13afab4)


Resolves #(issue)
