### PR TITLE
Optimize threshold from 100 -> 350

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -80,11 +80,12 @@ const poller = new Poller();
 const pollResult = async (runId: string) => {
 	poller
 		.setInterval(5000)
-		.setThreshold(100)
+		.setThreshold(350)
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
 				const checkpointData = _.first(data.updates)?.data as CiemssOptimizeStatusUpdate;
+				console.log(checkpointData.progress);
 				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
 					state.currentProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -85,7 +85,6 @@ const pollResult = async (runId: string) => {
 		.setProgressAction((data: Simulation) => {
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
 				const checkpointData = _.first(data.updates)?.data as CiemssOptimizeStatusUpdate;
-				console.log(checkpointData.progress);
 				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
 					state.currentProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(


### PR DESCRIPTION
# Description
Some long running optimizations will take more than the 500 seconds provided in this poller.
This is causing errors for the demo videos.
https://app.staging.terarium.ai/projects/55901a7a-4e6b-4b9e-a07a-58c3a248c9fa/workflow/b913936f-5eb3-458c-af58-de7c9bd8e5cb

I am bumping our threshold to 350 as that should be more than enough time.
Later I can discuss a more dynamic approach to these values with Daniel 