### PR TITLE
Rename update output port

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/code-asset/tera-code-asset-wrapper.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/code-asset/tera-code-asset-wrapper.vue
@@ -25,14 +25,14 @@ const props = defineProps<{
 	node: WorkflowNode<CodeAssetState>;
 }>();
 
-const emit = defineEmits(['close', 'update-output-port', 'update-state']);
+const emit = defineEmits(['close', 'update-output', 'update-state']);
 
 async function onApplyChanges(code: Code) {
 	const outputPort = cloneDeep(props.node.outputs[0]);
 	if (!code || !outputPort) return;
 	const blocks = await getCodeBlocks(code);
 	outputPort.label = `${code.name} code blocks (${blocks.length})`;
-	emit('update-output-port', outputPort);
+	emit('update-output', outputPort);
 }
 </script>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -205,7 +205,7 @@ const props = defineProps<{
 	node: WorkflowNode<InterventionPolicyState>;
 }>();
 
-const emit = defineEmits(['close', 'update-state', 'select-output', 'append-output', 'update-output-port']);
+const emit = defineEmits(['close', 'update-state', 'select-output', 'append-output']);
 
 const confirm = useConfirm();
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -263,7 +263,7 @@ const isEditingDescription = ref(false);
 const newDescription = ref('');
 const descriptionTextareaRef = ref<ComponentPublicInstance<typeof Textarea> | null>(null);
 
-const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close', 'update-output-port']);
+const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
 
 interface BasicKnobs {
 	transientModelConfig: ModelConfiguration;
@@ -676,7 +676,7 @@ const resetConfiguration = () => {
 const updateThoughts = (data: any) => {
 	llmThoughts.value.push(data);
 	const llmResponse = llmThoughts.value.findLast((thought) => thought?.msg_type === 'llm_response');
-	// If the last thought is an llm response, update the notebook response
+	// If the last thought is a LLM response, update the notebook response
 	if (llmResponse) {
 		notebookResponse.value = llmResponse.content.text;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit.vue
@@ -132,7 +132,7 @@ import { ModelEditOperationState, ModelEditOperation } from './model-edit-operat
 const props = defineProps<{
 	node: WorkflowNode<ModelEditOperationState>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output', 'update-output-port']);
+const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output', 'update-output']);
 
 const outputs = computed(() => {
 	if (!isEmpty(props.node.outputs)) {
@@ -404,7 +404,7 @@ function updateNode(model: Model) {
 	if (!outputPort) return;
 	outputPort.label = model.header.name;
 
-	emit('update-output-port', outputPort);
+	emit('update-output', outputPort);
 }
 
 onMounted(async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -149,7 +149,6 @@
 		:asset="selectedModel"
 		:is-visible="showSaveModelModal"
 		@close-modal="onCloseModelModal"
-		@on-save="onAddModel"
 	/>
 </template>
 
@@ -183,7 +182,7 @@ import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import { ModelFromEquationsState, EquationBlock } from './model-from-equations-operation';
 
-const emit = defineEmits(['close', 'update-state', 'append-output', 'select-output', 'update-output']);
+const emit = defineEmits(['close', 'update-state', 'append-output', 'select-output']);
 const props = defineProps<{
 	node: WorkflowNode<ModelFromEquationsState>;
 }>();
@@ -364,20 +363,8 @@ async function fetchModel() {
 	loadingModel.value = false;
 }
 
-function onAddModel(model: Model) {
-	if (!model?.name || !selectedOutputId.value) return;
-	updateNodeLabel(selectedOutputId.value, model.name);
-}
-
 function onCloseModelModal() {
 	showSaveModelModal.value = false;
-}
-
-function updateNodeLabel(id: string, label: string) {
-	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.id === id));
-	if (!outputPort) return;
-	outputPort.label = label;
-	emit('update-output', outputPort);
 }
 
 function getEquations() {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -183,7 +183,7 @@ import TeraTextEditor from '@/components/documents/tera-text-editor.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import { ModelFromEquationsState, EquationBlock } from './model-from-equations-operation';
 
-const emit = defineEmits(['close', 'update-state', 'append-output', 'select-output', 'update-output-port']);
+const emit = defineEmits(['close', 'update-state', 'append-output', 'select-output', 'update-output']);
 const props = defineProps<{
 	node: WorkflowNode<ModelFromEquationsState>;
 }>();
@@ -377,7 +377,7 @@ function updateNodeLabel(id: string, label: string) {
 	const outputPort = cloneDeep(props.node.outputs?.find((port) => port.id === id));
 	if (!outputPort) return;
 	outputPort.label = label;
-	emit('update-output-port', outputPort);
+	emit('update-output', outputPort);
 }
 
 function getEquations() {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -163,7 +163,7 @@ import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.
 import TeraAssetBlock from '@/components/widgets/tera-asset-block.vue';
 import { computed, onMounted, ref, watch } from 'vue';
 import { downloadDocumentAsset, getDocumentAsset, getDocumentFileAsText } from '@/services/document-assets';
-import type { Card, DocumentAsset, DocumentExtraction, Model } from '@/types/Types';
+import type { Card, DocumentAsset, Model } from '@/types/Types';
 import { cloneDeep, isEmpty } from 'lodash';
 import { equationsToAMR, type EquationsToAMRRequest } from '@/services/knowledge';
 import Button from 'primevue/button';
@@ -248,7 +248,6 @@ onMounted(async () => {
 	}
 
 	const documentId = props.node.inputs?.[0]?.value?.[0]?.documentId;
-	const equations: AssetBlock<DocumentExtraction>[] = props.node.inputs?.[0]?.value?.[0]?.equations;
 
 	assetLoading.value = true;
 	if (documentId) {
@@ -284,19 +283,18 @@ onMounted(async () => {
 			);
 		}
 		if (documentEquations.value && documentEquations.value?.length > 0) {
-			clonedState.value.equations = documentEquations.value;
-		}
+			clonedState.value.equations = documentEquations.value.map((e, index) => ({
+				name: `${e.name} ${index}`,
+				includeInProcess: e.includeInProcess,
+				asset: { text: e.asset.text }
+			}));
 
-		state.equations = equations.map((e, index) => ({
-			name: `${e.name} ${index}`,
-			includeInProcess: e.includeInProcess,
-			asset: { text: e.asset.metadata.text }
-		}));
+			state.equations = clonedState.value.equations;
+		}
 
 		state.text = document.value?.text ?? '';
 		emit('update-state', state);
 	}
-
 	assetLoading.value = false;
 });
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -152,7 +152,7 @@ import { blankStratifyGroup, StratifyGroup, StratifyOperationStateMira } from '.
 const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'close', 'update-output-port', 'select-output']);
+const emit = defineEmits(['append-output', 'update-state', 'close', 'update-output', 'select-output']);
 
 enum StratifyTabs {
 	Wizard = 'Wizard',
@@ -466,7 +466,7 @@ function updateNodeOutput(model: Model) {
 	if (!outputPort) return;
 	outputPort.label = model.header.name;
 
-	emit('update-output-port', outputPort);
+	emit('update-output', outputPort);
 }
 
 // check if user has made changes to the code

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-mira.vue
@@ -110,7 +110,6 @@
 		:initial-name="outputAmr.name"
 		:is-visible="showSaveModelModal"
 		:is-updating-asset="true"
-		@on-save="updateNodeOutput"
 		@close-modal="showSaveModelModal = false"
 	/>
 </template>
@@ -152,7 +151,7 @@ import { blankStratifyGroup, StratifyGroup, StratifyOperationStateMira } from '.
 const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
-const emit = defineEmits(['append-output', 'update-state', 'close', 'update-output', 'select-output']);
+const emit = defineEmits(['append-output', 'update-state', 'close', 'select-output']);
 
 enum StratifyTabs {
 	Wizard = 'Wizard',
@@ -248,7 +247,7 @@ const stratifyModel = () => {
 		concepts_to_stratify: conceptsToStratify,
 		params_to_stratify: parametersToStratify,
 		cartesian_control: strataOption.cartesianProduct,
-		structure: strataOption.useStructure === true ? null : []
+		structure: strataOption.useStructure ? null : []
 	};
 	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
 		kernelManager
@@ -332,10 +331,10 @@ const getStatesAndParameters = (amrModel: Model) => {
 			modelStates.push(o.id);
 		});
 	} else if (modelFramework === AMRSchemaNames.REGNET) {
-		model.vertices.forEach((v) => {
+		model.vertices.forEach((v: any) => {
 			modelStates.push(v.name);
 		});
-		model.parameters.forEach((p) => {
+		model.parameters.forEach((p: any) => {
 			modelParameters.push(p.id);
 		});
 	} else {
@@ -456,18 +455,6 @@ const isSaveDisabled = computed(() => {
 
 	return useProjects().hasAssetInActiveProject(outputPort?.value?.[0]);
 });
-
-function updateNodeOutput(model: Model) {
-	if (!selectedOutputId.value || !model) return;
-
-	amr.value = model;
-	const outputPort = _.cloneDeep(props.node.outputs?.find((port) => port.id === selectedOutputId.value));
-
-	if (!outputPort) return;
-	outputPort.label = model.header.name;
-
-	emit('update-output', outputPort);
-}
 
 // check if user has made changes to the code
 const hasCodeChange = () => {

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -780,7 +780,7 @@ const dist2 = (a: Position, b: Position) => (a.x - b.x) * (a.x - b.x) + (a.y - b
 const threshold2 = 5.0 * 5.0;
 
 /*
- * Relink edges that have become detatched
+ * Relink edges that have become detached
  *
  * [output-port](edge source => edge target)[input-port]
  *
@@ -1008,14 +1008,14 @@ onUnmounted(() => {
 
 <style scoped>
 .toolbar {
+	align-items: center;
+	background-color: var(--surface-transparent);
+	border-bottom: 1px solid var(--surface-border-light);
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	align-items: center;
-	padding: 0.5rem 1rem;
-	border-bottom: 1px solid var(--surface-border-light);
+	padding: var(--gap-2) var(--gap-4);
 	z-index: 900;
-	background-color: var(--surface-transparent);
 }
 
 .glass {
@@ -1023,15 +1023,15 @@ onUnmounted(() => {
 }
 
 .button-group {
-	display: flex;
 	align-items: center;
+	display: flex;
 	flex-direction: row;
-	gap: var(--gap-small);
+	gap: var(--gap-2);
 }
 
 .rename-workflow {
-	display: flex;
 	align-items: center;
+	display: flex;
 	flex-wrap: nowrap;
 }
 </style>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -153,17 +153,17 @@
 	<Teleport to="body">
 		<component
 			v-if="dialogIsOpened && currentActiveNode"
+			:downstream-operators-nav="downstreamOperatorsNav"
 			:is="registry.getDrilldown(currentActiveNode.operationType)"
 			:node="currentActiveNode"
-			:upstream-operators-nav="upstreamOperatorsNav"
-			:downstream-operators-nav="downstreamOperatorsNav"
 			:spawn-animation="drilldownSpawnAnimation"
+			:upstream-operators-nav="upstreamOperatorsNav"
+			@close="addOperatorToRoute(null)"
 			@append-output="(event: any) => appendOutput(currentActiveNode, event)"
+			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
+			@update-output="(event: any) => updateOutput(currentActiveNode, event)"
 			@update-state="(event: any) => updateWorkflowNodeState(currentActiveNode, event)"
 			@update-status="(status: OperatorStatus) => updateWorkflowNodeStatus(currentActiveNode, status)"
-			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
-			@close="addOperatorToRoute(null)"
-			@update-output-port="(event: any) => updateOutput(currentActiveNode, event)"
 		/>
 	</Teleport>
 </template>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -163,7 +163,7 @@
 			@update-status="(status: OperatorStatus) => updateWorkflowNodeStatus(currentActiveNode, status)"
 			@select-output="(event: any) => selectOutput(currentActiveNode, event)"
 			@close="addOperatorToRoute(null)"
-			@update-output-port="(event: any) => updateOutputPort(currentActiveNode, event)"
+			@update-output-port="(event: any) => updateOutput(currentActiveNode, event)"
 		/>
 	</Teleport>
 </template>
@@ -409,9 +409,9 @@ function selectOutput(node: WorkflowNode<any> | null, selectedOutputId: string) 
 	saveWorkflowHandler();
 }
 
-function updateOutputPort(node: WorkflowNode<any> | null, workflowOutput: WorkflowOutput<any>) {
+function updateOutput(node: WorkflowNode<any> | null, workflowOutput: WorkflowOutput<any>) {
 	if (!node) return;
-	workflowService.updateOutputPort(node, workflowOutput);
+	workflowService.updateOutput(node, workflowOutput);
 	saveWorkflowHandler();
 }
 

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -807,10 +807,16 @@ export function getActiveOutput(node: WorkflowNode<any>) {
 	return node.outputs.find((o) => o.id === node.active);
 }
 
-export function updateOutputPort(node: WorkflowNode<any>, updatedOutputPort: WorkflowOutput<any>) {
-	let outputPort = node.outputs.find((port) => port.id === updatedOutputPort.id);
-	if (!outputPort) return;
-	outputPort = Object.assign(outputPort, updatedOutputPort);
+/**
+ * Update the output of a node referenced by the output id
+ * @param node
+ * @param updatedOutput
+ */
+export function updateOutput(node: WorkflowNode<any>, updatedOutput: WorkflowOutput<any>) {
+	const foundOutput = node.outputs.find((output) => output.id === updatedOutput.id);
+	if (foundOutput) {
+		Object.assign(foundOutput, updatedOutput);
+	}
 }
 
 // Check if the current-state matches that of the output-state.


### PR DESCRIPTION
This pull request includes several changes focused on standardizing the event names in the `tera` components and improving code clarity. The changes primarily involve renaming the `update-output-port` event to `update-output` across various components and updating related function names accordingly.

Event name standardization:

* [`tera-code-asset-wrapper.vue`](diffhunk://#diff-87c6953826aa0eda7464920fac516185b0b9b8360e86d3053c702ce7a070f7b7L28-R35): Renamed the event `update-output-port` to `update-output` and updated the corresponding emit call in the `onApplyChanges` function.
* [`tera-intervention-policy-drilldown.vue`](diffhunk://#diff-54c31526a779022f9231558c720e27ce9e02ed6da5df3ff490e94bd8bc891248L208-R208): Removed the `update-output-port` event from the `defineEmits` call.
* [`tera-model-config-drilldown.vue`](diffhunk://#diff-9c14e9c321bc9b9b31d04842da2fdcbe723be5b0cbb908af74463564add63cceL266-R266): Removed the `update-output-port` event from the `defineEmits` call.
* [`ptera-model-edit.vue`](diffhunk://#diff-0a13f09762f1288ac204699953f96297a5753d282dd381ca4e4bc1bbb589af7fL135-R135): Renamed the event `update-output-port` to `update-output` and updated the corresponding emit call in the `updateNode` function. [[1]](diffhunk://#diff-0a13f09762f1288ac204699953f96297a5753d282dd381ca4e4bc1bbb589af7fL135-R135) [[2]](diffhunk://#diff-0a13f09762f1288ac204699953f96297a5753d282dd381ca4e4bc1bbb589af7fL407-R407)
* [`era-model-from-equations-drilldown.vue`](diffhunk://#diff-2f796b404e2219b0045f6ee5141b6caa46be4372ebd0720307afca92e0b412f2L186-R186): Renamed the event `update-output-port` to `update-output` and updated the corresponding emit call in the `updateNodeLabel` function. [[1]](diffhunk://#diff-2f796b404e2219b0045f6ee5141b6caa46be4372ebd0720307afca92e0b412f2L186-R186) [[2]](diffhunk://#diff-2f796b404e2219b0045f6ee5141b6caa46be4372ebd0720307afca92e0b412f2L380-R380)
* [`tera-stratify-mira.vue`](diffhunk://#diff-a458f50e7b6b63c930542f560b14920df8e46d18f5c02237dee5ab394fbcdc94L155-R155): Renamed the event `update-output-port` to `update-output` and updated the corresponding emit call in the `updateNodeOutput` function. [[1]](diffhunk://#diff-a458f50e7b6b63c930542f560b14920df8e46d18f5c02237dee5ab394fbcdc94L155-R155) [[2]](diffhunk://#diff-a458f50e7b6b63c930542f560b14920df8e46d18f5c02237dee5ab394fbcdc94L469-R469)

Code clarity improvements:

* [`tera-workflow.vue`](diffhunk://#diff-3ce4d75a5f0d2a6e1ece0fde9f65c23749895a1e2143a101bde090f7a908be76R156-L166): Updated the component bindings and event handlers to use `update-output` instead of `update-output-port`. [[1]](diffhunk://#diff-3ce4d75a5f0d2a6e1ece0fde9f65c23749895a1e2143a101bde090f7a908be76R156-L166) [[2]](diffhunk://#diff-3ce4d75a5f0d2a6e1ece0fde9f65c23749895a1e2143a101bde090f7a908be76L412-R414)
* [`services/workflow.ts`](diffhunk://#diff-b982e1f4bbcd8bca4c8812281c0bdb0b90cca4937e0b83547f3053daf02f0e74L810-R819): Updated the function `updateOutputPort` to `updateOutput` and modified the implementation to use the new event name.