### PR TITLE
fix observable mapping

### DIFF
--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -148,7 +148,7 @@ export async function getCalibrateBlobURL(runId: string) {
 }
 
 // @deprecated - The notion of RunResult is a outdated with introduction of Vegalite charts
-// that use a more barebone setups closwer to the raw data
+// that use a more barebone setup closer to the raw data
 export async function getRunResultCiemss(runId: string, filename = 'result.csv') {
 	const resultCsv = await getRunResult(runId, filename);
 	const csvData = csvParse(resultCsv);


### PR DESCRIPTION
### Summary
In `getRunResultCiemss` we establish how PyCIEMSS result should map back to the model, our mapping logic seem to be out-of-date for observable variables, which cause the ground-truth not not appear in calibrate operation.

This PR should fix the logic, but also mark getRunResultCiemss as deprecated as we start to replace the chart.js charts with Vegalite, which generally wants a more simplified data format that is closer to the raw produced data.

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/f0e760af-408e-4289-8944-3d0dd60f4de0">


### Testing
- Do a calibrate operation, the mapping should map an observed variable in the model to the grounding data
- When calibrate finishes, chart the observed variable, should see both the forecast-values and ground-truth-values
