### PR TITLE
fix branching workflow in diamond arrangement

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -369,9 +369,12 @@ export class WorkflowWrapper {
 			});
 		}
 
-		// 3. Collect the upstream edges of the anchor
-		const upstreamEdges = this.getEdges().filter((edge) => edge.target === anchor.id);
+		// 3. Collect the upstream edges
+		const targetIds = copyNodes.map((n) => n.id);
+		const upstreamEdges = this.getEdges().filter((edge) => targetIds.includes(edge.target as string));
+		const anchorUpstreamEdges = this.getEdges().filter((edge) => edge.target === anchor.id);
 		upstreamEdges.forEach((edge) => {
+			if (copyEdges.find((copyEdge) => copyEdge.id === edge.id)) return;
 			copyEdges.push(_.cloneDeep(edge));
 		});
 
@@ -391,8 +394,8 @@ export class WorkflowWrapper {
 		});
 
 		copyEdges.forEach((edge) => {
-			// Don't replace upstream edge sources, they are still valid
-			if (upstreamEdges.map((e) => e.source).includes(edge.source) === false) {
+			// Don't replace anchor upstream edge sources, they are still valid
+			if (anchorUpstreamEdges.map((e) => e.source).includes(edge.source) === false) {
 				edge.source = registry.get(edge.source as string);
 				edge.sourcePortId = registry.get(edge.sourcePortId as string);
 			}
@@ -420,10 +423,12 @@ export class WorkflowWrapper {
 		});
 		copyEdges.forEach((edge) => {
 			if (!edge.points || edge.points.length < 2) return;
-			if (upstreamEdges.map((e) => e.source).includes(edge.source) === false) {
+			if (copyNodes.map((n) => n.id).includes(edge.source as string) === true) {
 				edge.points[0].y += offset;
 			}
-			edge.points[edge.points.length - 1].y += offset;
+			if (copyNodes.map((n) => n.id).includes(edge.target as string) === true) {
+				edge.points[edge.points.length - 1].y += offset;
+			}
 		});
 
 		// 6. Finally put everything back into the workflow


### PR DESCRIPTION
### Summary
There is a bug with branching when the subgraph forms a diamond, the upstream edges are not calculated correctly.

Before: note one of the simulate is disconnected from its upstream model-config
<img width="645" alt="image" src="https://github.com/user-attachments/assets/73df74fc-eda4-4b24-b9d7-5d71a8ff7267">


After:
<img width="656" alt="image" src="https://github.com/user-attachments/assets/c72a361b-8f3b-4586-b5f6-f7566c3b56eb">


### Testing
In a workflow
- add model, model-config, intervention-policy, simulate
- connect model=>model-config, model=>intervention-policy, {intervention-policy, model-config} => simulate
- branch on either the intervention-policy or model-config node

The resulting new subgraph should still form a diamond formation with the existing graph

Fixes: https://github.com/DARPA-ASKEM/terarium/issues/4562