### PR TITLE
Update documentation link

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/regridding/regridding-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/regridding/regridding-operation.ts
@@ -1,7 +1,7 @@
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 
 const DOCUMENTATION_URL =
-	'https://github.com/DARPA-ASKEM/beaker-kernel/blob/main/docs/contexts_climate_data_utility.md';
+	'https://darpa-askem.github.io/askem-beaker/contexts_climate_data_utility.html';
 
 export interface RegriddingOperationState extends BaseState {
 	datasetId: string | null;


### PR DESCRIPTION
Update url from repo name change, but also point to pretty documentation instead of github documentation sourcefile.