### PR TITLE
fix: shutdown jupyter session on page unload

### DIFF
--- a/packages/client/hmi-client/src/services/jupyter.ts
+++ b/packages/client/hmi-client/src/services/jupyter.ts
@@ -280,6 +280,7 @@ export class KernelSessionManager {
 				console.log('waiting...', this.jupyterSession?.session?.kernel);
 				counter++;
 				if (this.jupyterSession?.session?.kernel) {
+					window.addEventListener('beforeunload', this.shutdown.bind(this));
 					clearInterval(id);
 					resolve(true);
 				}
@@ -318,6 +319,7 @@ export class KernelSessionManager {
 	}
 
 	shutdown() {
+		window.removeEventListener('beforeunload', this.shutdown.bind(this));
 		this.jupyterSession?.shutdown();
 	}
 }

--- a/packages/client/hmi-client/src/services/jupyter.ts
+++ b/packages/client/hmi-client/src/services/jupyter.ts
@@ -280,7 +280,7 @@ export class KernelSessionManager {
 				console.log('waiting...', this.jupyterSession?.session?.kernel);
 				counter++;
 				if (this.jupyterSession?.session?.kernel) {
-					window.addEventListener('beforeunload', this.shutdown.bind(this));
+					window.addEventListener('beforeunload', this.shutdown.bind(this)); // bind(this) ensures that this instance of the class is used
 					clearInterval(id);
 					resolve(true);
 				}
@@ -319,7 +319,7 @@ export class KernelSessionManager {
 	}
 
 	shutdown() {
-		window.removeEventListener('beforeunload', this.shutdown.bind(this));
+		window.removeEventListener('beforeunload', this.shutdown.bind(this)); // bind(this) ensures that this instance of the class is used
 		this.jupyterSession?.shutdown();
 	}
 }


### PR DESCRIPTION
# Description

- Avoids hanging jupyter sessions
- If the user unloads the page the session still exists, now it is shutdown
- The way we've been shutting down the session is limited to the component level - eg. in `tera-model-edit` the `onUnmounted(() => kernelManager.shutdown)` only triggers if you close the drilldown


https://github.com/DARPA-ASKEM/terarium/assets/28237258/65e7a01d-1d49-41a0-91f6-5780a586ec08


