### PR TITLE
fix: disable wizard for complex models

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -1,25 +1,14 @@
 <template>
 	<tera-drilldown
 		ref="drilldownRef"
+		v-bind="$attrs"
 		:node="node"
 		:menu-items="menuItems"
 		@update:selection="onSelection"
 		@on-close-clicked="onDrilldownClose"
 		@update-state="(state: any) => emit('update-state', state)"
 		@update-output-port="(output: any) => emit('update-output-port', output)"
-		v-bind="$attrs"
 	>
-		<tera-drilldown-section :tabName="DrilldownTabs.Wizard">
-			<tera-model-template-editor
-				v-if="amr"
-				:model="amr"
-				:kernel-manager="kernelManager"
-				@output-code="(data: any) => appendCode(data, 'executed_code')"
-				@sync-with-mira-model="syncWithMiraModel"
-				@save-new-model-output="createOutput"
-				@reset="resetModel"
-			/>
-		</tera-drilldown-section>
 		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="notebook-section">
 			<div class="toolbar">
 				<Suspense>
@@ -69,6 +58,20 @@
 				</div>
 			</tera-drilldown-preview>
 		</template>
+		<tera-drilldown-section :tabName="DrilldownTabs.Wizard">
+			<template v-if="amr">
+				<tera-model-template-editor
+					v-if="amr.model.transitions.length < 50"
+					:model="amr"
+					:kernel-manager="kernelManager"
+					@output-code="(data: any) => appendCode(data, 'executed_code')"
+					@sync-with-mira-model="syncWithMiraModel"
+					@save-new-model-output="createOutput"
+					@reset="resetModel"
+				/>
+				<p v-else class="m-4">Model makes too many amr-to-mmt calls. Wizard is disabled for now.</p>
+			</template>
+		</tera-drilldown-section>
 	</tera-drilldown>
 	<tera-save-asset-modal
 		v-if="amr"

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -41,6 +41,7 @@
 		<template #preview v-if="drilldownRef?.selectedTab === DrilldownTabs.Notebook">
 			<tera-drilldown-preview
 				title="Preview"
+				v-if="amr"
 				v-model:output="selectedOutputId"
 				@update:selection="onSelection"
 				:options="outputs"
@@ -52,10 +53,7 @@
 					:value="executeResponse.value"
 					:traceback="executeResponse.traceback"
 				/>
-				<tera-model-diagram v-else-if="amr" :model="amr" />
-				<div v-else>
-					<img src="@assets/svg/plants.svg" alt="" draggable="false" />
-				</div>
+				<tera-model-diagram :model="amr" />
 			</tera-drilldown-preview>
 		</template>
 		<tera-drilldown-section :tabName="DrilldownTabs.Wizard">


### PR DESCRIPTION
# Description

- model edit drilldown defaults to notebook
- wizard is disabled if there are more than 50 transitions (every transition is a template that triggers an `amr-to-mmt` call)

![image](https://github.com/user-attachments/assets/7fb66b4d-7afd-45f7-a40f-d6a863cd9c36)
