### PR TITLE
fix: render toggleable input as long as the value is a `string`

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
@@ -38,7 +38,6 @@ const inputRef = ref<ComponentPublicInstance<typeof TeraInputText> | null>(null)
 const isEditing = ref(false);
 
 const onEdit = async () => {
-	console.log(props.modelValue);
 	initialValue = props.modelValue;
 	isEditing.value = true;
 	await nextTick();

--- a/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
@@ -38,6 +38,7 @@ const inputRef = ref<ComponentPublicInstance<typeof TeraInputText> | null>(null)
 const isEditing = ref(false);
 
 const onEdit = async () => {
+	console.log(props.modelValue);
 	initialValue = props.modelValue;
 	isEditing.value = true;
 	await nextTick();

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -55,7 +55,7 @@
 			<tera-drilldown-section>
 				<template v-if="selectedPolicy?.id">
 					<tera-toggleable-input
-						v-if="selectedPolicy?.name"
+						v-if="typeof selectedPolicy?.name === 'string'"
 						class="mt-1"
 						:model-value="selectedPolicy.name"
 						@update:model-value="onChangeName"

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -55,7 +55,7 @@
 			<tera-drilldown-section>
 				<template v-if="selectedPolicy?.id">
 					<tera-toggleable-input
-						v-if="typeof selectedPolicy?.name === 'string'"
+						v-if="typeof selectedPolicy.name === 'string'"
 						class="mt-1"
 						:model-value="selectedPolicy.name"
 						@update:model-value="onChangeName"

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -66,7 +66,7 @@
 		<tera-drilldown-section :tabName="ConfigTabs.Wizard" class="pl-3">
 			<template #header-controls-left>
 				<tera-toggleable-input
-					v-if="knobs.transientModelConfig.name"
+					v-if="typeof knobs.transientModelConfig.name === 'string'"
 					v-model="knobs.transientModelConfig.name"
 					tag="h4"
 				/>


### PR DESCRIPTION
# Description

* An empty name was rejected by typescript, now I have to specifically check if a `string` exists
* I wonder if we can just make the `name` be of type `string` instead of `string | undefined`, that we don't need the `v-if` at all

https://github.com/user-attachments/assets/acd1c79e-f379-4b9a-8b2d-661ea4ca9403

