### PR TITLE
success criteria chart fix

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
@@ -355,7 +355,7 @@ const buildJupyterContext = () => {
 		return null;
 	}
 	return {
-		context: 'model_configuration',
+		context: 'mira_config_edit',
 		language: 'python3',
 		context_info: {
 			id: contextId
@@ -375,7 +375,7 @@ const executeResponse = ref({
 });
 const sampleAgentQuestions = [
 	'What are the current parameters values?',
-	'Update parameter gamma to constant 0.13'
+	'update the parameters {gamma: 0.13}'
 ];
 const contextLanguage = ref<string>('python3');
 
@@ -423,7 +423,7 @@ const runFromCode = () => {
 		.register('stream', (data) => {
 			notebookResponse.value = data.content.text;
 		})
-		.register('model_configuration_preview', (data) => {
+		.register('model_preview', (data) => {
 			if (!data.content) return;
 			handleModelPreview(data);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config.vue
@@ -355,7 +355,7 @@ const buildJupyterContext = () => {
 		return null;
 	}
 	return {
-		context: 'mira_config_edit',
+		context: 'model_configuration',
 		language: 'python3',
 		context_info: {
 			id: contextId
@@ -375,7 +375,7 @@ const executeResponse = ref({
 });
 const sampleAgentQuestions = [
 	'What are the current parameters values?',
-	'update the parameters {gamma: 0.13}'
+	'Update parameter gamma to constant 0.13'
 ];
 const contextLanguage = ref<string>('python3');
 
@@ -423,7 +423,7 @@ const runFromCode = () => {
 		.register('stream', (data) => {
 			notebookResponse.value = data.content.text;
 		})
-		.register('model_preview', (data) => {
+		.register('model_configuration_preview', (data) => {
 			if (!data.content) return;
 			handleModelPreview(data);
 

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -284,10 +284,16 @@ function formatSuccessChartData(
 	const maxValue = Math.max(...data);
 	const stepSize = (maxValue - minValue) / binCount;
 	const bins: { range: string; count: number; tag: 'in' | 'out' }[] = [];
-	const binLabels: string[] = [];
 	for (let i = binCount; i > 0; i--) {
-		const rangeStart = minValue + stepSize * (i - 1);
-		const rangeEnd = minValue + stepSize * i;
+		let rangeStart = minValue + stepSize * (i - 1);
+		let rangeEnd = minValue + stepSize * i;
+
+		// Handle edge case where stepSize is 0, and give the range a thickness so it can be seen
+		if (stepSize === 0) {
+			rangeStart = minValue - 1;
+			rangeEnd = maxValue + 1;
+		}
+
 		let tag;
 		if (isMinimized) {
 			tag = rangeEnd < threshold ? 'in' : 'out';
@@ -300,11 +306,12 @@ function formatSuccessChartData(
 			count: 0,
 			tag
 		});
-		binLabels.push(`${rangeStart.toFixed(4)} - ${rangeEnd.toFixed(4)}`);
 	}
 
 	const toBinIndex = (value: number) => {
 		if (value < minValue || value > maxValue) return -1;
+		// return first bin in cases where the max value is the same as the incoming value or when the min and max data values are the same (stepsize = 0)
+		if (stepSize === 0 || value === maxValue) return 0;
 		const index = binCount - 1 - Math.abs(Math.floor((value - minValue) / stepSize));
 		return index;
 	};


### PR DESCRIPTION
# Description

* Fixes an issue where success criteria charts wouldn't render when incoming data would be of size 1 or the min and max values in the dataset are the same.


