### PR TITLE
use id in intervention dropdown

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -212,7 +212,7 @@ const isSaved = computed(
 const parameterOptions = computed(() => {
 	if (!model.value) return [];
 	return getParameters(model.value).map((parameter) => ({
-		label: parameter.name ?? parameter.id,
+		label: parameter.id,
 		value: parameter.id
 	}));
 });
@@ -220,7 +220,7 @@ const parameterOptions = computed(() => {
 const stateOptions = computed(() => {
 	if (!model.value) return [];
 	return getStates(model.value).map((state) => ({
-		label: !isEmpty(state.name) ? state.name : state.id,
+		label: state.id,
 		value: state.id
 	}));
 });


### PR DESCRIPTION
# Description

* fixed a bug where showing the name for parameters and states would lead to confusion for stratified models in the intervention policy operator. 
* now we show the id in the UI rather than the name

<img width="388" alt="Screenshot 2024-08-30 at 11 10 05 AM" src="https://github.com/user-attachments/assets/84aa93d7-2a4b-46eb-b8f1-b815bf85b37a">
<img width="238" alt="Screenshot 2024-08-30 at 11 10 11 AM" src="https://github.com/user-attachments/assets/a4aed360-106f-48e0-97c0-2d5ade974b3f">
