### PR TITLE
extend MMT template-matrix to have subject-controller/subject-outcome configurations

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
@@ -200,7 +200,12 @@ export const extractTemplateMatrix = (templates: MiraTemplate[]) => {
 		if (template.subject) {
 			rowIdx = rowNames.indexOf(template.subject.name);
 		}
-		if (template.outcome) {
+
+		// Use subject-controller matrix if possible, otherwise fallback to subject-outcome matrix
+		// Note we still use the subject-outcome matrix grid
+		if (template.controller) {
+			colIdx = colNames.indexOf(template.controller.name);
+		} else if (template.outcome) {
 			colIdx = colNames.indexOf(template.outcome.name);
 		}
 		matrix[rowIdx][colIdx].content = {
@@ -208,5 +213,6 @@ export const extractTemplateMatrix = (templates: MiraTemplate[]) => {
 			id: template.name
 		};
 	}
+
 	return { rowNames, colNames, matrix };
 };

--- a/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
@@ -167,7 +167,10 @@ export const extractOutcomeControllersMatrix = (
 
 export const extractTemplateMatrix = (templates: MiraTemplate[]) => {
 	const rowNames = extractConceptNames(templates, 'subject');
-	const colNames = extractConceptNames(templates, 'outcome');
+
+	const colNames = templates[0]?.controller
+		? extractConceptNames(templates, 'controllers')
+		: extractConceptNames(templates, 'outcome');
 
 	// Not sure how to parse templates with no subject or no outcomes
 	// and interacts with only controllers and itself, return a matrix


### PR DESCRIPTION
### Summary
This is an addendum to https://github.com/DARPA-ASKEM/terarium/pull/5157, addressing the model-diagram not rendering the correct matrix configurations. When controller is present we should use a subject-controller configuration instead of a suject-outcome configuration.

### Testing
Load this given model 
[pascale-strata-problem-templates.json](https://github.com/user-attachments/files/17398164/pascale-strata-problem-templates.json) the model diagram should have 2 diagonal matrices and 2 full 3x3 matrices. Originally they were all diagonal matrices.

<img width="559" alt="image" src="https://github.com/user-attachments/assets/b1894e6a-bb16-4488-a0eb-9fe842853b81">



Note: there are known sympy parsing issues with this particular model. It will be dealt with separately as this touches our pyodide utilities and is out of scope w.r.t this PR.