### PR TITLE
funman false-boxes parsing, remove save-as UI until redesign

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-boundary-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-boundary-chart.vue
@@ -26,7 +26,6 @@ onMounted(async () => {
 		props.processedData,
 		props.param1,
 		props.param2,
-		props.timestep,
 		props.selectedBoxId,
 		renderOptions
 	);
@@ -40,7 +39,6 @@ watch(
 			props.processedData,
 			props.param1,
 			props.param2,
-			props.timestep,
 			props.selectedBoxId,
 			renderOptions
 		);

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman.vue
@@ -1,7 +1,6 @@
 <template>
 	<tera-drilldown
 		:node="node"
-		:menu-items="menuItems"
 		@update:selection="onSelection"
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"
@@ -288,15 +287,6 @@ const activeOutput = ref<WorkflowOutput<FunmanOperationState> | null>(null);
 const toggleAdditonalOptions = () => {
 	showAdditionalOptions.value = !showAdditionalOptions.value;
 };
-
-const menuItems = computed(() => [
-	{
-		label: 'Save as new model configurations',
-		icon: 'pi pi-pencil',
-		disabled: true,
-		command: () => {}
-	}
-]);
 
 const variablesOfInterest = ref<string[]>([]);
 const onToggleVariableOfInterest = (vals: string[]) => {

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -135,21 +135,21 @@ interface FunmanBoundingBox {
 	x2: number;
 	y2: number;
 }
-export const getBoxes = (
-	processedData: FunmanProcessedData,
-	param1: string,
-	param2: string,
-	_timestep: number,
-	boxType: string
-) => {
+export const getBoxes = (processedData: FunmanProcessedData, param1: string, param2: string, boxType: string) => {
 	const result: FunmanBoundingBox[] = [];
 
 	const temp = processedData.boxes
 		.filter((d: any) => d.label === boxType)
-		.map((box: any) => ({ id: box.id, timestep: box.timestep.lb }));
+		.map((box: any) => ({ id: box.id, timestep: box.timestep.ub }));
 	if (temp.length === 0) return [];
 
+	// grab latest step
 	const step = temp.sort((a, b) => b.timestep - a.timestep)[0].timestep;
+
+	// console.group(boxType);
+	// console.log('boxes', processedData.boxes);
+	// console.log('step', step);
+	// console.groupEnd();
 
 	processedData.boxes
 		.filter((d: any) => d.label === boxType)
@@ -164,7 +164,6 @@ export const getBoxes = (
 			});
 		});
 
-	// console.log('!!!', result);
 	return result;
 };
 
@@ -343,7 +342,7 @@ export const renderFunmanBoundaryChart = (
 	processedData: FunmanProcessedData,
 	param1: string,
 	param2: string,
-	timestep: number,
+	_timestep: number,
 	selectedBoxId: string,
 	options: RenderOptions
 ) => {
@@ -354,14 +353,10 @@ export const renderFunmanBoundaryChart = (
 		margin = 5;
 	}
 
-	const trueBoxes = getBoxes(processedData, param1, param2, timestep, 'true');
-	const falseBoxes = getBoxes(processedData, param1, param2, timestep, 'false');
-	const { minX, maxX, minY, maxY } = getBoxesDomain([...trueBoxes, ...falseBoxes]);
+	const trueBoxes = getBoxes(processedData, param1, param2, 'true');
+	const falseBoxes = getBoxes(processedData, param1, param2, 'false');
 
-	// console.log('true', param1, param2, trueBoxes);
-	// console.log('false', param1, param2, falseBoxes);
-	// console.log(processedData);
-	// console.log('');
+	const { minX, maxX, minY, maxY } = getBoxesDomain([...trueBoxes, ...falseBoxes]);
 
 	d3.select(element).selectAll('*').remove();
 	const svg = d3.select(element).append('svg').attr('width', width).attr('height', height);
@@ -378,7 +373,6 @@ export const renderFunmanBoundaryChart = (
 		.range([height - margin, margin]); // output range (inverted)
 
 	g.selectAll('.true-box').data(trueBoxes).enter().append('rect').classed('true-box', true).attr('fill', 'teal');
-
 	g.selectAll('.false-box').data(falseBoxes).enter().append('rect').classed('false-box', true).attr('fill', 'orange');
 
 	g.selectAll<any, FunmanBoundingBox>('rect')

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -146,11 +146,6 @@ export const getBoxes = (processedData: FunmanProcessedData, param1: string, par
 	// grab latest step
 	const step = temp.sort((a, b) => b.timestep - a.timestep)[0].timestep;
 
-	// console.group(boxType);
-	// console.log('boxes', processedData.boxes);
-	// console.log('step', step);
-	// console.groupEnd();
-
 	processedData.boxes
 		.filter((d: any) => d.label === boxType)
 		.filter((d: any) => d.timestep.ub === step)
@@ -342,7 +337,6 @@ export const renderFunmanBoundaryChart = (
 	processedData: FunmanProcessedData,
 	param1: string,
 	param2: string,
-	_timestep: number,
 	selectedBoxId: string,
 	options: RenderOptions
 ) => {


### PR DESCRIPTION
### Summary
Change parsing to use upper-bound instead of lower bound, previous assumption that for each box timestep's lb===ub is not correct.

Remove menuItem save-as, since we will be reworking the designs anyway.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/27037fac-9dce-44ea-86d1-f0457d3b3425">


Closes #4394 


### Testing
False boxes, if applicable, should be showing up in funman model-config validations.