### PR TITLE
feat: reset and save as for model page

### DIFF
--- a/packages/client/hmi-client/src/components/model/tera-model-parts.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model-parts.vue
@@ -32,14 +32,13 @@ import {
 	updateTransition,
 	updateTime
 } from '@/model-representation/service';
-import { logger } from '@/utils/logger';
 
 const props = defineProps<{
 	model: Model;
 	readonly?: boolean;
 }>();
 
-const emit = defineEmits(['update-model']);
+defineEmits(['update-model']);
 
 const mmt = ref<MiraModel>(emptyMiraModel());
 const mmtParams = ref<MiraTemplateParams>({});
@@ -90,16 +89,14 @@ function updateMMT() {
 	});
 }
 
-// Apply changes to the model when the component unmounts or the user navigates away
-function saveChanges() {
-	emit('update-model', transientModel.value);
-	logger.info('Saved changes');
+function reset() {
+	transientModel.value = cloneDeep(props.model);
 }
-defineExpose({ saveChanges });
 
 onMounted(() => updateMMT());
 
 // TODO: Do we still want autosave? It worked onUnmount but on staging the onbeforemount wasn't triggering
+// Apply changes to the model when the component unmounts or the user navigates away
 // onMounted(() => {
 // 	window.addEventListener('beforeunload', saveChanges);
 // 	updateMMT();
@@ -110,16 +107,16 @@ onMounted(() => updateMMT());
 // 	window.removeEventListener('beforeunload', saveChanges);
 // });
 
-// Meant to run when we want to view a different model, like when we swtich outputs in the stratify operator
-// This is not to be used a refresh when saving a model
 watch(
 	() => props.model,
 	() => {
-		transientModel.value = cloneDeep(props.model);
+		reset();
 		updateMMT();
 	},
 	{ deep: true }
 );
+
+defineExpose({ transientModel, reset });
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -1,5 +1,6 @@
 <template>
 	<tera-asset
+		v-bind="$attrs"
 		:id="assetId"
 		:name="model?.header.name"
 		:feature-config="featureConfig"
@@ -22,17 +23,12 @@
 			</div>
 		</template>
 		<template #edit-buttons v-if="!featureConfig.isPreview">
-			<Button
-				icon="pi pi-ellipsis-v"
-				class="p-button-icon-only p-button-text p-button-rounded"
-				@click="toggleOptionsMenu"
-			/>
+			<Button icon="pi pi-ellipsis-v" text rounded @click="toggleOptionsMenu" />
 			<ContextMenu ref="optionsMenu" :model="optionsMenuItems" :popup="true" />
 			<div class="btn-group">
-				<!-- TODO: Reset and Save as buttons
-				<Button label="Reset" severity="secondary" outlined />
-				<Button label="Save as..." severity="secondary" outlined /> -->
-				<Button label="Save" @click="teraModelPartsRef?.saveChanges()" />
+				<Button label="Reset" severity="secondary" outlined @click="teraModelPartsRef?.reset()" :disabled="isSaved" />
+				<Button label="Save as..." severity="secondary" outlined @click="showSaveModal = true" />
+				<Button label="Save" @click="updateModelContent(teraModelPartsRef?.transientModel)" :disabled="isSaved" />
 			</div>
 		</template>
 		<section v-if="model">
@@ -51,14 +47,23 @@
 			/>
 		</section>
 	</tera-asset>
+	<tera-save-asset-modal
+		:initial-name="model?.header.name"
+		:is-visible="showSaveModal"
+		:asset="teraModelPartsRef?.transientModel"
+		:asset-type="AssetType.Model"
+		@close-modal="showSaveModal = false"
+		@on-save="showSaveModal = false"
+	/>
 </template>
 
 <script setup lang="ts">
 import { computed, PropType, ref, watch } from 'vue';
-import { cloneDeep, isEmpty } from 'lodash';
+import { cloneDeep, isEmpty, isEqual } from 'lodash';
 import TeraAsset from '@/components/asset/tera-asset.vue';
 import TeraModelDescription from '@/components/model/petrinet/tera-model-description.vue';
 import TeraModelParts from '@/components/model/tera-model-parts.vue';
+import TeraSaveAssetModal from '@/components/project/tera-save-asset-modal.vue';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import ContextMenu from 'primevue/contextmenu';
@@ -87,8 +92,10 @@ const model = ref<Model | null>(null);
 const newName = ref('New Model');
 const isRenaming = ref(false);
 const isModelLoading = ref(false);
+const showSaveModal = ref(false);
 
 const isNaming = computed(() => isEmpty(props.assetId) || isRenaming.value);
+const isSaved = computed(() => isEqual(model.value, teraModelPartsRef.value?.transientModel));
 
 const toggleOptionsMenu = (event) => optionsMenu.value.toggle(event);
 
@@ -140,6 +147,7 @@ async function updateModelContent(updatedModel: Model) {
 		return;
 	}
 	await updateModel(updatedModel);
+	logger.info('Saved changes');
 	await useProjects().refresh();
 	await fetchModel();
 }

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -201,7 +201,9 @@ const title = computed(() => {
 	let value = '';
 	if (props.resourceType === ResourceType.XDD) {
 		value =
-			props.source === DocumentSource.XDD ? (props.asset as Document).title : (props.asset as DocumentAsset).name ?? '';
+			props.source === DocumentSource.XDD
+				? (props.asset as Document).title
+				: ((props.asset as DocumentAsset).name ?? '');
 	} else if (props.resourceType === ResourceType.MODEL) {
 		value = (props.asset as Model).header.name;
 	} else if (props.resourceType === ResourceType.DATASET) {


### PR DESCRIPTION
# Description

* Save as saves the current edited state of the model as a new model
* Reset resets the edited state to the original model


https://github.com/user-attachments/assets/97253e5c-f535-4ad8-a4a1-5d020dc2e4c6


