### PR TITLE
Task runner log: check for null type and log

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
@@ -18,7 +18,8 @@ public class TaskNotificationEventTypes {
 		final ClientEventType eventType = clientEventTypes.get(taskName);
 		if (eventType == null){
 			log.warn("Event type not found for task: " + taskName);
+			return ClientEventType.TASK_UNDEFINED_EVENT;
 		}
-		return eventType == null ? ClientEventType.TASK_UNDEFINED_EVENT : eventType;
+		return eventType;
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
@@ -2,7 +2,9 @@ package software.uncharted.terarium.hmiserver.service.tasks;
 
 import java.util.Map;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TaskNotificationEventTypes {
 
 	private static Map<String, ClientEventType> clientEventTypes = Map.of(
@@ -14,6 +16,9 @@ public class TaskNotificationEventTypes {
 
 	public static ClientEventType getTypeFor(String taskName) {
 		final ClientEventType eventType = clientEventTypes.get(taskName);
+		if (eventType == null){
+			log.warn("Event type not found for task: " + taskName);
+		}
 		return eventType == null ? ClientEventType.TASK_UNDEFINED_EVENT : eventType;
 	}
 }

--- a/testing/manual/test-workflow-interactions.md
+++ b/testing/manual/test-workflow-interactions.md
@@ -32,31 +32,27 @@ Estimated time to completion: [X] minutes
 2. Click the kebab menu in the top right of the newly added duplicate model operator node, select "Remove" from the menu
 3. __Expected Result__: The model operator node should have been duplicated, then deleted from the canvas.
 
-`[Task 4: Opening an operator drill down in a new window']`
-1. Click the kebab menu in the top right of the model operator node, select "Open in new window" from the menu
-2. __Expected Result__: The drill down of the model operator should open in a new window.
-
-`[Task 5: Connecting an operator nodes to another operator node']`
+`[Task 4: Connecting an operator nodes to another operator node']`
 1. Click the output port of the model operator node
 2. Drag the pipe line to the input port of the Stratify model operator node, click mouse to release
 3. __Expected Result__: The pipe should connect the output of the model operator node to the input port of the Stratify model operator node with the ends of the connection pipe attached to the ports. The input label on the Stratify node should be the same as the output port label of the mode, and an Edit button should appear in the Stratify model node.
 
-`[Task 6: Disconnecting an operator node']`
+`[Task 5: Disconnecting an operator node']`
 1. Hover over the Stratify Model input port label, 
 2. Click the Unlink button that appears on hover.
 3. __Expected Result__: The pipe connecting the model and stratify model operator nodes should be deleted. The input label on Stratify Model should change back to "Model or Model Configuration" hint text and the edit button should disappear.
 
-`[Task 7: Re-positioning a disconnected node on the canvas']`
+`[Task 6: Re-positioning a disconnected node on the canvas']`
 1. Hover the mouse anywhere over an operator node. A hover state should be indicated by the node's header changing to a darker shade of green and the node's shadow darkening.
 2. Click anywhere on the operator node, drag in somewhere else on the canvas and release the mouse button.
 3. __Expected Result__: The node's hover state should trigger on mouse over and the node should be repositioned on the canvas in the position of the mouse when the mouse button is released.
 
-`[Task 8: Re-positioning a connected node on the canvas']`
+`[Task 7: Re-positioning a connected node on the canvas']`
 1. Repeat the steps in Task 5 to connect two nodes.
 2. Repeate the steps in Task 7 to re-position one of the nodes.
 3. __Expected Result__: The node should reposition as in Task 7, and the pipe connecting the nodes should flex contort to accomodate the re-position of the node.
 
-`[Task 9: Canvas zoom in / out and pan']`
+`[Task 8: Canvas zoom in / out and pan']`
 1. With the mouse positioned over the canvas, scroll the mouse wheel up and down to zoom the canvas in and out.
 2. With the mouse positioned over the canvas, click and drag the mouse around.
 3. __Expected Result__: The canvas view should zoom in/out on mouse wheel scroll and pan on click and drag.


### PR DESCRIPTION
# Description
Add a logger for when we do not have an event type found. 
This will help us update our enums accordingly and have a bit more information when this scenario happens

```
2024-06-11 10:38:19 [WARN] Event type not found for task: mira_task:amr_to_mmt [software.uncharted.terarium.hmiserver.service.tasks.TaskNotificationEventTypes:21]
2024-06-11 10:38:19 [INFO] Sending client event with type TASK_UNDEFINED_EVENT for task befe548e-adf3-4614-8eec-26378b0f9b4f  [software.uncharted.terarium.hmiserver.service.tasks.TaskService:452]
```