### PR TITLE
Remove provenance from test

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -435,7 +435,7 @@ watch(
 				observableSemanticList: _.cloneDeep(baseConfig.observableSemanticList),
 				parameterSemanticList: [],
 				initialSemanticList: _.cloneDeep(baseConfig.initialSemanticList),
-				inferredParameterList: inferredParameters,
+				inferredParameterList: _.cloneDeep(inferredParameters),
 				temporary: true
 			};
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -435,7 +435,7 @@ watch(
 				observableSemanticList: _.cloneDeep(baseConfig.observableSemanticList),
 				parameterSemanticList: [],
 				initialSemanticList: _.cloneDeep(baseConfig.initialSemanticList),
-				inferredParameterList: _.cloneDeep(inferredParameters),
+				inferredParameterList: inferredParameters,
 				temporary: true
 			};
 

--- a/testing/manual/dataset-enrichment.md
+++ b/testing/manual/dataset-enrichment.md
@@ -33,7 +33,7 @@ Report any issues into GitHub: [open an issue](https://github.com/DARPA-ASKEM/te
 ### 4. Test dataset enrichment with a document
 1. Open the duplicated dataset
 2. Enrich the description with a document
-3. __Expected Result__: Column information is updated with more details (description, concept, unit, etc) and the link to the document (`SIR.pdf`) is added to the `Provenance` section.
+3. __Expected Result__: Column information is updated with more details (description, concept, unit, etc)
 4. __Expected Result__: the rows should be enriched as:
 
 | ID | Name | Description                                                                                                                                            | Concept                        | Unit       | Datatype | Stats                              |


### PR DESCRIPTION
# Description

I do not see this section in the test anywhere I am assuming this is just out of date?
Maybe i am also just missing it on the page?
https://app.staging.terarium.ai/projects/f8501b9d-31ab-4551-bdef-c8e8cd3c7491/dataset/5f916cb1-5ee6-4cb0-9b34-3e520ba7fa0c

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/56fbb2e5-7496-4a1c-afb1-3a0fdba7d741">
