### PR TITLE
Template transition matrices

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -226,8 +226,28 @@ async function getMatrixValue(variableName: string) {
 	return (await pythonInstance.parseExpression(expressionBase)).pmathml;
 }
 
+function setupMatrixOptions() {
+	// Find a default
+	if (currentMatrixtype.value) {
+		matrix.value = matrixMap.value[currentMatrixtype.value];
+		matrixType.value = currentMatrixtype.value;
+		return;
+	}
+
+	for (let i = 0; i < matrixTypes.length; i++) {
+		const typeStr = matrixTypes[i];
+
+		if (matrixMap.value[typeStr] && matrixMap.value[typeStr].length > 0) {
+			matrix.value = matrixMap.value[typeStr];
+			matrixType.value = typeStr;
+			break;
+		}
+	}
+}
+
 function generateMatrix() {
 	const stratifiedType = props.stratifiedMatrixType;
+	matrixMap.value = {};
 
 	if (stratifiedType === StratifiedMatrix.Initials) {
 		matrix.value = createInitialMatrix(props.mmt, props.id);
@@ -241,60 +261,23 @@ function generateMatrix() {
 			other: matrices.other
 		};
 
-		// Find a default
-		if (currentMatrixtype.value) {
-			matrix.value = matrixMap.value[currentMatrixtype.value];
-			matrixType.value = currentMatrixtype.value;
-			return;
-		}
-
-		for (let i = 0; i < matrixTypes.length; i++) {
-			const typeStr = matrixTypes[i];
-
-			if (matrixMap.value[typeStr] && matrixMap.value[typeStr].length > 0) {
-				matrix.value = matrixMap.value[typeStr];
-				matrixType.value = typeStr;
-				break;
-			}
-		}
+		setupMatrixOptions();
 	} else if (stratifiedType === StratifiedMatrix.Rates) {
 		const templatesMap = collapseTemplates(props.mmt).matrixMap;
 		const matrices = createDiagramTemplateMatrix(props.mmt, props.mmtParams, props.id);
-		console.log('test', matrices);
-		console.log('templatesMap', templatesMap);
-		console.log('props.mmtParams', props.mmtParams);
 
 		const transitionMatrix = templatesMap.get(props.id);
 		if (!transitionMatrix) {
 			logger.error('Failed to generate transition matrix');
 			return;
 		}
-		// matrix.value = extractTemplateMatrix(transitionMatrix).matrix;
 
 		matrixMap.value = {
-			template: extractTemplateMatrix(transitionMatrix).matrix,
 			subjectOutcome: extractTemplateMatrix(transitionMatrix).matrix,
-			// subjectControllers: matrices.subjectControllers.matrix,
-			// outcomeControllers: matrices.outcomeControllers.matrix,
 			other: matrices.other
 		};
 
-		// Find a default
-		if (currentMatrixtype.value) {
-			matrix.value = matrixMap.value[currentMatrixtype.value];
-			matrixType.value = currentMatrixtype.value;
-			return;
-		}
-
-		for (let i = 0; i < matrixTypes.length; i++) {
-			const typeStr = matrixTypes[i];
-
-			if (matrixMap.value[typeStr] && matrixMap.value[typeStr].length > 0) {
-				matrix.value = matrixMap.value[typeStr];
-				matrixType.value = typeStr;
-				break;
-			}
-		}
+		setupMatrixOptions();
 	}
 }
 

--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -274,6 +274,8 @@ function generateMatrix() {
 
 		matrixMap.value = {
 			subjectOutcome: extractTemplateMatrix(transitionMatrix).matrix,
+			subjectControllers: matrices.subjectControllers.matrix,
+			outcomeControllers: matrices.outcomeControllers.matrix,
 			other: matrices.other
 		};
 

--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -99,7 +99,12 @@ import Dropdown from 'primevue/dropdown';
 import Button from 'primevue/button';
 import { StratifiedMatrix } from '@/types/Model';
 import type { MiraMatrix, MiraModel, MiraTemplateParams } from '@/model-representation/mira/mira-common';
-import { createParameterMatrix, createInitialMatrix, collapseTemplates } from '@/model-representation/mira/mira';
+import {
+	createParameterMatrix,
+	createDiagramTemplateMatrix,
+	createInitialMatrix,
+	collapseTemplates
+} from '@/model-representation/mira/mira';
 import { getVariable } from '@/model-representation/service';
 import { extractTemplateMatrix } from '@/model-representation/mira/mira-util';
 import { logger } from '@/utils/logger';
@@ -254,13 +259,42 @@ function generateMatrix() {
 		}
 	} else if (stratifiedType === StratifiedMatrix.Rates) {
 		const templatesMap = collapseTemplates(props.mmt).matrixMap;
+		const matrices = createDiagramTemplateMatrix(props.mmt, props.mmtParams, props.id);
+		console.log('test', matrices);
+		console.log('templatesMap', templatesMap);
+		console.log('props.mmtParams', props.mmtParams);
 
 		const transitionMatrix = templatesMap.get(props.id);
 		if (!transitionMatrix) {
 			logger.error('Failed to generate transition matrix');
 			return;
 		}
-		matrix.value = extractTemplateMatrix(transitionMatrix).matrix;
+		// matrix.value = extractTemplateMatrix(transitionMatrix).matrix;
+
+		matrixMap.value = {
+			template: extractTemplateMatrix(transitionMatrix).matrix,
+			subjectOutcome: extractTemplateMatrix(transitionMatrix).matrix,
+			// subjectControllers: matrices.subjectControllers.matrix,
+			// outcomeControllers: matrices.outcomeControllers.matrix,
+			other: matrices.other
+		};
+
+		// Find a default
+		if (currentMatrixtype.value) {
+			matrix.value = matrixMap.value[currentMatrixtype.value];
+			matrixType.value = currentMatrixtype.value;
+			return;
+		}
+
+		for (let i = 0; i < matrixTypes.length; i++) {
+			const typeStr = matrixTypes[i];
+
+			if (matrixMap.value[typeStr] && matrixMap.value[typeStr].length > 0) {
+				matrix.value = matrixMap.value[typeStr];
+				matrixType.value = typeStr;
+				break;
+			}
+		}
 	}
 }
 

--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -345,7 +345,11 @@ export const createInitialMatrix = (miraModel: MiraModel, key: string) => {
 	return m2;
 };
 
-/** */
+/**
+ * For Template Matrix only
+ * Assumes one-to-one with cells
+ *
+ */
 export const createDiagramTemplateMatrix = (
 	miraModel: MiraModel,
 	miraTemplateParams: MiraTemplateParams,
@@ -417,7 +421,7 @@ export const createDiagramTemplateMatrix = (
 export const createParameterMatrix = (miraModel: MiraModel, miraTemplateParams: MiraTemplateParams, param: string) => {
 	const paramMap = collapseParameters(miraModel, miraTemplateParams);
 	const childrenParams = paramMap.get(param);
-	if (!childrenParams) throw new Error(`Cannot  map ${param}`);
+	if (!childrenParams) throw new Error(`Cannot map ${param}`);
 
 	// Create map for mapping params to row/col of matrix
 	//   param => [ [subject, outcome, controllers], [subject, outcome, controllers] ... ]

--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -352,11 +352,7 @@ export const createDiagramTemplateMatrix = (
 	param: string
 ) => {
 	const paramMap = collapseTemplates(miraModel).matrixMap;
-	const childrenParams = paramMap.get(param)?.map((p) => {
-		console.log(p.name);
-		return p.name;
-	});
-	console.log('childrenParams', childrenParams);
+	const childrenParams = paramMap.get(param)?.map((p) => p.name);
 	if (!childrenParams) throw new Error(`Cannot  map ${param}`);
 
 	// Create map for mapping params to row/col of matrix
@@ -387,14 +383,9 @@ export const createDiagramTemplateMatrix = (
 	// Find templates with expressions that contains one or more of the params
 	const templates = miraModel.templates.filter((t) => {
 		const miraTemplateParam = miraTemplateParams[t.name];
-		console.log('miraTemplateParam', miraTemplateParam);
-		console.log('childrenParams', childrenParams);
 		const intersection = _.intersection(childrenParams, [miraTemplateParam.name]);
-		console.log('intersection', intersection);
 		return intersection.length > 0;
 	});
-
-	const subjectOutcome = extractSubjectOutcomeMatrix(templates, childrenParams, paramValueMap, paramLocationMap);
 	const subjectControllers = extractSubjectControllersMatrix(
 		templates,
 		childrenParams,
@@ -412,7 +403,6 @@ export const createDiagramTemplateMatrix = (
 	const other: MiraMatrix = [];
 	childrenParams.forEach((name, idx) => {
 		const row: MiraMatrixEntry[] = [];
-		console.log('miraModel', miraModel);
 		row.push({
 			row: idx,
 			col: 0,
@@ -427,7 +417,6 @@ export const createDiagramTemplateMatrix = (
 	});
 
 	return {
-		subjectOutcome,
 		subjectControllers,
 		outcomeControllers,
 		other
@@ -440,9 +429,7 @@ export const createDiagramTemplateMatrix = (
  * */
 export const createParameterMatrix = (miraModel: MiraModel, miraTemplateParams: MiraTemplateParams, param: string) => {
 	const paramMap = collapseParameters(miraModel, miraTemplateParams);
-	console.log('paramMap', paramMap);
 	const childrenParams = paramMap.get(param);
-	console.log('childrenParams', childrenParams);
 	if (!childrenParams) throw new Error(`Cannot  map ${param}`);
 
 	// Create map for mapping params to row/col of matrix
@@ -473,14 +460,9 @@ export const createParameterMatrix = (miraModel: MiraModel, miraTemplateParams: 
 	// Find templates with expressions that contains one or more of the params
 	const templates = miraModel.templates.filter((t) => {
 		const miraTemplateParam = miraTemplateParams[t.name];
-		console.log('miraTemplateParam', miraTemplateParam);
-		console.log('childrenParams', childrenParams);
 		const intersection = _.intersection(childrenParams, miraTemplateParam.params);
-		console.log('intersection', intersection);
 		return intersection.length > 0;
 	});
-
-	console.log('templates', templates);
 
 	const subjectOutcome = extractSubjectOutcomeMatrix(templates, childrenParams, paramValueMap, paramLocationMap);
 	const subjectControllers = extractSubjectControllersMatrix(

--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -360,24 +360,21 @@ export const createDiagramTemplateMatrix = (
 	const paramLocationMap = new Map<string, TemplateSummary[]>();
 	const templateParams = Object.values(miraTemplateParams);
 	templateParams.forEach((templateParam) => {
-		const params = templateParam.params;
-		params.forEach((paramName) => {
-			if (!paramLocationMap.has(paramName)) paramLocationMap.set(paramName, []);
+		if (!paramLocationMap.has(templateParam.name)) paramLocationMap.set(templateParam.name, []);
 
-			paramLocationMap.get(paramName)?.push({
-				name: templateParam.name,
-				subject: templateParam.subject,
-				outcome: templateParam.outcome,
-				controllers: templateParam.controllers
-			});
+		paramLocationMap.get(templateParam.name)?.push({
+			name: templateParam.name,
+			subject: templateParam.subject,
+			outcome: templateParam.outcome,
+			controllers: templateParam.controllers
 		});
 	});
 
 	// Create map for param values
 	//   param => value
-	const paramValueMap = new Map<string, any>();
-	Object.values(miraModel.parameters).forEach((paramObj) => {
-		paramValueMap.set(paramObj.name, paramObj.value);
+	const tempValueMap = new Map<string, any>();
+	Object.values(miraModel.templates).forEach((tempObj) => {
+		tempValueMap.set(tempObj.name, tempObj);
 	});
 
 	// Find templates with expressions that contains one or more of the params
@@ -386,18 +383,8 @@ export const createDiagramTemplateMatrix = (
 		const intersection = _.intersection(childrenParams, [miraTemplateParam.name]);
 		return intersection.length > 0;
 	});
-	const subjectControllers = extractSubjectControllersMatrix(
-		templates,
-		childrenParams,
-		paramValueMap,
-		paramLocationMap
-	);
-	const outcomeControllers = extractOutcomeControllersMatrix(
-		templates,
-		childrenParams,
-		paramValueMap,
-		paramLocationMap
-	);
+	const subjectControllers = extractSubjectControllersMatrix(templates, childrenParams, tempValueMap, paramLocationMap);
+	const outcomeControllers = extractOutcomeControllersMatrix(templates, childrenParams, tempValueMap, paramLocationMap);
 
 	// Others, may be initial, maybe no in use ...
 	const other: MiraMatrix = [];


### PR DESCRIPTION
# Description

Design Change:

Add dropdown options for the template matrix.
![image](https://github.com/user-attachments/assets/8764206f-1d8f-4c2b-bb73-301775e089c3)

Testing: 
- Open a model that has be stratified. 
- Open the template matrix in the diagram, and under the Transition section.
- Both should have the options to show 4 different matrices 

![image](https://github.com/user-attachments/assets/d7a89c42-bd27-4ba1-be7d-f38c676b99f1)
![image](https://github.com/user-attachments/assets/3456e827-c603-4f22-906c-dc13619bfd0e)

Resolves #(issue)
