### PR TITLE
Add workflowid to notebooksession and create proper migration from name

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
@@ -404,7 +404,7 @@ watch(
 		if (props.notebookSession) {
 			await updateNotebookSession({
 				id: props.notebookSession.id,
-				name: props.notebookSession.name,
+				workflowId: props.notebookSession.workflowId,
 				description: props.notebookSession.description,
 				data: { history: notebookItems.value }
 			});

--- a/packages/client/hmi-client/src/components/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
@@ -59,7 +59,7 @@ onMounted(async () => {
 		// create a new notebook session log if it does not exist
 		const response = await createNotebookSession({
 			id: uuidv4(),
-			name: props.node.id,
+			workflowId: props.node.id,
 			description: '',
 			data: { history: [] }
 		});

--- a/packages/client/hmi-client/src/components/workflow/ops/model-transformer/tera-model-transformer.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-transformer/tera-model-transformer.vue
@@ -58,7 +58,7 @@ onMounted(async () => {
 		// create a new notebook session log if it does not exist
 		const response = await createNotebookSession({
 			id: uuidv4(),
-			name: props.node.id,
+			workflowId: props.node.id,
 			description: '',
 			data: { history: [] }
 		});

--- a/packages/client/hmi-client/src/components/workflow/ops/regridding/tera-regridding.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/regridding/tera-regridding.vue
@@ -50,7 +50,7 @@ onMounted(async () => {
 		// create a new notebook session log if it does not exist
 		const response = await createNotebookSession({
 			id: uuidv4(),
-			name: props.node.id,
+			workflowId: props.node.id,
 			description: '',
 			data: { history: [] }
 		});

--- a/packages/client/hmi-client/src/services/notebook-session.ts
+++ b/packages/client/hmi-client/src/services/notebook-session.ts
@@ -14,7 +14,7 @@ export const getNotebookSessionById = async (notebook_id: string) => {
 export const createNotebookSession = async (notebookSession: NotebookSession) => {
 	const response = await API.post(`/sessions`, {
 		id: notebookSession.id,
-		name: notebookSession.name,
+		workflowId: notebookSession.workflowId,
 		description: notebookSession.description,
 		data: notebookSession.data
 	} as NotebookSession);
@@ -24,7 +24,7 @@ export const createNotebookSession = async (notebookSession: NotebookSession) =>
 export const updateNotebookSession = async (notebookSession: NotebookSession) => {
 	const response = await API.put(`/sessions/${notebookSession.id}`, {
 		id: notebookSession.id,
-		name: notebookSession.name,
+		workflowId: notebookSession.workflowId,
 		description: notebookSession.description,
 		data: notebookSession.data
 	});

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -381,6 +381,7 @@ export interface DecapodesTerm {
 }
 
 export interface NotebookSession extends TerariumAsset {
+    workflowId: string;
     data: any;
 }
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/notebooksession/NotebookSession.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/notebooksession/NotebookSession.java
@@ -29,9 +29,12 @@ public class NotebookSession extends TerariumAsset {
 	@Column(columnDefinition = "json")
 	private JsonNode data;
 
+	@Override
 	public NotebookSession clone() {
-		NotebookSession session = new NotebookSession();
+		final NotebookSession session = new NotebookSession();
+		super.cloneSuperFields(session);
 		session.setData(data.deepCopy());
+		session.workflowId = workflowId;
 		return session;
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/notebooksession/NotebookSession.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/notebooksession/NotebookSession.java
@@ -5,6 +5,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import java.io.Serial;
+import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
@@ -22,8 +23,7 @@ public class NotebookSession extends TerariumAsset {
 	@Serial
 	private static final long serialVersionUID = 9176019416379347233L;
 
-	// TODO: https://github.com/DARPA-ASKEM/terarium/issues/3719
-	// private UUID workflowId;
+	private UUID workflowId;
 
 	@Type(JsonType.class)
 	@Column(columnDefinition = "json")

--- a/packages/server/src/main/resources/db/migration/V14__NotebookSession_name_to_workflowid.sql
+++ b/packages/server/src/main/resources/db/migration/V14__NotebookSession_name_to_workflowid.sql
@@ -1,0 +1,4 @@
+UPDATE notebook_session
+	SET workflow_id=cast(name as uuid),
+			name=NULL
+


### PR DESCRIPTION
# Description

* Migration from `name` to `workflowId`
* fixing clone logic in notebook session

## IMPORTANT
This CANNOT be merged until #3717 has been deployed to both staging and production.

Resolves #3719
