### PR TITLE
Do not mirror workflow

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -60,19 +60,8 @@ public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow,
 		final UUID projectId,
 		final Schema.Permission hasWritePermission
 	) throws IOException, IllegalArgumentException {
-		long start = 0;
-		long end = 0;
-		System.out.println("");
-		System.out.println("");
-		System.out.println("");
-
 		// Fetch database copy, we will update into it
-		start = System.currentTimeMillis();
 		final Workflow dbWorkflow = getAsset(asset.getId(), hasWritePermission).get();
-		end = System.currentTimeMillis();
-		System.out.println("Fetch dbWorkflow " + (end - start));
-
-		start = System.currentTimeMillis();
 
 		final List<WorkflowNode> dbWorkflowNodes = dbWorkflow.getNodes();
 		final List<WorkflowEdge> dbWorkflowEdges = dbWorkflow.getEdges();
@@ -185,12 +174,6 @@ public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow,
 		for (Map.Entry<UUID, WorkflowEdge> pair : edgeMap.entrySet()) {
 			dbWorkflowEdges.add(pair.getValue());
 		}
-
-		end = System.currentTimeMillis();
-		System.out.println("Elapsed time to do version update " + (end - start));
-		System.out.println("");
-		System.out.println("");
-		System.out.println("");
 
 		return super.updateAsset(dbWorkflow, projectId, hasWritePermission);
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -22,41 +22,17 @@ import software.uncharted.terarium.hmiserver.service.s3.S3ClientService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
 @Service
-public class WorkflowService extends TerariumAssetServiceWithSearch<Workflow, WorkflowRepository> {
+public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow, WorkflowRepository> {
 
 	public WorkflowService(
 		final ObjectMapper objectMapper,
 		final Config config,
-		final ElasticsearchConfiguration elasticConfig,
-		final ElasticsearchService elasticService,
 		final ProjectService projectService,
 		final ProjectAssetService projectAssetService,
 		final S3ClientService s3ClientService,
 		final WorkflowRepository repository
 	) {
-		super(
-			objectMapper,
-			config,
-			elasticConfig,
-			elasticService,
-			projectService,
-			projectAssetService,
-			s3ClientService,
-			repository,
-			Workflow.class
-		);
-	}
-
-	@Override
-	@Observed(name = "function_profile")
-	protected String getAssetIndex() {
-		return elasticConfig.getWorkflowIndex();
-	}
-
-	@Override
-	@Observed(name = "function_profile")
-	public String getAssetAlias() {
-		return elasticConfig.getWorkflowAlias();
+		super(objectMapper, config, projectService, projectAssetService, repository, s3ClientService, Workflow.class);
 	}
 
 	@Override
@@ -84,8 +60,19 @@ public class WorkflowService extends TerariumAssetServiceWithSearch<Workflow, Wo
 		final UUID projectId,
 		final Schema.Permission hasWritePermission
 	) throws IOException, IllegalArgumentException {
+		long start = 0;
+		long end = 0;
+		System.out.println("");
+		System.out.println("");
+		System.out.println("");
+
 		// Fetch database copy, we will update into it
+		start = System.currentTimeMillis();
 		final Workflow dbWorkflow = getAsset(asset.getId(), hasWritePermission).get();
+		end = System.currentTimeMillis();
+		System.out.println("Fetch dbWorkflow " + (end - start));
+
+		start = System.currentTimeMillis();
 
 		final List<WorkflowNode> dbWorkflowNodes = dbWorkflow.getNodes();
 		final List<WorkflowEdge> dbWorkflowEdges = dbWorkflow.getEdges();
@@ -198,6 +185,12 @@ public class WorkflowService extends TerariumAssetServiceWithSearch<Workflow, Wo
 		for (Map.Entry<UUID, WorkflowEdge> pair : edgeMap.entrySet()) {
 			dbWorkflowEdges.add(pair.getValue());
 		}
+
+		end = System.currentTimeMillis();
+		System.out.println("Elapsed time to do version update " + (end - start));
+		System.out.println("");
+		System.out.println("");
+		System.out.println("");
 
 		return super.updateAsset(dbWorkflow, projectId, hasWritePermission);
 	}

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowControllerTests.java
@@ -34,17 +34,13 @@ public class WorkflowControllerTests extends TerariumApplicationTests {
 
 	@BeforeEach
 	public void setup() throws IOException {
-		workflowService.setupIndexAndAliasAndEnsureEmpty();
-
 		project = projectService.createProject(
 			(Project) new Project().setPublicAsset(true).setName("test-project-name").setDescription("my description")
 		);
 	}
 
 	@AfterEach
-	public void teardown() throws IOException {
-		workflowService.teardownIndexAndAlias();
-	}
+	public void teardown() throws IOException {}
 
 	@Test
 	@WithUserDetails(MockUser.URSULA)

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
@@ -55,7 +55,6 @@ public class TerariumAssetCloneServiceTests extends TerariumApplicationTests {
 	@BeforeEach
 	public void setup() throws IOException {
 		documentService.setupIndexAndAliasAndEnsureEmpty();
-		workflowService.setupIndexAndAliasAndEnsureEmpty();
 		project = projectService.createProject(
 			(Project) new Project().setPublicAsset(true).setName("test-project-name").setDescription("my description")
 		);
@@ -64,7 +63,6 @@ public class TerariumAssetCloneServiceTests extends TerariumApplicationTests {
 	@AfterEach
 	public void teardown() throws IOException {
 		documentService.setupIndexAndAliasAndEnsureEmpty();
-		workflowService.setupIndexAndAliasAndEnsureEmpty();
 	}
 
 	static Grounding createGrounding(final String key) {


### PR DESCRIPTION
### Summary
Remove ES-mirroring, this speeds up the total round-trip time for workflow update by about 30-35 tiems, since it was waiting for ES to refresh. 

We have moved to PG, ES is no longer the primary data storage and this mirroring is not needed.