### PR TITLE
fix: AMR JSONs from MIRA can fail to load into Terarium due to mismat…

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-card.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-card.vue
@@ -74,7 +74,8 @@ const card = computed(() => {
 });
 
 const authors = computed(() => {
-	const authorsArray = props.model?.metadata?.annotations?.authors ?? [];
+	const authorsArray =
+		props.model?.metadata?.annotations?.authors?.map((author) => author.name) ?? [];
 
 	if (card.value?.authorAuthor) authorsArray.unshift(card.value?.authorAuthor);
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -176,7 +176,7 @@ const schema = computed(() => card.value?.schema ?? '');
 const authors = computed(() => {
 	const authorsSet: Set<string> = new Set();
 	if (props.model?.metadata?.annotations?.authors)
-		props.model.metadata.annotations.authors.forEach((ele) => authorsSet.add(ele));
+		props.model.metadata.annotations.authors.forEach((ele) => authorsSet.add(ele.name));
 	if (card.value?.ModelCardAuthors)
 		card.value.ModelCardAuthors.forEach((ele) => authorsSet.add(ele));
 	if (card.value?.authorAuthor)

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -263,6 +263,10 @@ export interface Semantic extends TerariumEntity {
     type: SemanticType;
 }
 
+export interface Author {
+    name: string;
+}
+
 export interface State {
     id: string;
     name?: string;
@@ -1052,7 +1056,7 @@ export interface OdeSemantics {
 
 export interface Annotations {
     license?: string;
-    authors?: string[];
+    authors?: Author[];
     references?: string[];
     locations?: string[];
     pathogens?: string[];

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Annotations.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Annotations.java
@@ -24,7 +24,7 @@ public class Annotations extends SupportAdditionalProperties implements Serializ
 	private String license;
 
 	@TSOptional
-	private List<String> authors;
+	private List<Author> authors;
 
 	@TSOptional
 	private List<String> references;
@@ -59,7 +59,7 @@ public class Annotations extends SupportAdditionalProperties implements Serializ
 
 	@Override
 	public Annotations clone() {
-		Annotations clone = (Annotations) super.clone();
+		final Annotations clone = (Annotations) super.clone();
 
 		clone.license = this.license;
 		if (authors != null) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Author.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/metadata/Author.java
@@ -1,0 +1,13 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata;
+
+import lombok.Data;
+import software.uncharted.terarium.hmiserver.annotations.AMRSchemaType;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@TSModel
+@Data
+@AMRSchemaType
+public class Author {
+
+	private String name;
+}


### PR DESCRIPTION
# Description

Updating the model author metadata to match the spec.  This *looks* like it should need a migration, but, because of the malformed metadata `authors` is only stored as `[]` so it works! Not to mention the upcoming data wipe...

Resolves #4060 
