### PR TITLE
fix invalid htmls

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -18,8 +18,10 @@
 							<section>
 								<table class="p-datatable-table">
 									<thead class="p-datatable-thead">
-										<th>Model config ID</th>
-										<th>Weight</th>
+										<tr>
+											<th>Model config ID</th>
+											<th>Weight</th>
+										</tr>
 									</thead>
 									<tbody class="p-datatable-tbody">
 										<!-- Index matching listModelLabels and ensembleConfigs-->
@@ -53,32 +55,32 @@
 						/>
 						<template v-if="knobs.ensembleConfigs.length > 0">
 							<table class="w-full mt-3">
-								<tr>
-									<th class="w-4">Ensemble variables</th>
-									<!-- Index matching listModelLabels and ensembleConfigs-->
-									<th v-for="(element, i) in listModelLabels" :key="i">
-										{{ element }}
-									</th>
-								</tr>
-								<tr>
-									<div class="row-header">
+								<tbody>
+									<tr>
+										<th class="w-4">Ensemble variables</th>
+										<!-- Index matching listModelLabels and ensembleConfigs-->
+										<th v-for="(element, i) in listModelLabels" :key="i">
+											{{ element }}
+										</th>
+									</tr>
+									<tr>
 										<td v-for="(element, i) in Object.keys(knobs.ensembleConfigs[0].solutionMappings)" :key="i">
 											{{ element }}
 										</td>
-									</div>
-									<td v-for="i in knobs.ensembleConfigs.length" :key="i">
-										<template
-											v-for="element in Object.keys(knobs.ensembleConfigs[i - 1].solutionMappings)"
-											:key="element"
-										>
-											<Dropdown
-												v-model="knobs.ensembleConfigs[i - 1].solutionMappings[element]"
-												:options="allModelOptions[i - 1]?.map((ele) => ele.referenceId ?? ele.id)"
-												class="w-full mb-2 mt-2"
-											/>
-										</template>
-									</td>
-								</tr>
+										<td v-for="i in knobs.ensembleConfigs.length" :key="i">
+											<template
+												v-for="element in Object.keys(knobs.ensembleConfigs[i - 1].solutionMappings)"
+												:key="element"
+											>
+												<Dropdown
+													v-model="knobs.ensembleConfigs[i - 1].solutionMappings[element]"
+													:options="allModelOptions[i - 1]?.map((ele) => ele.referenceId ?? ele.id)"
+													class="w-full mb-2 mt-2"
+												/>
+											</template>
+										</td>
+									</tr>
+								</tbody>
 							</table>
 						</template>
 						<Dropdown
@@ -92,27 +94,31 @@
 					<AccordionTab header="Additional fields">
 						<table>
 							<thead class="p-datatable-thead">
-								<th>Units</th>
-								<th>Number of particles</th>
-								<th>Number of iterations</th>
-								<th>Solver method</th>
+								<tr>
+									<th>Units</th>
+									<th>Number of particles</th>
+									<th>Number of iterations</th>
+									<th>Solver method</th>
+								</tr>
 							</thead>
 							<tbody class="p-datatable-tbody">
-								<td>Steps</td>
-								<td>
-									<tera-input-number v-model="knobs.extra.numParticles" />
-								</td>
-								<td>
-									<tera-input-number v-model="knobs.extra.numIterations" />
-								</td>
-								<td>
-									<Dropdown
-										class="p-inputtext-sm"
-										:options="['dopri5', 'euler']"
-										v-model="knobs.extra.solverMethod"
-										placeholder="Select"
-									/>
-								</td>
+								<tr>
+									<td>Steps</td>
+									<td>
+										<tera-input-number v-model="knobs.extra.numParticles" />
+									</td>
+									<td>
+										<tera-input-number v-model="knobs.extra.numIterations" />
+									</td>
+									<td>
+										<Dropdown
+											class="p-inputtext-sm"
+											:options="['dopri5', 'euler']"
+											v-model="knobs.extra.solverMethod"
+											placeholder="Select"
+										/>
+									</td>
+								</tr>
 							</tbody>
 						</table>
 					</AccordionTab>
@@ -396,15 +402,6 @@ watch(
 </script>
 
 <style scoped>
-.row-header {
-	display: flex;
-	flex-direction: column;
-}
-
-.row-header td {
-	margin: 1rem 0;
-}
-
 .tera-ensemble {
 	background: white;
 	z-index: 1;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -47,27 +47,29 @@
 						<p class="subheader">Map the variables from the models to the ensemble variables.</p>
 						<template v-if="ensembleConfigs.length > 0">
 							<table class="w-full mb-2">
-								<tr>
-									<th>Ensemble variables</th>
-									<th v-for="(element, i) in listModelLabels" :key="i">
-										{{ element }}
-									</th>
-								</tr>
+								<tbody>
+									<tr>
+										<th>Ensemble variables</th>
+										<th v-for="(element, i) in listModelLabels" :key="i">
+											{{ element }}
+										</th>
+									</tr>
 
-								<tr v-for="key in Object.keys(ensembleConfigs[0].solutionMappings)" :key="key">
-									<td>{{ key }}</td>
-									<td v-for="config in ensembleConfigs" :key="config.id">
-										<Dropdown
-											class="w-full"
-											:options="allModelOptions[config.id]"
-											v-model="config.solutionMappings[key]"
-											placeholder="Select a variable"
-										/>
-									</td>
-									<td>
-										<Button class="p-button-sm" icon="pi pi-times" rounded text @click="deleteMapping(key)" />
-									</td>
-								</tr>
+									<tr v-for="key in Object.keys(ensembleConfigs[0].solutionMappings)" :key="key">
+										<td>{{ key }}</td>
+										<td v-for="config in ensembleConfigs" :key="config.id">
+											<Dropdown
+												class="w-full"
+												:options="allModelOptions[config.id]"
+												v-model="config.solutionMappings[key]"
+												placeholder="Select a variable"
+											/>
+										</td>
+										<td>
+											<Button class="p-button-sm" icon="pi pi-times" rounded text @click="deleteMapping(key)" />
+										</td>
+									</tr>
+								</tbody>
 							</table>
 						</template>
 						<section class="add-mapping">
@@ -124,22 +126,26 @@
 						<p class="subheader">Set the time span and number of samples for the ensemble simulation.</p>
 						<table class="w-full">
 							<thead class="p-datatable-thead">
-								<th>Units</th>
-								<th>Start Step</th>
-								<th>End Step</th>
-								<th>Number of Samples</th>
+								<tr>
+									<th>Units</th>
+									<th>Start Step</th>
+									<th>End Step</th>
+									<th>Number of Samples</th>
+								</tr>
 							</thead>
 							<tbody class="p-datatable-tbody">
-								<td class="w-2">Steps</td>
-								<td>
-									<tera-input-number class="w-full" v-model="timeSpan.start" />
-								</td>
-								<td>
-									<tera-input-number class="w-full" v-model="timeSpan.end" />
-								</td>
-								<td>
-									<tera-input-number class="w-full" v-model="numSamples" />
-								</td>
+								<tr>
+									<td class="w-2">Steps</td>
+									<td>
+										<tera-input-number class="w-full" v-model="timeSpan.start" />
+									</td>
+									<td>
+										<tera-input-number class="w-full" v-model="timeSpan.end" />
+									</td>
+									<td>
+										<tera-input-number class="w-full" v-model="numSamples" />
+									</td>
+								</tr>
 							</tbody>
 						</table>
 					</AccordionTab>


### PR DESCRIPTION
### Summary
There are about a dozen warnings of invalid HTML in the ensemble operators - This PR just aims to clean things up so other potentially more serious problems are not getting hidden because of these.

e.g.
```
5:29:28 p.m. [vite] warning: <td> cannot be child of <tbody>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
139|  									<tera-input-number class="w-full" v-model="timeSpan.start" />
140|  								</td>
141|  								<td>
   |          ^^^^
142|  									<tera-input-number class="w-full" v-model="timeSpan.end" />
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
143|  								</td>
   |  ^^^^^^^^^^^^^
  Plugin: vite:vue
  File: /Users/dchang/workspace/askem/Terarium/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
5
```