### PR TITLE
support operator output with multiple types

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -109,7 +109,7 @@ export const addNode = (
 };
 
 /**
- * Create an eddge between two nodes, and transfer the value from
+* Create an edge between two nodes, and transfer the value from
  * source-node's output port to target-node's input port
  *
  * The terms are used as depicted in the following schematics

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -171,7 +171,7 @@ export const addEdge = (
 	const allowedInputTypes = targetInputPort.type.split('|');
 	const intersectionTypes = _.intersection(outputTypes, allowedInputTypes);
 
-	// Not supported if there are more than oen matches
+	// Not supported if there are more than one matche
 	if (intersectionTypes.length > 1) {
 		console.error(`Ambiguous matching types [${outputTypes}] to [${allowedInputTypes}]`);
 		return;

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -171,7 +171,7 @@ export const addEdge = (
 	const allowedInputTypes = targetInputPort.type.split('|');
 	const intersectionTypes = _.intersection(outputTypes, allowedInputTypes);
 
-	// Not supported if there are more than one matche
+  // Not supported if there are more than one match
 	if (intersectionTypes.length > 1) {
 		console.error(`Ambiguous matching types [${outputTypes}] to [${allowedInputTypes}]`);
 		return;

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -173,7 +173,7 @@ export const addEdge = (
 
 	// Not supported if there are more than oen matches
 	if (intersectionTypes.length > 1) {
-		console.error(`Ambiguous matching types ${intersectionTypes}`);
+		console.error(`Ambiguous matching types [${outputTypes}] to [${allowedInputTypes}]`);
 		return;
 	}
 

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -108,6 +108,38 @@ export const addNode = (
 	wf.nodes.push(node);
 };
 
+/**
+ * Create an eddge between two nodes, and transfer the value from
+ * source-node's output port to target-node's input port
+ *
+ * The terms are used as depicted in the following schematics
+ *
+ *
+ *  ------------             ------------
+ *  | Source    |            | Target    |
+ *  |           |            |           |
+ *  |  [output port] ---> [input port]   |
+ *  |           |            |           |
+ *  ------------             -------------
+ *
+ *
+ * There are several special cases
+ *
+ * The target-input can accept multiple types, but this is more of an exception
+ * rather than the norm. This is resolved by checking one of the accepted type
+ * matches the provided type.
+ *
+ * The second case is when the source produce multiple types, a similar check, but
+ * on the reverse side is performed.
+ *
+ *
+ * Ambiguity arises when the source provide multiple types and the target accepts multiple
+ * types and there is no resolution. For example
+ * - source provides {A, B, C}
+ * - target accepts A or C
+ * We do not deal with this and throw an error/warning, and the edge creation will be cancelled.
+ *
+ * */
 export const addEdge = (
 	wf: Workflow,
 	sourceId: string,
@@ -135,26 +167,38 @@ export const addEdge = (
 	if (existingEdge) return;
 
 	// Check if type is compatible
-	const allowedTypes = targetInputPort.type.split('|');
+	const outputTypes = sourceOutputPort.type.split('|');
+	const allowedInputTypes = targetInputPort.type.split('|');
+	const intersectionTypes = _.intersection(outputTypes, allowedInputTypes);
+
+	// Not supported if there are more than oen matches
+	if (intersectionTypes.length > 1) {
+		console.error(`Ambiguous matching types ${intersectionTypes}`);
+		return;
+	}
+
+	// Not supported if there is a mismatch
 	if (
-		!allowedTypes.includes(sourceOutputPort.type) ||
+		intersectionTypes.length === 0 ||
 		(!targetInputPort.acceptMultiple && targetInputPort.status === WorkflowPortStatus.CONNECTED)
 	) {
 		return;
 	}
 
 	// Transfer data value/reference
-	if (targetInputPort.acceptMultiple && targetInputPort.value && sourceOutputPort.value) {
-		targetInputPort.label = `${sourceOutputPort.label},${targetInputPort.label}`;
-		targetInputPort.value = [...targetInputPort.value, ...sourceOutputPort.value];
+	targetInputPort.label = sourceOutputPort.label;
+	if (outputTypes.length > 1) {
+		const concreteType = intersectionTypes[0];
+		if (sourceOutputPort.value) {
+			targetInputPort.value = [sourceOutputPort.value[0][concreteType]];
+		}
 	} else {
-		targetInputPort.label = sourceOutputPort.label;
 		targetInputPort.value = sourceOutputPort.value;
 	}
 
 	// Transfer concrete type to the input type to match the output type
 	// Saves the original type in case we want to revert when we unlink the edge
-	if (allowedTypes.length > 1) {
+	if (allowedInputTypes.length > 1) {
 		targetInputPort.originalType = targetInputPort.type;
 		targetInputPort.type = sourceOutputPort.type;
 	}

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -109,7 +109,7 @@ export const addNode = (
 };
 
 /**
-* Create an edge between two nodes, and transfer the value from
+ * Create an edge between two nodes, and transfer the value from
  * source-node's output port to target-node's input port
  *
  * The terms are used as depicted in the following schematics
@@ -171,7 +171,7 @@ export const addEdge = (
 	const allowedInputTypes = targetInputPort.type.split('|');
 	const intersectionTypes = _.intersection(outputTypes, allowedInputTypes);
 
-  // Not supported if there are more than one match
+	// Not supported if there are more than one match
 	if (intersectionTypes.length > 1) {
 		console.error(`Ambiguous matching types [${outputTypes}] to [${allowedInputTypes}]`);
 		return;

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -49,7 +49,7 @@ export interface OperationData {
 	type: string;
 	label?: string;
 	isOptional?: boolean;
-	acceptMultiple?: boolean;
+	acceptMultiple?: boolean; // @deprecated
 }
 
 // Defines a function: eg: model, simulate, calibrate
@@ -81,7 +81,7 @@ export interface WorkflowPort {
 	label?: string;
 	value?: any[] | null;
 	isOptional: boolean;
-	acceptMultiple?: boolean;
+	acceptMultiple?: boolean; // @deprecated
 }
 
 // Operator Output needs more information than a standard operator port.


### PR DESCRIPTION
### Summary
Initial work to support operator output that can contain more than one type. For example calibrate run create a dataset + config. The way this is handled is to piggy back on the current notion where we "accept" one or more types.

```
type: 'datasetId | modelConfigId`
```

and the value of the output being an object keyed by the type:
```
value = [{
  datasetId: 'abcdefg',
  modelConfigId: 'aaaaabbbbbb'
}]
```



I largely removed the "allowMultiple" idea, as it isn't been used from what I can gather and it creates a boatload of edge cases that we would need to deal with.



### Testing
In unit tests
```
yarn workspace hmi-client run test workflow
```