### PR TITLE
Update latex_style_guide.py

### DIFF
--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -1,9 +1,9 @@
 LATEXT_STYLE_GUIDE = """
-1) Derivatives must be written in Leibniz notation (for example, '\\frac{d X}{d t}').
-    a) Derivatives that are written in other notations, like Newton (\dot{X}) or Lagrange (X^\prime or X'), should be converted to Leibniz notation
-    b) Partial derivatives of one-variable functions (for example, '\\partial_t X' or '\\frac{\partial X}{\partial t}') should be rewritten as ordinary derivatives ('\\frac{d X}{d t}')
+1) Derivatives must be written in Leibniz notation (for example, "\\frac{d X}{d t}").
+    a) Derivatives that are written in other notations, like Newton ("\dot{X}") or Lagrange ("X^\prime" or "X'"), should be converted to Leibniz notation
+    b) Partial derivatives of one-variable functions (for example, "\\partial_t X" or "\\frac{\partial X}{\partial t}") should be rewritten as ordinary derivatives ("\\frac{d X}{d t}")
 2) First-order derivative must be on the left of the equal sign
-3) The use of '(t)' should be avoided
+3) The use of "(t)" should be avoided
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{...}"
 6) Avoid parentheses
@@ -11,7 +11,7 @@ LATEXT_STYLE_GUIDE = """
 8) Avoid non-ASCII characters when possible
 9) Avoid using homoglyphs
 10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
-11) Do not use '\\cdot' or '*' to indicate multiplication. Use whitespace instead.
-12) Replace \\epsilon with \\varepsilon when representing a parameter or variable
-13) Avoid using notation for mathematical constants like 'e' and 'pi'. Use their actual values up to 3 decimal places instead.
+11) Do not use "\\cdot" or "*" to indicate multiplication. Use whitespace instead.
+12) Replace "\\epsilon" with "\\varepsilon" when representing a parameter or variable
+13) Avoid using notation for mathematical constants like "e" and "pi". Use their actual values up to 3 decimal places instead.
 """

--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -1,19 +1,17 @@
 LATEXT_STYLE_GUIDE = """
-1) Derivatives must be written in Leibniz notation (for example, '\\frac{d X}{d t}'). 
+1) Derivatives must be written in Leibniz notation (for example, '\\frac{d X}{d t}').
     a) Derivatives that are written in other notations, like Newton (\dot{X}) or Lagrange (X^\prime or X'), should be converted to Leibniz notation
     b) Partial derivatives of one-variable functions (for example, '\\partial_t X' or '\\frac{\partial X}{\partial t}') should be rewritten as ordinary derivatives ('\\frac{d X}{d t}')
 2) First-order derivative must be on the left of the equal sign
 3) The use of '(t)' should be avoided
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{...}"
-6) Avoid mathematical constants like pi or Euler's number
-    a) Replace them as floats with 3 decimal places of precision
-7) Avoid parentheses
-8) Avoid capital sigma and pi notations for summation and product
-9) Avoid non-ASCII characters when possible
-10) Avoid using homoglyphs
-11) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
-12) Do not use '\\cdot' or '*' to indicate multiplication. Use whitespace instead.
-13) Replace \\epsilon with \\varepsilon when representing a parameter or variable
-14) Avoid using notation for mathematical constants like 'e' and 'pi'. Use their actual values up to 3 decimal places instead.
+6) Avoid parentheses
+7) Avoid capital sigma and pi notations for summation and product
+8) Avoid non-ASCII characters when possible
+9) Avoid using homoglyphs
+10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
+11) Do not use '\\cdot' or '*' to indicate multiplication. Use whitespace instead.
+12) Replace \\epsilon with \\varepsilon when representing a parameter or variable
+13) Avoid using notation for mathematical constants like 'e' and 'pi'. Use their actual values up to 3 decimal places instead.
 """

--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -1,11 +1,13 @@
 LATEXT_STYLE_GUIDE = """
-1) Derivatives must be written in Leibniz notation (for example, \\frac{d X}{d t}). Equations that are written in other notations, like Newton or Lagrange, should be converted.
+1) Derivatives must be written in Leibniz notation (for example, \\frac{d X}{d t}). 
+    a) Derivatives that are written in other notations, like Newton (\dot{X}) or Lagrange (X^\prime or X'), should be converted to Leibniz notation
+    b) Partial derivatives of one-variable functions (for example, \\partial_t X or \\frac{\partial X}{\partial t}) should be rewritten as ordinary derivatives (\\frac{d X}{d t})
 2) First-order derivative must be on the left of the equal sign
 3) Use whitespace to indicate multiplication
-    a) "*" is optional but probably should be avoided
-4) "(t)" is optional and probably should be avoided
-5) Avoid superscripts and LaTeX superscripts "^", particularly to denote sub-variables
-6) Subscripts using LaTeX "_" are permitted
+    a) "*" is optional but should be avoided
+4) "(t)" is optional and should be avoided
+5) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
+6) Replace any unicode subscripts with LaTeX subscripts using "_"
     a) Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{...}"
 7) Avoid mathematical constants like pi or Euler's number
     a) Replace them as floats with 3 decimal places of precision
@@ -16,4 +18,5 @@ LATEXT_STYLE_GUIDE = """
 12) Avoid words or multi-character names for variables and names
     a) Use camel case to express multi-word or multi-character names
 13) Do not use \\cdot for multiplication. Use whitespace instead.
+14) Replace \\epsilon with \\varepsilon when representing a parameter or variable
 """


### PR DESCRIPTION
# Description

Updated the style guide to clarify replacement of non-Leibniz derivatives and `\varepsilon` vs. `\epsilon`