### PR TITLE
guard inputs changes for model configuration and intervention policy

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -32,9 +32,10 @@ watch(
 	() => props.node.inputs,
 	(inputs) => {
 		const modelId = inputs.find((input) => input.type === 'modelId')?.value?.[0];
-		if (!modelId) return;
-
 		const state = cloneDeep(props.node.state);
+
+		if (!modelId || modelId === state.interventionPolicy?.modelId) return;
+
 		// Reset previous model cache
 		state.interventionPolicy = {
 			modelId,

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -24,7 +24,7 @@ import { postAsConfiguredModel } from '@/services/model-configurations';
 import { useClientEvent } from '@/composables/useClientEvent';
 import type { ClientEvent, TaskResponse } from '@/types/Types';
 import { ClientEventType, TaskStatus } from '@/types/Types';
-import { blankModelConfig, ModelConfigOperation, ModelConfigOperationState } from './model-config-operation';
+import { ModelConfigOperation, ModelConfigOperationState } from './model-config-operation';
 
 const props = defineProps<{
 	node: WorkflowNode<ModelConfigOperationState>;
@@ -60,32 +60,6 @@ watch(
 		const modelInputs = inputs.filter((input) => input.type === 'modelId');
 		const modelId = modelInputs?.[0]?.value?.[0];
 
-		if (modelId) {
-			let configs = await getModelConfigurationsForModel(modelId);
-			if (!configs[0]?.id) {
-				const model = await getModel(modelId);
-				if (model) await postAsConfiguredModel(model); // Create a model configuration if it does not exist
-				configs = await getModelConfigurationsForModel(modelId);
-			}
-			// Auto append output
-			if (configs[0]?.id) {
-				const config = configs[0];
-				state.transientModelConfig = config;
-				emit('update-state', state);
-				emit('append-output', {
-					type: ModelConfigOperation.outputs[0].type,
-					label: config.name,
-					value: config.id,
-					isSelected: false,
-					state: omit(state, ['transientModelConfig'])
-				});
-			}
-		} else {
-			// Reset previous model cache
-			state.transientModelConfig = blankModelConfig;
-			emit('update-state', state);
-		}
-
 		// If all document inputs are connected, add a new document input port
 		if (documentInputs.every((input) => input.status === WorkflowPortStatus.CONNECTED)) {
 			emit('append-input-port', { type: 'documentId', label: 'Document', isOptional: true });
@@ -94,6 +68,28 @@ watch(
 		// If all dataset inputs are connected, add a new dataset input port
 		if (datasetInputs.every((input) => input.status === WorkflowPortStatus.CONNECTED)) {
 			emit('append-input-port', { type: 'datasetId', label: 'Dataset', isOptional: true });
+		}
+
+		// model
+		if (!modelId || modelId === state.transientModelConfig?.modelId) return;
+		let configs = await getModelConfigurationsForModel(modelId);
+		if (!configs[0]?.id) {
+			const model = await getModel(modelId);
+			if (model) await postAsConfiguredModel(model); // Create a model configuration if it does not exist
+			configs = await getModelConfigurationsForModel(modelId);
+		}
+		// Auto append output
+		if (configs[0]?.id) {
+			const config = configs[0];
+			state.transientModelConfig = config;
+			emit('update-state', state);
+			emit('append-output', {
+				type: ModelConfigOperation.outputs[0].type,
+				label: config.name,
+				value: config.id,
+				isSelected: false,
+				state: omit(state, ['transientModelConfig'])
+			});
 		}
 	},
 	{ deep: true }


### PR DESCRIPTION
# Description

* Adding an extra guard here for the watcher on the model config and intervention policy nodes.  The extra guard will not change the `state` if the incoming input model id is the same as the model config's/ intervention policy's `state` `modelID`

