### PR TITLE
model config tooltips

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
@@ -7,30 +7,33 @@
 	</header>
 	<main>
 		<span class="flex gap-2">
-			<Dropdown
-				:model-value="parameterDistribution.type"
-				@change="
-					emit('update-parameter', {
-						id: parameterId,
-						distribution: formatPayloadFromTypeChange($event.value)
-					})
-				"
-				filter
-				option-label="name"
-				option-value="value"
-				:options="distributionTypeOptions()"
-			>
-				<template #value="{ value }">
-					<span class="flex flex-1" v-tooltip.top="getTooltipContent(value)">{{
-						DistributionTypeLabel[value]
-					}}</span>
+			<tera-tooltip position="top" :has-arrow="false">
+				<Dropdown
+					:model-value="parameterDistribution.type"
+					@change="
+						emit('update-parameter', {
+							id: parameterId,
+							distribution: formatPayloadFromTypeChange($event.value)
+						})
+					"
+					filter
+					option-label="name"
+					option-value="value"
+					:options="distributionTypeOptions()"
+				>
+					<template #option="{ option }">
+						<span class="flex flex-1" v-tooltip="getTooltipContent(option.value)">{{
+							option.name
+						}}</span>
+					</template>
+				</Dropdown>
+				<template #tooltip-content>
+					<h1 class="pb-1">{{ DistributionTypeLabel[parameterDistribution.type] }}</h1>
+					<p class="distribution-description">
+						{{ DistributionTypeDescription[parameterDistribution.type] }}
+					</p>
 				</template>
-				<template #option="{ option }">
-					<span class="flex flex-1" v-tooltip="getTooltipContent(option.value)">{{
-						option.name
-					}}</span>
-				</template>
-			</Dropdown>
+			</tera-tooltip>
 
 			<!-- Constant -->
 			<tera-input
@@ -106,6 +109,7 @@ import {
 	DistributionTypeLabel,
 	distributionTypeOptions
 } from '@/services/distribution';
+import TeraTooltip from '@/components/widgets/tera-tooltip.vue';
 
 const props = defineProps<{
 	modelConfiguration: ModelConfiguration;
@@ -185,5 +189,9 @@ main {
 
 :deep(.p-dropdown-label) {
 	min-width: 10rem;
+}
+
+.distribution-description {
+	width: 12rem;
 }
 </style>

--- a/packages/client/hmi-client/src/services/distribution.ts
+++ b/packages/client/hmi-client/src/services/distribution.ts
@@ -8,7 +8,13 @@ export const DistributionTypeLabel: { [key in DistributionType]: string } = {
 	[DistributionType.Uniform]: 'Uniform'
 };
 
-export const distributionTypeOptions = (): { name: string; value: string }[] =>
+export const DistributionTypeDescription: { [key in DistributionType]: string } = {
+	[DistributionType.Constant]: 'value is the constant value.',
+	[DistributionType.Uniform]:
+		'low is the lower range (inclusive), high is the upper range (exclusive).'
+};
+
+export const distributionTypeOptions = (): { name: string; value: DistributionType }[] =>
 	Object.values(DistributionType).map((dist) => ({
 		name: DistributionTypeLabel[dist],
 		value: dist

--- a/packages/client/hmi-client/src/services/distribution.ts
+++ b/packages/client/hmi-client/src/services/distribution.ts
@@ -10,8 +10,7 @@ export const DistributionTypeLabel: { [key in DistributionType]: string } = {
 
 export const DistributionTypeDescription: { [key in DistributionType]: string } = {
 	[DistributionType.Constant]: 'value is the constant value.',
-	[DistributionType.Uniform]:
-		'low is the lower range (inclusive), high is the upper range (exclusive).'
+	[DistributionType.Uniform]: 'low is the lower range, high is the upper range.'
 };
 
 export const distributionTypeOptions = (): { name: string; value: DistributionType }[] =>


### PR DESCRIPTION
# Description

* Just adding a tooltip to describe the distribution type
* Was having some formatting some issues with `tera-tooltip` so I couldn't use a custom component for the dropdown options.  Im using the primvue tooltip directive until we have some time to rework the tooltip.

https://github.com/DARPA-ASKEM/terarium/assets/33158416/c4adf786-a62d-4549-9784-8f383e36b3c7

