### PR TITLE
Select only relavant variables for the chart

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -354,7 +354,6 @@ const preparedCharts = computed(() => {
 
 	const result = runResults.value[selectedRunId.value];
 	const resultSummary = runResultsSummary.value[selectedRunId.value];
-
 	const reverseMap: Record<string, string> = {};
 	Object.keys(pyciemssMap).forEach((key) => {
 		reverseMap[`${pyciemssMap[key]}_mean`] = key;

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -1,5 +1,5 @@
 import { percentile } from '@/utils/math';
-import { isEmpty } from 'lodash';
+import { isEmpty, pick } from 'lodash';
 import { VisualizationSpec } from 'vega-embed';
 import { v4 as uuidv4 } from 'uuid';
 import { ChartAnnotation, Intervention } from '@/types/Types';
@@ -398,8 +398,12 @@ export function createForecastChart(
 
 	// Helper function to capture common layer structure
 	const newLayer = (layer: ForecastChartLayer, markType: string) => {
+		const selectedFields = layer.variables.concat([layer.timeField]);
+		if (layer.groupField) selectedFields.push(layer.groupField);
+
+		const data = Array.isArray(layer.data) ? { values: layer.data.map((d) => pick(d, selectedFields)) } : layer.data;
 		const header = {
-			data: Array.isArray(layer.data) ? { values: layer.data } : layer.data,
+			data,
 			transform: [
 				{
 					fold: layer.variables,


### PR DESCRIPTION
# Description

It looks like there's no way to filter or select data columns to reduce the size of the data using only vegalite chart spec. So , I just chopped off the unused variables from the datasets before passing it to the chart. 

Before we had an issue of browser crashing when more than 3 variables are selected. Now more variables can be selected. 

![Screenshot 2024-09-20 at 2 15 58 PM](https://github.com/user-attachments/assets/04b0b347-9286-4b86-a42e-269724c3b781)

Note: We still have issues when too many variables are selected with large dataset. For this particular example (https://app.staging.terarium.ai/projects/f6a5af08-8d19-4462-bc5b-c12a9d6f6616/workflow/d7bf01c5-7c6e-4503-800c-f2d03dea9d1e?operator=bff38ac4-ca7a-44c4-8eca-e82f2a69dccb) , it will still crash the browser when all variables are selected. We may want to introduce the limit on the chart to prevent user from selecting too many variables. 

Resolves #4731 
