### PR TITLE
Fixed scroll weirdness

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
@@ -109,6 +109,7 @@ aside {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	overflow-y: auto;
 }
 
 header {


### PR DESCRIPTION
# Description

Before:
<img width="361" alt="Screenshot 2024-10-03 at 2 50 47 PM" src="https://github.com/user-attachments/assets/e9307dda-7c6f-4609-8b72-c9d00bc26308">


After:
<img width="360" alt="Screenshot 2024-10-03 at 2 51 45 PM" src="https://github.com/user-attachments/assets/2415c1cd-768d-4fa0-938e-43f5943d5c1d">

Fixed the issue when chart settings overlay was scrolling along with the content behind it.

Resolves #(issue)
