### PR TITLE
fix: add + button back into asset card

### DIFF
--- a/packages/client/hmi-client/DEVELOPMENT.md
+++ b/packages/client/hmi-client/DEVELOPMENT.md
@@ -81,9 +81,7 @@ Basic rules to write organised code.
 
     ```html
     <tera-model 
-        :asset-id="previewItemId"
-        :project="resources.activeProject" 
-        :highlight="searchTerm"
+        :asset-id="previewItemId"  
         :feature-config="{ isPreview: true }"
     />
     ```

--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -308,7 +308,7 @@ header.with-tabs {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: var(--gap);
+	gap: var(--gap-2);
 }
 
 .close {

--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -87,10 +87,6 @@ const props = defineProps({
 		type: Object as PropType<FeatureConfig>,
 		default: { isPreview: false } as FeatureConfig
 	},
-	highlight: {
-		type: String,
-		default: null
-	},
 	source: {
 		type: String as PropType<Source>,
 		default: DatasetSource.TERARIUM

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -323,8 +323,6 @@ onMounted(async () => {
 	modelCardsToCompare.value = modelsToCompare.value.map(({ metadata }) => metadata?.gollmCard);
 	fields.value = [...new Set(modelCardsToCompare.value.flatMap((card) => (card ? Object.keys(card) : [])))];
 
-	console.log(modelsToCompare.value);
-
 	buildJupyterContext();
 	processCompareModels(modelIds, props.node.workflowId, props.node.id);
 });

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -323,6 +323,8 @@ onMounted(async () => {
 	modelCardsToCompare.value = modelsToCompare.value.map(({ metadata }) => metadata?.gollmCard);
 	fields.value = [...new Set(modelCardsToCompare.value.flatMap((card) => (card ? Object.keys(card) : [])))];
 
+	console.log(modelsToCompare.value);
+
 	buildJupyterContext();
 	processCompareModels(modelIds, props.node.workflowId, props.node.id);
 });

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-asset-card.vue
@@ -40,6 +40,8 @@
 			</div>
 			<footer><!--pill tags if already in another project--></footer>
 		</main>
+		<!--Add button from tera-search-item-->
+		<slot />
 	</div>
 </template>
 

--- a/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
+++ b/packages/client/hmi-client/src/page/data-explorer/components/tera-preview-panel.vue
@@ -12,7 +12,6 @@
 			<tera-dataset
 				v-else-if="previewItemResourceType === ResourceType.DATASET"
 				:asset-id="previewItemId"
-				:highlight="searchTerm"
 				:feature-config="{ isPreview: true }"
 				:source="source"
 				@close-preview="closePreview"
@@ -20,7 +19,6 @@
 			<tera-model
 				v-else-if="previewItemResourceType === ResourceType.MODEL"
 				:asset-id="previewItemId"
-				:highlight="searchTerm"
 				:feature-config="{ isPreview: true }"
 				@close-preview="closePreview"
 			/>


### PR DESCRIPTION
# Description

* When testing compare models the add to project button was missing when I was searching for the models to compare
* I know we are getting rid of search but this still will be helpful for a while
* Also cleaned up some unused props