### PR TITLE
default to 0 if no value found for pyodide paramters-map gen

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -453,7 +453,8 @@ const setModelOptions = async () => {
 
 	const parametersMap = {};
 	semantics?.ode.parameters?.forEach((d) => {
-		parametersMap[renameReserved(d.id)] = d.value;
+		// FIXME: may need to sample distributions if value is not available
+		parametersMap[renameReserved(d.id)] = d.value || 0;
 	});
 
 	const massValue = await pythonInstance.evaluateExpression(


### PR DESCRIPTION
### Summary
Fix pyodide errors that arose because parameters have no values - for now default to 0. 
May need to revisit in the future to sample distribution if provided.