### PR TITLE
[BUG]: 400 error occurs when navigating from workflow to home

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -223,6 +223,7 @@ import * as ModelComparisonOp from '@/components/workflow/ops/model-comparison/m
 import * as RegriddingOp from '@/components/workflow/ops/regridding/mod';
 import * as InterventionPolicyOp from '@/components/workflow/ops/intervention-policy/mod';
 import { subscribe, unsubscribe } from '@/services/ClientEventService';
+import { activeProjectId } from '@/composables/activeProject';
 
 const WORKFLOW_SAVE_INTERVAL = 4000;
 
@@ -279,6 +280,7 @@ const contextMenu = ref();
 
 const isRenamingWorkflow = ref(false);
 const newWorkflowName = ref('');
+const currentProjectId = ref<string | null>(null);
 
 const optionsMenu = ref();
 const optionsMenuItems = ref([
@@ -308,7 +310,7 @@ async function updateWorkflowName() {
 
 // eslint-disable-next-line
 const _saveWorkflow = async () => {
-	await workflowService.updateWorkflow(wf.value.dump());
+	await workflowService.updateWorkflow(wf.value.dump(), currentProjectId.value ?? undefined);
 	// wf.value.update(updated);
 };
 // eslint-disable-next-line
@@ -972,6 +974,7 @@ onMounted(() => {
 	}, WORKFLOW_SAVE_INTERVAL);
 
 	subscribe(ClientEventType.WorkflowUpdate, updateWorkflowHandler);
+	currentProjectId.value = activeProjectId.value;
 });
 
 onUnmounted(() => {

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -665,9 +665,9 @@ export const createWorkflow = async (workflow: Workflow) => {
 };
 
 // Update
-export const updateWorkflow = async (workflow: Workflow) => {
+export const updateWorkflow = async (workflow: Workflow, projectId?: string) => {
 	const id = workflow.id;
-	const response = await API.put(`/workflows/${id}`, workflow);
+	const response = await API.put(`/workflows/${id}`, workflow, { params: { 'project-id': projectId } });
 	return response?.data ?? null;
 };
 


### PR DESCRIPTION
# Description

Saving the active project id in the workflow, as when we unmount this component we lose this injection later on.

Resolves #3672 
