### PR TITLE
Fixed the issue that error chart not showing up

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -1172,7 +1172,12 @@ watch(
 			if (!runResult.value.length) return;
 			pyciemssMap.value = parsePyCiemssMap(runResult.value[0]);
 
-			errorData.value = getErrorData(groundTruthData.value, runResult.value, mapping.value);
+			errorData.value = getErrorData(
+				groundTruthData.value,
+				runResult.value,
+				mapping.value,
+				knobs.value.timestampColName
+			);
 		}
 	},
 	{ immediate: true }


### PR DESCRIPTION
# Description

Fixed the issue that error chart wasn't showing up in the calibrate operator drilldown.
The issue was caused because the dataset time column was moved from `mapping` (`CalibrateMap`) to `knobs.value.timestampColName` but `getErrorData` function wasn't updated accordingly. This change fixed the issue.

Resolves #(issue)
