### PR TITLE
fix workflow output numbering

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -45,7 +45,7 @@ import {
 	parsePyCiemssMap
 } from '@/services/models/simulation-service';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
-import { nodeMetadata } from '@/components/workflow/util';
+import { nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
 import { logger } from '@/utils/logger';
 import { Poller, PollerState } from '@/api/api';
 import type { WorkflowNode } from '@/types/workflow';
@@ -235,7 +235,7 @@ watch(
 			const portLabel = props.node.inputs[0].label;
 			emit('append-output', {
 				type: 'calibrateSimulationId',
-				label: `${portLabel} Result`,
+				label: nodeOutputLabel(props.node, `${portLabel} Result`),
 				value: [state.calibrationId],
 				state: {
 					calibrationId: state.calibrationId,

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -51,7 +51,7 @@ import {
 	makeEnsembleCiemssSimulation
 } from '@/services/models/simulation-service';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
-import { chartActionsProxy, nodeMetadata } from '@/components/workflow/util';
+import { chartActionsProxy, nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
 import { logger } from '@/utils/logger';
 
 import { Poller, PollerState } from '@/api/api';
@@ -158,7 +158,7 @@ watch(
 			const portLabel = props.node.inputs[0].label;
 			emit('append-output', {
 				type: 'calibrateSimulationId',
-				label: `${portLabel} Result`,
+				label: nodeOutputLabel(props.node, `${portLabel} Result`),
 				value: [state.calibrationId]
 			});
 		}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-julia/tera-calibrate-node-julia.vue
@@ -49,7 +49,7 @@ import { csvParse } from 'd3';
 import { Poller, PollerState } from '@/api/api';
 import { logger } from '@/utils/logger';
 import { setupDatasetInput } from '@/services/calibrate-workflow';
-import { chartActionsProxy } from '@/components/workflow/util';
+import { chartActionsProxy, nodeOutputLabel } from '@/components/workflow/util';
 import type { CsvAsset } from '@/types/Types';
 import type { WorkflowNode } from '@/types/workflow';
 import { CalibrationOperationStateJulia, CalibrationOperationJulia } from './calibrate-operation';
@@ -101,7 +101,7 @@ const processResult = (id: string) => {
 
 	emit('append-output', {
 		type: CalibrationOperationJulia.outputs[0].type,
-		label: `Output - ${props.node.outputs.length + 1}`,
+		label: nodeOutputLabel(props.node, 'Output'),
 		value: [id],
 		isSelected: false,
 		state: {

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-node.vue
@@ -25,6 +25,7 @@ import {
 import Button from 'primevue/button';
 import { Poller, PollerState } from '@/api/api';
 import { pollAction } from '@/services/models/simulation-service';
+import { nodeOutputLabel } from '@/components/workflow/util';
 
 const emit = defineEmits(['open-drilldown', 'append-output', 'update-state']);
 
@@ -42,7 +43,7 @@ const addOutputPorts = async (runId: string) => {
 	outState.inProgressId = '';
 
 	emit('append-output', {
-		label: `${portLabel} Result ${props.node.outputs.length + 1}`,
+		label: nodeOutputLabel(props.node, `${portLabel} Result`),
 		type: FunmanOperation.outputs[0].type,
 		value: runId,
 		state: outState

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -44,7 +44,7 @@ import {
 	getRunResultCSV,
 	parsePyCiemssMap
 } from '@/services/models/simulation-service';
-import { nodeMetadata } from '@/components/workflow/util';
+import { nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
 import { SimulationRequest, InterventionPolicy } from '@/types/Types';
 import { createLLMSummary } from '@/services/summary-service';
 import VegaChart from '@/components/widgets/VegaChart.vue';
@@ -213,7 +213,7 @@ Provide a consis summary in 100 words or less.
 
 			emit('append-output', {
 				type: OptimizeCiemssOperation.outputs[0].type,
-				label: `Simulation output - ${props.node.outputs.length + 1}`,
+				label: nodeOutputLabel(props.node, `Simulation output`),
 				value: [postSimId],
 				isSelected: false,
 				state

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -41,7 +41,7 @@ import {
 } from '@/services/models/simulation-service';
 import { Poller, PollerState } from '@/api/api';
 import { logger } from '@/utils/logger';
-import { chartActionsProxy } from '@/components/workflow/util';
+import { chartActionsProxy, nodeOutputLabel } from '@/components/workflow/util';
 
 import type { WorkflowNode } from '@/types/workflow';
 import { createLLMSummary } from '@/services/summary-service';
@@ -135,7 +135,7 @@ Provide a summary in 100 words or less.
 
 	emit('append-output', {
 		type: SimulateCiemssOperation.outputs[0].type,
-		label: `Output - ${props.node.outputs.length + 1}`,
+		label: nodeOutputLabel(props.node, 'Output'),
 		value: [runId],
 		state: {
 			currentTimespan: state.currentTimespan,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -45,7 +45,7 @@ import TeraSimulateChart from '@/components/workflow/tera-simulate-chart.vue';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { logger } from '@/utils/logger';
-import { chartActionsProxy } from '@/components/workflow/util';
+import { chartActionsProxy, nodeOutputLabel } from '@/components/workflow/util';
 import {
 	SimulateEnsembleCiemssOperation,
 	SimulateEnsembleCiemssOperationState
@@ -110,7 +110,7 @@ const processResult = async (simulationId: string) => {
 
 	emit('append-output', {
 		type: SimulateEnsembleCiemssOperation.outputs[0].type,
-		label: `${portLabel} Result`,
+		label: nodeOutputLabel(props.node, `${portLabel} Result`),
 		value: [simulationId],
 		state: {
 			mapping: state.mapping,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/tera-simulate-node-julia.vue
@@ -39,7 +39,7 @@ import { getRunResult, pollAction } from '@/services/models/simulation-service';
 import { csvParse } from 'd3';
 import { Poller, PollerState } from '@/api/api';
 import { logger } from '@/utils/logger';
-import { chartActionsProxy } from '@/components/workflow/util';
+import { chartActionsProxy, nodeOutputLabel } from '@/components/workflow/util';
 import { SimulateJuliaOperation, SimulateJuliaOperationState } from './simulate-julia-operation';
 
 const props = defineProps<{
@@ -86,7 +86,7 @@ const processResult = async (runId: string) => {
 
 	emit('append-output', {
 		type: SimulateJuliaOperation.outputs[0].type,
-		label: `Output - ${props.node.outputs.length + 1}`,
+		label: nodeOutputLabel(props.node, 'Output'),
 		value: [runId],
 		state: {
 			currentTimespan: state.currentTimespan

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -131,6 +131,7 @@ import type { Model } from '@/types/Types';
 import { AssetType } from '@/types/Types';
 import { AMRSchemaNames } from '@/types/common';
 import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
+import { nodeOutputLabel } from '@/components/workflow/util';
 
 /* Jupyter imports */
 import { KernelSessionManager } from '@/services/jupyter';
@@ -286,7 +287,7 @@ const handleModelPreview = async (data: any) => {
 
 	emit('append-output', {
 		id: uuidv4(),
-		label: `Output ${Date.now()}`,
+		label: nodeOutputLabel(props.node, 'Output'),
 		type: 'modelId',
 		state: {
 			strataGroup: _.cloneDeep(props.node.state.strataGroup),

--- a/packages/client/hmi-client/src/components/workflow/util.ts
+++ b/packages/client/hmi-client/src/components/workflow/util.ts
@@ -48,6 +48,11 @@ export const chartActionsProxy = (node: WorkflowNode<any>, updateStateCallback: 
 	};
 };
 
+export const nodeOutputLabel = (node: WorkflowNode<any>, prefix: string) => {
+	const outputNumber = node.outputs.filter((d) => d.value).length;
+	return `${prefix} - ${outputNumber + 1}`;
+};
+
 export const nodeMetadata = (node: WorkflowNode<any>) => ({
 	workflowId: node.workflowId,
 	workflowName: useProjects().getAssetName(node.workflowId),


### PR DESCRIPTION
### Summary
This is an attempt to fix and harmonize operator output numbering, where they are used. The numbering system is now generated in a util function rather than having each operator roll their own length check.

Not clear where we will go in terms of naming and design, but for now this will fix confusions in the TA3 realm where outputs are generally named "output-1, output-2, output-3 ... etc".

<img width="491" alt="image" src="https://github.com/user-attachments/assets/6704eb1f-e42c-40da-a15d-0bea426fbd1f">


### Testing
We should generate the numbers in sequence, and not have 2 output-2s