### PR TITLE
4452 Added expand feature for the vega chart

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "runtimeExecutable": "yarn",
             "cwd": "${workspaceFolder}/packages/client/hmi-client",
             "runtimeArgs": [
-                "dev"
+                "staging"
             ],
             // Run vite dev server using `yarn dev` and then luanch the chrome browser
             "serverReadyAction": {

--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -70,8 +70,8 @@ const isExpanded = ref(false);
 const onExpand = async () => {
 	if (vegaContainerLg.value) {
 		const defaultSize = {
-			width: window.innerWidth / 1.3,
-			height: window.innerHeight / 1.3
+			width: window.innerWidth / 1.5,
+			height: window.innerHeight / 1.5
 		};
 		let spec = deepToRaw(props.visualizationSpec) as any;
 		spec.width = defaultSize.width;

--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -49,7 +49,7 @@ const props = withDefaults(
 		areEmbedActionsVisible: true,
 		intervalSelectionSignalNames: () => [],
 		config: null,
-		expand: true
+		expand: false
 	}
 );
 const vegaContainer = ref<HTMLElement>();
@@ -147,6 +147,7 @@ async function createVegaVisualization(
 	});
 
 	// Add expand button to the vega container
+	console.log(options);
 	if (options.expand) {
 		const expandButton = h(Button, {
 			icon: 'pi pi-expand',
@@ -172,7 +173,7 @@ watch([vegaContainer, () => props.visualizationSpec], async () => {
 	const spec = deepToRaw(props.visualizationSpec);
 	vegaVisualization.value = await createVegaVisualization(vegaContainer.value, spec, props.config, {
 		actions: props.areEmbedActionsVisible,
-		expand: true
+		expand: props.expand
 	});
 });
 
@@ -183,7 +184,7 @@ defineExpose({
 <style>
 #vg-tooltip-element {
 	/* Make sure this is higher than the z-index of the Dialog(modal) */
-	z-index: 1102;
+	z-index: 2000;
 }
 </style>
 <style scoped>
@@ -206,8 +207,10 @@ defineExpose({
 	padding: 6px;
 	color: black;
 	position: absolute;
-	right: 30px;
 	background-color: transparent;
+}
+:deep(.vega-embed.has-actions .expand-button) {
+	right: 28px;
 }
 
 /* adjust style, position and rotation of action button */

--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -2,7 +2,7 @@
 	<Dialog
 		class="vega-chart-modal"
 		modal
-		v-model:visible="showLargeChart"
+		v-model:visible="isExpanded"
 		:dismissableMask="true"
 		:closable="true"
 		:closeOnEscape="true"
@@ -65,8 +65,7 @@ const vegaContainerLg = ref<HTMLElement>();
 const vegaVisualizationExpanded = ref<Result>();
 const expandedView = computed(() => vegaVisualizationExpanded.value?.view);
 
-// const renderErrorMessage = ref<String>();
-const showLargeChart = ref(false);
+const isExpanded = ref(false);
 
 const onExpand = async () => {
 	if (vegaContainerLg.value) {
@@ -165,7 +164,7 @@ async function createVegaVisualization(
 			rounded: true,
 			text: true,
 			onClick: () => {
-				showLargeChart.value = true;
+				isExpanded.value = true;
 			}
 		});
 		const div = document.createElement('div');

--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -1,8 +1,17 @@
 <template>
+	<Dialog
+		class="vega-chart-modal"
+		modal
+		v-model:visible="showLargeChart"
+		:closable="false"
+		:dismissableMask="true"
+		@show="onExpand"
+	>
+		<div>
+			<div ref="vegaContainerLg"></div>
+		</div>
+	</Dialog>
 	<div class="vega-chart-container">
-		<p v-if="renderErrorMessage" class="p-error">
-			{{ renderErrorMessage }}
-		</p>
 		<div ref="vegaContainer"></div>
 		<footer v-if="$slots.footer">
 			<slot name="footer" />
@@ -14,8 +23,10 @@
 import embed, { Result, VisualizationSpec } from 'vega-embed';
 import { Config as VgConfig } from 'vega';
 import { Config as VlConfig } from 'vega-lite';
+import Button from 'primevue/button';
+import Dialog from 'primevue/dialog';
 
-import { ref, watch, toRaw, isRef, isReactive, isProxy, computed } from 'vue';
+import { ref, watch, toRaw, isRef, isReactive, isProxy, computed, h, render } from 'vue';
 
 export type Config = VgConfig | VlConfig;
 
@@ -32,18 +43,39 @@ const props = withDefaults(
 		 */
 		intervalSelectionSignalNames?: string[];
 		config?: Config | null;
+		expand?: boolean;
 	}>(),
 	{
 		areEmbedActionsVisible: true,
 		intervalSelectionSignalNames: () => [],
-		config: null
+		config: null,
+		expand: true
 	}
 );
 const vegaContainer = ref<HTMLElement>();
 const vegaVisualization = ref<Result>();
 const view = computed(() => vegaVisualization.value?.view);
 
-const renderErrorMessage = ref<String>();
+const vegaContainerLg = ref<HTMLElement>();
+
+// const renderErrorMessage = ref<String>();
+const showLargeChart = ref(false);
+
+const onExpand = async () => {
+	if (vegaContainerLg.value) {
+		const defaultSize = {
+			width: window.innerWidth / 1.3,
+			height: window.innerHeight / 1.3
+		};
+		const spec = deepToRaw(props.visualizationSpec) as any;
+		spec.width = defaultSize.width;
+		spec.height = defaultSize.height;
+		await createVegaVisualization(vegaContainerLg.value, spec, props.config, {
+			actions: props.areEmbedActionsVisible,
+			expand: false
+		});
+	}
+};
 
 const emit = defineEmits<{
 	(
@@ -87,48 +119,73 @@ function deepToRaw<T extends Record<string, any>>(sourceObj: T): T {
 	return objectIterator(sourceObj);
 }
 
-async function updateVegaVisualization(container: HTMLElement, visualizationSpec: VisualizationSpec) {
-	renderErrorMessage.value = undefined;
-	vegaVisualization.value = undefined;
-	try {
-		vegaVisualization.value = await embed(
-			container,
-			{ ...visualizationSpec },
-			{
-				config: props.config || {},
-				actions: props.areEmbedActionsVisible === false ? false : undefined
+async function createVegaVisualization(
+	container: HTMLElement,
+	visualizationSpec: VisualizationSpec,
+	config: Config | null,
+	options: { actions?: boolean; expand?: boolean } = {}
+) {
+	const viz = await embed(
+		container,
+		{ ...visualizationSpec },
+		{
+			config: config || {},
+			actions: options.actions === false ? false : undefined
+		}
+	);
+	props.intervalSelectionSignalNames.forEach((signalName) => {
+		viz.view.addSignalListener(signalName, (name, valueRange: { [fieldName: string]: [number, number] }) => {
+			if (valueRange === undefined || Object.keys(valueRange).length === 0) {
+				emit('update-interval-selection', name, null);
+				return;
 			}
-		);
-		props.intervalSelectionSignalNames.forEach((signalName) => {
-			view.value!.addSignalListener(signalName, (name, valueRange: { [fieldName: string]: [number, number] }) => {
-				if (valueRange === undefined || Object.keys(valueRange).length === 0) {
-					emit('update-interval-selection', name, null);
-					return;
-				}
-				emit('update-interval-selection', name, valueRange);
-			});
+			emit('update-interval-selection', name, valueRange);
 		});
-		view.value!.addEventListener('click', (_event, item) => {
-			emit('chart-click', item?.datum ?? null);
+	});
+	viz.view.addEventListener('click', (_event, item) => {
+		emit('chart-click', item?.datum ?? null);
+	});
+
+	// Add expand button to the vega container
+	if (options.expand) {
+		const expandButton = h(Button, {
+			icon: 'pi pi-expand',
+			class: 'expand-button',
+			severity: 'secondary',
+			rounded: true,
+			text: true,
+			onClick: () => {
+				showLargeChart.value = true;
+			}
 		});
-	} catch (e) {
-		// renderErrorMessage.value = getErrorMessage(e);
-		// renderErrorMessage.value = e;
+		const div = document.createElement('div');
+		render(expandButton, div);
+		container.appendChild(div.firstChild as Node);
 	}
+	return viz;
 }
 
-watch([vegaContainer, () => props.visualizationSpec], () => {
+watch([vegaContainer, () => props.visualizationSpec], async () => {
 	if (!vegaContainer.value) {
 		return;
 	}
 	const spec = deepToRaw(props.visualizationSpec);
-	updateVegaVisualization(vegaContainer.value, spec);
+	vegaVisualization.value = await createVegaVisualization(vegaContainer.value, spec, props.config, {
+		actions: props.areEmbedActionsVisible,
+		expand: true
+	});
 });
 
 defineExpose({
 	view
 });
 </script>
+<style>
+#vg-tooltip-element {
+	/* Make sure this is higher than the z-index of the Dialog(modal) */
+	z-index: 1102;
+}
+</style>
 <style scoped>
 .vega-chart-container {
 	background: var(--surface-a);
@@ -141,6 +198,18 @@ defineExpose({
 	}
 }
 
+:deep(.vega-embed .expand-button, .vega-embed .expand-button:focus) {
+	padding-right: 0px;
+	position: relative;
+	top: 0;
+	right: 0;
+	padding: 6px;
+	color: black;
+	position: absolute;
+	right: 30px;
+	background-color: transparent;
+}
+
 /* adjust style, position and rotation of action button */
 :deep(.vega-embed.has-actions) {
 	padding-right: 0px;
@@ -151,7 +220,8 @@ defineExpose({
 	opacity: 1;
 	box-shadow: none;
 }
-:deep(.vega-embed summary):hover {
+:deep(.vega-embed summary):hover,
+:deep(.vega-embed .expand-button):hover {
 	border: 1px solid transparent;
 	background: var(--surface-hover);
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -155,6 +155,7 @@
 				<h5>Loss</h5>
 				<div ref="lossChartContainer">
 					<vega-chart
+						expand
 						v-if="lossValues.length > 0 || showSpinner"
 						ref="lossChartRef"
 						:are-embed-actions-visible="true"
@@ -175,6 +176,7 @@
 						/>
 						<template v-for="param of node.state.selectedParameters" :key="param">
 							<vega-chart
+								expand
 								:are-embed-actions-visible="true"
 								:visualization-spec="preparedDistributionCharts[param].histogram"
 							>
@@ -212,7 +214,7 @@
 							@configuration-change="updateSelectedVariables"
 						/>
 						<template v-for="variable of node.state.selectedVariables" :key="variable">
-							<vega-chart :are-embed-actions-visible="true" :visualization-spec="preparedCharts[variable]" />
+							<vega-chart expand :are-embed-actions-visible="true" :visualization-spec="preparedCharts[variable]" />
 						</template>
 					</section>
 					<section v-else-if="!modelConfig" class="emptyState">

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -89,7 +89,11 @@
 							<ul class="flex flex-column gap-2">
 								<li v-for="(interventions, appliedTo) in groupedOutputParameters" :key="appliedTo">
 									<h5 class="pb-2">{{ appliedTo }}</h5>
-									<vega-chart :are-embed-actions-visible="false" :visualization-spec="preparedCharts[appliedTo]" />
+									<vega-chart
+										expand
+										:are-embed-actions-visible="false"
+										:visualization-spec="preparedCharts[appliedTo]"
+									/>
 									<ul>
 										<li class="pb-2" v-for="intervention in interventions" :key="intervention.name">
 											<h6 class="pb-1">{{ intervention.name }}</h6>

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -264,7 +264,11 @@
 							<AccordionTab header="Success criteria">
 								<ul>
 									<li v-for="(_constraint, key) in node.state.constraintGroups" :key="key">
-										<vega-chart are-embed-actions-visible :visualization-spec="preparedSuccessCriteriaCharts[key]" />
+										<vega-chart
+											expand
+											are-embed-actions-visible
+											:visualization-spec="preparedSuccessCriteriaCharts[key]"
+										/>
 									</li>
 								</ul>
 							</AccordionTab>
@@ -272,6 +276,7 @@
 								<ul>
 									<li v-for="(_, key) of knobs.selectedInterventionVariables" :key="key">
 										<vega-chart
+											expand
 											are-embed-actions-visible
 											:visualization-spec="preparedForecastCharts.interventionCharts[key]"
 										/>
@@ -282,6 +287,7 @@
 								<ul>
 									<li v-for="(_, key) of knobs.selectedSimulationVariables" :key="key">
 										<vega-chart
+											expand
 											are-embed-actions-visible
 											:visualization-spec="preparedForecastCharts.simulationCharts[key]"
 										/>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -142,7 +142,7 @@
 								@configuration-change="chartProxy.configurationChange(index, $event)"
 								@remove="chartProxy.removeChart(index)"
 							/>
-							<vega-chart :are-embed-actions-visible="true" :visualization-spec="preparedCharts[index]" />
+							<vega-chart expand :are-embed-actions-visible="true" :visualization-spec="preparedCharts[index]" />
 						</template>
 						<Button size="small" text @click="chartProxy.addChart()" label="Add chart" icon="pi pi-plus" />
 					</div>

--- a/packages/client/hmi-client/src/temp/Vegalite.vue
+++ b/packages/client/hmi-client/src/temp/Vegalite.vue
@@ -1,7 +1,7 @@
 <template>
 	<div style="padding: 2rem; display: flex; flex-direction: col">
 		<div>
-			<vega-chart :visualization-spec="forecastChartSpec" />
+			<vega-chart expand :visualization-spec="forecastChartSpec" />
 			<div>
 				<div v-for="a in forecastAnnotations" :key="a.id">
 					{{ a.layerSpec.description }} <i class="pi pi-trash pi-trash" @click="removeAnnotation(a.id)" />
@@ -23,14 +23,15 @@
 		</div>
 		<div>
 			<vega-chart
+				expand
 				:interval-selection-signal-names="['brush']"
 				:visualization-spec="spec"
 				@chart-click="handleChartClick($event)"
 				@update-interval-selection="debounceHandleIntervalSelect"
 			/>
-			<vega-chart :visualization-spec="spec2" style="" />
+			<vega-chart expand :visualization-spec="spec2" style="" />
 		</div>
-		<vega-chart :visualization-spec="specHistogram" />
+		<vega-chart expand :visualization-spec="specHistogram" />
 	</div>
 </template>
 

--- a/packages/client/hmi-client/src/temp/Vegalite.vue
+++ b/packages/client/hmi-client/src/temp/Vegalite.vue
@@ -119,7 +119,7 @@ const spec = ref<any>(
 const onExpandErrorChart = () => {
 	const spec = createErrorChart(dataChart1, {
 		title: '',
-		width: window.innerWidth / 1.3,
+		width: window.innerWidth / 1.5,
 		height: 230,
 		boxPlotHeight: 50,
 		areaChartHeight: 150,

--- a/packages/client/hmi-client/src/temp/Vegalite.vue
+++ b/packages/client/hmi-client/src/temp/Vegalite.vue
@@ -23,7 +23,7 @@
 		</div>
 		<div>
 			<vega-chart
-				expand
+				:expand="onExpandErrorChart"
 				:interval-selection-signal-names="['brush']"
 				:visualization-spec="spec"
 				@chart-click="handleChartClick($event)"
@@ -116,6 +116,18 @@ const spec = ref<any>(
 		xAxisTitle: 'Error'
 	})
 );
+const onExpandErrorChart = () => {
+	const spec = createErrorChart(dataChart1, {
+		title: '',
+		width: window.innerWidth / 1.3,
+		height: 230,
+		boxPlotHeight: 50,
+		areaChartHeight: 150,
+		variables: [{ field: 'error' }, { field: 'error2', label: 'e2' }],
+		xAxisTitle: 'Error'
+	});
+	return spec as any;
+};
 
 const spec2 = ref<any>(makeLineChart(dataChart2));
 

--- a/packages/client/hmi-client/src/temp/Vegalite.vue
+++ b/packages/client/hmi-client/src/temp/Vegalite.vue
@@ -117,6 +117,7 @@ const spec = ref<any>(
 	})
 );
 const onExpandErrorChart = () => {
+	// Customize the chart size by modifying the spec before expanding the chart
 	const spec = createErrorChart(dataChart1, {
 		title: '',
 		width: window.innerWidth / 1.5,


### PR DESCRIPTION
# Description

- Allow vega chart to be expanded and rendered in a larger modal once expand button is clicked.
- Added `expand` prop to the vegachart to show the expand button on the chart.
- When a function is provided to `expand`,  function returns the customized chart spec to be rendered in the expand mode. 

https://github.com/user-attachments/assets/a46440be-f05f-4816-8d10-c7c10ce9f6c3



Resolves #4452 
