### PR TITLE
fix menuitem generation logic

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -813,11 +813,27 @@ export function getNodeMenu(operationMap: Map<string, Operation>) {
 	const inputMap = assetToOperation(operationMap);
 	const outputMap = operationToAsset(operationMap);
 
-	const uniqInputMap: Map<string, OperatorMenuItem[]> = new Map();
-	inputMap.forEach((menuItem, key) => uniqInputMap.set(key, _.uniqBy(menuItem, 'type')));
+	// Going from
+	//   outputMap(Operator => assetId[]) => inputMap(assetId => Operator[]) ;
+	//
+	// For example
+	//   Calibrate => [datasetId, modelConfig] => [Validate, Simulate, DataTransform...]
+	outputMap.forEach((assetTypes, operationKey) => {
+		const check = new Set<String>();
+		const menuItems: OperatorMenuItem[] = [];
 
-	outputMap.forEach((value, key) => {
-		menuOptions.set(key, uniqInputMap.get(value[0]) ?? []);
+		assetTypes.forEach((assetType) => {
+			const availableInputOperations = inputMap.get(assetType) ?? [];
+
+			availableInputOperations.forEach((item) => {
+				if (!check.has(item.type)) {
+					check.add(item.type);
+					menuItems.push(item);
+				}
+			});
+		});
+		menuOptions.set(operationKey, menuItems);
 	});
+
 	return menuOptions;
 }


### PR DESCRIPTION
### Summary
The generator is faulty because it only looks at the first item from the outputMap, but there can be multiple items when an operator produces 2 or more different asset types (e.g. calibration). This PR reworks the logic to take this into account.