### PR TITLE
remove seemingly unnecessary onUpdated hook that is causing emit opti…

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-node.vue
@@ -7,10 +7,10 @@
 </template>
 
 <script setup lang="ts">
+import { watch, ref } from 'vue';
 import Button from 'primevue/button';
 import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
-import { onMounted, ref } from 'vue';
 import { ModelOperationState } from '@/components/workflow/ops/model/model-operation';
 import { getModel } from '@/services/model';
 import { Model } from '@/types/Types';
@@ -30,5 +30,12 @@ const updateModel = async () => {
 		model.value = await getModel(modelId);
 	}
 };
-onMounted(updateModel);
+
+watch(
+	() => props.node.active,
+	() => {
+		updateModel();
+	},
+	{ immediate: true }
+);
 </script>

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-node.vue
@@ -10,7 +10,7 @@
 import Button from 'primevue/button';
 import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
-import { onMounted, onUpdated, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import { ModelOperationState } from '@/components/workflow/ops/model/model-operation';
 import { getModel } from '@/services/model';
 import { Model } from '@/types/Types';
@@ -31,5 +31,4 @@ const updateModel = async () => {
 	}
 };
 onMounted(updateModel);
-onUpdated(updateModel);
 </script>


### PR DESCRIPTION
### Summary 
The onUpdated life hook seem to be invoked excessively and break the workflow with dozens of JS-errors about emitOptions.

```
TypeError: Cannot read properties of null (reading 'emitsOptions')
    at shouldUpdateComponent (main-D6Jm0a4N.js:16:49752)
    at hu (main-D6Jm0a4N.js:16:37244)
    at uu (main-D6Jm0a4N.js:16:36880)
    at Us (main-D6Jm0a4N.js:16:32744)
    at du (main-D6Jm0a4N.js:16:35960)
    at su (main-D6Jm0a4N.js:16:35132)
    at tu (main-D6Jm0a4N.js:16:33486)
    at Us (main-D6Jm0a4N.js:16:32708)
    at ReactiveEffect.jp [as fn] (main-D6Jm0a4N.js:16:37875)
    at ReactiveEffect.run (main-D6Jm0a4N.js:9:2226)
```

### Testing
With `yarn staging` to connect to staging data, goto `https://app.staging.terarium.ai/projects/a9d892c8-7ed0-4589-b286-49ef15b71c52/workflow/42c0f2d4-b24b-41e8-b5e2-6efc800b4367`, should not see any emitOption errors and workflow should function as normal.