### PR TITLE
Handle error state for the notification

### DIFF
--- a/packages/client/hmi-client/src/components/navbar/tera-notification-panel.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-notification-panel.vue
@@ -90,7 +90,8 @@ const sortedNotificationItems = computed(() => orderBy(notificationItems.value, 
 
 const isComplete = (item: NotificationItem) => item.status === ProgressState.Complete;
 const isQueued = (item: NotificationItem) => item.status === ProgressState.Queued;
-const isFailed = (item: NotificationItem) => item.status === ProgressState.Failed;
+const isFailed = (item: NotificationItem) =>
+	item.status === ProgressState.Failed || item.status === ProgressState.Error;
 const isRunning = (item: NotificationItem) => item.status === ProgressState.Running;
 const isCancelling = (item: NotificationItem) => item.status === ProgressState.Cancelling;
 const isCancelled = (item: NotificationItem) => item.status === ProgressState.Cancelled;

--- a/packages/client/hmi-client/src/composables/notificationManager.ts
+++ b/packages/client/hmi-client/src/composables/notificationManager.ts
@@ -12,7 +12,7 @@ import { ProgressState } from '@/types/Types';
 let initialized = false;
 
 const isFinished = (item: NotificationItem) =>
-	[ProgressState.Complete, ProgressState.Failed, ProgressState.Cancelled].includes(item.status);
+	[ProgressState.Complete, ProgressState.Failed, ProgressState.Cancelled, ProgressState.Error].includes(item.status);
 
 // Items stores the notifications for all projects
 const items = ref<NotificationItem[]>([]);


### PR DESCRIPTION
# Description

There was an issue that error state notification appeared as normal and can't be cleared out from the notification panel. 
This fixes the issue.
<img width="490" alt="Screenshot 2024-08-21 at 11 45 20 AM" src="https://github.com/user-attachments/assets/87e23299-6c63-43d5-be12-f4e97c0c5caf">
E.g ^ notification errored out but looks fine and wasn't being cleared out when clear notification was clicked. 

Resolves #(issue)
