### PR TITLE
fix collapse initials

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -166,6 +166,17 @@ export const collapseInitials = (miraModel: MiraModel) => {
 			map.set(rootName, [name]);
 		}
 	}
+
+	// when a key only has one child, we will rename the key of the root to the child.
+	// this is to avoid renaming when a single entry key has an underscore
+	[...map.keys()].forEach((key) => {
+		const newKey = map.get(key)?.[0];
+		if (newKey && map.get(key)?.length === 1 && newKey !== key) {
+			map.set(newKey, [newKey]);
+			map.delete(key);
+		}
+	});
+
 	return map;
 };
 

--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -295,11 +295,19 @@ export const collapseTemplates = (miraModel: MiraModel) => {
 	};
 };
 
-export const collapseObservableReferences = (observableSummary: ObservableSummary) => {
+export const collapseObservableReferences = (
+	observableSummary: ObservableSummary,
+	initials: Map<string, string[]>
+) => {
 	const collapsedObservableSummary: ObservableSummary = cloneDeep(observableSummary);
 	Object.values(collapsedObservableSummary).forEach((observable) => {
 		// Extract the first part of the reference before the first underscore
-		observable.references = uniq(observable.references.map((r) => r.split('_')[0]));
+		observable.references = uniq(
+			observable.references.map((r) => {
+				const splitReference = r.split('_')[0];
+				return initials.has(splitReference) ? splitReference : r;
+			})
+		);
 	});
 	return collapsedObservableSummary;
 };
@@ -418,6 +426,7 @@ export const createParameterMatrix = (
 // const genKey = (t: TemplateSummary) => `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
 export const convertToIGraph = (
 	miraModel: MiraModel,
+	mmtParams: MiraTemplateParams,
 	initObservableSummary: ObservableSummary,
 	isStratified: boolean
 ) => {
@@ -426,7 +435,10 @@ export const convertToIGraph = (
 
 	if (isStratified) {
 		templates.push(...collapseTemplates(miraModel).templatesSummary);
-		observableSummary = collapseObservableReferences(initObservableSummary);
+		observableSummary = collapseObservableReferences(
+			initObservableSummary,
+			collapseInitials(miraModel)
+		);
 	} else {
 		templates.push(...rawTemplatesSummary(miraModel));
 		observableSummary = cloneDeep(initObservableSummary);

--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -426,7 +426,6 @@ export const createParameterMatrix = (
 // const genKey = (t: TemplateSummary) => `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
 export const convertToIGraph = (
 	miraModel: MiraModel,
-	mmtParams: MiraTemplateParams,
 	initObservableSummary: ObservableSummary,
 	isStratified: boolean
 ) => {


### PR DESCRIPTION
# Description

* Fixes an edge cases issue where initials have an underscore AND that are not stratified the initial is renamed to something unrecognized.
* The fix is if there is only 1 child initial when we collapse the initials, we rename the root to the child initial which is recognized


Example:
We have `Cumulative_cases` which is an initial target, but this is not a stratified initial:
before fix collapseInitials:
```
{"Cumulative" => Array(1)}
key: "Cumulative"
value: ['Cumulative_cases']
```

On the model config node it will look for `Cumulative` to edit which does not exist

after fix :
```
{"Cumulative_cases" => Array(1)}
key: "Cumulative_cases"
value: ['Cumulative_cases']
```
On the model config node it will look for `Cumulative_cases` to edit which does exist


An example where this was causing an issue:
[SEIRHD vacc model for LA County t0 = 10_28_2021.json](https://github.com/user-attachments/files/16197543/SEIRHD.vacc.model.for.LA.County.t0.10_28_2021.json)
