### PR TITLE
fix(model concept editing): accept empty value and input value

### DIFF
--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -143,7 +143,6 @@ export function updateModelPartProperty(modelPart: any, key: string, value: any)
 		modelPart.units.expression_mathml = `<ci>${value}</ci>`;
 	} else if (key === 'concept') {
 		if (!modelPart.grounding?.identifiers) modelPart.grounding = { identifiers: {}, modifiers: {} };
-		console.log(value);
 		modelPart.grounding.identifiers = parseCurie(value);
 	} else {
 		modelPart[key] = value;

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -143,6 +143,7 @@ export function updateModelPartProperty(modelPart: any, key: string, value: any)
 		modelPart.units.expression_mathml = `<ci>${value}</ci>`;
 	} else if (key === 'concept') {
 		if (!modelPart.grounding?.identifiers) modelPart.grounding = { identifiers: {}, modifiers: {} };
+		console.log(value);
 		modelPart.grounding.identifiers = parseCurie(value);
 	} else {
 		modelPart[key] = value;


### PR DESCRIPTION
# Description

- When adding the concept input to `tera-dataset`'s `tera-column-info`  I found that going back to an empty concept or accepting a valid input (without choosing an autocomplete option) wasn't accepted as a valid edit
- Here is the fix done for the model page
- Also cleaned up a conditional button

https://github.com/user-attachments/assets/2b3d6410-3371-443c-bf39-aaa09554e46c

