### PR TITLE
prevent rendering if data dependencies are not ready

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -120,6 +120,9 @@ const resetZoom = async () => {
 };
 
 async function renderGraph() {
+	// Sanity guard
+	if (mmt.value.templates.length === 0) return;
+
 	renderer = getModelRenderer(
 		mmt.value,
 		graphElement.value as HTMLDivElement,


### PR DESCRIPTION
### Summary
It looks like with the resize-observer getting kicked off right away, it is possible to render a graph without the correct dependencies and this eventually result in JS errors that partially break the UI. This is a quick-and-dirty fix to add a sanity check to exit the rendering function if things are not in place.


### Testing
Adding a model onto the cavas should not result in any vue-warnings or js-errors