### PR TITLE
include interventions in summary generation

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -129,6 +129,8 @@ The input parameters are as follows:
 - samples: ${state.numSamples}
 - method: ${state.method}
 - timespan: ${JSON.stringify(state.currentTimespan)}
+- interventions: ${JSON.stringify(interventionPolicy.value?.interventions)};
+
 
 The output has these metrics at the start:
 - ${JSON.stringify(start)}


### PR DESCRIPTION
### Summary
provisionally Include interventions in summary generation. 

<img width="994" alt="image" src="https://github.com/user-attachments/assets/c8303167-d3f3-41bc-960f-a5c774804cb4">


Relates to: https://github.com/DARPA-ASKEM/terarium/issues/4850