### PR TITLE
fix POST /model-configuration endpoint logic

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -53,8 +53,8 @@ import {
 	SimulationRequest,
 	Model,
 	ModelConfiguration,
-	ParameterSemantic,
-	SemanticType
+	SemanticType,
+	InferredParameterSemantic
 } from '@/types/Types';
 import { createLLMSummary } from '@/services/summary-service';
 import { createForecastChart } from '@/services/charts';
@@ -371,14 +371,14 @@ watch(
 				}
 			});
 
-			const inferredParameters: ParameterSemantic[] = [];
+			const inferredParameters: InferredParameterSemantic[] = [];
 			Object.keys(parameterTable).forEach((parameterId) => {
 				const mean = stats.mean(parameterTable[parameterId]);
 				const stddev = stats.stddev(parameterTable[parameterId]);
 
 				inferredParameters.push({
 					source: 'calibration',
-					type: SemanticType.Parameter,
+					type: SemanticType.Inferred,
 					referenceId: parameterId,
 					default: false,
 					distribution: {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -217,6 +217,12 @@ export interface ModelFramework extends TerariumAssetThatSupportsAdditionalPrope
     semantics: string;
 }
 
+export interface InferredParameterSemantic extends Semantic {
+    referenceId: string;
+    distribution: ModelDistribution;
+    default: boolean;
+}
+
 export interface InitialSemantic extends Semantic {
     target: string;
     expression: string;
@@ -229,7 +235,7 @@ export interface ModelConfiguration extends TerariumAsset {
     observableSemanticList: ObservableSemantic[];
     parameterSemanticList: ParameterSemantic[];
     initialSemanticList: InitialSemantic[];
-    inferredParameterList?: ParameterSemantic[];
+    inferredParameterList?: InferredParameterSemantic[];
 }
 
 export interface ObservableSemantic extends Semantic {
@@ -1232,6 +1238,7 @@ export enum SemanticType {
     Initial = "initial",
     Parameter = "parameter",
     Observable = "observable",
+    Inferred = "inferredParameter",
 }
 
 export enum ProvenanceRelationType {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
@@ -345,8 +345,12 @@ public class ModelConfigurationController {
 			projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
 
 		try {
+			if (modelConfiguration.getId() == null) {
+				modelConfiguration.setId(UUID.randomUUID());
+			}
+
 			return ResponseEntity.status(HttpStatus.CREATED).body(
-				modelConfigurationService.createAsset(modelConfiguration.clone(), projectId, permission)
+				modelConfigurationService.createAsset(modelConfiguration, projectId, permission)
 			);
 		} catch (final IOException e) {
 			log.error("Unable to get model configuration from postgres db", e);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/InferredParameterSemantic.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/InferredParameterSemantic.java
@@ -1,0 +1,49 @@
+package software.uncharted.terarium.hmiserver.models.dataservice.model.configurations;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+import org.hibernate.annotations.Type;
+import software.uncharted.terarium.hmiserver.annotations.TSIgnore;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelDistribution;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@TSModel
+@Accessors
+@Entity
+public class InferredParameterSemantic extends Semantic {
+
+	private String referenceId;
+
+	@Type(JsonType.class)
+	@Column(columnDefinition = "json")
+	private ModelDistribution distribution;
+
+	private boolean isDefault;
+
+	@ManyToOne
+	@JsonBackReference
+	@Schema(hidden = true)
+	@TSIgnore
+	@NotNull
+	private ModelConfiguration modelConfiguration;
+
+	@Override
+	public InferredParameterSemantic clone() {
+		final InferredParameterSemantic clone = new InferredParameterSemantic();
+		super.cloneSuperFields(clone);
+		clone.referenceId = this.referenceId;
+		clone.distribution = this.distribution.clone();
+		clone.isDefault = this.isDefault;
+		return clone;
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/ModelConfiguration.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/ModelConfiguration.java
@@ -58,7 +58,7 @@ public class ModelConfiguration extends TerariumAsset {
 	@TSOptional
 	@OneToMany(mappedBy = "modelConfiguration", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@JsonManagedReference
-	private List<ParameterSemantic> inferredParameterList = new ArrayList<>();
+	private List<InferredParameterSemantic> inferredParameterList = new ArrayList<>();
 
 	@Override
 	public ModelConfiguration clone() {
@@ -66,6 +66,7 @@ public class ModelConfiguration extends TerariumAsset {
 		super.cloneSuperFields(clone);
 
 		clone.setModelId(this.modelId);
+		clone.setSimulationId(this.simulationId);
 
 		if (this.observableSemanticList != null) {
 			clone.setObservableSemanticList(new ArrayList<>());
@@ -83,7 +84,7 @@ public class ModelConfiguration extends TerariumAsset {
 
 		if (this.inferredParameterList != null) {
 			clone.setInferredParameterList(new ArrayList<>());
-			for (final ParameterSemantic semantic : inferredParameterList) {
+			for (final InferredParameterSemantic semantic : inferredParameterList) {
 				clone.getInferredParameterList().add(semantic.clone());
 			}
 		}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/SemanticType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/configurations/SemanticType.java
@@ -10,5 +10,8 @@ public enum SemanticType {
 	PARAMETER,
 
 	@JsonProperty("observable")
-	OBSERVABLE
+	OBSERVABLE,
+
+	@JsonProperty("inferredParameter")
+	INFERRED
 }

--- a/packages/server/src/main/resources/db/migration/V16_semantic_constraint.sql
+++ b/packages/server/src/main/resources/db/migration/V16_semantic_constraint.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE semantic DROP CONSTRAINT semantic_type_check;
+ALTER TABLE semantic ADD CONSTRAINT semantic_type_check CHECK (type >= 0 AND type <= 3);
+
+COMMIT;

--- a/packages/server/src/main/resources/db/migration/V16_semantic_constraint.sql
+++ b/packages/server/src/main/resources/db/migration/V16_semantic_constraint.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+ALTER TABLE model_configuration DROP COLUMN IF EXISTS calibration_run_id;
 ALTER TABLE semantic DROP CONSTRAINT semantic_type_check;
 ALTER TABLE semantic ADD CONSTRAINT semantic_type_check CHECK (type >= 0 AND type <= 3);
 


### PR DESCRIPTION
### Summary
`POST /model-configuration` is janky due to a handful of issues, while the object is created in the DB, it is missing bits and pieces, and at times will pull back incorrect data.

- Fix a chicken-and-egg problem problem with model-configuration-id, this was causing children to be orphaned
- Yes, `InferredParameterSemantic` is exactly the same as `ParameterSemantic`, hibernate shoves children objects into the same table (via the dtype column), so you cannot have `List<Foo> a, List<Foo> b`, the lists need to be of different class types otherwise it will end up fetching the wrong thing
- As a consequence of the above, we need to do data migration - took this opportunity to remove the extra calibration-run-id column
- Fix places where we missed setting a few needed fields