### PR TITLE
Update tera-stratification-group-form to remove Max 100

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -19,10 +19,7 @@
 			/>
 		</div>
 		<div class="input-row">
-			<label>
-				Enter a comma separated list of labels for each group.
-				<span class="subdued-text">(Max 100)</span>
-			</label>
+			<label>Enter a comma separated list of labels for each group.</label>
 			<tera-input-text v-model="labels" placeholder="e.g., Young, Old" @focusout="emit('update-self', updatedConfig)" />
 		</div>
 		<div class="input-row">


### PR DESCRIPTION
This pull request includes a small change to the `tera-stratification-group-form.vue` file. The change simplifies the label for entering a comma-separated list of labels by removing the additional text about the maximum number of labels.