### PR TITLE
fix: Put the failed-run indicator on the output border

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -950,7 +950,7 @@ watch(
 	flex-grow: 1;
 }
 
-.failed-run {
+:deep(.failed-run main .content-container) {
 	border: 2px solid var(--error-color);
 	border-radius: var(--border-radius-big);
 	color: var(--error-color-text);


### PR DESCRIPTION
BEFORE
![image](https://github.com/user-attachments/assets/1a572194-d3d5-4b98-bd15-34c037ac3bc6)


AFTER
![image](https://github.com/user-attachments/assets/d3e27ced-f0a7-4dee-9515-2f5c106de9fc)
