### PR TITLE
show spinner for model-config extraction

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
@@ -10,8 +10,8 @@ export interface ModelConfigOperationState extends BaseState {
 	transientModelConfig: ModelConfiguration;
 	notebookHistory: NotebookHistory[];
 	hasCodeRun: boolean;
-	datasetModelConfigTaskId?: string;
-	documentModelConfigTaskId?: string;
+	datasetModelConfigTaskId: string;
+	documentModelConfigTaskId: string;
 }
 
 export const blankModelConfig: ModelConfiguration = {
@@ -43,7 +43,9 @@ export const ModelConfigOperation: Operation = {
 		const init: ModelConfigOperationState = {
 			transientModelConfig: blankModelConfig,
 			notebookHistory: [],
-			hasCodeRun: false
+			hasCodeRun: false,
+			datasetModelConfigTaskId: '',
+			documentModelConfigTaskId: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
@@ -10,6 +10,8 @@ export interface ModelConfigOperationState extends BaseState {
 	transientModelConfig: ModelConfiguration;
 	notebookHistory: NotebookHistory[];
 	hasCodeRun: boolean;
+	datasetModelConfigTaskId?: string;
+	documentModelConfigTaskId?: string;
 }
 
 export const blankModelConfig: ModelConfiguration = {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -461,11 +461,7 @@ const suggestedConfigurationContext = ref<{
 	modelConfiguration: null
 });
 const isFetching = ref(false);
-const documentModelConfigTaskId = ref('');
-const datasetModelConfigTaskId = ref('');
-const isLoading = computed(
-	() => documentModelConfigTaskId.value !== '' || datasetModelConfigTaskId.value !== '' || isFetching.value
-);
+const isLoading = ref(false);
 
 const model = ref<Model | null>(null);
 const mmt = ref<MiraModel>(emptyMiraModel());
@@ -620,16 +616,16 @@ const resetConfiguration = () => {
 };
 
 watch(
-	() => props.node.state.documentModelConfigTaskId,
-	() => {
-		documentModelConfigTaskId.value = props.node.state.documentModelConfigTaskId ?? '';
-	}
-);
-
-watch(
-	() => props.node.state.datasetModelConfigTaskId,
-	() => {
-		datasetModelConfigTaskId.value = props.node.state.datasetModelConfigTaskId ?? '';
+	() => `${props.node.state.datasetModelConfigTaskId}:${props.node.state.documentModelConfigTaskId}`,
+	async (watchStr) => {
+		if (watchStr !== ':') {
+			isLoading.value = true;
+		} else {
+			isLoading.value = false;
+			const modelId = props.node.inputs[0].value?.[0];
+			if (!modelId) return;
+			await fetchConfigurations(modelId);
+		}
 	}
 );
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -418,6 +418,7 @@ const initializeEditor = (editorInstance: any) => {
 };
 
 const extractConfigurationsFromInputs = async () => {
+	const state = cloneDeep(props.node.state);
 	if (!model.value?.id) {
 		return;
 	}
@@ -428,6 +429,7 @@ const extractConfigurationsFromInputs = async () => {
 			props.node.workflowId,
 			props.node.id
 		);
+		state.documentModelConfigTaskId = resp.id;
 		documentModelConfigTaskId.value = resp.id;
 	}
 	if (datasetIds.value) {
@@ -440,7 +442,9 @@ const extractConfigurationsFromInputs = async () => {
 			props.node.id
 		);
 		datasetModelConfigTaskId.value = resp.id;
+		state.datasetModelConfigTaskId = resp.id;
 	}
+	emit('update-state', state);
 };
 
 const configModelEventHandler = async (event: ClientEvent<TaskResponse>) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -429,7 +429,6 @@ const extractConfigurationsFromInputs = async () => {
 			props.node.id
 		);
 		state.documentModelConfigTaskId = resp.id;
-		documentModelConfigTaskId.value = resp.id;
 	}
 	if (datasetIds.value) {
 		const matrixStr = generateModelDatasetConfigurationContext(mmt.value, mmtParams.value);
@@ -440,7 +439,6 @@ const extractConfigurationsFromInputs = async () => {
 			props.node.workflowId,
 			props.node.id
 		);
-		datasetModelConfigTaskId.value = resp.id;
 		state.datasetModelConfigTaskId = resp.id;
 	}
 	emit('update-state', state);

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -123,8 +123,8 @@ watch(
 	() => {
 		if (!isLoading.value) {
 			const state = cloneDeep(props.node.state);
-			state.documentModelConfigTaskId = documentModelConfigTaskId.value;
-			state.datasetModelConfigTaskId = datasetModelConfigTaskId.value;
+			state.documentModelConfigTaskId = '';
+			state.datasetModelConfigTaskId = '';
 			emit('update-state', state);
 		}
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -48,7 +48,7 @@ const configModelEventHandler = async (event: ClientEvent<TaskResponse>) => {
 useClientEvent(ClientEventType.TaskGollmConfigureModel, configModelEventHandler);
 useClientEvent(ClientEventType.TaskGollmConfigureFromDataset, configModelEventHandler);
 
-const isLoading = computed(() => datasetModelConfigTaskId.value !== '' || datasetModelConfigTaskId.value !== '');
+const isLoading = computed(() => datasetModelConfigTaskId.value !== '' || documentModelConfigTaskId.value !== '');
 
 const modelInput = props.node.inputs.find((input) => input.type === 'modelId');
 const isModelInputConnected = computed(() => modelInput?.status === WorkflowPortStatus.CONNECTED);

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -117,4 +117,16 @@ watch(
 		datasetModelConfigTaskId.value = props.node.state.datasetModelConfigTaskId ?? '';
 	}
 );
+
+watch(
+	() => isLoading.value,
+	() => {
+		if (!isLoading.value) {
+			const state = cloneDeep(props.node.state);
+			state.documentModelConfigTaskId = documentModelConfigTaskId.value;
+			state.datasetModelConfigTaskId = datasetModelConfigTaskId.value;
+			emit('update-state', state);
+		}
+	}
+);
 </script>


### PR DESCRIPTION
# Description

Add spinner to model config node when user extracts inputs

![Screenshot 2024-08-21 at 8 53 27 AM](https://github.com/user-attachments/assets/f74426cb-23da-4c58-b72b-7e8887f7a17f)

Resolves #(issue)
