### PR TITLE
added subtle shadow to header when panel is scrolled

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
@@ -1,7 +1,7 @@
 <template>
 	<tera-slider :content-width="contentWidth" :tab-width="tabWidth" :direction="direction" :is-open="isOpen">
 		<template v-slot:content>
-			<div class="panel-container" @scroll="onScroll">
+			<aside class="panel-container" @scroll="onScroll">
 				<header class="slider-header content sticky" :class="{ 'header-shadow': isScrolled }">
 					<i
 						:class="`slider-header-item pi ${directionMap[direction].iconOpen}`"
@@ -14,7 +14,7 @@
 					</section>
 				</header>
 				<slot name="content"></slot>
-			</div>
+			</aside>
 		</template>
 		<template v-slot:tab>
 			<div :class="`slider-tab-header ${direction}`">

--- a/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
@@ -1,15 +1,20 @@
 <template>
 	<tera-slider :content-width="contentWidth" :tab-width="tabWidth" :direction="direction" :is-open="isOpen">
 		<template v-slot:content>
-			<header class="slider-header content sticky">
-				<i :class="`slider-header-item pi ${directionMap[direction].iconOpen}`" @click="emit('update:isOpen', false)" />
-				<slot name="header"></slot>
-				<section>
-					<h4 class="slider-header-item">{{ header }}</h4>
-					<slot name="subHeader"></slot>
-				</section>
-			</header>
-			<slot name="content"></slot>
+			<div class="panel-container" @scroll="onScroll">
+				<header class="slider-header content sticky" :class="{ 'header-shadow': isScrolled }">
+					<i
+						:class="`slider-header-item pi ${directionMap[direction].iconOpen}`"
+						@click="emit('update:isOpen', false)"
+					/>
+					<slot name="header"></slot>
+					<section>
+						<h4 class="slider-header-item">{{ header }}</h4>
+						<slot name="subHeader"></slot>
+					</section>
+				</header>
+				<slot name="content"></slot>
+			</div>
 		</template>
 		<template v-slot:tab>
 			<div :class="`slider-tab-header ${direction}`">
@@ -29,6 +34,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import Badge from 'primevue/badge';
 import TeraSlider from './tera-slider.vue';
 
@@ -73,9 +79,20 @@ const directionMap = {
 		iconClosed: 'pi-angle-double-left'
 	}
 };
+
+/* This is for adding a subtle shadow to the header when the panel is scrolled */
+const isScrolled = ref(false);
+const onScroll = (event: Event) => {
+	// Check if the panel is scrolled beyond a certain point
+	isScrolled.value = (event.target as HTMLElement).scrollTop > 0;
+};
 </script>
 
 <style scoped>
+.panel-container {
+	height: 100%;
+	overflow-y: auto;
+}
 i {
 	font-size: 1.25rem;
 	cursor: pointer;
@@ -84,6 +101,10 @@ i {
 .slider-header {
 	display: flex;
 	align-items: start;
+}
+
+.header-shadow {
+	box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.1);
 }
 
 section {


### PR DESCRIPTION
**BEFORE**
I don't like how text is cut off at an arbitrary point here.
![image](https://github.com/user-attachments/assets/ceae2b6b-c219-446d-90d2-bf533908d0dd)

**AFTER**
I added an @scroll listener to the resource panel, and if the user scrolls down, we add a class to the header that adds a shadow.

![scroll-shadow](https://github.com/user-attachments/assets/bee6e463-37a5-4543-b030-1fede46c0c8d)
