### PR TITLE
Add llm prompt to generated code

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
@@ -92,7 +92,7 @@ const hideAutoComplete = ref(false);
 
 const contextLanguageOptions = ref<string[]>(['python3', 'julia-1.10']);
 
-const addQuestionToCode = (question, code) => `# ${question}\n\n${code}`;
+const addQuestionToCode = (question, code) => `\n# Prompt: ${question}\n\n${code}`;
 
 const submitQuestion = () => {
 	const message = props.kernelManager.sendMessage('llm_request', {

--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
@@ -92,7 +92,7 @@ const hideAutoComplete = ref(false);
 
 const contextLanguageOptions = ref<string[]>(['python3', 'julia-1.10']);
 
-const addQuestionToCode = (question, code) => `\n# Prompt: ${question}\n\n${code}`;
+const addQuestionToCode = (question, code) => `\n# Prompt: ${question}\n\n${code}\n# End: =================`;
 
 const submitQuestion = () => {
 	const message = props.kernelManager.sendMessage('llm_request', {

--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
@@ -92,6 +92,8 @@ const hideAutoComplete = ref(false);
 
 const contextLanguageOptions = ref<string[]>(['python3', 'julia-1.10']);
 
+const addQuestionToCode = (question, code) => `# ${question}\n\n${code}`;
+
 const submitQuestion = () => {
 	const message = props.kernelManager.sendMessage('llm_request', {
 		request: questionString.value
@@ -103,6 +105,7 @@ const submitQuestion = () => {
 		kernelStatus.value = data.content.execution_state;
 	});
 	message.register('code_cell', (data) => {
+		data.content.code = addQuestionToCode(questionString.value, data.content.code);
 		emit('llm-output', data);
 	});
 	message.register('llm_thought', (data) => {


### PR DESCRIPTION
# Description

Add the LLM prompt to the beginning of the code generated

Testing: After generating the code, the prompt should appear at the top of the generated code

![image](https://github.com/user-attachments/assets/1ad731ff-30b6-43ad-b290-9800f2e9204b)

Resolves #(issue)
