### PR TITLE
Remove code files from resources panel

### DIFF
--- a/packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue
+++ b/packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue
@@ -49,25 +49,22 @@
 			<AccordionTab v-for="[type, assetItems] in assetItemsMap" :key="type">
 				<template #header>
 					<div class="flex justify-space-between w-full">
-						<div class="flex align-items-center w-full">
-							<template v-if="type === AssetType.Document">Documents</template>
-							<template v-else-if="type === AssetType.Code">Code Files</template>
-							<template v-else>{{ capitalize(type) }}s</template>
+						<header class="flex align-items-center w-full">
+							{{ capitalize(type) }}s
 							<aside>({{ assetItems.length }})</aside>
-						</div>
+						</header>
 						<!-- New asset buttons for some types -->
 						<Button
+							v-if="type === AssetType.Model || type === AssetType.Workflow"
 							class="new-button"
-							v-if="type === AssetType.Model || type === AssetType.Code || type === AssetType.Workflow"
 							icon="pi pi-plus"
 							label="New"
-							text
 							size="small"
+							text
 							@click.stop="emit('open-new-asset', type)"
 						/>
 					</div>
 				</template>
-
 				<!-- These are all the resources. They're buttons because they're click and draggable. -->
 				<Button
 					v-for="assetItem in assetItems"
@@ -94,14 +91,13 @@
 							pageType === AssetType.Workflow &&
 							(assetItem.pageType === AssetType.Model ||
 								assetItem.pageType === AssetType.Dataset ||
-								assetItem.pageType === AssetType.Code ||
 								assetItem.pageType === AssetType.Document)
 						"
 						@dragstart="startDrag({ assetId: assetItem.assetId, pageType: assetItem.pageType })"
 						@dragend="endDrag"
 						:class="isEqual(draggedAsset, assetItem) ? 'dragged-asset' : ''"
 						fallback-class="original-asset"
-						:force-fallback="true"
+						force-fallback
 					>
 						<tera-asset-icon :asset-type="assetItem.pageType as AssetType" />
 						<span class="p-button-label">{{ assetItem.assetName }}</span>
@@ -221,7 +217,7 @@ nav {
 	gap: var(--gap-4);
 }
 
-header {
+nav > header {
 	padding-left: var(--gap-2);
 	padding-right: var(--gap-2);
 	display: flex;

--- a/packages/client/hmi-client/src/types/Project.ts
+++ b/packages/client/hmi-client/src/types/Project.ts
@@ -10,9 +10,13 @@ export enum ProjectPages {
  */
 export const listOfVisibleAssetTypes: AssetType[] = Object.values(AssetType).filter(
 	(type) =>
-		![AssetType.Artifact, AssetType.Simulation, AssetType.ModelConfiguration, AssetType.InterventionPolicy].includes(
-			type
-		)
+		![
+			AssetType.Artifact,
+			AssetType.Code,
+			AssetType.Simulation,
+			AssetType.ModelConfiguration,
+			AssetType.InterventionPolicy
+		].includes(type)
 );
 
 /**


### PR DESCRIPTION
This pull request includes changes to the `tera-resource-sidebar.vue` component and the `Project.ts` types to improve the user interface and update asset type handling. The most important changes include simplifying the header template, updating the asset type filtering, and refining the drag-and-drop functionality.

Improvements to user interface:

* [`packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue`](diffhunk://#diff-1125f9c09f1cc74700a2612655a5f2f52aa0fd8a2507aa2ff7a5ad4c087d9033L52-L70): Simplified the header template by removing conditional templates and using a single template with `capitalize(type)` for displaying asset types.
* [`packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue`](diffhunk://#diff-1125f9c09f1cc74700a2612655a5f2f52aa0fd8a2507aa2ff7a5ad4c087d9033L224-R220): Adjusted the CSS selector for the header to apply styles specifically within the `nav` element.

Refinements to asset type handling:

* [`packages/client/hmi-client/src/types/Project.ts`](diffhunk://#diff-115b5268a74e35a66b22749951f9808759fb77a750e93898c5b24529b1bc4ba6L13-R19): Updated the `listOfVisibleAssetTypes` to include `AssetType.Code` in the filtered list.

Enhancements to drag-and-drop functionality:

* [`packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue`](diffhunk://#diff-1125f9c09f1cc74700a2612655a5f2f52aa0fd8a2507aa2ff7a5ad4c087d9033L97-R100): Removed `AssetType.Code` from the conditional check for drag-and-drop compatibility.
* [`packages/client/hmi-client/src/components/project/tera-resource-sidebar.vue`](diffhunk://#diff-1125f9c09f1cc74700a2612655a5f2f52aa0fd8a2507aa2ff7a5ad4c087d9033L97-R100): Simplified the `force-fallback` attribute usage by removing the binding syntax.