### PR TITLE
style: fix overflow in asset pages and model entry

### DIFF
--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -236,6 +236,8 @@ main > section {
 	flex: 1;
 	& > :deep(*:not(nav, i)) {
 		flex: 1;
+		max-width: 100%;
+		overflow-x: auto;
 	}
 }
 

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -103,6 +103,9 @@ section {
 		'expression expression expression expression expression'
 		'description description description description description';
 	grid-template-columns: max-content max-content max-content auto max-content;
+	grid-auto-flow: dense;
+	max-width: 100%;
+	overflow: auto;
 	gap: var(--gap-2);
 	align-items: center;
 	font-size: var(--font-caption);
@@ -137,6 +140,8 @@ h6 {
 
 .unit {
 	grid-area: unit;
+	max-width: 20rem;
+	overflow: auto;
 }
 
 .expression {


### PR DESCRIPTION
# Description

This page tends to be cut off when there are long stratified variables. This quickly addresses the issue.

https://github.com/user-attachments/assets/c1c6f881-1866-42ce-88fc-413e66d5d3f7

