### PR TITLE
fix with equations not appearing

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -283,13 +283,13 @@ onMounted(async () => {
 			);
 		}
 		if (documentEquations.value && documentEquations.value?.length > 0) {
-			clonedState.value.equations = documentEquations.value;
-
-			state.equations = documentEquations.value.map((e, index) => ({
+			clonedState.value.equations = documentEquations.value.map((e, index) => ({
 				name: `${e.name} ${index}`,
 				includeInProcess: e.includeInProcess,
 				asset: { text: e.asset.text }
 			}));
+
+			state.equations = clonedState.value.equations;
 		}
 
 		state.text = document.value?.text ?? '';

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -163,7 +163,7 @@ import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.
 import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
 import { computed, onMounted, ref, watch } from 'vue';
 import { downloadDocumentAsset, getDocumentAsset, getDocumentFileAsText } from '@/services/document-assets';
-import type { Card, DocumentAsset, DocumentExtraction, Model } from '@/types/Types';
+import type { Card, DocumentAsset, Model } from '@/types/Types';
 import { cloneDeep, isEmpty } from 'lodash';
 import { equationsToAMR, type EquationsToAMRRequest } from '@/services/knowledge';
 import Button from 'primevue/button';
@@ -248,7 +248,6 @@ onMounted(async () => {
 	}
 
 	const documentId = props.node.inputs?.[0]?.value?.[0]?.documentId;
-	const equations: AssetBlock<DocumentExtraction>[] = props.node.inputs?.[0]?.value?.[0]?.equations;
 
 	assetLoading.value = true;
 	if (documentId) {
@@ -285,18 +284,17 @@ onMounted(async () => {
 		}
 		if (documentEquations.value && documentEquations.value?.length > 0) {
 			clonedState.value.equations = documentEquations.value;
-		}
 
-		state.equations = equations.map((e, index) => ({
-			name: `${e.name} ${index}`,
-			includeInProcess: e.includeInProcess,
-			asset: { text: e.asset.metadata.text }
-		}));
+			state.equations = documentEquations.value.map((e, index) => ({
+				name: `${e.name} ${index}`,
+				includeInProcess: e.includeInProcess,
+				asset: { text: e.asset.text }
+			}));
+		}
 
 		state.text = document.value?.text ?? '';
 		emit('update-state', state);
 	}
-
 	assetLoading.value = false;
 });
 


### PR DESCRIPTION
# Description

Issue
- The equations after starting a new project and uploading a new doc would not appear. This was caused by assigning the equations to a unused ref

Testing:
- Open a new project and upload a new PDF.
- Add doc to workflow and connect model from equation node
- open node and the extracted equations should appear

![image](https://github.com/user-attachments/assets/3867b811-75ca-4516-bafb-b3e3a57c3a76)

Resolves #(issue)
