### PR TITLE
Optimize spinner progress

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -73,7 +73,7 @@ export interface OptimizeCiemssOperationState extends BaseState {
 	optimizeErrorMessage: { name: string; value: string; traceback: string };
 	simulateErrorMessage: { name: string; value: string; traceback: string };
 	// Intermediate:
-	currentProgress: number;
+	currentProgress: number; // optimization run's 2 digit %
 }
 
 // This is used as a map between dropdown labels and the inner values used by pyciemss-service.

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -72,6 +72,8 @@ export interface OptimizeCiemssOperationState extends BaseState {
 	optimizedInterventionPolicyId: string;
 	optimizeErrorMessage: { name: string; value: string; traceback: string };
 	simulateErrorMessage: { name: string; value: string; traceback: string };
+	// Intermediate:
+	currentProgress: number;
 }
 
 // This is used as a map between dropdown labels and the inner values used by pyciemss-service.
@@ -150,7 +152,8 @@ export const OptimizeCiemssOperation: Operation = {
 			optimizationRunId: '',
 			optimizedInterventionPolicyId: '',
 			optimizeErrorMessage: { name: '', value: '', traceback: '' },
-			simulateErrorMessage: { name: '', value: '', traceback: '' }
+			simulateErrorMessage: { name: '', value: '', traceback: '' },
+			currentProgress: 0
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -254,7 +254,10 @@
 					/>
 				</template>
 				<tera-progress-spinner v-if="showSpinner" :font-size="2" is-centered style="height: 100%">
-					<div>{{ props.node.state.currentProgress }}% of maximum iterations complete</div>
+					<div v-if="node.state.inProgressOptimizeId !== ''">
+						{{ props.node.state.currentProgress }}% of maximum iterations complete
+					</div>
+					<div v-else>Optimize complete. Running simulations</div>
 				</tera-progress-spinner>
 				<tera-operator-output-summary v-if="node.state.summaryId && !showSpinner" :summary-id="node.state.summaryId" />
 				<!-- Optimize result.json display: -->

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -239,7 +239,6 @@
 		<template #preview>
 			<tera-drilldown-section
 				class="ml-3 mr-3"
-				:is-loading="showSpinner"
 				:class="{ 'failed-run': optimizationResult.success === 'False' ?? 'successful-run' }"
 			>
 				<template #header-controls-left v-if="optimizedInterventionPolicy?.name">
@@ -254,10 +253,16 @@
 						@click="showSaveInterventionPolicy = true"
 					/>
 				</template>
-
+				<section v-if="showSpinner" class="spinner-message">
+					<tera-progress-spinner :font-size="2" is-centered style="height: 12rem" />
+					<p>{{ node.state.currentProgress }}% of maximum iterations complete</p>
+				</section>
 				<tera-operator-output-summary v-if="node.state.summaryId && !showSpinner" :summary-id="node.state.summaryId" />
 				<!-- Optimize result.json display: -->
-				<div v-if="optimizationResult && displayOptimizationResultMessage" class="result-message-grid mt-2 mb-2">
+				<div
+					v-if="optimizationResult && displayOptimizationResultMessage && !showSpinner"
+					class="result-message-grid mt-2 mb-2"
+				>
 					<span class="flex flex-row">
 						<p class="mt-2">For debugging</p>
 						<Button
@@ -275,6 +280,7 @@
 					</div>
 				</div>
 				<SelectButton
+					v-if="!showSpinner"
 					:model-value="outputViewSelection"
 					@change="if ($event.value) outputViewSelection = $event.value;"
 					:options="outputViewOptions"
@@ -288,7 +294,7 @@
 				</SelectButton>
 				<tera-notebook-error v-bind="node.state.optimizeErrorMessage" />
 				<tera-notebook-error v-bind="node.state.simulateErrorMessage" />
-				<template v-if="runResults[knobs.postForecastRunId] && runResults[knobs.preForecastRunId]">
+				<template v-if="runResults[knobs.postForecastRunId] && runResults[knobs.preForecastRunId] && !showSpinner">
 					<section v-if="outputViewSelection === OutputView.Charts" ref="outputPanel">
 						<Accordion multiple :active-index="[0, 1, 2]">
 							<AccordionTab header="Success criteria">
@@ -379,6 +385,7 @@ import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.
 import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
 import TeraPyciemssCancelButton from '@/components/pyciemss/tera-pyciemss-cancel-button.vue';
 import TeraOperatorOutputSummary from '@/components/operator/tera-operator-output-summary.vue';
+import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import { getUnitsFromModelParts, getModelByModelConfigurationId } from '@/services/model';
 import { createModelConfiguration, getModelConfigurationById } from '@/services/model-configurations';
 import {
@@ -1119,6 +1126,17 @@ watch(
 	padding: var(--gap-1) var(--gap);
 	gap: var(--gap-2);
 }
+
+.spinner-message {
+	align-items: center;
+	align-self: center;
+	display: flex;
+	flex-direction: column;
+	gap: var(--gap-2);
+	margin-top: 15rem;
+	text-align: center;
+}
+
 .info-circle {
 	color: var(--text-color-secondary);
 	font-size: var(--font-caption);

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -253,10 +253,9 @@
 						@click="showSaveInterventionPolicy = true"
 					/>
 				</template>
-				<section v-if="showSpinner" class="spinner-message">
-					<tera-progress-spinner :font-size="2" is-centered style="height: 12rem" />
-					<p>{{ node.state.currentProgress }}% of maximum iterations complete</p>
-				</section>
+				<tera-progress-spinner v-if="showSpinner" :font-size="2" is-centered style="height: 100%">
+					<div>{{ props.node.state.currentProgress }}% of maximum iterations complete</div>
+				</tera-progress-spinner>
 				<tera-operator-output-summary v-if="node.state.summaryId && !showSpinner" :summary-id="node.state.summaryId" />
 				<!-- Optimize result.json display: -->
 				<div

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -5,7 +5,10 @@
 		</tera-operator-placeholder>
 		<template v-if="node.inputs[0].value">
 			<div v-if="showSpinner">
-				<p>{{ node.state.currentProgress }}% of maximum iterations complete</p>
+				<div v-if="node.state.inProgressOptimizeId !== ''">
+					{{ props.node.state.currentProgress }}% of maximum iterations complete
+				</div>
+				<div v-else>Optimize complete. Running simulations</div>
 				<tera-progress-spinner :font-size="2" is-centered style="height: 100%" />
 			</div>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -201,6 +201,7 @@ watch(
 			state.inProgressPreForecastId = preForecastId;
 			state.inProgressPostForecastId = postForecastId;
 			state.optimizedInterventionPolicyId = newInterventionResponse.id ?? '';
+			state.currentProgress = 0;
 			emit('update-state', state);
 		} else {
 			// Simulation Failed:

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -80,9 +80,6 @@ const pollResult = async (runId: string) => {
 		.setThreshold(100)
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
-			if (data?.updates?.length) {
-				console.log(data.updates);
-			}
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
 				const checkpoint = _.first(data.updates);
 				if (checkpoint) {
@@ -90,7 +87,6 @@ const pollResult = async (runId: string) => {
 					state.currentProgress = +((100 * checkpoint.data.progress) / checkpoint.data.totalPossibleIterations).toFixed(
 						2
 					);
-					console.log(state.currentProgress);
 					emit('update-state', state);
 				}
 			}

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -201,7 +201,6 @@ watch(
 			state.inProgressPreForecastId = preForecastId;
 			state.inProgressPostForecastId = postForecastId;
 			state.optimizedInterventionPolicyId = newInterventionResponse.id ?? '';
-			state.currentProgress = 0;
 			emit('update-state', state);
 		} else {
 			// Simulation Failed:
@@ -255,6 +254,7 @@ Provide a consis summary in 100 words or less.
 			state.preForecastRunId = preSimId;
 			state.inProgressPostForecastId = '';
 			state.postForecastRunId = postSimId;
+			state.currentProgress = 0;
 			emit('update-state', state);
 
 			const datasetName = `Forecast run ${state.postForecastRunId}`;
@@ -302,6 +302,7 @@ Provide a consis summary in 100 words or less.
 			state.inProgressOptimizeId = '';
 			state.inProgressPreForecastId = '';
 			state.inProgressPostForecastId = '';
+			state.currentProgress = 0;
 			emit('update-state', state);
 		}
 	},

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -37,7 +37,7 @@ import {
 	parsePyCiemssMap
 } from '@/services/models/simulation-service';
 import { nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
-import { SimulationRequest, InterventionPolicy, Simulation } from '@/types/Types';
+import { SimulationRequest, InterventionPolicy, Simulation, CiemssOptimizeStatusUpdate } from '@/types/Types';
 import { createLLMSummary } from '@/services/summary-service';
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import { createForecastChart } from '@/services/charts';
@@ -81,10 +81,10 @@ const pollResult = async (runId: string) => {
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
-				const checkpoint = _.first(data.updates);
-				if (checkpoint) {
+				const checkpointData = _.first(data.updates)?.data as CiemssOptimizeStatusUpdate;
+				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
-					state.currentProgress = +((100 * checkpoint.data.progress) / checkpoint.data.totalPossibleIterations).toFixed(
+					state.currentProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(
 						2
 					);
 					emit('update-state', state);

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -553,14 +553,6 @@ export interface CalibrationRequestCiemss {
     engine: string;
 }
 
-export interface CiemssStatusUpdate {
-    jobId: string;
-    progress: number;
-    loss?: number;
-    currentResults?: number[];
-    totalPossibleIterations?: number;
-}
-
 export interface EnsembleCalibrationCiemssRequest {
     modelConfigs: EnsembleModelConfigs[];
     dataset: DatasetLocation;
@@ -672,6 +664,21 @@ export interface OptimizeQoi {
 export interface TimeSpan {
     start: number;
     end: number;
+}
+
+export interface CiemssCalibrateStatusUpdate extends CiemssStatusUpdate {
+    loss: number;
+}
+
+export interface CiemssOptimizeStatusUpdate extends CiemssStatusUpdate {
+    currentResults: number[];
+    totalPossibleIterations: number;
+}
+
+export interface CiemssStatusUpdate {
+    jobId: string;
+    progress: number;
+    type: CiemssStatusType;
 }
 
 export interface TaskResponse {
@@ -1026,6 +1033,11 @@ export enum AssetType {
 export enum EvaluationScenarioStatus {
     Started = "STARTED",
     Stopped = "STOPPED",
+}
+
+export enum CiemssStatusType {
+    Optimize = "optimize",
+    Calibrate = "calibrate",
 }
 
 export enum TaskStatus {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -554,9 +554,11 @@ export interface CalibrationRequestCiemss {
 }
 
 export interface CiemssStatusUpdate {
-    loss: number;
-    progress: number;
     jobId: string;
+    progress: number;
+    loss?: number;
+    currentResults?: number[];
+    totalPossibleIterations?: number;
 }
 
 export interface EnsembleCalibrationCiemssRequest {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/CiemssStatusUpdate.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/CiemssStatusUpdate.java
@@ -4,19 +4,30 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import lombok.Data;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 
 @Data
 @TSModel
 public class CiemssStatusUpdate {
 
-	private Number loss;
+	@JsonAlias("job_id")
+	private String jobId;
 
 	private Number progress;
 
-	@JsonAlias("job_id")
-	private String jobId;
+	@TSOptional
+	private Number loss;
+
+	@TSOptional
+	@JsonAlias("current_results")
+	private List<Number> currentResults;
+
+	@TSOptional
+	@JsonAlias("total_possible_iterations")
+	private Number totalPossibleIterations;
 
 	@JsonIgnore
 	public JsonNode getDataToPersist() {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssCalibrateStatusUpdate.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssCalibrateStatusUpdate.java
@@ -1,0 +1,11 @@
+package software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates;
+
+import lombok.Data;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@Data
+@TSModel
+public class CiemssCalibrateStatusUpdate extends CiemssStatusUpdate {
+
+	private Number loss;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssOptimizeStatusUpdate.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssOptimizeStatusUpdate.java
@@ -1,0 +1,26 @@
+package software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import lombok.Data;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@Data
+@TSModel
+public class CiemssOptimizeStatusUpdate extends CiemssStatusUpdate {
+
+	@JsonAlias("current_results")
+	private List<Number> currentResults;
+
+	@JsonAlias("total_possible_iterations")
+	private Number totalPossibleIterations;
+
+	@JsonIgnore
+	public JsonNode getDataToPersist() {
+		final ObjectMapper mapper = new ObjectMapper();
+		return mapper.valueToTree(this);
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssStatusType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssStatusType.java
@@ -1,0 +1,22 @@
+package software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@TSModel
+public enum CiemssStatusType {
+	OPTIMIZE("optimize"),
+	CALIBRATE("calibrate");
+
+	public final String type;
+
+	CiemssStatusType(final String type) {
+		this.type = type;
+	}
+
+	@Override
+	@JsonValue
+	public String toString() {
+		return type;
+	}
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssStatusUpdate.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/statusupdates/CiemssStatusUpdate.java
@@ -1,33 +1,22 @@
-package software.uncharted.terarium.hmiserver.models.simulationservice;
+package software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import lombok.Data;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
-import software.uncharted.terarium.hmiserver.annotations.TSOptional;
 
 @Data
 @TSModel
-public class CiemssStatusUpdate {
+public abstract class CiemssStatusUpdate {
 
 	@JsonAlias("job_id")
 	private String jobId;
 
 	private Number progress;
 
-	@TSOptional
-	private Number loss;
-
-	@TSOptional
-	@JsonAlias("current_results")
-	private List<Number> currentResults;
-
-	@TSOptional
-	@JsonAlias("total_possible_iterations")
-	private Number totalPossibleIterations;
+	private CiemssStatusType type;
 
 	@JsonIgnore
 	public JsonNode getDataToPersist() {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
@@ -162,20 +162,20 @@ public class SimulationEventService {
 				message,
 				CiemssOptimizeStatusUpdate.class
 			);
-			updateAndSendMessage(message, update);
+			updateAndSendPyciemssMessage(message, update);
 		} else if (updateType.equals(CiemssStatusType.CALIBRATE.toString())) {
 			final CiemssCalibrateStatusUpdate update = ClientEventService.decodeMessage(
 				message,
 				CiemssCalibrateStatusUpdate.class
 			);
-			updateAndSendMessage(message, update);
+			updateAndSendPyciemssMessage(message, update);
 		} else {
 			log.error("message in simulation-status with unknown type: " + updateType);
 			return;
 		}
 	}
 
-	private void updateAndSendMessage(final Message message, final CiemssStatusUpdate update) {
+	private void updateAndSendPyciemssMessage(final Message message, final CiemssStatusUpdate update) {
 		if (update == null) {
 			return;
 		}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/SimulationEventService.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.rabbitmq.client.Channel;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -26,8 +27,11 @@ import software.uncharted.terarium.hmiserver.models.ClientEvent;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.User;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.SimulationUpdate;
-import software.uncharted.terarium.hmiserver.models.simulationservice.CiemssStatusUpdate;
 import software.uncharted.terarium.hmiserver.models.simulationservice.ScimlStatusUpdate;
+import software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates.CiemssCalibrateStatusUpdate;
+import software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates.CiemssOptimizeStatusUpdate;
+import software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates.CiemssStatusType;
+import software.uncharted.terarium.hmiserver.models.simulationservice.statusupdates.CiemssStatusUpdate;
 import software.uncharted.terarium.hmiserver.service.data.SimulationService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
@@ -151,11 +155,30 @@ public class SimulationEventService {
 
 	@RabbitListener(queues = "${terarium.simulation-status}", concurrency = "1")
 	private void onPyciemssOneInstanceReceives(final Message message, final Channel channel) throws IOException {
-		final CiemssStatusUpdate update = ClientEventService.decodeMessage(message, CiemssStatusUpdate.class);
+		// Parse message to get message type:
+		final String updateType = (ClientEventService.decodeMessage(message, JsonNode.class)).get("type").asText();
+		if (updateType.equals(CiemssStatusType.OPTIMIZE.toString())) {
+			final CiemssOptimizeStatusUpdate update = ClientEventService.decodeMessage(
+				message,
+				CiemssOptimizeStatusUpdate.class
+			);
+			updateAndSendMessage(message, update);
+		} else if (updateType.equals(CiemssStatusType.CALIBRATE.toString())) {
+			final CiemssCalibrateStatusUpdate update = ClientEventService.decodeMessage(
+				message,
+				CiemssCalibrateStatusUpdate.class
+			);
+			updateAndSendMessage(message, update);
+		} else {
+			log.error("message in simulation-status with unknown type: " + updateType);
+			return;
+		}
+	}
+
+	private void updateAndSendMessage(final Message message, final CiemssStatusUpdate update) {
 		if (update == null) {
 			return;
 		}
-
 		try {
 			final SimulationUpdate simulationUpdate = new SimulationUpdate();
 			simulationUpdate.setData(update.getDataToPersist());
@@ -193,26 +216,45 @@ public class SimulationEventService {
 	)
 	private void onPyciemssAllInstanceReceive(final Message message) {
 		try {
-			final CiemssStatusUpdate update = ClientEventService.decodeMessage(message, CiemssStatusUpdate.class);
-			if (update == null) {
+			// Parse message to get message type:
+			final String updateType = (ClientEventService.decodeMessage(message, JsonNode.class)).get("type").asText();
+			if (updateType.equals(CiemssStatusType.OPTIMIZE.toString())) {
+				final CiemssOptimizeStatusUpdate update = ClientEventService.decodeMessage(
+					message,
+					CiemssOptimizeStatusUpdate.class
+				);
+				passPyciemssToUser(update);
+			} else if (updateType.equals(CiemssStatusType.CALIBRATE.toString())) {
+				final CiemssCalibrateStatusUpdate update = ClientEventService.decodeMessage(
+					message,
+					CiemssCalibrateStatusUpdate.class
+				);
+				passPyciemssToUser(update);
+			} else {
+				log.error("message in simulation-status with unknown type: " + updateType);
 				return;
-			}
-
-			final ClientEvent<CiemssStatusUpdate> status = ClientEvent.<CiemssStatusUpdate>builder()
-				.type(ClientEventType.SIMULATION_PYCIEMSS)
-				.data(update)
-				.build();
-
-			final String id = update.getJobId();
-			if (simulationIdToUserIds.containsKey(id)) {
-				simulationIdToUserIds
-					.get(id)
-					.forEach(userId -> {
-						clientEventService.sendToUser(status, userId);
-					});
 			}
 		} catch (final Exception e) {
 			log.error("Error processing event", e);
+		}
+	}
+
+	private void passPyciemssToUser(final CiemssStatusUpdate update) {
+		if (update == null) {
+			return;
+		}
+		final ClientEvent<CiemssStatusUpdate> status = ClientEvent.<CiemssStatusUpdate>builder()
+			.type(ClientEventType.SIMULATION_PYCIEMSS)
+			.data(update)
+			.build();
+
+		final String id = update.getJobId();
+		if (simulationIdToUserIds.containsKey(id)) {
+			simulationIdToUserIds
+				.get(id)
+				.forEach(userId -> {
+					clientEventService.sendToUser(status, userId);
+				});
 		}
 	}
 }


### PR DESCRIPTION
# Description

- Allow for optimize's intermediate results to be captured in `CiemssStatusUpdate` by adding optional fields
- Adding `currentProgress` to optimize state
- Adding % message to optimize node and drilldown based off of the optimize iteration step.
- Adding a static message when forecast runs are running.

# DEPENDS ON
https://github.com/DARPA-ASKEM/pyciemss-service/pull/116

# Testing:
-Running the above pyciemss-service branch we can run optimize which will now have intermediate results sent to rabbitmq
-We can also confirm the type change has no impact on calibration's intermediate results

# Pictures
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/e2484f74-fe09-4b2a-a5a1-d33f2ef3dbc4">
<img width="115" alt="image" src="https://github.com/user-attachments/assets/ca414957-65e1-41dd-9cdd-4d5640beaa3e">
