### PR TITLE
another attempt at fixing workflow bugs

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -57,7 +57,25 @@ export class WorkflowWrapper {
 			const updated = updatedNodeMap.get(nodeId);
 			if (updated) {
 				if ((updated.version as number) > (nodes[i].version as number)) {
-					nodes[i] = Object.assign(nodes[i], updated);
+					nodes[i].version = updated.version;
+					nodes[i].isDeleted = updated.isDeleted;
+					nodes[i].status = updated.status;
+					nodes[i].x = updated.x;
+					nodes[i].y = updated.y;
+					nodes[i].width = updated.width;
+					nodes[i].height = updated.height;
+					nodes[i].active = updated.active;
+
+					if (!_.isEqual(nodes[i].inputs, updated.inputs)) {
+						nodes[i].inputs = updated.inputs;
+					}
+					if (!_.isEqual(nodes[i].outputs, updated.outputs)) {
+						nodes[i].outputs = updated.outputs;
+					}
+					if (!_.isEqual(nodes[i].state, updated.state)) {
+						nodes[i].state = updated.state;
+					}
+					// nodes[i] = Object.assign(nodes[i], updated);
 				}
 				updatedNodeMap.delete(nodeId);
 			}


### PR DESCRIPTION
### Summary
We cannot just do `nodeA = Object.assign(nodeA, update)` because some of our operators are written to be very reactive - in their watcher they do not check if the new/old values are equivalent. So when we sync up with the database it triggers, among other things, unwanted append-output cycles, which itself invalidates downstream and marks the workflow dirty in order to trigger another update ... and so the cycle repeats.

So instead we need to update node piecemeal 