### PR TITLE
fix yaxis label extraction expression

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -147,10 +147,7 @@ const preparedCharts = computed(() => {
 				height: 120,
 				legend: true,
 				xAxisTitle: modelVarUnits.value._time || 'Time',
-				yAxisTitle:
-					_.uniq(modelVarUnits.value[variable])
-						.filter((v) => !!v)
-						.join(',') || '',
+				yAxisTitle: modelVarUnits.value[variable] || '',
 				translationMap: {
 					[`${pyciemssMap[variable]}_mean:pre`]: `${variable} before optimization`,
 					[`${pyciemssMap[variable]}_mean`]: `${variable} after optimization`


### PR DESCRIPTION
### Summary
`_.uniq`  causing a problem splitting a single variable string into a character-array