### PR TITLE
do not render chart is there are no variables

### DIFF
--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -1,4 +1,4 @@
-import { mean } from 'lodash';
+import { mean, isEmpty } from 'lodash';
 
 const VEGALITE_SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json';
 
@@ -147,7 +147,7 @@ export const createForecastChart = (
 	};
 
 	// Build sample layer
-	if (samplingLayer) {
+	if (samplingLayer && !isEmpty(samplingLayer.variables)) {
 		const layerSpec = newLayer(samplingLayer, 'line');
 
 		Object.assign(layerSpec.encoding, {
@@ -160,7 +160,7 @@ export const createForecastChart = (
 	}
 
 	// Build statistical layer
-	if (statisticsLayer) {
+	if (statisticsLayer && !isEmpty(statisticsLayer.variables)) {
 		const layerSpec = newLayer(statisticsLayer, 'line');
 		Object.assign(layerSpec.encoding, {
 			opacity: { value: 1.0 },
@@ -189,7 +189,7 @@ export const createForecastChart = (
 	}
 
 	// Build ground truth layer
-	if (groundTruthLayer) {
+	if (groundTruthLayer && !isEmpty(groundTruthLayer.variables)) {
 		const layerSpec = newLayer(groundTruthLayer, 'point');
 
 		// FIXME: variables not aligned, set unique color for now
@@ -218,7 +218,7 @@ export const createForecastChart = (
 
 	// Build a transparent layer with fat lines as a better hover target for tooltips
 	// Re-Build statistical layer
-	if (statisticsLayer) {
+	if (statisticsLayer && !isEmpty(statisticsLayer.variables)) {
 		const tooltipContent = statisticsLayer.variables?.map((d) => {
 			const tip: any = {
 				field: d,


### PR DESCRIPTION
### Summary
Don't render charts if there are no variables, trying to render with a 0-length variable list can cause transform problems that later results in infinity-warnings.

