### PR TITLE
fix simulate preset selection not triggering update

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -255,11 +255,11 @@ const codeText = ref('');
 const policyInterventionId = computed(() => props.node.inputs[1].value?.[0]);
 const interventionPolicy = ref<InterventionPolicy | null>(null);
 
-const timespan = ref<TimeSpan>(props.node.state.currentTimespan);
 const llmThoughts = ref<any[]>([]);
 const llmQuery = ref('');
 
-// extras
+// input params
+const timespan = ref<TimeSpan>(props.node.state.currentTimespan);
 const numSamples = ref<number>(props.node.state.numSamples);
 const method = ref(props.node.state.method);
 
@@ -268,12 +268,12 @@ enum OutputView {
 	Data = 'Data'
 }
 
-const speedValues = Object.freeze({
+const speedPreset = Object.freeze({
 	numSamples: 10,
 	method: CiemssMethodOptions.euler
 });
 
-const qualityValues = Object.freeze({
+const qualityPreset = Object.freeze({
 	numSamples: 100,
 	method: CiemssMethodOptions.dopri5
 });
@@ -315,10 +315,10 @@ const outputs = computed(() => {
 });
 
 const presetType = computed(() => {
-	if (numSamples.value === speedValues.numSamples && method.value === speedValues.method) {
+	if (numSamples.value === speedPreset.numSamples && method.value === speedPreset.method) {
 		return CiemssPresetTypes.Fast;
 	}
-	if (numSamples.value === qualityValues.numSamples && method.value === qualityValues.method) {
+	if (numSamples.value === qualityPreset.numSamples && method.value === qualityPreset.method) {
 		return CiemssPresetTypes.Normal;
 	}
 
@@ -338,13 +338,14 @@ const chartProxy = chartActionsProxy(props.node, (state: SimulateCiemssOperation
 
 const setPresetValues = (data: CiemssPresetTypes) => {
 	if (data === CiemssPresetTypes.Normal) {
-		numSamples.value = qualityValues.numSamples;
-		method.value = qualityValues.method;
+		numSamples.value = qualityPreset.numSamples;
+		method.value = qualityPreset.method;
 	}
 	if (data === CiemssPresetTypes.Fast) {
-		numSamples.value = speedValues.numSamples;
-		method.value = speedValues.method;
+		numSamples.value = speedPreset.numSamples;
+		method.value = speedPreset.method;
 	}
+	updateState();
 };
 
 const groupedInterventionOutputs = computed(() => _.groupBy(interventionPolicy.value?.interventions, 'appliedTo'));
@@ -413,18 +414,16 @@ const run = async () => {
 
 const makeForecastRequest = async () => {
 	const modelConfigId = props.node.inputs[0].value?.[0];
-	const state = props.node.state;
-
 	const payload: SimulationRequest = {
 		modelConfigId,
 		timespan: {
-			start: state.currentTimespan.start,
-			end: state.currentTimespan.end
+			start: timespan.value.start,
+			end: timespan.value.end
 		},
 		extra: {
-			solver_method: state.method,
+			solver_method: method.value,
 			solver_step_size: 1,
-			num_samples: state.numSamples
+			num_samples: numSamples.value
 		},
 		engine: 'ciemss'
 	};


### PR DESCRIPTION
### Summary
Change the order of variable updates for presets to take effect


### Testing
- Select a model with some parameter value variability (with lower/upper bound not equal). 
- Hook up model => model-config => simulate
- Run "normal" simulation, then run "fast" simulation, it should be obvious the two runs are different as the former has significantly more samples than the latter.

Fixes: https://github.com/DARPA-ASKEM/terarium/issues/4848