### PR TITLE
Ts/4904 calibrate timestamp field UI tweak

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -52,7 +52,7 @@ export const CalibrationOperationCiemss: Operation = {
 		const init: CalibrationOperationStateCiemss = {
 			method: 'dopri5',
 			chartSettings: [],
-			mapping: [{ modelVariable: '', datasetVariable: '' }],
+			mapping: [{ modelVariable: 'timestamp', datasetVariable: '' }],
 			simulationsInProgress: [],
 			currentProgress: 0,
 			inProgressPreForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -30,11 +30,54 @@
 							dataset.
 						</p>
 
-						<!-- Mapping table: Other variables -->
-						<DataTable class="mapping-table" :value="mapping">
+						<!-- Mapping table: Time variables -->
+						<DataTable
+							v-if="mapping.find((ele) => ele.modelVariable === 'timestamp')"
+							class="mapping-table"
+							:value="mapping.filter((ele) => ele.modelVariable === 'timestamp')"
+						>
 							<Column field="modelVariable">
 								<template #header>
-									<span class="column-header">Model variables</span>
+									<span class="column-header">Model: Timeline variable</span>
+								</template>
+								<template #body="{ data, field }">
+									<Dropdown
+										class="w-full"
+										:placeholder="mappingDropdownPlaceholder"
+										v-model="data[field]"
+										:disabled="true"
+										:options="modelStateOptions?.map((ele) => ele.referenceId ?? ele.id)"
+									/>
+								</template>
+							</Column>
+							<Column field="datasetVariable">
+								<template #header>
+									<span class="column-header">Dataset: Timeline variable</span>
+								</template>
+								<template #body="{ data, field }">
+									<Dropdown
+										class="w-full"
+										:placeholder="mappingDropdownPlaceholder"
+										v-model="data[field]"
+										:options="datasetColumns?.map((ele) => ele.name)"
+									/>
+								</template>
+							</Column>
+							<Column field="deleteRow">
+								<template #header>
+									<span class="column-header"></span>
+								</template>
+								<template #body="{ index }">
+									<Button class="p-button-sm p-button-text" icon="pi pi-trash" @click="deleteMapRow(index)" />
+								</template>
+							</Column>
+						</DataTable>
+
+						<!-- Mapping table: Other variables -->
+						<DataTable class="mapping-table" :value="mapping.filter((ele) => ele.modelVariable !== 'timestamp')">
+							<Column field="modelVariable">
+								<template #header>
+									<span class="column-header">Model: Other variables</span>
 								</template>
 								<template #body="{ data, field }">
 									<Dropdown
@@ -47,7 +90,7 @@
 							</Column>
 							<Column field="datasetVariable">
 								<template #header>
-									<span class="column-header">Dataset variables</span>
+									<span class="column-header">Dataset: Other variables</span>
 								</template>
 								<template #body="{ data, field }">
 									<Dropdown
@@ -1147,7 +1190,7 @@ th {
 .column-header {
 	color: var(--text-color-primary);
 	font-size: var(--font-body-small);
-	font-weight: var(--font-weight);
+	font-weight: var(--font-weight-semibold);
 	padding-top: var(--gap-2);
 }
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -1050,6 +1050,16 @@ const initialize = async () => {
 	datasetColumns.value = datasetOptions;
 
 	getConfiguredModelConfig();
+
+	// look for timestamp col in dataset if its not yet filled in.
+	const timeCol = datasetColumns.value?.find((ele) => ele.name.startsWith('time'));
+	if (timeCol) {
+		for (let i = 0; i < mapping.value.length; i++) {
+			if (mapping.value[i].modelVariable === 'timestamp' && mapping.value[i].datasetVariable === '') {
+				mapping.value[i].datasetVariable = timeCol.name;
+			}
+		}
+	}
 };
 
 const onSaveAsModelConfiguration = async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -25,7 +25,10 @@
 					<!-- Mapping section -->
 					<div class="form-section">
 						<h5 class="mb-1">Mapping</h5>
-						<p class="mb-2">Map model variables to dataset columns. Don't forget the timeline variable.</p>
+						<p class="mb-2">
+							Select a subset of output variables of the model and individually assosiate them to columns in the
+							dataset.
+						</p>
 
 						<!-- Mapping table: Other variables -->
 						<DataTable class="mapping-table" :value="mapping">


### PR DESCRIPTION
# Description
Goal: To have calibration mapping easier to follow and fill in

-add a mapping for timestamp on state init
-Include timestamp mapping section in its own datatable as per design.
-Try to fill in any missing timestamp's mapping on initialize with a very rough string match

# Pictures
![image](https://github.com/user-attachments/assets/dcbc1788-e5e6-416b-9d86-f8b4a03c2eae)


# Draft due to:
Delete will now need to be distinct for each map just need to tweak that