### PR TITLE
Fix bug on grouping interventions

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -458,7 +458,7 @@ import { displayNumber } from '@/utils/number';
 import TeraPyciemssCancelButton from '@/components/pyciemss/tera-pyciemss-cancel-button.vue';
 import TeraSaveSimulationModal from '@/components/project/tera-save-simulation-modal.vue';
 import { useClientEvent } from '@/composables/useClientEvent';
-import { getInterventionPolicyById } from '@/services/intervention-policy';
+import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import TeraInterventionSummaryCard from '@/components/workflow/ops/simulate-ciemss/tera-intervention-summary-card.vue';
 import { getParameters } from '@/model-representation/service';
 import type { CalibrationOperationStateCiemss } from './calibrate-operation';
@@ -690,7 +690,9 @@ const preparedChartInputs = computed(() => {
 	};
 });
 
-const groupedInterventionOutputs = computed(() => _.groupBy(interventionPolicy.value?.interventions, 'appliedTo'));
+const groupedInterventionOutputs = computed(() =>
+	_.groupBy(flattenInterventionData(interventionPolicy.value?.interventions ?? []), 'appliedTo')
+);
 
 const preparedCharts = computed(() => {
 	if (!preparedChartInputs.value) return {};

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -66,7 +66,7 @@ import { createDatasetFromSimulationResult } from '@/services/dataset';
 import { useProjects } from '@/composables/project';
 import { fetchAnnotations } from '@/services/chart-settings';
 import { useClientEvent } from '@/composables/useClientEvent';
-import { getInterventionPolicyById } from '@/services/intervention-policy';
+import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import type { CalibrationOperationStateCiemss } from './calibrate-operation';
 import { CalibrationOperationCiemss } from './calibrate-operation';
 import { renameFnGenerator, mergeResults } from './calibrate-utils';
@@ -137,7 +137,9 @@ onMounted(async () => updateLossChartWithSimulation());
 
 let pyciemssMap: Record<string, string> = {};
 
-const groupedInterventionOutputs = computed(() => _.groupBy(interventionPolicy.value?.interventions, 'appliedTo'));
+const groupedInterventionOutputs = computed(() =>
+	_.groupBy(flattenInterventionData(interventionPolicy.value?.interventions ?? []), 'appliedTo')
+);
 
 const preparedCharts = computed(() => {
 	const state = props.node.state;

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -115,15 +115,13 @@
 								<ul>
 									<li
 										class="pb-2"
-										v-for="intervention in knobs.transientInterventionPolicy.interventions"
+										v-for="intervention in getInterventionsAppliedTo(appliedTo)"
 										:key="intervention.name"
 									>
 										<h6 class="pb-1">{{ intervention.name }}</h6>
-										<ul v-if="!isEmpty(intervention.staticInterventions.filter((i) => i.appliedTo === appliedTo))">
+										<ul v-if="!isEmpty(intervention.staticInterventions)">
 											<li
-												v-for="staticIntervention in intervention.staticInterventions.filter(
-													(i) => i.appliedTo === appliedTo
-												)"
+												v-for="staticIntervention in intervention.staticInterventions"
 												:key="staticIntervention.timestep"
 											>
 												<p>
@@ -132,13 +130,12 @@
 												</p>
 											</li>
 										</ul>
-										<p v-else-if="!isEmpty(intervention.dynamicInterventions.find((i) => i.appliedTo === appliedTo))">
-											Set {{ intervention.dynamicInterventions.find((i) => i.appliedTo === appliedTo)?.type }}
-											{{ appliedTo }} to
-											{{ intervention.dynamicInterventions.find((i) => i.appliedTo === appliedTo)?.value }} when the
-											{{ intervention.dynamicInterventions.find((i) => i.appliedTo === appliedTo)?.parameter }}
+										<p v-else-if="!isEmpty(intervention.dynamicInterventions)">
+											Set {{ intervention.dynamicInterventions[0].type }} {{ appliedTo }} to
+											{{ intervention.dynamicInterventions[0].value }} when the
+											{{ intervention.dynamicInterventions[0].parameter }}
 											when it crosses the threshold value
-											{{ intervention.dynamicInterventions.find((i) => i.appliedTo === appliedTo)?.threshold }}.
+											{{ intervention.dynamicInterventions[0].threshold }}.
 										</p>
 									</li>
 								</ul>
@@ -305,6 +302,19 @@ const preparedCharts = computed(() =>
 		})
 	)
 );
+
+const getInterventionsAppliedTo = (appliedTo: string) =>
+	knobs.value.transientInterventionPolicy.interventions
+		.map((i) => {
+			const staticInterventions = i.staticInterventions.filter((s) => s.appliedTo === appliedTo);
+			const dynamicInterventions = i.dynamicInterventions.filter((d) => d.appliedTo === appliedTo);
+			return {
+				name: i.name,
+				staticInterventions,
+				dynamicInterventions
+			};
+		})
+		.filter((i) => i.dynamicInterventions.length + i.staticInterventions.length > 0);
 
 const initialize = async (overwriteWithState: boolean = false) => {
 	const state = props.node.state;

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -22,7 +22,7 @@ import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import Button from 'primevue/button';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import _, { cloneDeep, groupBy } from 'lodash';
-import { blankIntervention } from '@/services/intervention-policy';
+import { blankIntervention, flattenInterventionData } from '@/services/intervention-policy';
 import { createInterventionChart } from '@/services/charts';
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import { InterventionPolicyState } from './intervention-policy-operation';
@@ -35,7 +35,9 @@ const props = defineProps<{
 const modelInput = props.node.inputs.find((input) => input.type === 'modelId');
 const isModelInputConnected = computed(() => modelInput?.status === WorkflowPortStatus.CONNECTED);
 
-const groupedOutputParameters = computed(() => groupBy(props.node.state.interventionPolicy.interventions, 'appliedTo'));
+const groupedOutputParameters = computed(() =>
+	groupBy(flattenInterventionData(props.node.state.interventionPolicy.interventions), 'appliedTo')
+);
 
 const preparedCharts = computed(() =>
 	_.mapValues(groupedOutputParameters.value, (interventions, key) =>

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -429,7 +429,7 @@ import { WorkflowNode } from '@/types/workflow';
 import TeraSliderPanel from '@/components/widgets/tera-slider-panel.vue';
 
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
-import { getInterventionPolicyById } from '@/services/intervention-policy';
+import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import TeraCheckbox from '@/components/widgets/tera-checkbox.vue';
 import Divider from 'primevue/divider';
 import Accordion from 'primevue/accordion';
@@ -911,7 +911,7 @@ const setOutputValues = async () => {
 	optimizeRequestPayload.value = (await getSimulation(knobs.value.optimizationRunId))?.executionPayload || '';
 };
 
-const preProcessedInterventionsData = computed<Dictionary<Intervention[]>>(() => {
+const preProcessedInterventionsData = computed<Dictionary<ReturnType<typeof flattenInterventionData>>>(() => {
 	// Combine before and after interventions
 	const combinedInterventions = [
 		...knobs.value.interventionPolicyGroups.flatMap((group) => group.intervention),
@@ -919,7 +919,7 @@ const preProcessedInterventionsData = computed<Dictionary<Intervention[]>>(() =>
 	];
 
 	// Group by appliedTo
-	return _.groupBy(combinedInterventions, 'appliedTo');
+	return _.groupBy(flattenInterventionData(combinedInterventions), 'appliedTo');
 });
 
 onMounted(async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -238,7 +238,7 @@ import { createForecastChart, createInterventionChartMarkers } from '@/services/
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import { CiemssPresetTypes, DrilldownTabs } from '@/types/common';
 import { getModelConfigurationById } from '@/services/model-configurations';
-import { getInterventionPolicyById } from '@/services/intervention-policy';
+import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import TeraInterventionSummaryCard from '@/components/workflow/ops/simulate-ciemss/tera-intervention-summary-card.vue';
 import TeraSaveSimulationModal from '@/components/project/tera-save-simulation-modal.vue';
 import { SimulateCiemssOperationState } from './simulate-ciemss-operation';
@@ -345,7 +345,9 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 	updateState();
 };
 
-const groupedInterventionOutputs = computed(() => _.groupBy(interventionPolicy.value?.interventions, 'appliedTo'));
+const groupedInterventionOutputs = computed(() =>
+	_.groupBy(flattenInterventionData(interventionPolicy.value?.interventions ?? []), 'appliedTo')
+);
 
 const preparedCharts = computed(() => {
 	if (!selectedRunId.value) return [];

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -44,7 +44,7 @@ import { createForecastChart, createInterventionChartMarkers } from '@/services/
 import { createDatasetFromSimulationResult } from '@/services/dataset';
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import type { InterventionPolicy, Model } from '@/types/Types';
-import { getInterventionPolicyById } from '@/services/intervention-policy';
+import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import { SimulateCiemssOperationState, SimulateCiemssOperation } from './simulate-ciemss-operation';
 
 const props = defineProps<{
@@ -110,8 +110,7 @@ const chartProxy = chartActionsProxy(props.node, (state: SimulateCiemssOperation
 const processResult = async (runId: string) => {
 	const state = _.cloneDeep(props.node.state);
 	if (interventionPolicyId.value && _.isEmpty(state.chartConfigs)) {
-		const groupedInterventions = _.groupBy(interventionPolicy.value?.interventions, 'appliedTo');
-		_.keys(groupedInterventions).forEach((key) => {
+		_.keys(groupedInterventionOutputs.value).forEach((key) => {
 			chartProxy.addChart([key]);
 		});
 	} else if (_.isEmpty(state.chartConfigs)) {
@@ -164,7 +163,9 @@ Provide a summary in 100 words or less.
 		isSelected: false
 	});
 };
-const groupedInterventionOutputs = computed(() => _.groupBy(interventionPolicy.value?.interventions, 'appliedTo'));
+const groupedInterventionOutputs = computed(() =>
+	_.groupBy(flattenInterventionData(interventionPolicy.value?.interventions ?? []), 'appliedTo')
+);
 
 const preparedCharts = computed(() => {
 	if (!selectedRunId.value) return [];

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -2,7 +2,7 @@ import { percentile } from '@/utils/math';
 import { isEmpty, pick } from 'lodash';
 import { VisualizationSpec } from 'vega-embed';
 import { v4 as uuidv4 } from 'uuid';
-import { ChartAnnotation, Intervention } from '@/types/Types';
+import { ChartAnnotation } from '@/types/Types';
 import { flattenInterventionData } from './intervention-policy';
 
 const VEGALITE_SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json';
@@ -765,8 +765,10 @@ interface InterventionChartOptions extends Omit<BaseChartOptions, 'legend'> {
 	hideLabels?: boolean;
 }
 
-export function createInterventionChart(interventions: Intervention[], chartOptions: InterventionChartOptions) {
-	const interventionsData = flattenInterventionData(interventions);
+export function createInterventionChart(
+	interventions: ReturnType<typeof flattenInterventionData>,
+	chartOptions: InterventionChartOptions
+) {
 	const titleObj = chartOptions.title
 		? {
 				text: chartOptions.title,
@@ -785,14 +787,14 @@ export function createInterventionChart(interventions: Intervention[], chartOpti
 		},
 		layer: []
 	};
-	if (!isEmpty(interventionsData)) {
+	if (!isEmpty(interventions)) {
 		// markers
 		createInterventionChartMarkers(interventions, chartOptions.hideLabels).forEach((marker) => {
 			spec.layer.push(marker);
 		});
 		// chart
 		spec.layer.push({
-			data: { values: interventionsData },
+			data: { values: interventions },
 			mark: 'point',
 			encoding: {
 				x: { field: 'time', type: 'quantitative', title: chartOptions.xAxisTitle },

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -730,8 +730,10 @@ export function createSuccessCriteriaChart(
 	};
 }
 
-export function createInterventionChartMarkers(interventions: Intervention[], hideLabels = false): any[] {
-	const data = flattenInterventionData(interventions);
+export function createInterventionChartMarkers(
+	data: ReturnType<typeof flattenInterventionData>,
+	hideLabels = false
+): any[] {
 	const markerSpec = {
 		data: { values: data },
 		mark: { type: 'rule', strokeDash: [4, 4], color: 'black' },


### PR DESCRIPTION
# Description

There was issues in multiple drilldown caused by wrong use of groupBy on intervention array data. 
For example, 
```
interface Intervention {
    name: string;
    staticInterventions: StaticIntervention[];
    dynamicInterventions: DynamicIntervention[];
}
const groupedInterventions = _.groupBy(interventions, 'appliedTo'); // interventions as Intervention[]
```
We were doing groupby 'appliedTo` field while the top level Intervention object doesn't have it. 

In this change, I fixed issues caused by ^ in multiple operators. 

**Simulation operator**

**BEFORE:**
![Screenshot 2024-09-27 at 4 36 50 PM](https://github.com/user-attachments/assets/b2822e72-6464-4da4-a283-e41b1d79e18f)

**AFTER:**
![Screenshot 2024-09-27 at 4 35 54 PM](https://github.com/user-attachments/assets/4a76f167-3831-4f1b-a56a-831c83052b4f)

**Intervention policy operator**

**BEFORE:**
![Screenshot 2024-09-27 at 5 19 39 PM](https://github.com/user-attachments/assets/7fb6c225-a06f-489d-9776-772f8ef35928)
**AFTER:**
![Screenshot 2024-09-27 at 5 09 14 PM](https://github.com/user-attachments/assets/6a927538-920a-4d9d-8520-6d2a9b13e374)




Resolves #(issue)
