### PR TITLE
fix: Missing column after dataset added to project

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
@@ -36,7 +36,7 @@
 		<!-- Datable -->
 		<DataTable
 			:class="previewMode ? 'p-datatable-xsm' : 'p-datatable-sm'"
-			:value="props.rawContent?.data ? csvContent : csvContent?.slice(1, csvContent.length)"
+			:value="csvContent?.slice(1, csvContent.length)"
 			:rows="props.rows"
 			paginator
 			:paginatorPosition="paginatorPosition ? paginatorPosition : `bottom`"
@@ -52,7 +52,7 @@
 			<Column
 				v-for="(colName, index) of selectedColumns"
 				:key="index"
-				:field="props.rawContent?.data ? colName : index.toString()"
+				:field="index.toString()"
 				:header="colName"
 				:style="previousHeaders && !previousHeaders.includes(colName) ? 'border-color: green' : ''"
 				sortable
@@ -99,7 +99,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ComputedRef, ref, watch } from 'vue';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import type { CsvAsset } from '@/types/Types';
@@ -123,7 +123,7 @@ const MINBARLENGTH = 1;
 
 const showSummaries = ref(true);
 
-const csvContent = computed(() => props.rawContent?.data || props.rawContent?.csv);
+const csvContent: ComputedRef<string[][] | undefined> = computed(() => props.rawContent?.csv);
 const csvHeaders = computed(() => props.rawContent?.headers);
 const chartData = computed(() =>
 	props.rawContent?.stats?.map((stat) => setBarChartData(stat.bins))

--- a/packages/client/hmi-client/src/services/dataset.ts
+++ b/packages/client/hmi-client/src/services/dataset.ts
@@ -316,7 +316,6 @@ const createCsvAssetFromRunResults = (runResults: RunResults, runId?: string): C
 	const csvColHeaders = Object.keys(runResult[runIdList[0]][0]);
 	let csvData: CsvAsset = {
 		headers: csvColHeaders,
-		data: [],
 		csv: [csvColHeaders],
 		rowCount: 0,
 		stats: []
@@ -327,7 +326,6 @@ const createCsvAssetFromRunResults = (runResults: RunResults, runId?: string): C
 	runIdList.forEach((id) => {
 		csvData = {
 			...csvData,
-			data: [...csvData.data, ...(runResult[id] as any)],
 			rowCount: csvData.rowCount + runResult[id].length
 		};
 		runResult[id].forEach((row) => {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -93,7 +93,6 @@ export interface CsvAsset {
     stats?: CsvColumnStats[];
     headers: string[];
     rowCount: number;
-    data: { [index: string]: string }[];
 }
 
 export interface CsvColumnStats {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/CsvAsset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/CsvAsset.java
@@ -2,10 +2,7 @@ package software.uncharted.terarium.hmiserver.models.dataservice;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -23,29 +20,6 @@ public class CsvAsset implements Serializable {
 	@Serial
 	private static final long serialVersionUID = -3242849061655394707L;
 
-	public CsvAsset(
-			final List<List<String>> csv,
-			final List<CsvColumnStats> stats,
-			final List<String> headers,
-			final Integer rowCount) {
-		this.csv = csv;
-		this.stats = stats;
-		this.headers = headers;
-		this.rowCount = rowCount;
-		this.data = new ArrayList<>();
-		for (int i = 1; i < csv.size(); i++) {
-			final Map<String, String> row = new HashMap<>();
-			for (int j = 0; j < headers.size(); j++) {
-				try {
-					row.put(headers.get(j), csv.get(i).get(j));
-				} catch (final Exception e) {
-					row.put(headers.get(j), "");
-				}
-			}
-			data.add(row);
-		}
-	}
-
 	/** The csv data. Note that this may be incomplete if the dataset is too large. */
 	List<List<String>> csv;
 
@@ -58,7 +32,4 @@ public class CsvAsset implements Serializable {
 
 	/** The number of rows in the CSV file. This may be a larger value than the csv object contained within */
 	Integer rowCount;
-
-	/** The CSV represented in a map form, where each entry in the list is a row. Column names are keys */
-	List<Map<String, String>> data;
 }


### PR DESCRIPTION
# Description

We had duplicate data structures on the `CsvAsset` class for unclear reasons - i think it was a legacy fix for column hiding that is not longer relevant? A `Map` however is not an appropriate container for a CSV as it requires unique column names which we don't have, and empty strings broke in transfer between the front and back end

Resolves #4051