### PR TITLE
remove operation-type enum

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -122,12 +122,14 @@ const selectedOutputId = computed(() => {
 const outputOptions = computed(() => {
 	// We do not display output selection for Asset operators
 	if (
-		[
-			WorkflowOperationTypes.MODEL,
-			WorkflowOperationTypes.DATASET,
-			WorkflowOperationTypes.DOCUMENT,
-			WorkflowOperationTypes.CODE
-		].includes(props.node.operationType)
+		(
+			[
+				WorkflowOperationTypes.MODEL,
+				WorkflowOperationTypes.DATASET,
+				WorkflowOperationTypes.DOCUMENT,
+				WorkflowOperationTypes.CODE
+			] as string[]
+		).includes(props.node.operationType)
 	) {
 		return null;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-julia/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-julia/calibrate-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
+import { Operation, BaseState } from '@/types/workflow';
 
 const DOCUMENTATION_URL = 'https://github.com/DARPA-ASKEM/sciml-service/blob/main/src/operations.jl#L245';
 
@@ -33,7 +33,7 @@ export interface CalibrationOperationStateJulia extends BaseState {
 }
 
 export const CalibrationOperationJulia: Operation = {
-	name: WorkflowOperationTypes.CALIBRATION_JULIA,
+	name: 'calibrateJulia',
 	displayName: 'Calibrate with SciML',
 	description:
 		'given a model id, a dataset id, and optionally a configuration. calibrate the models initial values and rates',

--- a/packages/client/hmi-client/src/components/workflow/ops/decapodes/decapodes-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/decapodes/decapodes-operation.ts
@@ -1,4 +1,4 @@
-import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
+import { Operation, BaseState } from '@/types/workflow';
 
 export interface CodeHistory {
 	code: string;
@@ -9,7 +9,7 @@ export interface DecapodesOperationState extends BaseState {
 }
 
 export const DecapodesOperation: Operation = {
-	name: WorkflowOperationTypes.DECAPODES,
+	name: 'decapodes',
 	displayName: 'Decapodes',
 	description: 'Decapodes notebook.',
 	isRunnable: true,

--- a/packages/client/hmi-client/src/components/workflow/ops/model-coupling/model-coupling-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-coupling/model-coupling-operation.ts
@@ -1,12 +1,11 @@
 import type { Operation, BaseState } from '@/types/workflow';
-import { WorkflowOperationTypes } from '@/types/workflow';
 
 const DOCUMENTATION_URL = 'https://algebraicjulia.github.io/Decapodes.jl/dev/overview/#Merging-Multiple-Physics';
 
 export interface ModelCouplingState extends BaseState {}
 
 export const ModelCouplingOperation: Operation = {
-	name: WorkflowOperationTypes.MODEL_COUPLING,
+	name: 'modelCoupling',
 	description: 'Couple models',
 	displayName: 'Couple models',
 	documentationUrl: DOCUMENTATION_URL,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/simulate-julia-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-julia/simulate-julia-operation.ts
@@ -1,5 +1,5 @@
 import type { TimeSpan } from '@/types/Types';
-import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
+import { Operation, BaseState } from '@/types/workflow';
 
 const DOCUMENTATION_URL = 'https://github.com/DARPA-ASKEM/sciml-service/blob/main/src/operations.jl#L222';
 
@@ -15,7 +15,7 @@ export interface SimulateJuliaOperationState extends BaseState {
 }
 
 export const SimulateJuliaOperation: Operation = {
-	name: WorkflowOperationTypes.SIMULATE_JULIA,
+	name: 'simulateJulia',
 	displayName: 'Simulate with SciML',
 	description: 'given a model id, and configuration id, run a simulation',
 	documentationUrl: DOCUMENTATION_URL,

--- a/packages/client/hmi-client/src/page/WorkflowNode.vue
+++ b/packages/client/hmi-client/src/page/WorkflowNode.vue
@@ -5,8 +5,6 @@
 		<tera-dataset-transformer v-else-if="isNodeType(OperationType.DATASET_TRANSFORMER)" :node="node" />
 		<tera-dataset-drilldown v-else-if="isNodeType(OperationType.DATASET)" :node="node" />
 		<tera-regridding-drilldown v-else-if="isNodeType(OperationType.REGRIDDING)" :node="node" />
-		<tera-calibrate-julia v-else-if="isNodeType(OperationType.CALIBRATION_JULIA)" :node="node" />
-		<tera-simulate-julia v-else-if="isNodeType(OperationType.SIMULATE_JULIA)" :node="node" />
 		<tera-calibrate-ciemss v-else-if="isNodeType(OperationType.CALIBRATION_CIEMSS)" :node="node" />
 		<tera-calibrate-ensemble-ciemss v-else-if="isNodeType(OperationType.CALIBRATE_ENSEMBLE_CIEMSS)" :node="node" />
 		<tera-simulate-ciemss v-else-if="isNodeType(OperationType.SIMULATE_CIEMSS)" :node="node" />
@@ -26,21 +24,19 @@ import TeraModelWorkflowWrapper from '@/components/workflow/ops/model/tera-model
 import TeraDatasetDrilldown from '@/components/workflow/ops/dataset/tera-dataset-drilldown.vue';
 import TeraRegriddingDrilldown from '@/components/workflow/ops/regridding/tera-regridding.vue';
 import TeraDatasetTransformer from '@/components/workflow/ops/dataset-transformer/tera-dataset-transformer.vue';
-import TeraCalibrateJulia from '@/components/workflow/ops/calibrate-julia/tera-calibrate-julia.vue';
-import TeraSimulateJulia from '@/components/workflow/ops/simulate-julia/tera-simulate-julia.vue';
 import TeraCalibrateCiemss from '@/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue';
 import TeraCalibrateEnsembleCiemss from '@/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss.vue';
 import TeraSimulateCiemss from '@/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss.vue';
 import TeraSimulateEnsembleCiemss from '@/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss.vue';
 import TeraFunman from '@/components/workflow/ops/funman/tera-funman.vue';
-import teraStratifyMira from '@/components/workflow/ops/stratify-mira/tera-stratify-mira.vue';
+import TeraStratifyMira from '@/components/workflow/ops/stratify-mira/tera-stratify-mira.vue';
 import TeraCodeAssetWrapper from '@/components/workflow/ops/code-asset/tera-code-asset-wrapper.vue';
 
 const props = defineProps<{ nodeId: string; workflowId: string }>();
 
 const node = ref<WorkflowNode<any>>();
 
-function isNodeType(type: OperationType): boolean {
+function isNodeType(type: string): boolean {
 	return node.value?.operationType === type;
 }
 

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -1,35 +1,28 @@
 import type { Position } from '@/types/common';
 
-export enum WorkflowOperationTypes {
-	ADD = 'add', // temp for test to work
-	TEST = 'TestOperation',
-	CALIBRATION_JULIA = 'CalibrationOperationJulia',
-	CALIBRATION_CIEMSS = 'CalibrationOperationCiemss',
-	DATASET = 'Dataset',
-	MODEL = 'ModelOperation',
-	SIMULATE_JULIA = 'SimulateJuliaOperation',
-	SIMULATE_CIEMSS = 'SimulateCiemssOperation',
-	STRATIFY_JULIA = 'StratifyJulia',
-	STRATIFY_MIRA = 'StratifyMira',
-	SIMULATE_ENSEMBLE_CIEMSS = 'SimulateEnsembleCiemms',
-	CALIBRATE_ENSEMBLE_CIEMSS = 'CalibrateEnsembleCiemms',
-	DATASET_TRANSFORMER = 'DatasetTransformer',
-	SUBSET_DATA = 'SubsetData',
-	MODEL_TRANSFORMER = 'ModelTransformer',
-	MODEL_FROM_CODE = 'ModelFromCode',
-	FUNMAN = 'Funman',
-	CODE = 'Code',
-	MODEL_COMPARISON = 'ModelComparison',
-	MODEL_CONFIG = 'ModelConfiguration',
-	OPTIMIZE_CIEMSS = 'OptimizeCiemss',
-	MODEL_COUPLING = 'ModelCoupling',
-	MODEL_EDIT = 'ModelEdit',
-	DOCUMENT = 'Document',
-	MODEL_FROM_EQUATIONS = 'ModelFromEquations',
-	DECAPODES = 'Decapodes',
-	REGRIDDING = 'Regridding',
-	INTERVENTION_POLICY = 'InterventionPolicy'
-}
+export const WorkflowOperationTypes = Object.freeze({
+	CALIBRATION_CIEMSS: 'CalibrationOperationCiemss',
+	DATASET: 'Dataset',
+	MODEL: 'ModelOperation',
+	SIMULATE_CIEMSS: 'SimulateCiemssOperation',
+	STRATIFY_MIRA: 'StratifyMira',
+	SIMULATE_ENSEMBLE_CIEMSS: 'SimulateEnsembleCiemms',
+	CALIBRATE_ENSEMBLE_CIEMSS: 'CalibrateEnsembleCiemms',
+	DATASET_TRANSFORMER: 'DatasetTransformer',
+	SUBSET_DATA: 'SubsetData',
+	MODEL_TRANSFORMER: 'ModelTransformer',
+	MODEL_FROM_CODE: 'ModelFromCode',
+	FUNMAN: 'Funman',
+	CODE: 'Code',
+	MODEL_COMPARISON: 'ModelComparison',
+	MODEL_CONFIG: 'ModelConfiguration',
+	OPTIMIZE_CIEMSS: 'OptimizeCiemss',
+	MODEL_EDIT: 'ModelEdit',
+	DOCUMENT: 'Document',
+	MODEL_FROM_EQUATIONS: 'ModelFromEquations',
+	REGRIDDING: 'Regridding',
+	INTERVENTION_POLICY: 'InterventionPolicy'
+});
 
 export enum OperatorStatus {
 	DEFAULT = 'default',
@@ -54,7 +47,7 @@ export interface OperationData {
 
 // Defines a function: eg: model, simulate, calibrate
 export interface Operation {
-	name: WorkflowOperationTypes;
+	name: string;
 	description: string;
 	displayName: string; // Human-readable name for each node.
 	documentationUrl?: string;

--- a/packages/client/hmi-client/src/types/workflow.ts
+++ b/packages/client/hmi-client/src/types/workflow.ts
@@ -99,7 +99,7 @@ export interface WorkflowNode<S> {
 	id: string;
 	displayName: string;
 	workflowId: string;
-	operationType: WorkflowOperationTypes;
+	operationType: string;
 	documentationUrl?: string;
 	imageUrl?: string;
 

--- a/packages/client/hmi-client/tests/unit/services/workflow.spec.ts
+++ b/packages/client/hmi-client/tests/unit/services/workflow.spec.ts
@@ -1,19 +1,11 @@
-import {
-	OperatorStatus,
-	Workflow,
-	WorkflowPort,
-	Operation,
-	WorkflowNode,
-	WorkflowOperationTypes,
-	WorkflowPortStatus
-} from '@/types/workflow';
+import { OperatorStatus, Workflow, WorkflowPort, Operation, WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import * as workflowService from '@/services/workflow';
 
 import { describe, expect, it } from 'vitest';
 import _ from 'lodash';
 
 const addOperation: Operation = {
-	name: WorkflowOperationTypes.ADD,
+	name: 'add',
 	displayName: 'Add',
 	description: 'add two numbers',
 	inputs: [{ type: 'number' }, { type: 'number' }],


### PR DESCRIPTION
### Summary
Enums are useful for capturing controlled a vocabulary, things that do not change very often or are static in nature.

Since we are adding and removing operators at a fairly quick cadence this is not an appropriate data structure, especially if we want to model this in the DB which will likely mean a data-migration every time we add or remove operators.

In additional, while the keys are unique,  there is no guarantee on the value so there isn't really a safe guarantee.


Change this to a frozen-object, and the datatype of operator name to just a string.


### Testing
I removed a few references to operators that are deprecated, otherwise no functional changes, app should work as before.