### PR TITLE
fix compound type propagation for selectOutput

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -473,8 +473,29 @@ export class WorkflowWrapper {
 				const targetPort = targetNode.inputs.find((port) => port.id === edge.targetPortId);
 				if (!targetPort) return;
 				edge.sourcePortId = selected.id; // Sync edge source port to selected output
+
+				const selectedTypes = selected.type.split('|').map((d) => d.trim());
+				const allowedInputTypes = targetPort.type.split('|').map((d) => d.trim());
+				const intersectionTypes = _.intersection(selectedTypes, allowedInputTypes);
+
+				// Not supported if there are more than one match
+				if (intersectionTypes.length > 1) {
+					console.error(`Ambiguous matching types [${selectedTypes}] to [${allowedInputTypes}]`);
+					return;
+				}
+				if (intersectionTypes.length === 0) {
+					return;
+				}
+				if (selectedTypes.length > 1) {
+					const concreteType = intersectionTypes[0];
+					if (selected.value) {
+						targetPort.value = [selected.value[0][concreteType]];
+					}
+				} else {
+					targetPort.value = selected.value; // mark
+				}
+
 				targetPort.label = selected.label;
-				targetPort.value = selected.value;
 			}
 
 			// Collect node cache

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -474,18 +474,24 @@ export class WorkflowWrapper {
 				if (!targetPort) return;
 				edge.sourcePortId = selected.id; // Sync edge source port to selected output
 
+				/**
+				 * Handle compound type unwrangling, this is very similar to what
+				 * we do in addEdge(...) but s already connected.
+				 * */
 				const selectedTypes = selected.type.split('|').map((d) => d.trim());
 				const allowedInputTypes = targetPort.type.split('|').map((d) => d.trim());
 				const intersectionTypes = _.intersection(selectedTypes, allowedInputTypes);
 
-				// Not supported if there are more than one match
+				// Sanity check: multiple matches found
 				if (intersectionTypes.length > 1) {
 					console.error(`Ambiguous matching types [${selectedTypes}] to [${allowedInputTypes}]`);
 					return;
 				}
+				// Sanity check: no matches found
 				if (intersectionTypes.length === 0) {
 					return;
 				}
+
 				if (selectedTypes.length > 1) {
 					const concreteType = intersectionTypes[0];
 					if (selected.value) {


### PR DESCRIPTION
### Summary
`WorkflowWrapper#selectOutput(...)` is used to propagate output changes, this was copying the values directly which does not work for compounded outputs such as calibrate. 


### Testing
The following sequence of actions to build a workflow should work and not crash
- add calibrate
- add simulate
- connect calibrate => simulate
- run calibarate
- run simulate