### PR TITLE
propagate asset renaming

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -43,7 +43,7 @@
 						<Chip
 							v-for="(input, index) in node.inputs.filter((input) => input.value)"
 							:key="index"
-							:label="input.label"
+							:label="useProjects().getAssetName(input.value?.[0]) || input.label"
 						>
 							<template #icon>
 								<tera-operator-port-icon v-if="input.type" :portType="input.type" />
@@ -135,6 +135,7 @@ import TeraOperatorAnnotation from '@/components/operator/tera-operator-annotati
 import TeraOperatorPortIcon from '@/components/operator/tera-operator-port-icon.vue';
 import TeraOutputDropdown from '@/components/drilldown/tera-output-dropdown.vue';
 import TeraTooltip from '@/components/widgets/tera-tooltip.vue';
+import { useProjects } from '@/composables/project';
 
 const props = defineProps<{
 	node: WorkflowNode<any>;

--- a/packages/client/hmi-client/src/components/operator/tera-operator-inputs.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-inputs.vue
@@ -18,7 +18,9 @@
 					<div class="port" />
 				</div>
 				<div class="relative w-full">
-					<div class="truncate text-left">{{ getPortLabel(input) }}</div>
+					<div class="truncate text-left">
+						{{ useProjects().getAssetName(input.value?.[0]) || getPortLabel(input) }}
+					</div>
 					<!--TODO: label is a string type not an array consider adding this back in if we support an array of labels-->
 					<!-- <label v-for="(label, labelIdx) in input.label?.split(',') ?? []" :key="labelIdx">
 					{{ label }}
@@ -42,6 +44,7 @@ import { PropType } from 'vue';
 import { WorkflowPort, WorkflowPortStatus, WorkflowDirection } from '@/types/workflow';
 import { getPortLabel } from '@/services/workflow';
 import Button from 'primevue/button';
+import { useProjects } from '@/composables/project';
 
 const emit = defineEmits(['port-mouseover', 'port-selected', 'port-mouseover', 'port-mouseleave', 'remove-edges']);
 

--- a/packages/client/hmi-client/src/components/operator/tera-operator-outputs.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-outputs.vue
@@ -28,7 +28,7 @@
 					<div class="port" />
 				</div>
 				<div class="relative w-full">
-					<div class="truncate text-right">{{ output.label }}</div>
+					<div class="truncate text-right">{{ useProjects().getAssetName(output.value?.[0]) || output.label }}</div>
 					<Button
 						class="unlink"
 						label="Unlink"
@@ -74,6 +74,7 @@ import { WorkflowPortStatus, WorkflowDirection, WorkflowOutput } from '@/types/w
 import Button from 'primevue/button';
 import { OperatorMenuItem } from '@/services/workflow';
 import TeraOperatorMenu from '@/components/operator/tera-operator-menu.vue';
+import { useProjects } from '@/composables/project';
 
 const menuFocusId = ref<string | null>(null);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -169,6 +169,7 @@ import { sortDatesDesc } from '@/utils/date';
 import { createInterventionChart } from '@/services/charts';
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import TeraSaveAssetModal from '@/components/project/tera-save-asset-modal.vue';
+import { useProjects } from '@/composables/project';
 import TeraInterventionCard from './tera-intervention-card.vue';
 import {
 	InterventionPolicyOperation,
@@ -396,6 +397,7 @@ const onSaveInterventionPolicy = async () => {
 		return;
 	}
 	initialize();
+	useProjects().refresh();
 };
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -235,6 +235,7 @@ import { useConfirm } from 'primevue/useconfirm';
 import TeraToggleableInput from '@/components/widgets/tera-toggleable-input.vue';
 import { saveCodeToState } from '@/services/notebook';
 import TeraSaveAssetModal from '@/components/project/tera-save-asset-modal.vue';
+import { useProjects } from '@/composables/project';
 import TeraModelConfigurationItem from './tera-model-configuration-item.vue';
 import {
 	blankModelConfig,
@@ -546,6 +547,7 @@ const onSaveConfiguration = async () => {
 		return;
 	}
 	initialize();
+	useProjects().refresh();
 	logger.success('Saved model configuration');
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -23,7 +23,8 @@ import { getModel, getModelConfigurationsForModel } from '@/services/model';
 import { postAsConfiguredModel } from '@/services/model-configurations';
 import { useClientEvent } from '@/composables/useClientEvent';
 import type { ClientEvent, TaskResponse } from '@/types/Types';
-import { ClientEventType, TaskStatus } from '@/types/Types';
+import { AssetType, ClientEventType, TaskStatus } from '@/types/Types';
+import { useProjects } from '@/composables/project';
 import { ModelConfigOperation, ModelConfigOperationState } from './model-config-operation';
 
 const props = defineProps<{
@@ -75,7 +76,10 @@ watch(
 		let configs = await getModelConfigurationsForModel(modelId);
 		if (!configs[0]?.id) {
 			const model = await getModel(modelId);
-			if (model) await postAsConfiguredModel(model); // Create a model configuration if it does not exist
+			if (model) {
+				const modelConfig = await postAsConfiguredModel(model); // Create a model configuration if it does not exist
+				useProjects().addAsset(AssetType.ModelConfiguration, modelConfig.id);
+			}
 			configs = await getModelConfigurationsForModel(modelId);
 		}
 		// Auto append output

--- a/packages/client/hmi-client/src/services/save-asset.ts
+++ b/packages/client/hmi-client/src/services/save-asset.ts
@@ -53,16 +53,15 @@ export async function saveAs(
 	const projectId = useProjects().activeProject.value?.id;
 
 	// save to project
-	if (assetType !== AssetType.InterventionPolicy && assetType !== AssetType.ModelConfiguration) {
-		if (!projectId) {
-			logger.error(`Asset can't be saved since target project doesn't exist.`);
-			return;
-		}
-		await useProjects().addAsset(assetType, response.id, projectId);
-
-		// After saving notify the user and do any necessary actions
-		logger.info(`${response.name} saved successfully in project ${useProjects().activeProject.value?.name}.`);
+	if (!projectId) {
+		logger.error(`Asset can't be saved since target project doesn't exist.`);
+		return;
 	}
+	await useProjects().addAsset(assetType, response.id, projectId);
+
+	// After saving notify the user and do any necessary actions
+	logger.info(`${response.name} saved successfully in project ${useProjects().activeProject.value?.name}.`);
+	await useProjects().refresh();
 
 	// redirect to the asset page
 	if (openOnSave) {
@@ -110,14 +109,14 @@ export async function updateAddToProject(newAsset: AssetToSave, assetType: Asset
 		return;
 	}
 
-	if (assetType !== AssetType.InterventionPolicy && assetType !== AssetType.ModelConfiguration) {
-		const projectId = useProjects().activeProject.value?.id;
-		if (!projectId) {
-			logger.error(`Asset can't be saved since target project doesn't exist.`);
-			return;
-		}
-		await useProjects().addAsset(assetType, response.id, projectId);
+	const projectId = useProjects().activeProject.value?.id;
+	if (!projectId) {
+		logger.error(`Asset can't be saved since target project doesn't exist.`);
+		return;
 	}
+	await useProjects().addAsset(assetType, response.id, projectId);
+
 	logger.info(`Updated ${response.name}.`);
+	await useProjects().refresh();
 	if (onSaveFunction) onSaveFunction(response);
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
@@ -43,6 +44,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.model.ModelDescr
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelMetadata;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.metadata.Annotations;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceQueryParam;
 import software.uncharted.terarium.hmiserver.models.dataservice.provenance.ProvenanceType;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
@@ -562,6 +564,17 @@ public class ModelController {
 				null
 			);
 			modelConfigurationService.createAsset(modelConfiguration, projectId, permission);
+
+			// add default model configuration to project
+			final Optional<Project> project = projectService.getProject(projectId);
+			if (project.isPresent()) {
+				projectAssetService.createProjectAsset(
+					project.get(),
+					AssetType.MODEL_CONFIGURATION,
+					modelConfiguration,
+					permission
+				);
+			}
 
 			return ResponseEntity.status(HttpStatus.CREATED).body(created);
 		} catch (final IOException e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
@@ -15,6 +15,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.document.Documen
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
+import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission;
 
 @Service
@@ -28,6 +29,7 @@ public class TerariumAssetServices {
 	private final ModelConfigurationService modelConfigurationService;
 	private final ModelService modelService;
 	private final WorkflowService workflowService;
+	private final InterventionService interventionService;
 
 	/**
 	 * Get the service for a given asset type
@@ -45,6 +47,7 @@ public class TerariumAssetServices {
 			case MODEL_CONFIGURATION -> modelConfigurationService;
 			case MODEL -> modelService;
 			case WORKFLOW -> workflowService;
+			case INTERVENTION_POLICY -> interventionService;
 			default -> throw new IllegalArgumentException("Invalid asset type: " + type);
 		};
 	}
@@ -70,6 +73,8 @@ public class TerariumAssetServices {
 				return modelService.updateAsset((Model) asset, projectId, permission);
 			case WORKFLOW:
 				return workflowService.updateAsset((Workflow) asset, projectId, permission);
+			case INTERVENTION_POLICY:
+				return interventionService.updateAsset((InterventionPolicy) asset, projectId, permission);
 			default:
 				throw new IllegalArgumentException("Invalid asset type: " + type);
 		}


### PR DESCRIPTION
# Description

* propagate asset renaming in nodes
* node label now depends on the project asset name and falls back to the label name
* model configurations and intervention policies can now be added to projects

https://github.com/user-attachments/assets/c0facde2-30f1-4ec6-86dc-077d8b411db3


