### PR TITLE
modelservice getOde null guard

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelService.java
@@ -163,7 +163,7 @@ public class ModelService extends TerariumAssetServiceWithSearch<Model, ModelRep
 		}
 
 		// Force observable to empty-list if null or not specified
-		if (asset.getSemantics() != null) {
+		if (asset.getSemantics() != null && asset.getSemantics().getOde() != null) {
 			if (asset.getSemantics().getOde().getObservables() == null) {
 				asset.getSemantics().getOde().setObservables(new ArrayList());
 			}
@@ -215,7 +215,7 @@ public class ModelService extends TerariumAssetServiceWithSearch<Model, ModelRep
 		}
 
 		// Force observable to empty-list if null or not specified
-		if (asset.getSemantics() != null) {
+		if (asset.getSemantics() != null && asset.getSemantics().getOde() != null) {
 			if (asset.getSemantics().getOde().getObservables() == null) {
 				asset.getSemantics().getOde().setObservables(new ArrayList());
 			}


### PR DESCRIPTION
### Summary
It seems like in some cases ODE is null when doing equations-to-model, this adds an extra guard so we do not end up with null-pointer exceptions.

Was reported by Holly - but lacking detail to reproduce the error.