### PR TITLE
improve error stack trace for amr-to-mmt task

### DIFF
--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -1,5 +1,7 @@
 import sys
 import json
+import traceback
+
 from taskrunner import TaskRunnerInterface
 from mira.sources.amr import model_from_json
 
@@ -75,6 +77,7 @@ def main():
         print("AMR to MMT conversion succeeded")
     except Exception as e:
         sys.stderr.write(f"Error: {str(e)}\n")
+        sys.stderr.write(traceback.format_exc())
         sys.stderr.flush()
         exitCode = 1
 


### PR DESCRIPTION
### Summary
Improve error tracing, the error wasn't sufficient enough to debug the issue effectively.

From
```
root@mira-taskrunner-5ddb8fb849-mdq7p:/tmp# mira_task\:amr_to_mmt --id xyz --input_pipe IN --output_pipe OUT --self_destruct_timeout_seconds 9999
Reading input from input pipe
Error: 'NoneType' object has no attribute 'items'
Shutting down
```


To
```
root@f6a2276abec3:/tmp# mira_task\:amr_to_mmt --id xyz --input_pipe IN --output_pipe OUT --self_destruct_timeout_seconds 9999
Reading input from input pipe
Error: 'NoneType' object has no attribute 'items'
Traceback (most recent call last):
  File "/mira_task/tasks/amr_to_mmt.py", line 24, in main
    mmt = model_from_json(amr)
  File "/usr/local/lib/python3.8/dist-packages/mira/sources/amr/__init__.py", line 67, in model_from_json
    return petrinet.template_model_from_amr_json(model_json)
  File "/usr/local/lib/python3.8/dist-packages/mira/sources/amr/petrinet.py", line 222, in template_model_from_amr_json
    for key, val in annotations.items():
AttributeError: 'NoneType' object has no attribute 'items'
Shutting down
```