### PR TITLE
Add asset name on ressource panel hover title

### DIFF
--- a/packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue
@@ -73,7 +73,7 @@
 					v-for="assetItem in assetItems"
 					:key="assetItem.assetId"
 					:active="assetItem.assetId === assetId && assetItem.pageType === pageType"
-					:title="getElapsedTimeText(assetItem.assetCreatedOn)"
+					:title="`${assetItem.assetName} — ${getElapsedTimeText(assetItem.assetCreatedOn)}`"
 					class="asset-button"
 					plain
 					text


### PR DESCRIPTION
# Description

When asset have long name, the ressource panel is too small to display the full name. Now the title will display the full name as well as the creation time