### PR TITLE
Build images locally for taskrunner rather than pulling

### DIFF
--- a/containers/scripts/docker-compose-taskrunner.yml
+++ b/containers/scripts/docker-compose-taskrunner.yml
@@ -13,7 +13,6 @@ services:
             dockerfile: ./packages/gollm/Dockerfile
             target: gollm_taskrunner_builder
         container_name: gollm-taskrunner
-        image: ghcr.io/darpa-askem/gollm-taskrunner:latest
         networks:
             - terarium
         environment:
@@ -39,7 +38,6 @@ services:
             dockerfile: ../../packages/mira/Dockerfile
             target: mira_taskrunner_builder
         container_name: mira-taskrunner
-        image: ghcr.io/darpa-askem/mira-taskrunner:latest
         networks:
             - terarium
         environment:
@@ -64,7 +62,6 @@ services:
             dockerfile: ../../packages/funman/Dockerfile
             target: funman_taskrunner_builder
         container_name: funman-taskrunner
-        image: ghcr.io/darpa-askem/funman-taskrunner:latest
         networks:
             - terarium
         environment:


### PR DESCRIPTION
We need to use the builder image, so it cannot be pulled.