### PR TITLE
Add missing model link in operator-annotations.md

### DIFF
--- a/testing/manual/operator-annotations.md
+++ b/testing/manual/operator-annotations.md
@@ -15,7 +15,7 @@ Estimated time to completion: [X] minutes
 ### 2. Test Scenarios
 
 `[Task 1: Adding a new annotation to an operator's workflow node']`
-1. Add a model to the project with Explorer.
+1. Add a model (e.g. [Configured SIR.json](https://github.com/DARPA-ASKEM/terarium/blob/main/testing/data/Configured%20SIR.json))to the project with Explorer.
 2. Create a new workflow - open it.
 3. Drag the model from the Resources panel onto the workflow canvas
 4. Click the kebab icon to open the model node's menu, click "Add a note"


### PR DESCRIPTION
# Description

* README asks tester to add a model without saying where to find such a model
* Added a link to `/testing/data/Configure SIR.json` 