### PR TITLE
work around workflow de-sync problem in stratify

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -149,6 +149,7 @@ const props = defineProps<{
 	hideDropdown?: boolean;
 }>();
 
+// FIXME: update-output-port unused
 const emit = defineEmits(['on-close-clicked', 'update-state', 'update:selection', 'update-output-port']);
 
 const slots = useSlots();

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -263,16 +263,6 @@ const stratifyModel = () => {
 	});
 };
 
-// const handleStratifyResponse = (data: any) => {
-// 	const executedCode = data.content.executed_code;
-// 	if (executedCode) {
-// 		codeText.value = executedCode;
-//
-// 		// If stratify is run from the wizard, save the code but set `hasCodeBeenRun` to false
-// 		saveCodeToState(executedCode, false);
-// 	}
-// };
-
 const handleModelPreview = async (data: any) => {
 	const amrResponse = data.content['application/json'] as Model;
 	isStratifyInProgress.value = false;

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -270,16 +270,17 @@ const handleStratifyResponse = (data: any) => {
 };
 
 const handleModelPreview = async (data: any) => {
-	outputAmr.value = data.content['application/json'];
+	const amrResponse = data.content['application/json'];
 	isStratifyInProgress.value = false;
-	if (!outputAmr.value) {
+	if (!amrResponse) {
 		logger.error('Error getting updated model from beaker');
 		return;
 	}
 
 	// Create output
-	const modelData = await createModel(outputAmr.value);
+	const modelData = await createModel(amrResponse);
 	if (!modelData) return;
+	outputAmr.value = modelData;
 
 	emit('append-output', {
 		id: uuidv4(),

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -4,7 +4,6 @@
 		:is-draft="isDraft"
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"
-		@update-output-port="(output: any) => emit('update-output-port', output)"
 		@update:selection="onSelection"
 		v-bind="$attrs"
 	>
@@ -144,7 +143,6 @@ import type { Model } from '@/types/Types';
 import { AssetType } from '@/types/Types';
 import { AMRSchemaNames } from '@/types/common';
 import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
-import { nodeOutputLabel } from '@/components/workflow/util';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 
 /* Jupyter imports */
@@ -243,6 +241,7 @@ const stratifyModel = () => {
 		if (modelParameters.includes(v)) parametersToStratify.push(v);
 	});
 
+	let executedCode = '';
 	const messageContent = {
 		key: strataOption.name,
 		strata: strataOption.groupLabels.split(',').map((d) => d.trim()),
@@ -254,28 +253,41 @@ const stratifyModel = () => {
 	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		kernelManager
 			.sendMessage('stratify_request', messageContent)
-			.register('stratify_response', handleStratifyResponse)
-			.register('model_preview', handleModelPreview);
+			.register('stratify_response', (data: any) => {
+				executedCode = data.content.executed_code;
+			})
+			.register('model_preview', async (data: any) => {
+				await handleModelPreview(data);
+				saveCodeToState(executedCode, false);
+			});
 	});
 };
 
-const handleStratifyResponse = (data: any) => {
-	const executedCode = data.content.executed_code;
-	if (executedCode) {
-		codeText.value = executedCode;
-
-		// If stratify is run from the wizard, save the code but set `hasCodeBeenRun` to false
-		saveCodeToState(executedCode, false);
-	}
-};
+// const handleStratifyResponse = (data: any) => {
+// 	const executedCode = data.content.executed_code;
+// 	if (executedCode) {
+// 		codeText.value = executedCode;
+//
+// 		// If stratify is run from the wizard, save the code but set `hasCodeBeenRun` to false
+// 		saveCodeToState(executedCode, false);
+// 	}
+// };
 
 const handleModelPreview = async (data: any) => {
-	const amrResponse = data.content['application/json'];
+	const amrResponse = data.content['application/json'] as Model;
 	isStratifyInProgress.value = false;
 	if (!amrResponse) {
 		logger.error('Error getting updated model from beaker');
 		return;
 	}
+
+	const state = props.node.state;
+
+	// Try to derive a better name
+	let newName = amr.value?.header.name ?? 'Model';
+	newName += ` (stratified ${state.strataGroup.name} with ${state.strataGroup.groupLabels.split(',').length} groups)`;
+	amrResponse.name = newName;
+	amrResponse.header.name = newName;
 
 	// Create output
 	const modelData = await createModel(amrResponse);
@@ -284,7 +296,7 @@ const handleModelPreview = async (data: any) => {
 
 	emit('append-output', {
 		id: uuidv4(),
-		label: nodeOutputLabel(props.node, 'Output'),
+		label: newName,
 		type: 'modelId',
 		state: {
 			strataGroup: _.cloneDeep(props.node.state.strataGroup),

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -48,6 +48,11 @@ export class WorkflowWrapper {
 		return this.wf;
 	}
 
+	/**
+	 * FIXME: Need to split workflow into different categories and sending the commands
+	 * instead of the result. It is possible here to become de-synced: eg state-update-response
+	 * comes in as we are about to change the output ports.
+	 * */
 	update(updatedWF: Workflow) {
 		if (updatedWF.id !== this.wf.id) {
 			throw new Error(`Workflow failed, inconsistent ids updated=${updatedWF.id} self=${this.wf.id}`);


### PR DESCRIPTION
### Summary
There are sync'ing issues when an output-creation is split into multiple stages, where each stage end up invoking workflow-updates. For example here when stratify finishes:
- update the state with the code written
- save a new model and append output

because the two not grouped together it means at the time we are ready to update the new output, it could have been overwritten by the response from the update-state. This PR adds logic to try to guard against these cases.

### In this PR:
- Tweak the model creation ordering, so we don't update the preview unless we have successfully create a model
- Group code-state update and appending output together 
- Add a few FIXMES for workflow-logic, and deprecation in tera-drilldown
- Better default output port labels (model-names)


### TODO: 
Ideally I think update-state and update-output would be their own thing so they do not cross contaminate, this will rerouting, additional API endpoints to do partial updates, and moving parts of the workflow management server-side.  


### Testing
Run stratify on a non-trivial model (not SIR) with different configurations, shouldn't see errors, and the number of outputs produced should be the number of times we have run stratification.



See: https://github.com/DARPA-ASKEM/terarium/issues/4780