### PR TITLE
Remove extractions from document asset n drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -5,111 +5,9 @@
 		:name="document?.name ?? ''"
 		:overline="document?.source ?? ''"
 		@close-preview="emit('close-preview')"
-		:hide-intro="view === DocumentView.PDF"
 		:is-loading="documentLoading"
 	>
-		<template #edit-buttons>
-			<SelectButton
-				:model-value="view"
-				@change="changeView"
-				:options="viewOptions"
-				option-value="value"
-				option-disabled="disabled"
-			>
-				<template #option="{ option }">
-					<i :class="`${option.icon} p-button-icon-left`" />
-					<span class="p-button-label">{{ option.value }}</span>
-				</template>
-			</SelectButton>
-			<Button
-				icon="pi pi-ellipsis-v"
-				class="p-button-icon-only p-button-text p-button-rounded"
-				@click="toggleOptionsMenu"
-			/>
-			<ContextMenu ref="optionsMenu" :model="optionsMenuItems" :popup="true" :pt="optionsMenuPt" />
-		</template>
-		<Accordion v-if="view === DocumentView.EXTRACTIONS" :multiple="true" :active-index="[0, 1, 2, 3, 4, 5, 6, 7]">
-			<!-- Abstract -->
-			<AccordionTab v-if="!isEmpty(formattedAbstract)">
-				<template #header>
-					<header id="Abstract">Abstract</header>
-				</template>
-				<p v-html="formattedAbstract" />
-			</AccordionTab>
-
-			<!-- Figures -->
-			<AccordionTab v-if="!isEmpty(figures)">
-				<template #header>
-					<header id="Figures">
-						Figures<span class="artifact-amount">({{ figures.length }})</span>
-					</header>
-				</template>
-				<ul>
-					<li v-for="(ex, index) in figures" :key="index" class="extracted-item">
-						<Image id="img" class="extracted-image col-4" :src="ex.metadata?.url" :alt="''" preview />
-						<tera-show-more-text
-							v-if="ex.metadata?.content"
-							class="extracted-caption col-7"
-							:text="ex.metadata?.content ?? ''"
-							:lines="previewLineLimit"
-						/>
-						<div v-else class="no-extracted-text">No extracted text</div>
-					</li>
-				</ul>
-			</AccordionTab>
-
-			<!-- Tables -->
-			<AccordionTab v-if="!isEmpty(tables)">
-				<template #header>
-					<header id="Tables">
-						Tables<span class="artifact-amount">({{ tables.length }})</span>
-					</header>
-				</template>
-				<ul>
-					<li v-for="(ex, index) in tables" :key="index" class="extracted-item">
-						<Image id="img" class="extracted-image col-4" :src="ex.metadata?.url" :alt="''" preview />
-						<tera-show-more-text
-							v-if="ex.metadata?.content"
-							class="extracted-caption col-7"
-							:text="ex.metadata?.content ?? ''"
-							:lines="previewLineLimit"
-						/>
-						<div v-else class="no-extracted-text">No extracted text</div>
-					</li>
-				</ul>
-			</AccordionTab>
-
-			<!-- Equations -->
-			<AccordionTab v-if="!isEmpty(equations)">
-				<template #header>
-					<header id="Equations">
-						Equations<span class="artifact-amount">({{ equations.length }})</span>
-					</header>
-				</template>
-				<ul>
-					<li v-for="(ex, index) in equations" :key="index" class="extracted-item">
-						<Image id="img" class="extracted-image col-4" :src="ex.metadata?.url" :alt="''" preview />
-						<tera-show-more-text
-							v-if="ex.metadata?.content"
-							class="extracted-caption col-7"
-							:text="ex.metadata?.content ?? ''"
-							:lines="previewLineLimit"
-						/>
-						<div v-else class="no-extracted-text">No extracted text</div>
-
-						<tera-math-editor v-if="ex.metadata.equation" :latex-equation="ex.metadata.equation" />
-					</li>
-				</ul>
-			</AccordionTab>
-		</Accordion>
-		<p
-			class="pl-3"
-			v-if="
-				isEmpty(document?.assets) && view === DocumentView.EXTRACTIONS && viewOptions[1]?.value === DocumentView.PDF
-			"
-		>
-			PDF Extractions are processing please come back in some time...
-		</p>
+		<p class="pl-3" v-if="documentLoading">PDF Loading...</p>
 		<tera-pdf-embed
 			v-else-if="view === DocumentView.PDF && pdfLink"
 			:pdf-link="pdfLink"
@@ -120,24 +18,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, onUpdated, ref, watch } from 'vue';
-import { isEmpty } from 'lodash';
-import Accordion from 'primevue/accordion';
-import AccordionTab from 'primevue/accordiontab';
+import { onMounted, onUnmounted, onUpdated, ref, watch } from 'vue';
 import type { FeatureConfig, ExtractionStatusUpdate } from '@/types/common';
 import TeraPdfEmbed from '@/components/widgets/tera-pdf-embed.vue';
 import TeraAsset from '@/components/asset/tera-asset.vue';
 import type { ClientEvent, DocumentAsset } from '@/types/Types';
-import { AssetType, ClientEventType, ExtractionAssetType, ProgressState } from '@/types/Types';
+import { ClientEventType, ProgressState } from '@/types/Types';
 import { downloadDocumentAsset, getDocumentAsset, getDocumentFileAsText } from '@/services/document-assets';
-import Image from 'primevue/image';
-import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
-import SelectButton from 'primevue/selectbutton';
-import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
-import { useProjects } from '@/composables/project';
-import { logger } from '@/utils/logger';
-import Button from 'primevue/button';
-import ContextMenu from 'primevue/contextmenu';
 import { subscribe, unsubscribe } from '@/services/ClientEventService';
 import TeraTextEditor from './tera-text-editor.vue';
 
@@ -157,88 +44,11 @@ const emit = defineEmits(['close-preview', 'asset-loaded', 'remove']);
 
 const document = ref<DocumentAsset | null>(null);
 const pdfLink = ref<string | null>(null);
-const view = ref(DocumentView.EXTRACTIONS);
-
-const extractionsOption = { value: DocumentView.EXTRACTIONS, icon: 'pi pi-list' };
-const pdfOption = { value: DocumentView.PDF, icon: 'pi pi-file-pdf' };
-const txtOption = { value: DocumentView.TXT, icon: 'pi pi-file' };
-const notFoundOption = { value: DocumentView.NOT_FOUND, icon: 'pi pi-file', disabled: true };
-
-const changeView = (event) => {
-	if (event.value) {
-		view.value = event.value;
-	}
-};
-
-const viewOptions = computed(() => {
-	const options: { value: DocumentView; icon: string; disabled?: boolean }[] = [extractionsOption];
-	const isPdf = document.value?.fileNames?.some((file) => file.endsWith('.pdf')) ?? false;
-
-	if (isPdf) {
-		options.push({ ...pdfOption, disabled: documentLoading.value });
-	} else if (docText.value) {
-		options.push({ ...txtOption, disabled: documentLoading.value });
-	} else {
-		options.push(notFoundOption);
-	}
-	return options;
-});
+const view = ref(DocumentView.PDF);
 
 const docText = ref<string | null>(null);
 
 const documentLoading = ref(false);
-
-const figures = computed(
-	() => document.value?.assets?.filter((asset) => asset.assetType === ExtractionAssetType.Figure) || []
-);
-const tables = computed(
-	() => document.value?.assets?.filter((asset) => asset.assetType === ExtractionAssetType.Table) || []
-);
-const equations = computed(
-	() => document.value?.assets?.filter((asset) => asset.assetType === ExtractionAssetType.Equation) || []
-);
-
-const optionsMenu = ref();
-const optionsMenuItems = ref([
-	{
-		icon: 'pi pi-plus',
-		label: 'Add to project',
-		items:
-			useProjects()
-				.allProjects.value?.filter((project) => project.id !== useProjects().activeProject.value?.id)
-				.map((project) => ({
-					label: project.name,
-					command: async () => {
-						const response = await useProjects().addAsset(AssetType.Document, props.assetId, project.id);
-						if (response) logger.info(`Added asset to ${project.name}`);
-					}
-				})) ?? []
-	},
-	{
-		icon: 'pi pi-download',
-		label: 'Download',
-		command: async () => {
-			if (pdfLink.value) {
-				const link = window.document.createElement('a');
-				link.href = pdfLink.value;
-				link.download = document.value?.name ?? 'document.pdf';
-				link.click();
-				URL.revokeObjectURL(link.href);
-			}
-			emit('close-preview');
-		}
-	},
-	{ icon: 'pi pi-trash', label: 'Remove', command: () => emit('remove') }
-]);
-const optionsMenuPt = {
-	submenu: {
-		class: 'max-h-30rem overflow-y-scroll'
-	}
-};
-
-const toggleOptionsMenu = (event) => {
-	optionsMenu.value.toggle(event);
-};
 
 /* TODO: When fetching a document by id, its id and fileNames don't get returned.
  Once they do see about adjusting the conditionals */
@@ -246,7 +56,7 @@ watch(
 	() => props.assetId,
 	async () => {
 		if (props.assetId) {
-			view.value = DocumentView.EXTRACTIONS;
+			view.value = DocumentView.PDF;
 			pdfLink.value = null;
 			documentLoading.value = true;
 			document.value = await getDocumentAsset(props.assetId);
@@ -278,8 +88,6 @@ watch(
 	},
 	{ immediate: true }
 );
-
-const formattedAbstract = computed<string>(() => document.value?.documentAbstract ?? '');
 
 onUpdated(() => {
 	if (document.value) {

--- a/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
@@ -9,7 +9,7 @@
 				<tera-pdf-embed v-if="pdfLink" :pdf-link="pdfLink" :title="document?.name || ''" />
 				<tera-text-editor v-else-if="docText" :initial-text="docText" />
 			</tera-drilldown-section>
-			<tera-drilldown-preview hide-header class="pt-3 pl-2 pr-4 pb-3">
+			<!-- <tera-drilldown-preview hide-header class="pt-3 pl-2 pr-4 pb-3">
 				<h5>{{ document?.name }}</h5>
 				<Accordion multiple :active-index="[0, 1, 2]">
 					<AccordionTab v-if="!isEmpty(clonedState.equations)">
@@ -74,31 +74,31 @@
 				<template #footer?>
 					<Button label="Close" @click="emit('close')" />
 				</template>
-			</tera-drilldown-preview>
+			</tera-drilldown-preview> -->
 		</tera-columnar-panel>
 	</tera-drilldown>
 </template>
 
 <script setup lang="ts">
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import { AssetBlock, WorkflowNode, WorkflowOutput } from '@/types/workflow';
-import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
+import { AssetBlock, WorkflowNode } from '@/types/workflow';
+// import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
-import Button from 'primevue/button';
+// import Button from 'primevue/button';
 import TeraPdfEmbed from '@/components/widgets/tera-pdf-embed.vue';
 import { onMounted, ref, watch } from 'vue';
 import { ExtractionAssetType } from '@/types/Types';
 import type { DocumentAsset, DocumentExtraction } from '@/types/Types';
 import { downloadDocumentAsset, getDocumentAsset, getDocumentFileAsText } from '@/services/document-assets';
-import { cloneDeep, isEmpty } from 'lodash';
-import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
-import Image from 'primevue/image';
-import Accordion from 'primevue/accordion';
-import AccordionTab from 'primevue/accordiontab';
+import { cloneDeep } from 'lodash';
+// import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
+// import Image from 'primevue/image';
+// import Accordion from 'primevue/accordion';
+// import AccordionTab from 'primevue/accordiontab';
 import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
-import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
+// import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
 import TeraColumnarPanel from '@/components/widgets/tera-columnar-panel.vue';
-import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
+// import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
 import { DocumentOperationState } from './document-operation';
 
 const emit = defineEmits(['close', 'update-state', 'append-output']);
@@ -151,45 +151,45 @@ onMounted(async () => {
 	}
 });
 
-function onUpdateInclude(asset: AssetBlock<DocumentExtraction>) {
-	asset.includeInProcess = !asset.includeInProcess;
-	emit('update-state', clonedState.value);
+// function onUpdateInclude(asset: AssetBlock<DocumentExtraction>) {
+// 	asset.includeInProcess = !asset.includeInProcess;
+// 	emit('update-state', clonedState.value);
 
-	let outputPort: WorkflowOutput<DocumentOperationState> | null = null;
+// 	let outputPort: WorkflowOutput<DocumentOperationState> | null = null;
 
-	const portType = assetTypeToPortType(asset.asset.assetType);
-	if (!portType) return;
+// 	const portType = assetTypeToPortType(asset.asset.assetType);
+// 	if (!portType) return;
 
-	outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
-	if (!outputPort) return;
-	outputPort.value = [
-		{
-			...outputPort.value?.[0],
-			[portType]: clonedState.value[portType]
-		}
-	];
+// 	outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
+// 	if (!outputPort) return;
+// 	outputPort.value = [
+// 		{
+// 			...outputPort.value?.[0],
+// 			[portType]: clonedState.value[portType]
+// 		}
+// 	];
 
-	emit('append-output', outputPort);
-}
+// 	emit('append-output', outputPort);
+// }
 
-function assetTypeToPortType(assetType: ExtractionAssetType) {
-	switch (assetType) {
-		case ExtractionAssetType.Equation:
-			return 'equations';
-		case ExtractionAssetType.Figure:
-			return 'figures';
-		case ExtractionAssetType.Table:
-			return 'tables';
-		default:
-			return null;
-	}
-}
+// function assetTypeToPortType(assetType: ExtractionAssetType) {
+// 	switch (assetType) {
+// 		case ExtractionAssetType.Equation:
+// 			return 'equations';
+// 		case ExtractionAssetType.Figure:
+// 			return 'figures';
+// 		case ExtractionAssetType.Table:
+// 			return 'tables';
+// 		default:
+// 			return null;
+// 	}
+// }
 // since AWS links expire we need to use the refetched document image urls to display the images
-function getAssetUrl(asset: AssetBlock<DocumentExtraction>): string {
-	const foundAsset = document.value?.assets?.find((a) => a.fileName === asset.asset.fileName);
-	if (!foundAsset) return '';
-	return foundAsset.metadata?.url;
-}
+// function getAssetUrl(asset: AssetBlock<DocumentExtraction>): string {
+// 	const foundAsset = document.value?.assets?.find((a) => a.fileName === asset.asset.fileName);
+// 	if (!foundAsset) return '';
+// 	return foundAsset.metadata?.url;
+// }
 
 watch(
 	() => props.node.state,

--- a/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/document/tera-document-operation-drilldown.vue
@@ -9,96 +9,20 @@
 				<tera-pdf-embed v-if="pdfLink" :pdf-link="pdfLink" :title="document?.name || ''" />
 				<tera-text-editor v-else-if="docText" :initial-text="docText" />
 			</tera-drilldown-section>
-			<!-- <tera-drilldown-preview hide-header class="pt-3 pl-2 pr-4 pb-3">
-				<h5>{{ document?.name }}</h5>
-				<Accordion multiple :active-index="[0, 1, 2]">
-					<AccordionTab v-if="!isEmpty(clonedState.equations)">
-						<template #header>
-							<header>Equation images</header>
-						</template>
-						<tera-asset-block
-							v-for="(equation, i) in clonedState.equations"
-							:key="i"
-							:is-toggleable="false"
-							:is-included="equation.includeInProcess"
-							@update:is-included="onUpdateInclude(equation)"
-							class="mb-2"
-						>
-							<template #default>
-								<tera-math-editor
-									v-if="equation.asset?.metadata?.text"
-									:latex-equation="equation.asset?.metadata?.text"
-									:is-editable="false"
-								/>
-							</template>
-						</tera-asset-block>
-					</AccordionTab>
-					<AccordionTab v-if="!isEmpty(clonedState.figures)">
-						<template #header>
-							<header>Figure images</header>
-						</template>
-						<tera-asset-block
-							v-for="(figure, i) in clonedState.figures"
-							:key="i"
-							:is-included="figure.includeInProcess"
-							@update:is-included="onUpdateInclude(figure)"
-							class="mb-2"
-						>
-							<template #header>
-								<h5>{{ figure.name }}</h5>
-							</template>
-							<Image id="img" :src="getAssetUrl(figure)" :alt="''" preview />
-						</tera-asset-block>
-					</AccordionTab>
-					<AccordionTab v-if="!isEmpty(clonedState.tables)">
-						<template #header>
-							<header>Table images</header>
-						</template>
-						<tera-asset-block
-							v-for="(table, i) in clonedState.tables"
-							:key="i"
-							:is-included="table.includeInProcess"
-							@update:is-included="onUpdateInclude(table)"
-							class="mb-2"
-						>
-							<template #header>
-								<h5>{{ table.name }}</h5>
-							</template>
-							<Image id="img" :src="getAssetUrl(table)" :alt="''" preview />
-						</tera-asset-block>
-					</AccordionTab>
-					<AccordionTab v-if="!isEmpty(document?.text)" header="Text">
-						<tera-show-more-text :text="document?.text ?? ''" :lines="5" />
-					</AccordionTab>
-				</Accordion>
-				<template #footer?>
-					<Button label="Close" @click="emit('close')" />
-				</template>
-			</tera-drilldown-preview> -->
 		</tera-columnar-panel>
 	</tera-drilldown>
 </template>
 
 <script setup lang="ts">
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import { AssetBlock, WorkflowNode } from '@/types/workflow';
-// import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
+import { WorkflowNode } from '@/types/workflow';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
-// import Button from 'primevue/button';
 import TeraPdfEmbed from '@/components/widgets/tera-pdf-embed.vue';
-import { onMounted, ref, watch } from 'vue';
-import { ExtractionAssetType } from '@/types/Types';
-import type { DocumentAsset, DocumentExtraction } from '@/types/Types';
+import { onMounted, ref } from 'vue';
+import type { DocumentAsset } from '@/types/Types';
 import { downloadDocumentAsset, getDocumentAsset, getDocumentFileAsText } from '@/services/document-assets';
-import { cloneDeep } from 'lodash';
-// import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
-// import Image from 'primevue/image';
-// import Accordion from 'primevue/accordion';
-// import AccordionTab from 'primevue/accordiontab';
 import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
-// import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
 import TeraColumnarPanel from '@/components/widgets/tera-columnar-panel.vue';
-// import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
 import { DocumentOperationState } from './document-operation';
 
 const emit = defineEmits(['close', 'update-state', 'append-output']);
@@ -107,11 +31,9 @@ const props = defineProps<{
 }>();
 
 const document = ref<DocumentAsset | null>();
-const equations = ref<AssetBlock<DocumentExtraction>[]>();
 const pdfLink = ref<string | null>();
 const docText = ref<string | null>();
 const isFetchingPDF = ref(false);
-const clonedState = ref(cloneDeep(props.node.state));
 
 onMounted(async () => {
 	if (props.node.state.documentId) {
@@ -126,81 +48,7 @@ onMounted(async () => {
 				docText.value = await getDocumentFileAsText(document.value.id, filename);
 			}
 		}
-		if (document.value?.metadata?.equations) {
-			equations.value = document.value.metadata.equations
-				.filter((pages) => pages.length)
-				.flatMap((page) =>
-					page.map((equation) => {
-						const asset: AssetBlock<DocumentExtraction> = {
-							name: 'Equation',
-							includeInProcess: false,
-							asset: {
-								fileName: filename ?? '',
-								assetType: ExtractionAssetType.Equation,
-								metadata: { text: equation }
-							}
-						};
-						return asset;
-					})
-				);
-		}
-		if (equations.value && equations.value?.length > 0) {
-			clonedState.value.equations = equations.value;
-		}
 		isFetchingPDF.value = false;
 	}
 });
-
-// function onUpdateInclude(asset: AssetBlock<DocumentExtraction>) {
-// 	asset.includeInProcess = !asset.includeInProcess;
-// 	emit('update-state', clonedState.value);
-
-// 	let outputPort: WorkflowOutput<DocumentOperationState> | null = null;
-
-// 	const portType = assetTypeToPortType(asset.asset.assetType);
-// 	if (!portType) return;
-
-// 	outputPort = cloneDeep(props.node.outputs?.find((port) => port.type === 'documentId')) || null;
-// 	if (!outputPort) return;
-// 	outputPort.value = [
-// 		{
-// 			...outputPort.value?.[0],
-// 			[portType]: clonedState.value[portType]
-// 		}
-// 	];
-
-// 	emit('append-output', outputPort);
-// }
-
-// function assetTypeToPortType(assetType: ExtractionAssetType) {
-// 	switch (assetType) {
-// 		case ExtractionAssetType.Equation:
-// 			return 'equations';
-// 		case ExtractionAssetType.Figure:
-// 			return 'figures';
-// 		case ExtractionAssetType.Table:
-// 			return 'tables';
-// 		default:
-// 			return null;
-// 	}
-// }
-// since AWS links expire we need to use the refetched document image urls to display the images
-// function getAssetUrl(asset: AssetBlock<DocumentExtraction>): string {
-// 	const foundAsset = document.value?.assets?.find((a) => a.fileName === asset.asset.fileName);
-// 	if (!foundAsset) return '';
-// 	return foundAsset.metadata?.url;
-// }
-
-watch(
-	() => props.node.state,
-	() => {
-		clonedState.value = cloneDeep(props.node.state);
-	},
-	{ deep: true }
-);
 </script>
-<style scoped>
-.p-panel:deep(.p-panel-footer) {
-	display: none;
-}
-</style>

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -270,20 +270,18 @@ onMounted(async () => {
 		if (state.equations.length) return;
 
 		if (document.value?.metadata?.equations) {
-			documentEquations.value = document.value.metadata.equations
-				.filter((pages) => pages.length)
-				.flatMap((page) =>
-					page.map((equation) => {
-						const asset: AssetBlock<EquationBlock> = {
-							name: 'Equation',
-							includeInProcess: false,
-							asset: {
-								text: equation
-							}
-						};
-						return asset;
-					})
-				);
+			documentEquations.value = document.value.metadata.equations.flatMap((page) =>
+				page.map((equation) => {
+					const asset: AssetBlock<EquationBlock> = {
+						name: 'Equation',
+						includeInProcess: false,
+						asset: {
+							text: equation
+						}
+					};
+					return asset;
+				})
+			);
 		}
 		if (documentEquations.value && documentEquations.value?.length > 0) {
 			clonedState.value.equations = documentEquations.value;

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -53,7 +53,11 @@
 										:class="selectedItem === equation.name ? 'currenly-selected' : 'asset-panel'"
 									>
 										<section>
-											<Checkbox v-model="equation.includeInProcess" :binary="true" />
+											<Checkbox
+												v-model="equation.includeInProcess"
+												@update:model-value="onCheckBoxChange(equation)"
+												:binary="true"
+											/>
 											<div class="block-container">
 												<tera-math-editor
 													v-if="equation.asset.text"
@@ -89,7 +93,11 @@
 										:class="selectedItem === equation.name ? 'currenly-selected' : 'asset-panel'"
 									>
 										<section>
-											<Checkbox v-model="equation.includeInProcess" :binary="true" />
+											<Checkbox
+												v-model="equation.includeInProcess"
+												@update:model-value="onCheckBoxChange(equation)"
+												:binary="true"
+											/>
 											<div class="block-container">
 												<tera-math-editor
 													v-if="equation.asset.text"
@@ -173,7 +181,7 @@ import TeraSliderPanel from '@/components/widgets/tera-slider-panel.vue';
 import TeraPdfEmbed from '@/components/widgets/tera-pdf-embed.vue';
 import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
-import { ModelFromEquationsState } from './model-from-equations-operation';
+import { ModelFromEquationsState, EquationBlock } from './model-from-equations-operation';
 
 const emit = defineEmits(['close', 'update-state', 'append-output', 'select-output', 'update-output-port']);
 const props = defineProps<{
@@ -231,6 +239,8 @@ const isDocViewerOpen = ref(true);
 const isInputOpen = ref(true);
 const isOutputOpen = ref(true);
 
+const documentEquations = ref<AssetBlock<EquationBlock>[]>();
+
 onMounted(async () => {
 	clonedState.value = cloneDeep(props.node.state);
 	if (selectedOutputId.value) {
@@ -257,12 +267,34 @@ onMounted(async () => {
 		isFetchingPDF.value = false;
 
 		const state = cloneDeep(props.node.state);
+		if (state.equations.length) return;
+
+		if (document.value?.metadata?.equations) {
+			documentEquations.value = document.value.metadata.equations
+				.filter((pages) => pages.length)
+				.flatMap((page) =>
+					page.map((equation) => {
+						const asset: AssetBlock<EquationBlock> = {
+							name: 'Equation',
+							includeInProcess: false,
+							asset: {
+								text: equation
+							}
+						};
+						return asset;
+					})
+				);
+		}
+		if (documentEquations.value && documentEquations.value?.length > 0) {
+			clonedState.value.equations = documentEquations.value;
+		}
 
 		state.equations = equations.map((e, index) => ({
 			name: `${e.name} ${index}`,
 			includeInProcess: e.includeInProcess,
 			asset: { text: e.asset.metadata.text }
 		}));
+
 		state.text = document.value?.text ?? '';
 		emit('update-state', state);
 	}
@@ -273,6 +305,13 @@ onMounted(async () => {
 const onSelection = (id: string) => {
 	emit('select-output', id);
 };
+
+function onCheckBoxChange(equation) {
+	const state = cloneDeep(props.node.state);
+	const index = state.equations.findIndex((e) => e.name === equation.name);
+	state.equations[index].includeInProcess = equation.includeInProcess;
+	emit('update-state', state);
+}
 
 async function onRun() {
 	const equations = clonedState.value.equations


### PR DESCRIPTION
# Description

Design Change: 
- Remove the extraction from the document viewer and document drill down
- Only enable extractions in the drill down 

Testing:
- Opening a PDF document from the resources panel or  drill down the extraction option should not appear
- When opening Model from Equations, all extracted equations should appear here

![image](https://github.com/user-attachments/assets/b16cb165-7489-499b-9ed4-0ce59197fd8f)
![image](https://github.com/user-attachments/assets/dee06484-69f6-4737-ba52-c045f2e15688)


Resolves #(issue)
