### PR TITLE
switch threshold and value, use states

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-input.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input.vue
@@ -9,7 +9,7 @@
 				:value="getValue()"
 				@input="updateValue"
 				@onFocusOut="emit('on-focus-out')"
-				:style="{ 'text-align': textAlign }"
+				:style="inputStyle"
 				@blur="unmask"
 				:type="getType"
 				:placeholder="placeholder"
@@ -21,7 +21,7 @@
 
 <script setup lang="ts">
 import { nistToNumber, numberToNist, scrubAndParse } from '@/utils/number';
-import { InputTypeHTMLAttribute, computed, onMounted, ref, watch } from 'vue';
+import { CSSProperties, InputTypeHTMLAttribute, computed, onMounted, ref, watch } from 'vue';
 
 const props = defineProps<{
 	modelValue: string | number | undefined;
@@ -30,6 +30,7 @@ const props = defineProps<{
 	disabled?: boolean;
 	type?: InputTypeHTMLAttribute | 'nist';
 	placeholder?: string;
+	autoWidth?: boolean;
 }>();
 
 const emit = defineEmits(['update:model-value', 'on-focus-out']);
@@ -38,13 +39,31 @@ const error = ref('');
 const maskedValue = ref('');
 
 const isNistType = props.type === 'nist';
-const textAlign = props.type === 'number' || isNistType ? 'right' : 'left';
 const getType = isNistType ? 'text' : props.type;
 const getDisabled = props.disabled ?? false;
 
 const focusInput = () => {
 	inputField.value?.focus();
 };
+
+// Computed property to dynamically adjust the input's style based on the autoWidth prop
+const inputStyle = computed(() => {
+	const style: CSSProperties = {
+		'text-align': props.type === 'number' || props.type === 'nist' ? 'right' : 'left' // Set textAlign based on type
+	};
+
+	if (props.autoWidth) {
+		const textToMeasure = maskedValue.value?.length > 0 ? maskedValue.value : props.placeholder;
+		// Estimate the width based on the length of the value. Adjust the multiplier as needed for your font.
+		// Use the length of the text to measure as the width in ch units
+		// Estimate the width based on the length of the text to measure. Adjust the multiplier as needed for your font.
+		const width = (textToMeasure?.length || 1) * 8 + 4; // 8px per character + 4px padding
+		style.width = `${width}px`; // Dynamically set the width
+		style['min-width'] = '20px'; // Ensure a minimum width
+	}
+
+	return style; // Return the combined style object
+});
 
 const getErrorMessage = computed(() => props.errorMessage || error.value);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -226,8 +226,8 @@ const onRemoveStaticIntervention = (index: number) => {
 const onAddNewStaticIntervention = () => {
 	const intervention = cloneDeep(props.intervention);
 	intervention.staticInterventions.push({
-		threshold: Number.NaN,
-		value: Number.NaN
+		threshold: 0,
+		value: 0
 	});
 	emit('update', intervention);
 };
@@ -237,8 +237,8 @@ const onInterventionTypeChange = (value: string) => {
 	if (value === 'static') {
 		intervention.staticInterventions = [
 			{
-				threshold: Number.NaN,
-				value: Number.NaN
+				threshold: 0,
+				value: 0
 			}
 		];
 		intervention.dynamicInterventions = [];
@@ -246,8 +246,8 @@ const onInterventionTypeChange = (value: string) => {
 		intervention.staticInterventions = [];
 		intervention.dynamicInterventions = [
 			{
-				threshold: Number.NaN,
-				value: Number.NaN,
+				threshold: 0,
+				value: 0,
 				parameter: props.stateOptions[0].value,
 				isGreaterThan: true
 			}

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -59,7 +59,7 @@
 							type="nist"
 							:model-value="intervention.staticInterventions[0].threshold"
 							@update:model-value="(val) => onUpdateThreshold(val, 0)"
-							placeholder="time step"
+							placeholder="timepoint value"
 						/>
 						.
 					</template>
@@ -78,7 +78,7 @@
 									type="nist"
 									:model-value="i.threshold"
 									@update:model-value="(val) => onUpdateThreshold(val, index)"
-									placeholder="time step"
+									placeholder="timepoint value"
 								/>
 								.
 								<Button
@@ -110,7 +110,6 @@
 						option-value="value"
 						placeholder="Select a trigger"
 					/>
-					is
 					<Dropdown
 						:model-value="intervention.dynamicInterventions[0].isGreaterThan"
 						@change="onComparisonOperatorChange"
@@ -118,7 +117,6 @@
 						option-label="label"
 						option-value="value"
 					/>
-					than the threshold value
 					<tera-input
 						type="nist"
 						:model-value="intervention.dynamicInterventions[0].threshold"

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -43,6 +43,7 @@
 					:options="semanticOptions"
 					option-label="label"
 					option-value="value"
+					placeholder="Select"
 				/>
 				<span>to<span v-if="intervention.staticInterventions.length > 1">...</span></span>
 				<template v-if="interventionType === 'static'">
@@ -107,6 +108,7 @@
 						:options="stateOptions"
 						option-label="label"
 						option-value="value"
+						placeholder="Select a trigger"
 					/>
 					is
 					<Dropdown
@@ -181,8 +183,8 @@ const interventionType = computed(() => {
 });
 
 const comparisonOperations = [
-	{ label: 'greater', value: true },
-	{ label: 'less', value: false }
+	{ label: 'increases to above', value: true },
+	{ label: 'falls to below', value: false }
 ];
 
 const onUpdateName = (name: string) => {
@@ -248,7 +250,7 @@ const onInterventionTypeChange = (value: string) => {
 			{
 				threshold: Number.NaN,
 				value: Number.NaN,
-				parameter: props.stateOptions[0].value,
+				parameter: '',
 				isGreaterThan: true
 			}
 		];
@@ -273,9 +275,9 @@ const onSemanticChange = (event: DropdownChangeEvent) => {
 	const intervention = cloneDeep(props.intervention);
 	intervention.type = event.value;
 	if (event.value === InterventionSemanticType.Variable) {
-		intervention.appliedTo = props.stateOptions[0].value;
+		intervention.appliedTo = '';
 	} else {
-		intervention.appliedTo = props.parameterOptions[0].value;
+		intervention.appliedTo = '';
 	}
 	emit('update', intervention);
 };

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -48,14 +48,14 @@
 				<template v-if="interventionType === 'static'">
 					<template v-if="intervention.staticInterventions.length === 1">
 						<tera-input
-							type="number"
+							type="nist"
 							:model-value="intervention.staticInterventions[0].value"
 							@update:model-value="(val) => onUpdateValue(val, 0)"
 							placeholder="value"
 						/>
 						starting at
 						<tera-input
-							type="number"
+							type="nist"
 							:model-value="intervention.staticInterventions[0].threshold"
 							@update:model-value="(val) => onUpdateThreshold(val, 0)"
 							placeholder="time step"
@@ -67,14 +67,14 @@
 						<li v-for="(i, index) in intervention.staticInterventions" :key="index">
 							<div class="flex align-items-center pt-2 pb-2 gap-2">
 								<tera-input
-									type="number"
+									type="nist"
 									:model-value="i.value"
 									@update:model-value="(val) => onUpdateValue(val, index)"
 									placeholder="value"
 								/>
 								starting at
 								<tera-input
-									type="number"
+									type="nist"
 									:model-value="i.threshold"
 									@update:model-value="(val) => onUpdateThreshold(val, index)"
 									placeholder="time step"
@@ -95,7 +95,7 @@
 				<!-- Dynamic -->
 				<template v-else>
 					<tera-input
-						type="number"
+						type="nist"
 						:model-value="intervention.dynamicInterventions[0].value"
 						@update:model-value="(val) => onUpdateValue(val, 0)"
 						placeholder="value"
@@ -118,7 +118,7 @@
 					/>
 					than the threshold value
 					<tera-input
-						type="number"
+						type="nist"
 						:model-value="intervention.dynamicInterventions[0].threshold"
 						@update:model-value="(val) => onUpdateThreshold(val, 0)"
 						placeholder="threshold"
@@ -226,8 +226,8 @@ const onRemoveStaticIntervention = (index: number) => {
 const onAddNewStaticIntervention = () => {
 	const intervention = cloneDeep(props.intervention);
 	intervention.staticInterventions.push({
-		threshold: 0,
-		value: 0
+		threshold: Number.NaN,
+		value: Number.NaN
 	});
 	emit('update', intervention);
 };
@@ -237,8 +237,8 @@ const onInterventionTypeChange = (value: string) => {
 	if (value === 'static') {
 		intervention.staticInterventions = [
 			{
-				threshold: 0,
-				value: 0
+				threshold: Number.NaN,
+				value: Number.NaN
 			}
 		];
 		intervention.dynamicInterventions = [];
@@ -246,8 +246,8 @@ const onInterventionTypeChange = (value: string) => {
 		intervention.staticInterventions = [];
 		intervention.dynamicInterventions = [
 			{
-				threshold: 0,
-				value: 0,
+				threshold: Number.NaN,
+				value: Number.NaN,
 				parameter: props.stateOptions[0].value,
 				isGreaterThan: true
 			}

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -50,6 +50,7 @@
 					<template v-if="intervention.staticInterventions.length === 1">
 						<tera-input
 							type="nist"
+							auto-width
 							:model-value="intervention.staticInterventions[0].value"
 							@update:model-value="(val) => onUpdateValue(val, 0)"
 							placeholder="value"
@@ -57,18 +58,20 @@
 						starting at
 						<tera-input
 							type="nist"
+							auto-width
 							:model-value="intervention.staticInterventions[0].threshold"
 							@update:model-value="(val) => onUpdateThreshold(val, 0)"
-							placeholder="timepoint value"
+							placeholder="timestep"
 						/>
 						.
 					</template>
 
-					<ul v-if="intervention.staticInterventions.length > 1">
+					<ul v-if="intervention.staticInterventions.length > 1" class="flex-1">
 						<li v-for="(i, index) in intervention.staticInterventions" :key="index">
 							<div class="flex align-items-center pt-2 pb-2 gap-2">
 								<tera-input
 									type="nist"
+									auto-width
 									:model-value="i.value"
 									@update:model-value="(val) => onUpdateValue(val, index)"
 									placeholder="value"
@@ -76,9 +79,10 @@
 								starting at
 								<tera-input
 									type="nist"
+									auto-width
 									:model-value="i.threshold"
 									@update:model-value="(val) => onUpdateThreshold(val, index)"
-									placeholder="timepoint value"
+									placeholder="timestep"
 								/>
 								.
 								<Button
@@ -97,6 +101,7 @@
 				<template v-else>
 					<tera-input
 						type="nist"
+						auto-width
 						:model-value="intervention.dynamicInterventions[0].value"
 						@update:model-value="(val) => onUpdateValue(val, 0)"
 						placeholder="value"
@@ -119,6 +124,7 @@
 					/>
 					<tera-input
 						type="nist"
+						auto-width
 						:model-value="intervention.dynamicInterventions[0].threshold"
 						@update:model-value="(val) => onUpdateThreshold(val, 0)"
 						placeholder="threshold"
@@ -182,7 +188,7 @@ const interventionType = computed(() => {
 
 const comparisonOperations = [
 	{ label: 'increases to above', value: true },
-	{ label: 'falls to below', value: false }
+	{ label: 'decreases to below', value: false }
 ];
 
 const onUpdateName = (name: string) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -99,15 +99,15 @@
 				to
 				<tera-input
 					type="number"
-					:model-value="intervention.dynamicInterventions[0].threshold"
-					@update:model-value="(val) => onUpdateThreshold(val, 0)"
+					:model-value="intervention.dynamicInterventions[0].value"
+					@update:model-value="(val) => onUpdateTimestep(val, 0)"
 					placeholder="value"
 				/>
 				when
 				<Dropdown
 					:model-value="intervention.dynamicInterventions[0].parameter"
 					@change="onTargetParameterChange"
-					:options="parameterOptions"
+					:options="stateOptions"
 					option-label="label"
 					option-value="value"
 				/>
@@ -122,9 +122,9 @@
 				than the threshold value
 				<tera-input
 					type="number"
-					:model-value="intervention.dynamicInterventions[0].value"
-					@update:model-value="(val) => onUpdateTimestep(val, 0)"
-					placeholder="time step"
+					:model-value="intervention.dynamicInterventions[0].threshold"
+					@update:model-value="(val) => onUpdateThreshold(val, 0)"
+					placeholder="threshold"
 				/>
 				.
 			</div>
@@ -157,6 +157,7 @@ const emit = defineEmits(['update', 'delete', 'add']);
 const props = defineProps<{
 	intervention: Intervention;
 	parameterOptions: { label: string; value: string }[];
+	stateOptions: { label: string; value: string }[];
 }>();
 
 const interventionType = computed(() => {
@@ -237,7 +238,7 @@ const onInterventionTypeChange = (value: string) => {
 			{
 				threshold: 0,
 				value: 0,
-				parameter: props.parameterOptions[0].value,
+				parameter: props.stateOptions[0].value,
 				isGreaterThan: true
 			}
 		];

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -42,15 +42,15 @@
 					<template v-if="intervention.staticInterventions.length === 1">
 						<tera-input
 							type="number"
-							:model-value="intervention.staticInterventions[0].threshold"
-							@update:model-value="(val) => onUpdateThreshold(val, 0)"
+							:model-value="intervention.staticInterventions[0].value"
+							@update:model-value="(val) => onUpdateValue(val, 0)"
 							placeholder="value"
 						/>
 						starting at
 						<tera-input
 							type="number"
-							:model-value="intervention.staticInterventions[0].value"
-							@update:model-value="(val) => onUpdateTimestep(val, 0)"
+							:model-value="intervention.staticInterventions[0].threshold"
+							@update:model-value="(val) => onUpdateThreshold(val, 0)"
 							placeholder="time step"
 						/>
 						.
@@ -62,15 +62,15 @@
 						<div class="flex align-items-center pt-2 pb-2 gap-2">
 							<tera-input
 								type="number"
-								:model-value="i.threshold"
-								@update:model-value="(val) => onUpdateThreshold(val, index)"
+								:model-value="i.value"
+								@update:model-value="(val) => onUpdateValue(val, index)"
 								placeholder="value"
 							/>
 							starting at
 							<tera-input
 								type="number"
-								:model-value="i.value"
-								@update:model-value="(val) => onUpdateTimestep(val, index)"
+								:model-value="i.threshold"
+								@update:model-value="(val) => onUpdateThreshold(val, index)"
 								placeholder="time step"
 							/>
 							.
@@ -100,7 +100,7 @@
 				<tera-input
 					type="number"
 					:model-value="intervention.dynamicInterventions[0].value"
-					@update:model-value="(val) => onUpdateTimestep(val, 0)"
+					@update:model-value="(val) => onUpdateValue(val, 0)"
 					placeholder="value"
 				/>
 				when
@@ -197,7 +197,7 @@ const onUpdateThreshold = (value: number, index: number) => {
 	emit('update', intervention);
 };
 
-const onUpdateTimestep = (value: number, index: number) => {
+const onUpdateValue = (value: number, index: number) => {
 	const intervention = cloneDeep(props.intervention);
 	if (interventionType.value === 'static') {
 		intervention.staticInterventions[index].value = value;

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-intervention-card.vue
@@ -28,17 +28,24 @@
 		</header>
 		<section>
 			<!-- Static -->
-			<template v-if="interventionType === 'static'">
-				<div class="flex align-items-center flex-wrap gap-2">
-					Set Parameter
-					<Dropdown
-						:model-value="intervention.appliedTo"
-						@change="onAppliedToParameterChange"
-						:options="parameterOptions"
-						option-label="label"
-						option-value="value"
-					/>
-					<span>to<span v-if="intervention.staticInterventions.length > 1">...</span></span>
+			<div class="flex align-items-center flex-wrap gap-2">
+				Set
+				<Dropdown
+					:model-value="intervention.type"
+					@change="onSemanticChange"
+					:options="interventionSemanticOptions"
+					option-label="label"
+					option-value="value"
+				/>
+				<Dropdown
+					:model-value="intervention.appliedTo"
+					@change="onAppliedToParameterChange"
+					:options="semanticOptions"
+					option-label="label"
+					option-value="value"
+				/>
+				<span>to<span v-if="intervention.staticInterventions.length > 1">...</span></span>
+				<template v-if="interventionType === 'static'">
 					<template v-if="intervention.staticInterventions.length === 1">
 						<tera-input
 							type="number"
@@ -55,78 +62,69 @@
 						/>
 						.
 					</template>
-				</div>
 
-				<ul v-if="intervention.staticInterventions.length > 1">
-					<li v-for="(i, index) in intervention.staticInterventions" :key="index">
-						<div class="flex align-items-center pt-2 pb-2 gap-2">
-							<tera-input
-								type="number"
-								:model-value="i.value"
-								@update:model-value="(val) => onUpdateValue(val, index)"
-								placeholder="value"
-							/>
-							starting at
-							<tera-input
-								type="number"
-								:model-value="i.threshold"
-								@update:model-value="(val) => onUpdateThreshold(val, index)"
-								placeholder="time step"
-							/>
-							.
-							<Button
-								class="ml-auto"
-								icon="pi pi-times"
-								text
-								@click="onRemoveStaticIntervention(index)"
-							/>
-						</div>
-						<Divider />
-					</li>
-				</ul>
-			</template>
+					<ul v-if="intervention.staticInterventions.length > 1">
+						<li v-for="(i, index) in intervention.staticInterventions" :key="index">
+							<div class="flex align-items-center pt-2 pb-2 gap-2">
+								<tera-input
+									type="number"
+									:model-value="i.value"
+									@update:model-value="(val) => onUpdateValue(val, index)"
+									placeholder="value"
+								/>
+								starting at
+								<tera-input
+									type="number"
+									:model-value="i.threshold"
+									@update:model-value="(val) => onUpdateThreshold(val, index)"
+									placeholder="time step"
+								/>
+								.
+								<Button
+									class="ml-auto"
+									icon="pi pi-times"
+									text
+									@click="onRemoveStaticIntervention(index)"
+								/>
+							</div>
+							<Divider />
+						</li>
+					</ul>
+				</template>
 
-			<!-- Dynamic -->
-			<div v-else class="flex align-items-center flex-wrap gap-2">
-				Set Parameter
-				<Dropdown
-					:model-value="intervention.appliedTo"
-					@change="onAppliedToParameterChange"
-					:options="parameterOptions"
-					option-label="label"
-					option-value="value"
-				/>
-				to
-				<tera-input
-					type="number"
-					:model-value="intervention.dynamicInterventions[0].value"
-					@update:model-value="(val) => onUpdateValue(val, 0)"
-					placeholder="value"
-				/>
-				when
-				<Dropdown
-					:model-value="intervention.dynamicInterventions[0].parameter"
-					@change="onTargetParameterChange"
-					:options="stateOptions"
-					option-label="label"
-					option-value="value"
-				/>
-				is
-				<Dropdown
-					:model-value="intervention.dynamicInterventions[0].isGreaterThan"
-					@change="onComparisonOperatorChange"
-					:options="comparisonOperations"
-					option-label="label"
-					option-value="value"
-				/>
-				than the threshold value
-				<tera-input
-					type="number"
-					:model-value="intervention.dynamicInterventions[0].threshold"
-					@update:model-value="(val) => onUpdateThreshold(val, 0)"
-					placeholder="threshold"
-				/>
-				.
+				<!-- Dynamic -->
+				<template v-else>
+					<tera-input
+						type="number"
+						:model-value="intervention.dynamicInterventions[0].value"
+						@update:model-value="(val) => onUpdateValue(val, 0)"
+						placeholder="value"
+					/>
+					when
+					<Dropdown
+						:model-value="intervention.dynamicInterventions[0].parameter"
+						@change="onTargetParameterChange"
+						:options="stateOptions"
+						option-label="label"
+						option-value="value"
+					/>
+					is
+					<Dropdown
+						:model-value="intervention.dynamicInterventions[0].isGreaterThan"
+						@change="onComparisonOperatorChange"
+						:options="comparisonOperations"
+						option-label="label"
+						option-value="value"
+					/>
+					than the threshold value
+					<tera-input
+						type="number"
+						:model-value="intervention.dynamicInterventions[0].threshold"
+						@update:model-value="(val) => onUpdateThreshold(val, 0)"
+						placeholder="threshold"
+					/>
+					.
+				</template>
 			</div>
 		</section>
 		<footer>
@@ -147,7 +145,7 @@ import TeraToggleableEdit from '@/components/widgets/tera-toggleable-edit.vue';
 import Button from 'primevue/button';
 import RadioButton from 'primevue/radiobutton';
 import { computed } from 'vue';
-import { Intervention } from '@/types/Types';
+import { Intervention, InterventionSemanticType } from '@/types/Types';
 import Dropdown, { DropdownChangeEvent } from 'primevue/dropdown';
 import TeraInput from '@/components/widgets/tera-input.vue';
 import { cloneDeep, uniqueId } from 'lodash';
@@ -159,6 +157,18 @@ const props = defineProps<{
 	parameterOptions: { label: string; value: string }[];
 	stateOptions: { label: string; value: string }[];
 }>();
+
+const interventionSemanticOptions = [
+	{ label: 'Parameter', value: InterventionSemanticType.Parameter },
+	{ label: 'Variable', value: InterventionSemanticType.Variable }
+];
+
+const semanticOptions = computed(() => {
+	if (props.intervention.type === InterventionSemanticType.Variable) {
+		return props.stateOptions;
+	}
+	return props.parameterOptions;
+});
 
 const interventionType = computed(() => {
 	if (props.intervention.staticInterventions.length > 0) {
@@ -216,8 +226,8 @@ const onRemoveStaticIntervention = (index: number) => {
 const onAddNewStaticIntervention = () => {
 	const intervention = cloneDeep(props.intervention);
 	intervention.staticInterventions.push({
-		threshold: 0,
-		value: 0
+		threshold: Number.NaN,
+		value: Number.NaN
 	});
 	emit('update', intervention);
 };
@@ -227,8 +237,8 @@ const onInterventionTypeChange = (value: string) => {
 	if (value === 'static') {
 		intervention.staticInterventions = [
 			{
-				threshold: 0,
-				value: 0
+				threshold: Number.NaN,
+				value: Number.NaN
 			}
 		];
 		intervention.dynamicInterventions = [];
@@ -236,8 +246,8 @@ const onInterventionTypeChange = (value: string) => {
 		intervention.staticInterventions = [];
 		intervention.dynamicInterventions = [
 			{
-				threshold: 0,
-				value: 0,
+				threshold: Number.NaN,
+				value: Number.NaN,
 				parameter: props.stateOptions[0].value,
 				isGreaterThan: true
 			}
@@ -256,6 +266,17 @@ const onTargetParameterChange = (event: DropdownChangeEvent) => {
 const onComparisonOperatorChange = (event: DropdownChangeEvent) => {
 	const intervention = cloneDeep(props.intervention);
 	intervention.dynamicInterventions[0].isGreaterThan = event.value;
+	emit('update', intervention);
+};
+
+const onSemanticChange = (event: DropdownChangeEvent) => {
+	const intervention = cloneDeep(props.intervention);
+	intervention.type = event.value;
+	if (event.value === InterventionSemanticType.Variable) {
+		intervention.appliedTo = props.stateOptions[0].value;
+	} else {
+		intervention.appliedTo = props.parameterOptions[0].value;
+	}
 	emit('update', intervention);
 };
 </script>

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -289,7 +289,15 @@ const fetchInterventionPolicies = async (modelId: string) => {
 };
 
 const onUpdateInterventionCard = (intervention: Intervention, index: number) => {
-	knobs.value.transientInterventionPolicy.interventions[index] = cloneDeep(intervention);
+	// Clone the entire interventions array
+	const updatedInterventions = [...knobs.value.transientInterventionPolicy.interventions];
+
+	// Replace the intervention at the specified index with a deep clone of the updated intervention
+	updatedInterventions[index] = cloneDeep(intervention);
+
+	// Reassign the updated interventions array back to the transientInterventionPolicy
+	// This ensures that we're not modifying the original array in place
+	knobs.value.transientInterventionPolicy.interventions = updatedInterventions;
 };
 
 const onSelection = (id: string) => {
@@ -312,14 +320,21 @@ const onAddIntervention = () => {
 		name: 'New Intervention',
 		appliedTo: parameterOptions.value[0].value,
 		type: InterventionSemanticType.Parameter,
-		staticInterventions: [{ threshold: Number.NaN, value: Number.NaN }],
+		staticInterventions: [{ threshold: 0, value: 0 }],
 		dynamicInterventions: []
 	};
 	knobs.value.transientInterventionPolicy.interventions.push(intervention);
 };
 
 const onDeleteIntervention = (index: number) => {
-	knobs.value.transientInterventionPolicy.interventions.splice(index, 1);
+	// Create a new array excluding the intervention at the specified index
+	const updatedInterventions = knobs.value.transientInterventionPolicy.interventions.filter(
+		(_, i) => i !== index
+	);
+
+	// Reassign the updated interventions array back to the transientInterventionPolicy
+	// This ensures that we're not modifying the original array in place and Vue's reactivity system detects the change
+	knobs.value.transientInterventionPolicy.interventions = updatedInterventions;
 };
 
 const onChangeName = async (name: string) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -318,7 +318,7 @@ const onAddIntervention = () => {
 	// by default add the first parameter with a static intervention
 	const intervention: Intervention = {
 		name: 'New Intervention',
-		appliedTo: parameterOptions.value[0].value,
+		appliedTo: '',
 		type: InterventionSemanticType.Parameter,
 		staticInterventions: [{ threshold: Number.NaN, value: Number.NaN }],
 		dynamicInterventions: []

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -320,7 +320,7 @@ const onAddIntervention = () => {
 		name: 'New Intervention',
 		appliedTo: parameterOptions.value[0].value,
 		type: InterventionSemanticType.Parameter,
-		staticInterventions: [{ threshold: 0, value: 0 }],
+		staticInterventions: [{ threshold: Number.NaN, value: Number.NaN }],
 		dynamicInterventions: []
 	};
 	knobs.value.transientInterventionPolicy.interventions.push(intervention);

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -111,13 +111,14 @@
 													:key="staticIntervention.threshold"
 												>
 													<p>
-														Set parameter {{ appliedTo }} to {{ staticIntervention.value }} at time
-														step {{ staticIntervention.threshold }}.
+														Set {{ intervention.type }} {{ appliedTo }} to
+														{{ staticIntervention.value }} at time step
+														{{ staticIntervention.threshold }}.
 													</p>
 												</li>
 											</ul>
 											<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
-												Set parameter {{ appliedTo }} to
+												Set {{ intervention.type }} {{ appliedTo }} to
 												{{ intervention.dynamicInterventions[0].value }} when the
 												{{ intervention.dynamicInterventions[0].parameter }} is
 												{{
@@ -153,7 +154,7 @@ import { cloneDeep, groupBy, isEmpty } from 'lodash';
 import Button from 'primevue/button';
 import TeraInput from '@/components/widgets/tera-input.vue';
 import { getInterventionPoliciesForModel, getModel } from '@/services/model';
-import { Intervention, InterventionPolicy, Model } from '@/types/Types';
+import { Intervention, InterventionPolicy, InterventionSemanticType, Model } from '@/types/Types';
 import { logger } from '@/utils/logger';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { useConfirm } from 'primevue/useconfirm';
@@ -310,7 +311,8 @@ const onAddIntervention = () => {
 	const intervention: Intervention = {
 		name: 'New Intervention',
 		appliedTo: parameterOptions.value[0].value,
-		staticInterventions: [{ threshold: 0, value: 0 }],
+		type: InterventionSemanticType.Parameter,
+		staticInterventions: [{ threshold: Number.NaN, value: Number.NaN }],
 		dynamicInterventions: []
 	};
 	knobs.value.transientInterventionPolicy.interventions.push(intervention);

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -124,7 +124,7 @@
 												{{
 													intervention.dynamicInterventions[0].isGreaterThan
 														? 'increases to above'
-														: 'falls to below'
+														: 'decreases to below'
 												}}
 												{{ intervention.dynamicInterventions[0].threshold }}.
 											</p>

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -48,6 +48,7 @@
 						<tera-intervention-card
 							:intervention="intervention"
 							:parameterOptions="parameterOptions"
+							:stateOptions="stateOptions"
 							@update="onUpdateInterventionCard($event, index)"
 							@delete="onDeleteIntervention(index)"
 						/>
@@ -117,14 +118,14 @@
 											</ul>
 											<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
 												Set parameter {{ appliedTo }} to
-												{{ intervention.dynamicInterventions[0].threshold }} when the
+												{{ intervention.dynamicInterventions[0].value }} when the
 												{{ intervention.dynamicInterventions[0].parameter }} is
 												{{
 													intervention.dynamicInterventions[0].isGreaterThan
 														? 'greater than'
 														: 'less than'
 												}}
-												the threshold value {{ intervention.dynamicInterventions[0].value }}.
+												the threshold value {{ intervention.dynamicInterventions[0].threshold }}.
 											</p>
 										</li>
 									</ul>
@@ -156,7 +157,7 @@ import { Intervention, InterventionPolicy, Model } from '@/types/Types';
 import { logger } from '@/utils/logger';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { useConfirm } from 'primevue/useconfirm';
-import { getParameters } from '@/model-representation/service';
+import { getParameters, getStates } from '@/model-representation/service';
 import TeraToggleableEdit from '@/components/widgets/tera-toggleable-edit.vue';
 import {
 	createInterventionPolicy,
@@ -218,6 +219,14 @@ const parameterOptions = computed(() => {
 	return getParameters(model.value).map((parameter) => ({
 		label: parameter.name ?? parameter.id,
 		value: parameter.id
+	}));
+});
+
+const stateOptions = computed(() => {
+	if (!model.value) return [];
+	return getStates(model.value).map((state) => ({
+		label: state.name ?? state.id,
+		value: state.id
 	}));
 });
 

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -111,8 +111,8 @@
 													:key="staticIntervention.threshold"
 												>
 													<p>
-														Set parameter {{ appliedTo }} to {{ staticIntervention.threshold }} at
-														time step {{ staticIntervention.value }}.
+														Set parameter {{ appliedTo }} to {{ staticIntervention.value }} at time
+														step {{ staticIntervention.threshold }}.
 													</p>
 												</li>
 											</ul>

--- a/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/interventions/tera-interventions-drilldown.vue
@@ -120,13 +120,13 @@
 											<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
 												Set {{ intervention.type }} {{ appliedTo }} to
 												{{ intervention.dynamicInterventions[0].value }} when the
-												{{ intervention.dynamicInterventions[0].parameter }} is
+												{{ intervention.dynamicInterventions[0].parameter }}
 												{{
 													intervention.dynamicInterventions[0].isGreaterThan
-														? 'greater than'
-														: 'less than'
+														? 'increases to above'
+														: 'falls to below'
 												}}
-												the threshold value {{ intervention.dynamicInterventions[0].threshold }}.
+												{{ intervention.dynamicInterventions[0].threshold }}.
 											</p>
 										</li>
 									</ul>

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -763,6 +763,7 @@ export interface DynamicIntervention {
 export interface Intervention {
     name: string;
     appliedTo: string;
+    type: InterventionSemanticType;
     staticInterventions: StaticIntervention[];
     dynamicInterventions: DynamicIntervention[];
 }
@@ -1408,6 +1409,11 @@ export enum SimulationType {
 export enum SimulationEngine {
     Sciml = "SCIML",
     Ciemss = "CIEMSS",
+}
+
+export enum InterventionSemanticType {
+    Variable = "variable",
+    Parameter = "parameter",
 }
 
 export enum ExtractionAssetType {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/interventions/Intervention.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/interventions/Intervention.java
@@ -11,6 +11,7 @@ public class Intervention {
 
 	private String name;
 	private String appliedTo;
+	private InterventionSemanticType type;
 	private List<StaticIntervention> staticInterventions;
 	private List<DynamicIntervention> dynamicInterventions;
 
@@ -19,6 +20,7 @@ public class Intervention {
 		Intervention intervention = new Intervention();
 		intervention.setName(name);
 		intervention.setAppliedTo(appliedTo);
+		intervention.setType(type);
 		if (staticInterventions != null) {
 			intervention.setStaticInterventions(new ArrayList<>());
 			for (StaticIntervention staticIntervention : staticInterventions) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/interventions/InterventionSemanticType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/interventions/InterventionSemanticType.java
@@ -1,0 +1,11 @@
+package software.uncharted.terarium.hmiserver.models.simulationservice.interventions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum InterventionSemanticType {
+	@JsonProperty("variable")
+	VARIABLE,
+
+	@JsonProperty("parameter")
+	PARAMETER,
+}


### PR DESCRIPTION
# Description

* Use states instead of parameters for target in dynamic interventions as per this [thread](https://unchartedsoftware.slack.com/archives/C03S02YH3D5/p1720047460929369?thread_ts=1720042002.213279&cid=C03S02YH3D5)
* switched threshold and value around
* added intervention semantic type (variable, parameter) selection
