### PR TITLE
Copy edits for error messages

### DIFF
--- a/packages/server/src/main/resources/messages.properties
+++ b/packages/server/src/main/resources/messages.properties
@@ -1,88 +1,88 @@
 generic.unknown = Oops! Something went wrong. Please try again later.
-generic.invalid-uuid = The ID you supplied is not a valid UUID. Please ensure that the ID is correct.
-generic.io-error.read = An error occurred while trying to read data. Please try again later.
-generic.io-error.write = An error occurred while trying to write data. Please try again later.
+generic.invalid-uuid = The ID you selected isn't valid. Please verify that the ID is correct and try again.
+generic.io-error.read = We couldn't read your data. Please try again later.
+generic.io-error.write = We couldn't write your data. Please try again later.
 
-artifact.not-found = We were unable to find the requested artifact. Please ensure that the artifact ID you supplied is correct or contact support.
-artifact.unable-to-delete = We were unable to delete the artifact asset. Please try again later.
-artifact.unable-to-update = We were unable to update the artifact asset. Please try again later.
-artifact.files.not-found = We were unable to find any files associated with this artifact. This may be due to the service being unavailable, or the artifact being corrupted. Please re-upload the artifact or contact support.
-artifact.file.unable-to-read = An error occurred while trying to read the artifact contents. This may be due to the service being unavailable, or the artifact being corrupted. Please re-upload the artifact or contact support.
-artifact.file.content.empty = The supplied artifact does not contain any information. This may be due to the artifact being corrupted. Please check your files and upload the artifact again, or contact support.
-artifact.file-type = The supplied file type is not supported. Please ensure that the file type is correct and try again.
+artifact.not-found = We couldn't find the requested resource. Please verify that the resource is correct or contact support.
+artifact.unable-to-delete = We couldn't delete the resource. Please try again later.
+artifact.unable-to-update = We couldn't update the resource. Please try again later.
+artifact.files.not-found = We couldn't find any files associated with this resource. The service may be unavailable, or the resource may be corrupted. Please upload the resource again or contact support.
+artifact.file.unable-to-read =  We couldn't read the resource contents. The service may be unavailable, or the resource may be corrupted. Please upload the resource again or contact support.
+artifact.file.content.empty = The selected resource is empty and may be corrupted. Please check your files and upload the resource again or contact support.
+artifact.file-type = We don't currently support the selected file type. Please check that the file type is correct and try again.
 
-asset.not-found = We were unable to find the requested asset. Please ensure that the ID you supplied is correct or contact support.
-asset.unable-to-create = We were unable to update the project asset. Please try again later.
+asset.not-found = We couldn't find the requested resource. Please verify that the resource you selected is correct or contact support.
+asset.unable-to-create = We couldn't update the project resource. Please try again later.
 
-code.filename-needed = You must supply a filename for the code asset.
-code.not-found = We were unable to find the requested code. Please ensure that the code ID you supplied is correct or contact support.
-code.unable-to-delete = We were unable to delete the code asset. Please try again later.
-code.unable-to-update = We were unable to update the code asset. Please try again later.
+code.filename-needed = Enter a filename for the code resource.
+code.not-found = We couldn't find the requested code. Please verify that the code you selected is correct or contact support.
+code.unable-to-delete = We couldn't delete the code resource. Please try again later.
+code.unable-to-update = We couldn't update the code resource. Please try again later.
 
-dataset.not-found = We were unable to find the requested dataset. Please ensure that the dataset ID you supplied is correct or contact support.
-dataset.unable-to-delete = We were unable to delete the dataset asset. Please try again later.
-dataset.unable-to-update = We were unable to update the dataset asset. Please try again later.
-dataset.files.not-found = We were unable to find any files associated with this dataset. This may be due to the service being unavailable, or the dataset being corrupted. Please re-upload the dataset or contact support.
+dataset.not-found = We couldn't find the requested dataset. Please verify that the dataset you selected is correct or contact support.
+dataset.unable-to-delete = We couldn't delete the dataset. Please try again later.
+dataset.unable-to-update = We couldn't update the dataset. Please try again later.
+dataset.files.not-found = We couldn't find any files associated with this dataset. The service may be unavailable, or the dataset may be corrupted. Please upload the dataset again or contact support.
 
-document.extraction.not-done = The document extraction process has not yet completed, and we are unable to perform this task. Please try again later.
-document.not-found = We were unable to find the requested document. Please ensure that the dataset ID you supplied is correct or contact support.
-document.unable-to-delete = We were unable to delete the dataset document. Please try again later.
-document.unable-to-update = We were unable to update the dataset document. Please try again later.
-document.text-length-exceeded = The length of this document exceeds the maximum allowed length of 600,000 words. Please contact support if you require this further analysis of this document.
+document.extraction.not-done = We can't complete this task because the document extraction is still in progress. Please try again when the extraction has finished.
+document.not-found = We couldn't find the requested document. Please verify that the dataset you selected is correct or contact support.
+document.unable-to-delete = We couldn't delete the document. Please try again later.
+document.unable-to-update = We couldn't update the document. Please try again later.
+document.text-length-exceeded = This document exceeds our 600,000-word limit. If you still need to analyze this document, contact support.
 
-mira.concept.bad-curies = Terarium's domain knowledge service (MIRA) did not return valid concepts based on the provided curies. Please review the curries that you supplied and try again.
-mira.concept.bad-query = Terarium's domain knowledge service (MIRA) did not return valid concepts based on the provided query. Please review your search criteria and try again.
-mira.ode.bad-model = Terarium's domain knowledge service (MIRA) did not return a valid ODE based on the provided model. Please ensure that the model you supplied is valid and try again.
-mira.similarity.bad-curies = Terarium's domain knowledge service (MIRA) did not return valid entity similarities based on the provided curies. Please review the curries that you supplied and try again.
-mira.internal-error = An error occurred in Terarium's model service (SKEMA), and it was not able to produce a valid model representation based on the provided resource. Please check that it is valid and try again.
-mira.service-unavailable = Terarium's domain knowledge service (MIRA) is temporarily unavailable. Please try again later.
+mira.concept.bad-curies = Our domain knowledge service (MIRA) couldn't find any valid concepts for the selected IDs. Please review the IDs that you selected and try again.
+mira.concept.bad-query = Our domain knowledge service (MIRA) couldn't find any valid concepts for the entered query. Please review your search criteria and try again.
+mira.ode.bad-model = Our domain knowledge service (MIRA) couldn't find a valid equation based on the selected model. Please verify the model you selected is valid and try again.
+mira.similarity.bad-curies = Our domain knowledge service (MIRA) couldn't find any valid entity similarities based on the selected IDs. Please review the IDs that you selected and try again.
+mira.internal-error = Our model service (SKEMA) couldn't produce a valid model representation based on the selected resource. Please check that it's valid and try again.
+mira.service-unavailable = Our domain knowledge service (MIRA) is temporarily unavailable. Please try again later.
 
 
-mit.service-unavailable = Terarium's text reading service (MIT-TR) is temporarily unavailable. Please try again later.
-mit.file.unable-to-read = An error occurred while trying to parse the supplied files. Please try again later.
-mit.internal-error = An unknown error occurred in Terarium's text reading service (MIT-TR), and it was not able to produce valid information based on your supplied model and documentation. Please check that your inputs are valid and try again.
+mit.service-unavailable = Our text reading service (MIT-TR) is temporarily unavailable. Please try again later.
+mit.file.unable-to-read = We couldn't parse the selected files. Please try again later.
+mit.internal-error = Our text reading service (MIT-TR) couldn't produce valid information based on the selected model and documentation. Please check that your inputs are valid and try again.
 
-model.not-found = We were unable to find the requested model. Please ensure that the model ID you supplied is correct or contact support.
-model.unable-to-delete = We were unable to delete the dataset model. Please try again later.
-model.unable-to-update = We were unable to update the dataset model. Please try again later.
+model.not-found = We couldn't find the requested model. Please verify that the model you selected is correct or contact support.
+model.unable-to-delete = We couldn't delete the model. Please try again later.
+model.unable-to-update = We couldn't update the model. Please try again later.
 
-modelconfig.not-found = We were unable to find the requested model configuration. Please ensure that the model configuration ID you supplied is correct or contact support.
+modelconfig.not-found = We couldn't find the requested model configuration. Please verify that the model configuration you selected is correct or contact support.
 
-postgres.service-unavailable = Terarium's data storage is temporarily unavailable. Please try again later.
+postgres.service-unavailable = Our data storage is temporarily unavailable. Please try again later.
 
-projects.asset-already-added = An asset with the same ID already exists in another project project. Please verify that the asset is not already in another project or contact support.
-projects.asset-conflict = An asset with the same ID already exists in the project. Please verify that the asset is not already in the project or contact support.
-projects.name-required = You must supply a name for the project.
-projects.not-found = We were unable to find the requested project. Please ensure that the project ID you supplied is correct or contact support.
-projects.unable-to-delete = We were unable to delete the project. Please try again later.
-projects.unable-to-get-permissions = Terarium was unable to determine read/write permissions. For safety reasons, we are unable to return results. Please try again later.
-projects.unable-to-update = We were unable to update the project. Please try again later.
-projects.import-parse-failure = We were unable to parse the import file. Please ensure that the file is in the correct format and try again.
+projects.asset-already-added = A resource with the same ID already exists in another project. If this problem continues, please contact support.
+projects.asset-conflict = A resource with the same ID already exists in the project. If this problem continues, please contact support.
+projects.name-required = Enter a unique project name.
+projects.not-found = We couldn't find the requested project. Please verify that the project you selected is correct or contact support.
+projects.unable-to-delete = We couldn't delete the project. Please try again later.
+projects.unable-to-get-permissions = We couldn't verify your read/write permissions. For safety reasons, we can't show results. Please try again later.
+projects.unable-to-update = We couldn't update the project. Please try again later.
+projects.import-parse-failure = We couldn't parse the import file. Please verify that the file is correctly formatted and try again.
 
-rebac.permissions.unable-to-set = An unknown error occurred while trying to set project permissions. Please try again later.
-rebac.relationship-already-exists = You already have permissions set to access this resource. Please contact the system administrator to upgrade permissions.
-rebac.service-unavailable = The service that Terarium uses for security and authorization is temporarily unavailable. Please try again later.
-rebac.unauthorized-delete = You are not authorized to delete this resource. Please contact the project owner to upgrade permissions.
-rebac.unauthorized-read = You are not authorized to access this resource. Please contact the project owner to upgrade permissions.
-rebac.unauthorized-update = You are not authorized to update this resource. Please contact the project owner to upgrade permissions.
+rebac.permissions.unable-to-set = We couldn't set project permissions. Please try again later.
+rebac.relationship-already-exists = You already have permission to access this resource. Contact the system administrator to upgrade permissions.
+rebac.service-unavailable = Our security and authorization service is temporarily unavailable. Please try again later.
+rebac.unauthorized-delete = You're not authorized to delete this resource. Contact the project owner to upgrade your permissions.
+rebac.unauthorized-read = You're not authorized to access this resource. Contact the project owner to upgrade your permissions.
+rebac.unauthorized-update = You're not authorized to update this resource. Contact the project owner to upgrade your permissions.
 
-skema.bad-code = Terarium's model service (SKEMA) did not return a valid model representation based on the provided code. This could be due to a number of code issues including syntax and semantic errors. Please review your code snippet and try again.
-skema.bad-equations = Terarium's model service (SKEMA) did not return a valid model representation based on the provided equations. This could be due to invalid equations or the inability to parse them into the requested framework.
-skema.error.align-model = An error occurred while trying to align the model with the supplied document. Please ensure that the model is valid and that the document has valid extractions.
-skema.internal-error = An error occurred in Terarium's model service (SKEMA), and it was not able to produce a valid model representation based on the provided resource. Please check that it is valid and try again.
-skema.service-unavailable = Terarium's model service (SKEMA) is temporarily unavailable. Please try again later.
+skema.bad-code = Our model service (SKEMA) couldn't find a valid model representation. This could be due to  syntax or semantic errors in your code. Please review your code snippet and try again.
+skema.bad-equations = Our model service (SKEMA) couldn't find a valid model representation. This could be due to invalid equations or an inability to parse them into the requested framework. Please review your equations and try again.
+skema.error.align-model = We couldn't align the model with the selected document. Please verify that the model is valid and that the document has valid extractions.
+skema.internal-error =  We couldn't produce a valid model representation based on the selected resource. Please verify that the resource is valid and try again.
+skema.service-unavailable = Our model service (SKEMA) is temporarily unavailable. Please try again later.
 
-task.gollm.json-processing = An error occurred while trying to process Terarium's LLM service (GoLLM) task data. Please ensure that the data is valid and try again.
-task.gollm.timeout = Terarium's LLM service (GoLLM) took too long to complete and was terminated. Please try again later. If this problem persists, please contact support.
-task.gollm.interrupted = The task sent to Terarium's LLM service (GoLLM) was interrupted and did not complete.
-task.gollm.execution-failure = Terarium's LLM service (GoLLM) failed to execute the supplied task. Please try again later. If this problem persists, please contact support.
-task.gollm.model-card.bad-number = At least two models with model cards are required for this task. Please ensure that the models you are trying to compare contain model cards and try again. If this problem persists, please contact support.
+task.gollm.json-processing = Our LLM service (GoLLM) couldn't process task data. Please verify that the data is valid and try again.
+task.gollm.timeout = We terminated our LLM service (GoLLM) because it took too long to complete. Please try again later. If this problem continues, contact support.
+task.gollm.interrupted = The task sent to our LLM service (GoLLM) was interrupted and didn't finish.
+task.gollm.execution-failure = Our LLM service (GoLLM) couldn't perform the selected task. Please try again later. If this problem persists, contact support.
+task.gollm.model-card.bad-number = Comparison requires at least two models with model cards. Verify that the selected models have model cards and try again. If this problem continues, contact support.
 
-task.mira.json-processing = An error occurred while trying to process Terarium's MIRA service task data. Please ensure that the data is valid and try again.
-task.mira.timeout = Terarium's MIRA service took too long to complete and was terminated. Please try again later. If this problem persists, please contact support.
-task.mira.interrupted = The task sent to Terarium's MIRA service was interrupted and did not complete.
-task.mira.execution-failure = Terarium's MIRA service failed to execute the supplied task. Please try again later. If this problem persists, please contact support.
+task.mira.json-processing = We couldn't process domain knowledge service (MIRA) task data. Please verify that the data is valid and try again.
+task.mira.timeout = We terminated our domain knowledge service (MIRA) because it took too long to complete. Please try again later. If this problem continues, please contact support.
+task.mira.interrupted = The task sent to our domain knowledge service (MIRA) was interrupted and didn't finish.
+task.mira.execution-failure = Our domain knowledge service (MIRA) couldn't perform the selected task. Please try again later. If this problem continues, please contact support.
 
-workflow.not-found = We were unable to find the requested workflow. Please ensure that the workflow ID you supplied is correct or contact support.
-workflow.unable-to-delete = We were unable to delete the workflow asset. Please try again later.
-workflow.unable-to-update = We were unable to update the workflow asset. Please try again later.
+workflow.not-found = We couldn't find the requested workflow. Please verify that the workflow you selected is correct or contact support.
+workflow.unable-to-delete = We couldn't delete the workflow resource. Please try again later.
+workflow.unable-to-update = We couldn't update the workflow resource. Please try again later.


### PR DESCRIPTION
Copy edits to Terarium error messages easier to understand. Below are some suggestions for adding to and maintaining these going forward.

## General tips
- Use informal conversational language wherever possible.
- Use contractions ("can't" instead of "cannot").
- Use active voice instead of passive (instead of "the service **was terminated**…" try "**We terminated** the service…").
- Avoid software development jargon that users may not understand ("UUID," "curies").
- Don't introduce backend terms that users never see in the UI. For example, avoid terms like "artifacts" and "assets" if users only see "resources" in the UI.
- Consider whether it's necessary to name a backend service that users never see. Instead of referencing "SKEMA," determine whether it would be clearer to refer to our "model service."

## Terms

<dl>
<dt>Curie</dt>
<dd>Not typically familiar to an end user. Replace with "ID" or "unique ID."</dd>

<dt>Error</dt>
<dd>Avoid negative terms. Simply state the results of the error. Instead of "An error occurred while trying to set project permissions…" try "We couldn't set project permissions…"</dd>

<dt>Fail</dt>
<dd>Avoid negative terms. Simply state the results of the failure. Instead of "the service failed to perform the task…" try "the service couldn't perform the task…"</dd>

<dt>Please</dt>
<dd>Only use "please" when we're asking the user to take an action as a result of a system error. If the error is a result of a user action (for example, trying to upload a file that's too big), state the corrective action without saying "please."</dd>

<dt>Provide</dt>
<dd>Avoid this verb when describing user actions. Be more descriptive about the action that triggered the error message, such as "selected" or "entered."</dd>

<dt>Return</dt>
<dd>Avoid this verb when describing search results or application outputs. Instead of "Our service didn't return any results…" try "Our service didn't find any results."</dd>

<dt>Request</dt>
<dd>Avoid this verb when describing user actions. Be more descriptive about the action that triggered the error message, such as "selected" or "entered."</dd>

<dt>Supply</dt>
<dd>Avoid this verb when describing user actions. Be more descriptive about the action that triggered the error message, such as "selected" or "entered."</dd>

<dt>Terarium</dt>
<dd>Don't repeat the name of the application in error messages; users know what tool they're using. Replace with first person plural (instead of "Terarium's model service is unavailable" try "Our model service is unavailable.")</dd>

<dt>Unable</dt>
<dd>Instead of saying we "were unable to…," simply state "we couldn't…"</dd>

<dt>UUID</dt>
<dd>Not typically familiar to an end user. Replace with "ID" or "unique ID."</dd>
</dl>