### PR TITLE
Add initials and observables into calibrated model-configs

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -396,9 +396,9 @@ watch(
 				description: `Calibrated: ${baseConfig.description}`,
 				simulationId: state.calibrationId,
 				modelId: baseConfig.modelId,
-				observableSemanticList: [],
+				observableSemanticList: _.cloneDeep(baseConfig.observableSemanticList),
 				parameterSemanticList: [],
-				initialSemanticList: [],
+				initialSemanticList: _.cloneDeep(baseConfig.initialSemanticList),
 				inferredParameterList: inferredParameters
 			};
 			const modelConfigResponse = await createModelConfiguration(calibratedModelConfig);


### PR DESCRIPTION
### Summary
Adding initials and observables into calibrated model-config.

initials are meant to be readonly ... you "could" modify them but it kind of voids the calibration effort.

observations need to be carried forward from the base-configuration, as the base-config observables can be different than that of the observables on the model iteself.

See also: https://github.com/DARPA-ASKEM/terarium/pull/4377


Example of calibrated-model-config, with initials and observables filled in.
```
{
  "id": "ba967f5c-dee2-46ec-8768-702c14544abc",
  "createdOn": "2024-08-08T16:38:14.549+00:00",
  "updatedOn": "2024-08-08T16:38:14.549+00:00",
  "name": "Calibrated: Default Configuration",
  "description": "Calibrated: This is a default configuration.",
  "fileNames": [],
  "temporary": false,
  "publicAsset": false,
  "modelId": "2314dc86-4c4e-453a-a993-723669029c43",
  "simulationId": "aaf0802f-2829-4cfd-a4b0-823c40a49896",
  "observableSemanticList": [
    {
      "id": "680feab8-f4ab-429c-8947-83942cfe5c91",
      "createdOn": "2024-07-03T13:48:38.268+00:00",
      "updatedOn": "2024-08-08T16:38:14.555+00:00",
      "referenceId": "noninf",
      "states": [
        "S",
        "R"
      ],
      "expression": "S+R",
      "expressionMathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
    }
  ],
  "parameterSemanticList": [],
  "initialSemanticList": [
    {
      "id": "b82934db-edb3-474e-8eaa-e45458aa5488",
      "createdOn": "2024-07-03T13:48:38.265+00:00",
      "updatedOn": "2024-08-08T16:38:14.555+00:00",
      "target": "S",
      "expression": "S0",
      "expressionMathml": "<ci>S0</ci>"
    },
    {
      "id": "a37bad16-7c0a-4c99-ac59-f95d29460f4b",
      "createdOn": "2024-07-03T13:48:38.266+00:00",
      "updatedOn": "2024-08-08T16:38:14.555+00:00",
      "target": "I",
      "expression": "I0",
      "expressionMathml": "<ci>I0</ci>"
    },
    {
      "id": "ec2561e6-6d63-4a75-bdd1-4c24d5eea557",
      "createdOn": "2024-07-03T13:48:38.267+00:00",
      "updatedOn": "2024-08-08T16:38:14.555+00:00",
      "target": "R",
      "expression": "R0",
      "expressionMathml": "<ci>R0</ci>"
    }
  ],
  "inferredParameterList": [
    {
      "id": "1ee9dc19-f36d-43e0-8b97-d528e0bcdb2b",
      "createdOn": "2024-08-08T16:38:14.550+00:00",
      "updatedOn": "2024-08-08T16:38:42.338+00:00",
      "source": "calibration",
      "type": "inferredParameter",
      "referenceId": "beta",
      "distribution": {
        "type": "inferred",
        "parameters": {
          "mean": 0.04140840321779251,
          "stddev": 0.0002171597874473378
        }
      },
      "default": false
    },
    {
      "id": "7c8829ff-ad50-4234-805d-e505ead21ace",
      "createdOn": "2024-08-08T16:38:14.550+00:00",
      "updatedOn": "2024-08-08T16:38:42.338+00:00",
      "source": "calibration",
      "type": "inferredParameter",
      "referenceId": "gamma",
      "distribution": {
        "type": "inferred",
        "parameters": {
          "mean": 0.02139683738350868,
          "stddev": 0.0002526928149557689
        }
      },
      "default": false
    },
    {
      "id": "00b6c9fe-a4c3-4a43-852c-4a44562b9d66",
      "createdOn": "2024-08-08T16:38:14.551+00:00",
      "updatedOn": "2024-08-08T16:38:42.338+00:00",
      "source": "calibration",
      "type": "inferredParameter",
      "referenceId": "S0",
      "distribution": {
        "type": "inferred",
        "parameters": {
          "mean": 2000,
          "stddev": 0
        }
      },
      "default": false
    },
    {
      "id": "4ac65847-e1e2-4435-82ea-2766a0b5a7ee",
      "createdOn": "2024-08-08T16:38:14.552+00:00",
      "updatedOn": "2024-08-08T16:38:42.338+00:00",
      "source": "calibration",
      "type": "inferredParameter",
      "referenceId": "I0",
      "distribution": {
        "type": "inferred",
        "parameters": {
          "mean": 1,
          "stddev": 0
        }
      },
      "default": false
    },
    {
      "id": "3cc2e511-794d-472b-90da-216ebf87e34d",
      "createdOn": "2024-08-08T16:38:14.552+00:00",
      "updatedOn": "2024-08-08T16:38:42.338+00:00",
      "source": "calibration",
      "type": "inferredParameter",
      "referenceId": "R0",
      "distribution": {
        "type": "inferred",
        "parameters": {
          "mean": 0,
          "stddev": 0
        }
      },
      "default": false
    }
  ]
}

```