### PR TITLE
Renaming model save edit too

### DIFF
--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -20,7 +20,13 @@
 				placeholder="Title of new model"
 			/>
 			<div v-if="isNaming" class="flex flex-nowrap ml-1 mr-3">
-				<Button icon="pi pi-check" rounded text @click="updateModelName" />
+				<Button
+					icon="pi pi-check"
+					rounded
+					text
+					@click="updateModelName"
+					title="This will rename the model and save all current changes."
+				/>
 			</div>
 		</template>
 		<template #edit-buttons v-if="!featureConfig.isPreview">
@@ -196,6 +202,7 @@ async function updateModelName() {
 		temporaryModel.value.header.name = newName.value;
 	}
 	isRenaming.value = false;
+	onSave();
 }
 
 function updateTemporaryModel(newModel: Model) {


### PR DESCRIPTION
This pull request includes changes to the `tera-model.vue` component to enhance user experience by adding a tooltip and ensuring that changes are saved when renaming a model.

* Added a tooltip to the rename button to inform users that renaming the model will save all current changes.
* Modified the `updateModelName` function to call `onSave()` after renaming the model, ensuring that all changes are saved.