### PR TITLE
add a mira observable summary section for amr-to-mmt task

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira-common.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-common.ts
@@ -81,7 +81,7 @@ export interface ObservableSummary {
 		display_name: string;
 		description: string;
 		expression: string;
-		states: string[];
+		references: string[];
 	};
 }
 

--- a/packages/client/hmi-client/src/model-representation/mira/mira-common.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-common.ts
@@ -74,3 +74,19 @@ export interface TemplateSummary {
 	outcome: string;
 	controllers: string[];
 }
+
+export interface ObservableSummary {
+	[key: string]: {
+		name: string;
+		display_name: string;
+		description: string;
+		expression: string;
+		states: string[];
+	};
+}
+
+export interface MMT {
+	mmt: MiraModel;
+	template_params: MiraTemplateParams;
+	observable_summary: ObservableSummary;
+}

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -7,6 +7,7 @@ import { AMRSchemaNames, ModelServiceType } from '@/types/common';
 import { fileToJson } from '@/utils/file';
 import { logger } from '@/utils/logger';
 import { isEmpty } from 'lodash';
+import type { MMT } from '@/model-representation/mira/mira-common';
 import { modelCard } from './goLLM';
 import { profileModel } from './knowledge';
 
@@ -51,7 +52,7 @@ export async function getMMT(model: Model) {
 	const miraModel = response?.data?.response;
 	if (!miraModel) throw new Error(`Failed to convert model ${model.id}`);
 
-	return response?.data?.response ?? null;
+	return (response?.data?.response as MMT) ?? null;
 }
 
 /**

--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -48,8 +48,10 @@ def main():
             }
             template_params[tm.name] = entry
 
-        # Summarize observables, extract out states
-        concept_names = list(map(lambda x: x.name, mmt.get_concepts_map().values()))
+        # Summarize observables, extract out concepts
+        # concept_names = list(map(lambda x: x.name, mmt.get_concepts_map().values()))
+        concept_names = list(map(lambda x: x["id"], amr["model"]["states"]))
+
         observable_summary = {}
         for ob in mmt.observables.items():
             obKey = ob[0]
@@ -58,7 +60,7 @@ def main():
                 "name": obKey,
                 "display_name": obValue.display_name,
                 "expression": str(obValue.expression),
-                "states": list(obValue.get_parameter_names(concept_names))
+                "references": list(obValue.get_parameter_names(concept_names))
             }
 
         result = {

--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -49,7 +49,9 @@ def main():
             template_params[tm.name] = entry
 
         # Summarize observables, extract out concepts
+
         # concept_names = list(map(lambda x: x.name, mmt.get_concepts_map().values()))
+        # FIXME: get_concept_map seems to be unreliable, need better/model-agnostic way to parse
         concept_names = list(map(lambda x: x["id"], amr["model"]["states"]))
 
         observable_summary = {}

--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -48,8 +48,22 @@ def main():
             }
             template_params[tm.name] = entry
 
+        # Summarize observables, extract out states
+        concept_names = list(map(lambda x: x.name, mmt.get_concepts_map().values()))
+        observable_summary = {}
+        for ob in mmt.observables.items():
+            obKey = ob[0]
+            obValue = ob[1]
+            observable_summary[obKey] = {
+                "name": obKey,
+                "display_name": obValue.display_name,
+                "expression": str(obValue.expression),
+                "states": list(obValue.get_parameter_names(concept_names))
+            }
+
         result = {
             "template_params": template_params,
+            "observable_summary": observable_summary,
             "mmt": json.loads(mmt.json())
         }
         taskrunner.write_output_dict_with_timeout({"response": result})


### PR DESCRIPTION
### Summary
MMT's observable contains an expression string that is a bit more difficult to work with in javascript space, we will add a transformer/summarizer at the task runner stage to make downstream consumption a little easier.

TLDR: This is effectively a subset of the mmt.observables section, but with better access to linked states.



<img width="1026" alt="image" src="https://github.com/DARPA-ASKEM/terarium/assets/1220927/c6bfd0b9-ab7a-4ed4-824d-39b525d45bd7">




The new object defn at hand, 
```
export interface ObservableSummary {
       [key: string]: {
               name: string;
               display_name: string;
               description: string;
               expression: string;
               references: string[];
       };
}
```


### Testing
amr-to-mmt should have a new section for obsrvable summary
