### PR TITLE
fix misinterpretation of progress as percentage-progress

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -193,7 +193,7 @@ const pollResult = async (runId: string) => {
 				const checkpoint = _.first(data.updates);
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
-					state.currentProgress = checkpoint.data.progress;
+					state.currentProgress = +((100 * checkpoint.data.progress) / state.numIterations).toFixed(2);
 					emit('update-state', state);
 				}
 			}


### PR DESCRIPTION
### Summary
We misinterpreted progress as a percentage progression, it is  number of completed iterations, so we need to instead do:

```
100 * progress / max-iteration
```