### PR TITLE
Set basic icons for input pills

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -11,7 +11,7 @@
 			>
 				{{ title ?? node.displayName }}
 				<template #top-header-actions>
-					<aside class="input-chips mr-auto">
+					<aside class="flex gap-1 ml-3 mr-auto">
 						<Chip
 							v-for="(input, index) in node.inputs.filter((input) => input.value)"
 							:key="index"
@@ -191,18 +191,12 @@ footer {
 	gap: 0.5rem;
 }
 
-.input-chips {
-	display: flex;
-	gap: var(--gap-1-5);
-	margin: 0 var(--gap);
-}
-
 .p-chip {
 	background-color: var(--surface-section);
 	color: var(--text-color-primary);
 }
 
 :deep(.p-chip .p-chip-text) {
-	font-size: var(--font-caption);
+	font-size: var(--font-body-small);
 }
 </style>

--- a/packages/client/hmi-client/src/components/operator/tera-operator-port-icon.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-port-icon.vue
@@ -1,40 +1,16 @@
 <template>
-	<i v-if="typeof portIcon === 'string'" class="p-chip-icon" :class="`pi ${portIcon}`" />
-	<!-- <component v-else :is="portIcon" class="p-button-icon-left icon" /> -->
+	<i class="p-chip-icon" :class="`pi ${icons.get(portType) ?? 'pi-cog'}`" />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-// import DatasetIcon from '@/assets/svg/icons/dataset.svg?component';
-
-const props = defineProps<{
-	portType: string;
-}>();
-
+defineProps<{ portType: string }>();
 const icons = new Map<string, string>([
-	// FIXME: should be <string, string | Component>, for some reason importing Component here breaks everything
 	['documentId', 'pi-file'],
 	['modelId', 'pi-share-alt'],
 	['datasetId', 'pi-table'],
 	['datasetId|simulationId', 'pi-table'],
-	// Use these once FIXME is solved
-	// ['datasetId', DatasetIcon],
-	// ['datasetId|simulationId', DatasetIcon],
 	['calibrateSimulationId', 'pi-chart-line'],
 	['simulationId', 'pi-chart-line'],
 	['modelConfigId', 'pi-cog']
 ]);
-
-const portIcon = computed(() => {
-	if (icons.has(props.portType)) {
-		return icons.get(props.portType) ?? 'circle';
-	}
-	return 'circle';
-});
 </script>
-
-<style scoped>
-svg {
-	scale: 0.8;
-}
-</style>


### PR DESCRIPTION
# Description

* Set the `pi-cog` icon as the default icons for input chips in drilldown header
* Some clean up and changes requested by design team

![Screenshot 2024-07-17 at 14 57 29](https://github.com/user-attachments/assets/b78fa6da-5145-460d-bbff-f6975490eb4c)
![Screenshot 2024-07-17 at 14 57 46](https://github.com/user-attachments/assets/81b652fe-91d4-4db9-a915-44837403bd53)