### PR TITLE
Add titles to generated compare models graphs

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/model-comparison-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/model-comparison-operation.ts
@@ -8,6 +8,7 @@ export interface ModelComparisonOperationState extends BaseState {
 	notebookHistory: NotebookHistory[];
 	hasCodeRun: boolean;
 	comparisonImageIds: string[];
+	comparisonPairs: string[][];
 }
 
 export const ModelComparisonOperation: Operation = {
@@ -26,7 +27,8 @@ export const ModelComparisonOperation: Operation = {
 		const init: ModelComparisonOperationState = {
 			notebookHistory: [],
 			hasCodeRun: false,
-			comparisonImageIds: []
+			comparisonImageIds: [],
+			comparisonPairs: []
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -104,7 +104,6 @@
 				/>
 				<ul>
 					<li v-for="(image, index) in structuralComparisons" :key="index">
-						{{ console.log(compareModelTitles) }}
 						<label>Comparison {{ index + 1 }}: {{ getTitle(index) }}</label>
 						<Image id="img" :src="image" :alt="`Structural comparison ${index + 1}`" preview />
 					</li>
@@ -265,15 +264,11 @@ function runCode() {
 
 	kernelManager.sendMessage('get_comparison_pairs_request', {}).register('any_get_comparison_pairs_reply', (data) => {
 		const comparisonPairs = data.msg.content?.return?.comparison_pairs;
-		console.log('comparisonPairs', comparisonPairs);
 		const state = cloneDeep(props.node.state);
 		if (comparisonPairs.length) {
 			updateComparisonTitlesState('add', comparisonPairs);
 			compareModelTitles.value = comparisonPairs;
-			console.log('compareModelTitles.value', compareModelTitles.value);
-			console.log('state.comparisonPairs', state);
 		} else if (state.comparisonPairs.length) {
-			console.log('state.comparisonPairs', state);
 			compareModelTitles.value = state.comparisonPairs;
 		}
 	});
@@ -321,9 +316,6 @@ async function buildJupyterContext() {
 				kernelManager.shutdown();
 			}
 			await kernelManager.init('beaker_kernel', 'Beaker Kernel', jupyterContext);
-			// kernelManager.sendMessage('get_comparison_pairs_request', {}).register('any_get_comparison_pairs_reply', (data) => {
-			// 	console.log('comparison data', data)
-			// });
 			isKernelReady.value = true;
 		}
 	} catch (error) {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -221,7 +221,7 @@ function updateImagesState(operationType: string, newImageId: string | null = nu
 
 function updateComparisonTitlesState(operationType: string, comparisonPairs: string[][] | null = null) {
 	const state = cloneDeep(props.node.state);
-	if (operationType === 'add' && comparisonPairs.length) state.comparisonPairs = comparisonPairs;
+	if (operationType === 'add' && comparisonPairs !== null) state.comparisonPairs = comparisonPairs;
 	else if (operationType === 'clear') state.comparisonPairs = [];
 	emit('update-state', state);
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -198,7 +198,7 @@ const code = ref(props.node.state.notebookHistory?.[0]?.code ?? '');
 const llmThoughts = ref<any[]>([]);
 const isKernelReady = ref(false);
 const contextLanguage = ref<string>('python3');
-const compareModelTitles = ref(props.node.state.comparisonPairs);
+const comparisonPairs = ref(props.node.state.comparisonPairs);
 
 const initializeAceEditor = (editorInstance: any) => {
 	editor = editorInstance;
@@ -219,16 +219,16 @@ function updateImagesState(operationType: string, newImageId: string | null = nu
 	emit('update-state', state);
 }
 
-function updateComparisonTitlesState(operationType: string, comparisonPairs: string[][] | null = null) {
+function updateComparisonTitlesState(operationType: string, pairs: string[][] | null = null) {
 	const state = cloneDeep(props.node.state);
-	if (operationType === 'add' && comparisonPairs !== null) state.comparisonPairs = comparisonPairs;
+	if (operationType === 'add' && pairs !== null) state.comparisonPairs = pairs;
 	else if (operationType === 'clear') state.comparisonPairs = [];
 	emit('update-state', state);
 }
 
 function getTitle(index: number) {
-	if (!compareModelTitles.value[index]) return '';
-	return `${compareModelTitles.value[index][0].replaceAll('_', ' ')} VS ${compareModelTitles.value[index][1].replaceAll('_', ' ')}`;
+	if (!comparisonPairs.value[index]) return '';
+	return `${comparisonPairs.value[index][0].replaceAll('_', ' ')} VS ${comparisonPairs.value[index][1].replaceAll('_', ' ')}`;
 }
 
 function updateCodeState() {
@@ -263,13 +263,13 @@ function runCode() {
 	updateCodeState();
 
 	kernelManager.sendMessage('get_comparison_pairs_request', {}).register('any_get_comparison_pairs_reply', (data) => {
-		const comparisonPairs = data.msg.content?.return?.comparison_pairs;
+		const pairs = data.msg.content?.return?.comparison_pairs;
 		const state = cloneDeep(props.node.state);
-		if (comparisonPairs.length) {
-			updateComparisonTitlesState('add', comparisonPairs);
-			compareModelTitles.value = comparisonPairs;
+		if (pairs.length) {
+			updateComparisonTitlesState('add', pairs);
+			comparisonPairs.value = pairs;
 		} else if (state.comparisonPairs.length) {
-			compareModelTitles.value = state.comparisonPairs;
+			comparisonPairs.value = state.comparisonPairs;
 		}
 	});
 


### PR DESCRIPTION
# Description

Design Change:
- When a user compares multiple models generating a graph. There were no titles added to the image generated.

Code Changes:
- added a KernelManager message to to request the title pair(s) of the compared models 

![image](https://github.com/user-attachments/assets/ded06a23-923a-473c-9321-e1886fe20981)

Resolves #(issue)
