### PR TITLE
Fixing wrong model configuration selection

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -517,6 +517,8 @@ const createConfiguration = async () => {
 		return;
 	}
 
+	knobs.value.transientModelConfig = cloneDeep(data);
+	state.transientModelConfig = knobs.value.transientModelConfig;
 	useToastService().success('', 'Created model configuration');
 	emit('append-output', {
 		type: ModelConfigOperation.outputs[0].type,

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -517,8 +517,7 @@ const createConfiguration = async () => {
 		return;
 	}
 
-	knobs.value.transientModelConfig = cloneDeep(data);
-	state.transientModelConfig = knobs.value.transientModelConfig;
+	state.transientModelConfig = knobs.value.transientModelConfig = cloneDeep(data);
 	useToastService().success('', 'Created model configuration');
 	emit('append-output', {
 		type: ModelConfigOperation.outputs[0].type,

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -517,7 +517,8 @@ const createConfiguration = async () => {
 		return;
 	}
 
-	state.transientModelConfig = knobs.value.transientModelConfig = cloneDeep(data);
+	knobs.value.transientModelConfig = cloneDeep(data);
+	state.transientModelConfig = knobs.value.transientModelConfig;
 	useToastService().success('', 'Created model configuration');
 	emit('append-output', {
 		type: ModelConfigOperation.outputs[0].type,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
@@ -202,8 +202,11 @@ public class ModelConfigurationController {
 			if (model.isEmpty()) {
 				throw new ResponseStatusException(HttpStatus.NOT_FOUND, messages.get("model.not-found"));
 			}
-			ModelConfigurationService.createAMRFromConfiguration(model.get(), modelConfiguration.get());
-			return ResponseEntity.ok(model.get());
+			final Model newModel = ModelConfigurationService.createAMRFromConfiguration(
+				model.get(),
+				modelConfiguration.get()
+			);
+			return ResponseEntity.ok(newModel);
 		} catch (final Exception e) {
 			log.error("Unable to get model configuration from postgres db", e);
 			throw new ResponseStatusException(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelDistribution.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/modelparts/ModelDistribution.java
@@ -20,11 +20,12 @@ public class ModelDistribution extends SupportAdditionalProperties implements Se
 
 	private String type;
 
+	//TODO the fact that this is `Object` is causing issues, however, I'm not sure if we can make this not an object??
 	private Map<String, Object> parameters;
 
 	@Override
 	public ModelDistribution clone() {
-		ModelDistribution clone = (ModelDistribution) super.clone();
+		final ModelDistribution clone = (ModelDistribution) super.clone();
 		clone.setParameters(this.getParameters());
 		clone.setType(this.getType());
 		return clone;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
@@ -3,6 +3,8 @@ package software.uncharted.terarium.hmiserver.service.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.annotation.Observed;
 import java.io.IOException;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -215,9 +217,15 @@ public class ModelConfigurationService
 			if (matchingConfigParameter != null) {
 				// set distributions
 				if (CONSTANT_TYPE.equals(matchingConfigParameter.getDistribution().getType())) {
-					modelParameter.setValue(
-						((Number) matchingConfigParameter.getDistribution().getParameters().get(VALUE_PARAM)).doubleValue()
-					);
+					try {
+						modelParameter.setValue(
+							NumberFormat.getInstance()
+								.parse(matchingConfigParameter.getDistribution().getParameters().get(VALUE_PARAM).toString())
+								.doubleValue()
+						);
+					} catch (final ParseException e) {
+						throw new RuntimeException(e);
+					}
 					modelParameter.setDistribution(null);
 				} else {
 					modelParameter.setDistribution(matchingConfigParameter.getDistribution());


### PR DESCRIPTION
# Description

* After creating a new model configuration, we weren't properly selecting it from the the list of model configs. As a result the output and the download would be the last selected/created config even though it *looked* like it shouldn't be.
* In addition I've found more casting exceptions because of the presence of `Object` in the back end. This should be `Number` but that could break our python services down stream, and requires a migration and I just want to get it in.
* Lastly, we should return the new model we've created ;)

Resolves #noissue
