### PR TITLE
[Fix]: Save dataset was always disabled due to mismatching types in function call

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-save-dataset-from-simulation.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-save-dataset-from-simulation.vue
@@ -42,8 +42,8 @@ const emit = defineEmits(['hide-dialog']);
 const saveDatasetToProject = async () => {
 	const { activeProject, refresh } = useProjects();
 	if (activeProject.value?.id) {
-		logger.success(`Added dataset: ${saveAsName.value}`);
 		if (await saveDataset(activeProject.value.id, props.simulationRunId, saveAsName.value)) {
+			logger.success(`Added dataset: ${saveAsName.value}`);
 			refresh();
 		}
 	}

--- a/packages/client/hmi-client/src/components/dataset/utils.ts
+++ b/packages/client/hmi-client/src/components/dataset/utils.ts
@@ -46,10 +46,10 @@ function enrichDataset(dataset: Dataset): Dataset {
 	return dataset;
 }
 
-function isSaveDataSetDisabled(id, projectid): boolean {
+function isSaveDatasetDisabled(id, projectid): boolean {
 	if (id === undefined || id === '' || !projectid) {
 		return true;
 	}
 	return false;
 }
-export { enrichDataset, isSaveDataSetDisabled };
+export { enrichDataset, isSaveDatasetDisabled };

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -241,7 +241,7 @@ interface BasicKnobs {
 }
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDatasetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(props.node.state.forecastRunId, useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue
@@ -216,7 +216,7 @@ import type {
 } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
 import { WorkflowNode } from '@/types/workflow';
-import { isSaveDataSetDisabled } from '@/components/dataset/utils';
+import { isSaveDatasetDisabled } from '@/components/dataset/utils';
 import {
 	CalibrateEnsembleCiemssOperationState,
 	EnsembleCalibrateExtraCiemss
@@ -241,7 +241,7 @@ interface BasicKnobs {
 }
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDataSetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
@@ -336,7 +336,7 @@ import { WorkflowNode } from '@/types/workflow';
 
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { useProjects } from '@/composables/project';
-import { isSaveDataSetDisabled } from '@/components/dataset/utils';
+import { isSaveDatasetDisabled } from '@/components/dataset/utils';
 import {
 	OptimizeCiemssOperationState,
 	InterventionTypes,
@@ -406,7 +406,7 @@ const cancelRunId = computed(
 );
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDataSetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss.vue
@@ -406,7 +406,7 @@ const cancelRunId = computed(
 );
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDatasetDisabled(props.node.state.forecastRunId, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(props.node.state.forecastRunId, useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -196,7 +196,7 @@ const viewOptions = ref([
 ]);
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDatasetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(selectedRunId.value, useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue
@@ -161,7 +161,7 @@ import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-datase
 import TeraPyciemssCancelButton from '@/components/pyciemss/tera-pyciemss-cancel-button.vue';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { useProjects } from '@/composables/project';
-import { isSaveDataSetDisabled } from '@/components/dataset/utils';
+import { isSaveDatasetDisabled } from '@/components/dataset/utils';
 import { SimulateCiemssOperationState } from './simulate-ciemss-operation';
 
 const props = defineProps<{
@@ -196,7 +196,7 @@ const viewOptions = ref([
 ]);
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDataSetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -128,7 +128,7 @@ import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 
-import { isSaveDataSetDisabled } from '@/components/dataset/utils';
+import { isSaveDatasetDisabled } from '@/components/dataset/utils';
 import { SimulateJuliaOperationState } from './simulate-julia-operation';
 
 const props = defineProps<{
@@ -200,7 +200,7 @@ const run = async () => {
 const showSaveDataDialog = ref<boolean>(false);
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDataSetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-julia.vue
@@ -200,7 +200,7 @@ const run = async () => {
 const showSaveDataDialog = ref<boolean>(false);
 
 const isSaveDisabled = computed<boolean>(() =>
-	isSaveDatasetDisabled(selectedRunId.value, !useProjects().activeProject.value?.id)
+	isSaveDatasetDisabled(selectedRunId.value, useProjects().activeProject.value?.id)
 );
 
 const menuItems = computed(() => [

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
@@ -332,7 +332,7 @@ public class SimulationController {
 			// Create the dataset asset:
 			final UUID simId = sim.get().getId();
 			final Dataset dataset = datasetService.createAsset(new Dataset(), permission);
-			dataset.setName(datasetName + " Result Dataset");
+			dataset.setName(datasetName);
 			dataset.setDescription(sim.get().getDescription());
 			dataset.setMetadata(mapper.convertValue(Map.of("simulationId", simId.toString()), JsonNode.class));
 			dataset.setFileNames(sim.get().getResultFiles());


### PR DESCRIPTION
# Description
Parameters sent to this `isSaveDatasetDisabled` were incorrect resulting in never being able to save a dataset :( 
![image](https://github.com/DARPA-ASKEM/terarium/assets/17088680/eefe35fd-d01d-4d75-997f-621ef9532be0)

# Updates
-Rename to have dataset not be camel cased as 2 works
-Change parameter from boolean to the value it wants
-remove the appending of "result dataset" for every file when user did not specify
-move logger success to after it actually succeeds  