### PR TITLE
Update the channel where we are grabbing the llm thoughts.

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-notebook-jupyter-input.vue
@@ -110,12 +110,18 @@ const submitQuestion = () => {
 	});
 	message.register('llm_thought', (data) => {
 		thoughts.value = data;
-		llmThoughts.value = [];
+		llmThoughts.value = []; // TODO Should this reset on thought? Or just response?
 		llmThoughts.value.push(data);
 		llmQuery.value = questionString.value;
 		emit('llm-thought-output', data);
 	});
 	message.register('llm_response', (data) => {
+		// Check if our llm_response is providing a response text to a user's question
+		if (data.content.name === 'response_text') {
+			llmThoughts.value = [];
+			llmThoughts.value.push(data);
+			emit('llm-thought-output', data);
+		}
 		thoughts.value = data;
 		emit('llm-thought-output', data);
 	});


### PR DESCRIPTION
# Description
Beaker has been updated to have the thoughts section more based off of the llm thoughts and added a new section for the responses. This means when we ask questions like the screenshot below we were no longer getting the response, we were only getting the thoughts.

Before:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/4164a166-9bf8-492c-be91-12d464340b86">

After:
<img width="609" alt="image" src="https://github.com/user-attachments/assets/d174a4d3-09ad-4db7-9d8f-518342a01e7e">

