### PR TITLE
tweak categorical color palette and y-label format

### DIFF
--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -2,7 +2,7 @@ import { isEmpty } from 'lodash';
 
 const VEGALITE_SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json';
 
-export const CATEGORICAL_SCHEME = ['#5F9E3E', '#4375B0', '#8F69B9', '#D67DBF', '#E18547', '#D2C446', '#84594D'];
+export const CATEGORICAL_SCHEME = ['#1B8073', '#6495E8', '#8F69B9', '#D67DBF', '#E18547', '#D2C446', '#84594D'];
 
 export interface ForecastChartOptions {
 	legend: boolean;

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -62,7 +62,7 @@ export const createForecastChart = (
 			}
 		: null;
 
-	const xaxis = {
+	const xaxis: any = {
 		domainColor: axisColor,
 		tickColor: { value: axisColor },
 		labelColor: { value: labelColor },
@@ -73,6 +73,7 @@ export const createForecastChart = (
 	};
 	const yaxis = structuredClone(xaxis);
 	yaxis.title = options.yAxisTitle;
+	yaxis.format = '.3s';
 
 	const translationMap = options.translationMap;
 	let labelExpr = '';


### PR DESCRIPTION
### Summary
Tweaks palette and y-axis formatting


#### 6 variables low sampling (15)
<img width="695" alt="image" src="https://github.com/user-attachments/assets/9334c55c-4592-426f-bbe9-797b73f1f456">


#### 6 variables high sampling (75)
<img width="694" alt="image" src="https://github.com/user-attachments/assets/de77b245-65dd-4566-ba0b-a82bdb3ed163">


#### 3 variables
<img width="685" alt="image" src="https://github.com/user-attachments/assets/7fd6aba9-8f32-4a7a-8a71-f12f8885e268">



