### PR TITLE
ux equation style change

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -241,7 +241,6 @@ onMounted(async () => {
 			}
 		}
 		isFetchingPDF.value = false;
-
 		const state = cloneDeep(props.node.state);
 		if (state.equations.length) return;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -49,7 +49,7 @@
 									:class="['asset-panel', { selected: selectedItem === equation.name }]"
 								>
 									<template #header>
-										<h6>{{ equation.name }} - Page({{ equation.asset.pageNumber }})</h6>
+										<h6>Page ({{ equation.asset.pageNumber }})</h6>
 									</template>
 									<section>
 										<Checkbox
@@ -87,7 +87,7 @@
 									:class="['asset-panel', { selected: selectedItem === equation.name }]"
 								>
 									<template #header>
-										<h6>{{ equation.name }} - Page({{ equation.asset.pageNumber }})</h6>
+										<h6>Page ({{ equation.asset.pageNumber }})</h6>
 									</template>
 									<section>
 										<Checkbox
@@ -224,6 +224,9 @@ onMounted(async () => {
 	const documentId = props.node.inputs?.[0]?.value?.[0]?.documentId;
 
 	assetLoading.value = true;
+	if (!selectedModel.value) {
+		isOutputOpen.value = false;
+	}
 	if (documentId) {
 		document.value = await getDocumentAsset(documentId);
 
@@ -238,6 +241,7 @@ onMounted(async () => {
 			}
 		}
 		isFetchingPDF.value = false;
+
 		const state = cloneDeep(props.node.state);
 		if (state.equations.length) return;
 


### PR DESCRIPTION
# Description

Design change:
- Have the Output Panel close when drill down is open and model has not been run.
- remove equation name but leave page number

![image](https://github.com/user-attachments/assets/61650cea-de90-4c16-be16-b92cb9718bd6)


Resolves #(issue)
