### PR TITLE
address sync problem of deletes within a short interval

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -55,8 +55,8 @@ export class WorkflowWrapper {
 		this.wf.name = updatedWF.name;
 		this.wf.description = updatedWF.description;
 
-		const nodes = this.getNodes();
-		const edges = this.getEdges();
+		const nodes = this.wf.nodes;
+		const edges = this.wf.edges;
 		const updatedNodeMap = new Map<string, WorkflowNode<any>>(updatedWF.nodes.map((n) => [n.id, n]));
 		const updatedEdgeMap = new Map<string, WorkflowEdge>(updatedWF.edges.map((e) => [e.id, e]));
 


### PR DESCRIPTION
### Summary
Should alleviate the issue when trying to delete nodes in quick succession, and causing the DB/client to become de-synced with each other.

The problem is getNodes/getEdges more excludes deleted elements, and we should use the full list when sync'ing