### PR TITLE
fix hardcoded margin causing nested levels to have negative radius

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -28,7 +28,6 @@ export interface NestedPetrinetOptions extends Options {
 	dims?: string[];
 }
 
-const CIRCLE_MARGIN = 2;
 const { getNodeTypeColor } = useNodeTypeColorPalette();
 const { getNestedTypeColor, setNestedTypeColor } = useNestedTypeColorPalette();
 
@@ -193,7 +192,8 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 			Object.entries(node).forEach((kvPair, i) => {
 				if (kvPair[0] === '_key') return;
 				const value = kvPair[1];
-				const childRadius = CIRCLE_PACKING_CHILD_NORMALIZED_RADII[nestedNodesLen] * parentRadius - CIRCLE_MARGIN;
+				const margin = parentRadius * 0.03;
+				const childRadius = CIRCLE_PACKING_CHILD_NORMALIZED_RADII[nestedNodesLen] * parentRadius - margin;
 
 				const xPos = parentRadius * CIRCLE_PACKING_CHILD_NORMALIZED_VECTORS[nestedNodesLen][i][0] + parentX;
 				const yPos = parentRadius * CIRCLE_PACKING_CHILD_NORMALIZED_VECTORS[nestedNodesLen][i][1] + parentY;

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -78,6 +78,7 @@ export const getModelRenderer = (
 			useAStarRouting: false,
 			useStableZoomPan: true,
 			zoomModifier: 'ctrlKey',
+			zoomRange: [0.1, 30],
 			runLayout: runDagreLayout,
 			dims,
 			nestedMap,


### PR DESCRIPTION
### Summary
Fixes #4578 

The problem is the margin is hardcoded, which means in deeper levels the radii go negative and although they are "rendered" they do not show up.


![image](https://github.com/user-attachments/assets/658fab6d-097c-46ec-abcf-09d2e74b934f)


### Testing
Use `yarn staging` for this one.

Goto http://localhost:8080/projects/34e7b955-f408-4e8b-be27-9429480ad6aa/model/7508b278-caea-4d35-bb17-097bdd463f07

Verify that state-S has 5 levels
