### PR TITLE
prevent click from being interpreted as drag event

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-canvas-item.vue
@@ -21,18 +21,23 @@ const emit = defineEmits(['dragging', 'dragstart', 'dragend']);
 
 const canvasItem = ref();
 
+let mousedown = false;
 let isDragging = false;
 let tempX = 0;
 let tempY = 0;
 
 const startDrag = (evt: MouseEvent) => {
+	mousedown = true;
 	tempX = evt.x;
 	tempY = evt.y;
-	isDragging = true;
-	emit('dragstart');
 };
 
 const drag = (evt: MouseEvent) => {
+	if (mousedown && !isDragging) {
+		isDragging = true;
+		emit('dragstart');
+		return;
+	}
 	if (!isDragging) return;
 
 	const dx = evt.x - tempX;
@@ -45,6 +50,8 @@ const drag = (evt: MouseEvent) => {
 };
 
 const stopDrag = (/* evt: MouseEvent */) => {
+	mousedown = false;
+
 	if (!isDragging) return;
 	tempX = 0;
 	tempY = 0;


### PR DESCRIPTION
### Summary
Clicking events on operators, such as opening the hamburger menu or annotations are interpreted as drag events, This is not desirable as these events queue up unnecessary workflow updates that get sent to the server. This PR adds an extra "mousedown" flag to better track state changes.


