### PR TITLE
additional heuristic for template parsing handling multiple outputs

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -230,6 +230,12 @@ export const rawTemplatesSummary = (miraModel: MiraModel) => {
 	return allTemplates;
 };
 
+const generateKey = (t: TemplateSummary) => {
+	if (t.name.split('_').length > 1) {
+		return `${t.name.split('_')[0]}:${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
+	}
+	return `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
+};
 export const collapseTemplates = (miraModel: MiraModel) => {
 	const allTemplates: TemplateSummary[] = [];
 	const uniqueTemplates: TemplateSummary[] = [];
@@ -279,7 +285,7 @@ export const collapseTemplates = (miraModel: MiraModel) => {
 	const matrixMap = new Map<string, MiraTemplate[]>();
 
 	allTemplates.forEach((t) => {
-		const key = `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
+		const key = generateKey(t);
 		if (!tempMatrixMap.has(key)) {
 			tempMatrixMap.set(key, []);
 		}
@@ -295,7 +301,7 @@ export const collapseTemplates = (miraModel: MiraModel) => {
 
 	// 3 Rename and sanitize everything
 	uniqueTemplates.forEach((t) => {
-		const key = `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
+		const key = generateKey(t);
 		t.name = `template-${check.get(key)}`;
 	});
 	tempMatrixMap.forEach((value, key) => {
@@ -425,7 +431,6 @@ export const createParameterMatrix = (miraModel: MiraModel, miraTemplateParams: 
 	};
 };
 
-// const genKey = (t: TemplateSummary) => `${t.subject}:${t.outcome}:${t.controllers.join('-')}`;
 export const convertToIGraph = (
 	miraModel: MiraModel,
 	initObservableSummary: ObservableSummary,


### PR DESCRIPTION
### Summary
This address an incorrect assumption we made earlier that a transition's signature/key can be calculated from its input and output component, for the purpose of calculating transition groups. This is not the case, e.g we can have this scenario:

```
transition1_xx: [ input: [a], output: [b] }
transition2_yy: [ input: [a], output: [b] }
```

Where we would want to keep these transitions as different groups. To do this we add the base transition name as part of the key.

### Testing
The model 
[pascale-strata-problem-templates.json](https://github.com/user-attachments/files/17383266/pascale-strata-problem-templates.json), when loaded into Terarium should look like

<img width="670" alt="image" src="https://github.com/user-attachments/assets/77231d07-0232-4067-a6c9-988778793b05">

Instead of:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/20417c4c-09f0-4a7a-a29a-beb5a46081b7">

Note the correct version should have 4 transition matrices instead of 3.

