### PR TITLE
Model Config only append to output when we dont yet have one.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -82,18 +82,21 @@ watch(
 			}
 			configs = await getModelConfigurationsForModel(modelId);
 		}
-		// Auto append output if and only if there isnt already an output
-		if (!props.node.outputs.at(0)?.value && configs[0]?.id) {
+
+		if (configs[0]?.id) {
 			const config = configs[0];
 			state.transientModelConfig = config;
 			emit('update-state', state);
-			emit('append-output', {
-				type: ModelConfigOperation.outputs[0].type,
-				label: config.name,
-				value: config.id,
-				isSelected: false,
-				state: omit(state, ['transientModelConfig'])
-			});
+			// Auto append output if and only if there isnt already an output
+			if (!props.node.outputs.at(0)?.value) {
+				emit('append-output', {
+					type: ModelConfigOperation.outputs[0].type,
+					label: config.name,
+					value: config.id,
+					isSelected: false,
+					state: omit(state, ['transientModelConfig'])
+				});
+			}
 		}
 	},
 	{ deep: true }

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -82,8 +82,8 @@ watch(
 			}
 			configs = await getModelConfigurationsForModel(modelId);
 		}
-		// Auto append output
-		if (configs[0]?.id) {
+		// Auto append output if and only if there isnt already an output
+		if (!props.node.outputs.at(0)?.value && configs[0]?.id) {
 			const config = configs[0];
 			state.transientModelConfig = config;
 			emit('update-state', state);


### PR DESCRIPTION
# Context:
here is a watcher on model config that will append a new output on every input change.
Issue is:
user plugs in a new model (1)
user plugs in a new document/dataset to enrich with (2)
user plugs in a new document/dataset to enrich with (3)

We already have 3 essentially duplicate outputs appended to our node.
This is causing unnecessarily large nodes

Here we check for the value as our default output will be assigned and its value is null.


