### PR TITLE
move menu save option to a button

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
@@ -23,6 +23,9 @@
 						@click="createConfiguration(false)"
 					/>
 				</template>
+				<template #header-controls-right>
+					<Button class="mr-3" label="Save" @click="() => createConfiguration(false)" />
+				</template>
 				<!-- Suggested configurations -->
 				<div class="box-container mr-2" v-if="model">
 					<Accordion multiple :active-index="[0]">
@@ -354,13 +357,6 @@ const props = defineProps<{
 }>();
 
 const menuItems = computed(() => [
-	{
-		label: 'Save as new configuration',
-		icon: 'pi pi-pencil',
-		command: () => {
-			createConfiguration(false);
-		}
-	},
 	{
 		label: 'Download',
 		icon: 'pi pi-download',


### PR DESCRIPTION
# Description

On the Model Config the save option should not be in the menu. It should be a button under it in the drill down section.
![image](https://github.com/DARPA-ASKEM/terarium/assets/95376249/117102b3-2cdb-474a-b066-a1d1938e25a6)

Resolves #(issue)
