### PR TITLE
fix "decimal" tera-input type

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -49,7 +49,7 @@
 						<div class="button-column">
 							<label>Tolerance</label>
 							<div class="input-tolerance fadein animation-ease-in-out animation-duration-350">
-								<tera-input type="decimal" :min="0" :max="1" v-model="knobs.tolerance" />
+								<tera-input type="nist" v-model="knobs.tolerance" />
 								<Slider
 									v-model="knobs.tolerance"
 									:min="0"

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue
@@ -27,7 +27,7 @@
 											{{ id }}
 										</td>
 										<td>
-											<tera-input type="decimal" v-model="ensembleConfigs[i].weight" />
+											<tera-input type="nist" v-model="ensembleConfigs[i].weight" />
 										</td>
 									</tr>
 								</tbody>


### PR DESCRIPTION
### Summary
"decimal" is an invalid option that gets routed to produce string-type, which then create problems for downstream consumers.