### PR TITLE
only make a project admin if necessary

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/askem/RebacUser.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/askem/RebacUser.java
@@ -74,18 +74,14 @@ public class RebacUser extends RebacObject {
 	}
 
 	public String getPermissionFor(final RebacProject rebacProject) throws Exception {
-		if (isAdmin()) {
-			return Schema.Relationship.ADMIN.toString();
-		}
-
 		if (reBACService.isCreator(getSchemaObject(), rebacProject.getSchemaObject())) {
 			return Schema.Relationship.CREATOR.toString();
-		} else if (can(rebacProject, Schema.Permission.ADMINISTRATE)) {
-			return Schema.Relationship.ADMIN.toString();
 		} else if (can(rebacProject, Schema.Permission.WRITE)) {
 			return Schema.Relationship.WRITER.toString();
 		} else if (can(rebacProject, Schema.Permission.READ)) {
 			return Schema.Relationship.READER.toString();
+		} else if (isAdmin() || can(rebacProject, Schema.Permission.ADMINISTRATE)) {
+			return Schema.Relationship.ADMIN.toString();
 		}
 		return "none";
 	}


### PR DESCRIPTION
This pull request includes a change to the `getPermissionFor` method in the `RebacUser` class to simplify the permission checking logic.

Codebase simplification:

* [`packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/askem/RebacUser.java`](diffhunk://#diff-3365cf1dba4e234022f64a5ab0f140ae916d2d44654d961603c51873b07ed1a1L77-R84): Refactored the `getPermissionFor` method to streamline the permission checks by consolidating the admin-related conditions into a single check.
