### PR TITLE
fix drag-end emission

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
@@ -69,6 +69,7 @@ onBeforeUnmount(() => {
 
 		dragHandle.removeEventListener('mousedown', startDrag);
 		document.removeEventListener('mousemove', drag);
+		document.removeEventListener('click', stopDrag);
 		dragHandle.removeEventListener('mouseup', stopDrag);
 	}
 });

--- a/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
@@ -45,6 +45,7 @@ const drag = (evt: MouseEvent) => {
 };
 
 const stopDrag = (/* evt: MouseEvent */) => {
+	if (!isDragging) return;
 	tempX = 0;
 	tempY = 0;
 	isDragging = false;


### PR DESCRIPTION
### Summary
Didn't realize we also had a drag-end event hooked into document click/mousemove - this creates unnecessary update-requests when moving around in the operator-drilldown space.

Fixes #4633 