### PR TITLE
Cast exception when recalling model config

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
@@ -203,10 +203,11 @@ public class ModelConfigurationService
 				// set distributions
 				if (CONSTANT_TYPE.equals(
 						matchingConfigParameter.getDistribution().getType())) {
-					modelParameter.setValue((Double) matchingConfigParameter
-							.getDistribution()
-							.getParameters()
-							.get(VALUE_PARAM));
+					modelParameter.setValue(((Number) matchingConfigParameter
+									.getDistribution()
+									.getParameters()
+									.get(VALUE_PARAM))
+							.doubleValue());
 					modelParameter.setDistribution(null);
 				} else {
 					modelParameter.setDistribution(matchingConfigParameter.getDistribution());


### PR DESCRIPTION


# Description

* If a number gets stored as an integer we can't just cast to a double. Go the long way around.

Resolves #noissue