### PR TITLE
Add base64 decode/encode to model description

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -30,13 +30,14 @@ import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
+import Editor from 'primevue/editor';
 import { FeatureConfig } from '@/types/common';
 import type { Dataset, Model } from '@/types/Types';
 import TeraModelDiagram from '@/components/model/petrinet/model-diagrams/tera-model-diagram.vue';
 import TeraModelEquation from '@/components/model/petrinet/tera-model-equation.vue';
-import { isDataset, isModel, type Asset } from '@/utils/asset';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
-import Editor from 'primevue/editor';
+import { isDataset, isModel, type Asset } from '@/utils/asset';
+import { b64DecodeUnicode, b64EncodeUnicode } from '@/utils/binary';
 
 const props = defineProps<{
 	model: Model;
@@ -53,13 +54,13 @@ const relatedTerariumModels = computed(() => relatedTerariumArtifacts.value.filt
 const relatedTerariumDatasets = computed(() => relatedTerariumArtifacts.value.filter((d) => isDataset(d)) as Dataset[]);
 
 // Editor for the description
-const editorContent = ref(props.model?.metadata?.description ?? '');
+const editorContent = ref(b64DecodeUnicode(props.model?.metadata?.description ?? ''));
 
 watch(editorContent, () => {
 	if (editorContent.value !== props.model?.metadata?.description) {
 		const updatedModel: Model = {
 			...props.model,
-			metadata: { ...props.model.metadata, description: editorContent.value }
+			metadata: { ...props.model.metadata, description: b64EncodeUnicode(editorContent.value) }
 		};
 		emit('update-model', updatedModel);
 	}
@@ -69,7 +70,7 @@ watch(
 	() => props.model?.metadata?.description,
 	(newDescription) => {
 		if (newDescription !== editorContent.value) {
-			editorContent.value = newDescription ?? '';
+			editorContent.value = b64DecodeUnicode(newDescription ?? '');
 		}
 	}
 );


### PR DESCRIPTION
This pull request includes several changes to the `tera-model-description.vue` component to enhance the handling of model descriptions by introducing base64 encoding and decoding. The key changes involve importing necessary utility functions, updating the editor content initialization, and modifying the watch function to ensure consistent encoding and decoding of the model descriptions.

### Enhancements to model description handling:

* [`packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue`](diffhunk://#diff-37bb08775f7fb2755f7c1843e1bb763eadfb08f535faf6a4962809fc91bc0f4bR33-R40): Imported `b64DecodeUnicode` and `b64EncodeUnicode` from `@/utils/binary` to handle encoding and decoding of model descriptions.
* [`packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue`](diffhunk://#diff-37bb08775f7fb2755f7c1843e1bb763eadfb08f535faf6a4962809fc91bc0f4bL56-R63): Updated `editorContent` initialization to decode the description using `b64DecodeUnicode`.
* [`packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue`](diffhunk://#diff-37bb08775f7fb2755f7c1843e1bb763eadfb08f535faf6a4962809fc91bc0f4bL56-R63): Modified the `watch` function to encode the description using `b64EncodeUnicode` before updating the model.
* [`packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue`](diffhunk://#diff-37bb08775f7fb2755f7c1843e1bb763eadfb08f535faf6a4962809fc91bc0f4bL72-R73): Adjusted the `watch` function to decode the new description using `b64DecodeUnicode` before assigning it to `editorContent`.# Description