### PR TITLE
Fix render graph being greedy

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { isEmpty, isEqual } from 'lodash';
+import { debounce, isEmpty, isEqual } from 'lodash';
 import { ref, watch, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import Button from 'primevue/button';
 import SelectButton from 'primevue/selectbutton';
@@ -214,7 +214,7 @@ watch(
 let graphResizeObserver: ResizeObserver;
 onMounted(() => {
 	if (graphElement.value) {
-		graphResizeObserver = observeElementSizeChange(graphElement.value, renderGraph);
+		graphResizeObserver = observeElementSizeChange(graphElement.value, debounce(renderGraph, 200));
 	}
 });
 onUnmounted(() => {

--- a/packages/client/hmi-client/src/components/widgets/tera-import-github-file.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-import-github-file.vue
@@ -459,7 +459,8 @@ ul li:hover {
 	color: white;
 	font-size: small;
 }
-:deep .dropdown-button.p-dropdown .p-dropdown-trigger {
+
+:deep(.dropdown-button.p-dropdown .p-dropdown-trigger) {
 	color: white;
 }
 </style>


### PR DESCRIPTION
* [`tera-model-diagram.vue`](diffhunk://#diff-303a3317222249b93370cfe83f7d622e89c0bf17842cd2dff787db26176e622cL67-R67): Added `debounce` import from `lodash` and applied it to the `renderGraph` function to improve performance by reducing the frequency of function calls during graph resizing.
* [`tera-import-github-file.vue`](diffhunk://#diff-3159ae1546c11e398546f45eaafa96f2c28fd3b8314394a7aec9211297a2f3d6L462-R463): Corrected the CSS syntax for the dropdown button to ensure proper styling.
