### PR TITLE
Put back removed generate summary handler

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -76,6 +76,7 @@ public class GoLLMController {
 	private final ConfigureModelFromDatasetResponseHandler configureModelFromDatasetResponseHandler;
 	private final CompareModelsResponseHandler compareModelsResponseHandler;
 	private final GenerateSummaryHandler generateSummaryHandler;
+	private final GenerateResponseHandler generateResponseHandler;
 	private final EnrichAmrResponseHandler enrichAmrResponseHandler;
 
 	private final Messages messages;
@@ -87,6 +88,7 @@ public class GoLLMController {
 		taskService.addResponseHandler(compareModelsResponseHandler);
 		taskService.addResponseHandler(configureModelFromDatasetResponseHandler);
 		taskService.addResponseHandler(generateSummaryHandler);
+		taskService.addResponseHandler(generateResponseHandler);
 		taskService.addResponseHandler(enrichAmrResponseHandler);
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskNotificationEventTypes.java
@@ -16,7 +16,7 @@ public class TaskNotificationEventTypes {
 		ClientEventType.TASK_GOLLM_CONFIGURE_MODEL_FROM_DATASET,
 		CompareModelsResponseHandler.NAME,
 		ClientEventType.TASK_GOLLM_COMPARE_MODEL,
-		GenerateResponseHandler.NAME,
+		GenerateSummaryHandler.NAME,
 		ClientEventType.TASK_GOLLM_GENERATE_SUMMARY,
 		ValidateModelConfigHandler.NAME,
 		ClientEventType.TASK_FUNMAN_VALIDATION,


### PR DESCRIPTION
# Description

Put back removed generate summary handler to the notification type and added missing GenerateResponse handler to the gollm controller. 

Resolves #(issue)
