### PR TITLE
fix drilldown styles

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-columnar-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-columnar-panel.vue
@@ -14,4 +14,8 @@ main {
 	gap: var(--gap-small);
 	flex-grow: 1;
 }
+
+main > :deep(*) {
+	overflow: hidden;
+}
 </style>

--- a/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-workflow-wrapper.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-workflow-wrapper.vue
@@ -4,12 +4,14 @@
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"
 	>
-		<tera-model
-			v-if="node.state.modelId"
-			:asset-id="node.state.modelId"
-			@new-model-configuration="refreshModelNode"
-			@update-model-configuration="refreshModelNode"
-		/>
+		<tera-drilldown-section>
+			<tera-model
+				v-if="node.state.modelId"
+				:asset-id="node.state.modelId"
+				@new-model-configuration="refreshModelNode"
+				@update-model-configuration="refreshModelNode"
+			/>
+		</tera-drilldown-section>
 	</tera-drilldown>
 </template>
 
@@ -21,6 +23,7 @@ import TeraModel from '@/components/model/tera-model.vue';
 // import { workflowEventBus } from '@/services/workflow';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 
+import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import { ModelOperationState } from './model-operation';
 
 defineProps<{


### PR DESCRIPTION
# Description

* With the recent changes to the model some css changes broke scrolling on some drilldown components.  This should fix it.
* surrounding `<tera-model>` with `<tera-drilldown-section>` allows unmount to be called

