### PR TITLE
Move get all projects from home to the whole App

### DIFF
--- a/packages/client/hmi-client/src/App.vue
+++ b/packages/client/hmi-client/src/App.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed, onMounted, watch } from 'vue';
 import Toast from 'primevue/toast';
 
 import { ToastSeverity, ToastSummaries, useToastService } from '@/services/toast';
@@ -53,6 +53,8 @@ API.interceptors.response.use(
 		}
 	}
 );
+
+onMounted(() => useProjects().getAll());
 
 // Update the project when the projectId changes
 watch(

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -161,7 +161,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import Button from 'primevue/button';
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
@@ -329,8 +329,6 @@ const isLoadingProjects = computed(() => !useProjects().allProjects.value);
 function openProject(projectId: string) {
 	router.push({ name: RouteName.Project, params: { projectId } });
 }
-
-onMounted(() => useProjects().getAll());
 
 watch(
 	() => cloningProjects.value,


### PR DESCRIPTION
* [`packages/client/hmi-client/src/App.vue`](diffhunk://#diff-65d7782b56078c5308cd17112762637391e0f43a56c430ce457272e745bba43cR57-R58): Added `onMounted` hook to initialize project data by calling `useProjects().getAll()` when the component mounts.
* [`packages/client/hmi-client/src/page/Home.vue`](diffhunk://#diff-5650009c620454ec91ed900cb36b50a03cd1d8cbee0760c1d7dbccecb1cbb169L333-L334): Removed `onMounted` hook that was previously used to initialize project data, as it is now handled in `App.vue`.