### PR TITLE
Fix: Use correct Id in calibrate drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -719,7 +719,8 @@ watch(
 	async () => {
 		// Update selected output
 		if (props.node.active) {
-			selectedOutputId.value = props.node.active;
+			const active = props.node.active;
+			selectedOutputId.value = props.node.outputs.find((o) => o.id === active)?.value?.[0];
 
 			// Fetch saved intermediate state
 			const simulationObj = await getSimulation(props.node.state.calibrationId);


### PR DESCRIPTION
# Description
Correcting the ID used in the calibration drilldown for the charts.
