### PR TITLE
multiple input field open when selecting one

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
@@ -113,6 +113,19 @@ const docText = ref<string | null>();
 const isFetchingPDF = ref(false);
 const clonedState = ref(cloneDeep(props.node.state));
 
+function updateOutputPort() {
+	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
+	if (!outputPort) return;
+	outputPort.value = [
+		{
+			...outputPort.value?.[0],
+			equations: clonedState.value.equations
+		}
+	];
+
+	emit('append-output', outputPort);
+}
+
 onMounted(async () => {
 	if (props.node.state.documentId) {
 		isFetchingPDF.value = true;
@@ -143,12 +156,11 @@ onMounted(async () => {
 						return asset;
 					})
 				);
-			// .map((equation, index) => equation.name = `equation ${index+1}`)
 		}
 		if (equations.value && equations.value?.length > 0) {
 			clonedState.value.equations = equations.value;
 		}
-
+		updateOutputPort();
 		isFetchingPDF.value = false;
 	}
 });
@@ -164,6 +176,7 @@ function onUpdateInclude(asset: AssetBlock<DocumentExtraction>) {
 
 	outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
 	if (!outputPort) return;
+	console.log('clonedState.value[portType]', clonedState.value[portType]);
 	outputPort.value = [
 		{
 			...outputPort.value?.[0],

--- a/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
@@ -113,19 +113,6 @@ const docText = ref<string | null>();
 const isFetchingPDF = ref(false);
 const clonedState = ref(cloneDeep(props.node.state));
 
-function updateOutputPort() {
-	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
-	if (!outputPort) return;
-	outputPort.value = [
-		{
-			...outputPort.value?.[0],
-			equations: clonedState.value.equations
-		}
-	];
-
-	emit('append-output', outputPort);
-}
-
 onMounted(async () => {
 	if (props.node.state.documentId) {
 		isFetchingPDF.value = true;
@@ -160,7 +147,6 @@ onMounted(async () => {
 		if (equations.value && equations.value?.length > 0) {
 			clonedState.value.equations = equations.value;
 		}
-		updateOutputPort();
 		isFetchingPDF.value = false;
 	}
 });
@@ -176,7 +162,6 @@ function onUpdateInclude(asset: AssetBlock<DocumentExtraction>) {
 
 	outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
 	if (!outputPort) return;
-	console.log('clonedState.value[portType]', clonedState.value[portType]);
 	outputPort.value = [
 		{
 			...outputPort.value?.[0],

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -257,8 +257,8 @@ onMounted(async () => {
 
 		const state = cloneDeep(props.node.state);
 
-		state.equations = equations.map((e) => ({
-			name: e.name,
+		state.equations = equations.map((e, index) => ({
+			name: `${e.name} ${index}`,
 			includeInProcess: e.includeInProcess,
 			asset: { text: e.asset.metadata.text }
 		}));

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -347,8 +347,9 @@ function updateNodeLabel(id: string, label: string) {
 function getEquations() {
 	const newEquations = multipleEquations.value.split('\n');
 	newEquations.forEach((equation) => {
+		const index = clonedState.value.equations.length;
 		clonedState.value.equations.push({
-			name: 'Equation',
+			name: `Equation ${index}`,
 			includeInProcess: true,
 			asset: {
 				text: equation

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -1,6 +1,7 @@
 <template>
 	<tera-drilldown
 		:node="node"
+		v-bind="$attrs"
 		@update:selection="onSelection"
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"


### PR DESCRIPTION
# Description

Issue:
When a user clicks on an equation, all of the equations input field appear. This is due to the equations all sharing the same name:

Change:
Add the array index of the equation to the name parameter.

Testing:
Add 2 equations using the add equation field and select one of the equations. Only one input field should appear.

![image](https://github.com/user-attachments/assets/5366d922-649d-4e4b-b4d7-9244f38a866c)
![image](https://github.com/user-attachments/assets/e9fa7eed-f094-4a84-85da-8f4935be07ff)


Resolves #(issue)
