### PR TITLE
better workflow save/update timing

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
@@ -16,7 +16,7 @@ defineProps<{
 	style: { width: string; top: string; left: string };
 }>();
 
-const emit = defineEmits(['dragging']);
+const emit = defineEmits(['dragging', 'dragstart', 'dragend']);
 
 const canvasItem = ref();
 
@@ -28,6 +28,7 @@ const startDrag = (evt: MouseEvent) => {
 	tempX = evt.x;
 	tempY = evt.y;
 	isDragging = true;
+	emit('dragstart');
 };
 
 const drag = (evt: MouseEvent) => {
@@ -46,6 +47,7 @@ const stopDrag = (/* evt: MouseEvent */) => {
 	tempX = 0;
 	tempY = 0;
 	isDragging = false;
+	emit('dragend');
 };
 
 onMounted(() => {

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -258,7 +258,7 @@ let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
 let saveTimer: any = null;
 
-const nodeDragging: boolean = false;
+const nodeDragging = false;
 let workflowDirty: boolean = false;
 let startTime: number = 0;
 

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -258,7 +258,7 @@ let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
 let saveTimer: any = null;
 
-const nodeDragging = false;
+const nodeDragging = ref<boolean>(false);
 let workflowDirty: boolean = false;
 let startTime: number = 0;
 
@@ -924,7 +924,7 @@ onMounted(() => {
 	document.addEventListener('mousemove', mouseUpdate);
 	window.addEventListener('beforeunload', unloadCheck);
 	saveTimer = setInterval(async () => {
-		if (workflowDirty && useProjects().hasEditPermission() && nodeDragging === false) {
+		if (workflowDirty && useProjects().hasEditPermission() && nodeDragging.value === false) {
 			const updated = await workflowService.updateWorkflow(wf.value.dump());
 			wf.value.update(updated);
 			workflowDirty = false;

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -258,7 +258,7 @@ let currentPortPosition: Position = { x: 0, y: 0 };
 let isMouseOverPort: boolean = false;
 let saveTimer: any = null;
 
-const nodeDragging = false;
+const nodeDragging: boolean = false;
 let workflowDirty: boolean = false;
 let startTime: number = 0;
 


### PR DESCRIPTION
### Summary
- Avoid save/update cycle when node being dragged, which can create weird jitter effects and disconnected edges
- Ensure save is called when changing between workflows



### Testing
Make some change to existing workflow, navigate away immediately, come back to save workflow and check the change persisted.