### PR TITLE
extra workflow update guard

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -49,6 +49,9 @@ export class WorkflowWrapper {
 	}
 
 	update(updatedWF: Workflow) {
+		if (updatedWF.id !== this.wf.id) {
+			throw new Error(`Workflow failed, inconsistent ids updated=${updatedWF.id} self=${this.wf.id}`);
+		}
 		this.wf.name = updatedWF.name;
 		this.wf.description = updatedWF.description;
 


### PR DESCRIPTION
### Summary
I can't think of a scenario of why this might happen, but just in case we will verify the ids are the same before allowing update to continue.