### PR TITLE
style: stretch toggleable input to fill space

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-section.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-section.vue
@@ -48,6 +48,10 @@ header > div {
 	display: inline-flex;
 	gap: var(--gap-1);
 	align-items: center;
+
+	&:first-child {
+		flex: 1;
+	}
 }
 
 section {

--- a/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-toggleable-input.vue
@@ -1,7 +1,8 @@
 <template>
-	<div v-if="isEditing" v-bind="$attrs" class="flex align-items-center gap-1">
+	<div v-if="isEditing" v-bind="$attrs" class="flex flex-1 align-items-center gap-1">
 		<tera-input-text
 			ref="inputRef"
+			class="w-full"
 			:model-value="modelValue"
 			@update:model-value="emit('update:model-value', $event)"
 			@keydown="handleKeyDown"
@@ -63,7 +64,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
 button.text-to-edit {
 	display: flex;
 	gap: var(--gap-3);
-	width: fit-content;
+	max-width: fit-content;
 	padding: var(--gap-2);
 
 	& > .btn-content {

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -1,30 +1,27 @@
 <template>
 	<div class="intervention-card">
-		<header class="flex align-items-center">
-			<tera-toggleable-input
-				class="mr-auto"
-				:model-value="intervention.name"
-				@update:model-value="onUpdateName($event)"
-				tag="h5"
-			/>
-			<RadioButton
-				:model-value="interventionType"
-				:input-id="uniqueId()"
-				name="interventionType"
-				value="static"
-				@click="onInterventionTypeChange('static')"
-			/>
-			<label for="static" class="ml-2">Static</label>
-			<RadioButton
-				:model-value="interventionType"
-				:input-id="uniqueId()"
-				name="interventionType"
-				value="dynamic"
-				class="ml-3"
-				@click="onInterventionTypeChange('dynamic')"
-			/>
-			<label for="dynamic" class="ml-2">Dynamic</label>
-			<Button class="ml-3" icon="pi pi-trash" text @click="emit('delete')" />
+		<header class="flex align-items-center gap-2">
+			<tera-toggleable-input :model-value="intervention.name" @update:model-value="onUpdateName($event)" tag="h5" />
+			<div class="flex align-items-center ml-auto">
+				<RadioButton
+					:model-value="interventionType"
+					:input-id="uniqueId()"
+					name="interventionType"
+					value="static"
+					@click="onInterventionTypeChange('static')"
+				/>
+				<label for="static" class="ml-2">Static</label>
+				<RadioButton
+					:model-value="interventionType"
+					:input-id="uniqueId()"
+					name="interventionType"
+					value="dynamic"
+					class="ml-3"
+					@click="onInterventionTypeChange('dynamic')"
+				/>
+				<label for="dynamic" class="ml-2">Dynamic</label>
+				<Button class="ml-3" icon="pi pi-trash" text @click="emit('delete')" />
+			</div>
 		</header>
 		<section>
 			<div class="flex align-items-center flex-wrap gap-2">

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -53,75 +53,72 @@
 				/>
 			</tera-drilldown-section>
 			<tera-drilldown-section>
-				<template v-if="selectedPolicy?.id">
+				<template v-if="selectedPolicy?.id" #header-controls-left>
 					<tera-toggleable-input
 						v-if="typeof selectedPolicy.name === 'string'"
-						class="mt-1"
 						:model-value="selectedPolicy.name"
 						@update:model-value="onChangeName"
 						tag="h4"
 					/>
-					<Accordion multiple :active-index="[0, 1]">
-						<AccordionTab>
-							<template #header>
-								<Button v-if="!isEditingDescription" class="start-edit" text @click.stop="onEditDescription">
-									<h5 class="btn-content">Description</h5>
-									<i class="pi pi-pencil" />
-								</Button>
-								<span v-else class="confirm-cancel">
-									<span>Description</span>
-									<Button icon="pi pi-times" text @click.stop="isEditingDescription = false" />
-									<Button icon="pi pi-check" text @click.stop="onConfirmEditDescription" />
-								</span>
-							</template>
-							<p class="description text" v-if="!isEditingDescription">
-								{{ selectedPolicy?.description }}
-							</p>
-							<Textarea
-								v-else
-								ref="descriptionTextareaRef"
-								class="w-full"
-								placeholder="Enter a description"
-								v-model="newDescription"
-							/>
-						</AccordionTab>
-						<AccordionTab header="Charts">
-							<ul class="flex flex-column gap-2">
-								<li v-for="(interventions, appliedTo) in groupedOutputParameters" :key="appliedTo">
-									<h5 class="pb-2">{{ appliedTo }}</h5>
-									<vega-chart :are-embed-actions-visible="false" :visualization-spec="preparedCharts[appliedTo]" />
-									<ul>
-										<li class="pb-2" v-for="intervention in interventions" :key="intervention.name">
-											<h6 class="pb-1">{{ intervention.name }}</h6>
-											<ul v-if="!isEmpty(intervention.staticInterventions)">
-												<li
-													v-for="staticIntervention in intervention.staticInterventions"
-													:key="staticIntervention.timestep"
-												>
-													<p>
-														Set {{ intervention.type }} {{ appliedTo }} to {{ staticIntervention.value }} at time step
-														{{ staticIntervention.timestep }}.
-													</p>
-												</li>
-											</ul>
-											<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
-												Set {{ intervention.type }} {{ appliedTo }} to
-												{{ intervention.dynamicInterventions[0].value }} when the
-												{{ intervention.dynamicInterventions[0].parameter }}
-												{{
-													intervention.dynamicInterventions[0].isGreaterThan
-														? 'increases to above'
-														: 'decreases to below'
-												}}
-												{{ intervention.dynamicInterventions[0].threshold }}.
-											</p>
-										</li>
-									</ul>
-								</li>
-							</ul>
-						</AccordionTab>
-					</Accordion>
 				</template>
+				<Accordion v-if="selectedPolicy?.id" multiple :active-index="[0, 1]">
+					<AccordionTab>
+						<template #header>
+							<Button v-if="!isEditingDescription" class="start-edit" text @click.stop="onEditDescription">
+								<h5 class="btn-content">Description</h5>
+								<i class="pi pi-pencil" />
+							</Button>
+							<span v-else class="confirm-cancel">
+								<span>Description</span>
+								<Button icon="pi pi-times" text @click.stop="isEditingDescription = false" />
+								<Button icon="pi pi-check" text @click.stop="onConfirmEditDescription" />
+							</span>
+						</template>
+						<p class="description text" v-if="!isEditingDescription">
+							{{ selectedPolicy?.description }}
+						</p>
+						<Textarea
+							v-else
+							ref="descriptionTextareaRef"
+							class="w-full"
+							placeholder="Enter a description"
+							v-model="newDescription"
+						/>
+					</AccordionTab>
+					<AccordionTab header="Charts">
+						<ul class="flex flex-column gap-2">
+							<li v-for="(interventions, appliedTo) in groupedOutputParameters" :key="appliedTo">
+								<h5 class="pb-2">{{ appliedTo }}</h5>
+								<vega-chart :are-embed-actions-visible="false" :visualization-spec="preparedCharts[appliedTo]" />
+								<ul>
+									<li class="pb-2" v-for="intervention in interventions" :key="intervention.name">
+										<h6 class="pb-1">{{ intervention.name }}</h6>
+										<ul v-if="!isEmpty(intervention.staticInterventions)">
+											<li
+												v-for="staticIntervention in intervention.staticInterventions"
+												:key="staticIntervention.timestep"
+											>
+												<p>
+													Set {{ intervention.type }} {{ appliedTo }} to {{ staticIntervention.value }} at time step
+													{{ staticIntervention.timestep }}.
+												</p>
+											</li>
+										</ul>
+										<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
+											Set {{ intervention.type }} {{ appliedTo }} to
+											{{ intervention.dynamicInterventions[0].value }} when the
+											{{ intervention.dynamicInterventions[0].parameter }}
+											{{
+												intervention.dynamicInterventions[0].isGreaterThan ? 'increases to above' : 'decreases to below'
+											}}
+											{{ intervention.dynamicInterventions[0].threshold }}.
+										</p>
+									</li>
+								</ul>
+							</li>
+						</ul>
+					</AccordionTab>
+				</Accordion>
 				<div v-else class="flex align-items-center h-full">
 					<Vue3Lottie :animationData="EmptySeed" :height="150" loop autoplay />
 				</div>


### PR DESCRIPTION
# Description

Using `flex-1` to fill in the space for the input field. Shifted around some html to accommodate this.

BEFORE: 
![image](https://github.com/user-attachments/assets/696984c3-75ce-4260-819a-16ce05707bdd)

AFTER:


https://github.com/user-attachments/assets/131751bc-2bcc-4cb6-9d67-3be9cc88e3ca


