### PR TITLE
Reset state feature for calibrate

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -661,7 +661,7 @@ const resetState = () => {
 		accept: () => {
 			// Retore to the original output port state
 			const outputPort = props.node.outputs.find((output) => output.id === selectedOutputId.value);
-			if (outputPort && outputPort.state) {
+			if (outputPort?.state) {
 				knobs.value = _.cloneDeep(outputPort.state as CalibrationOperationStateCiemss);
 				mapping.value = outputPort.state.mapping as CalibrateMap[];
 			}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -659,7 +659,7 @@ const resetState = () => {
 		header: 'Reset to original calibration state',
 		message: 'Are you sure you want to reset the state?',
 		accept: () => {
-			// Retore to the original output port state
+			// Restore to the original output port state
 			const outputPort = props.node.outputs.find((output) => output.id === selectedOutputId.value);
 			if (outputPort?.state) {
 				knobs.value = _.cloneDeep(outputPort.state as CalibrationOperationStateCiemss);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -449,6 +449,8 @@ watch(
 				return;
 			}
 
+			state.summaryId = summaryResponse?.id;
+
 			// const portLabel = props.node.inputs[0].label;
 			emit('append-output', {
 				type: CalibrationOperationCiemss.outputs[0].type,
@@ -459,14 +461,7 @@ watch(
 						datasetId: datasetResult.id
 					}
 				],
-				state: {
-					calibrationId: state.calibrationId,
-					forecastId: state.forecastId,
-					preForecastId: state.preForecastId,
-					numIterations: state.numIterations,
-					numSamples: state.numSamples,
-					summaryId: summaryResponse?.id
-				}
+				state
 			});
 		}
 	},

--- a/packages/client/hmi-client/src/services/concept.ts
+++ b/packages/client/hmi-client/src/services/concept.ts
@@ -255,6 +255,9 @@ const autoCalibrationMapping = async (modelOptions: State[], datasetOptions: Dat
 	entityResult.forEach((entity) => {
 		result.push({ modelVariable: entity.source, datasetVariable: entity.target });
 	});
+	if (isEmpty(result)) {
+		result.push({ modelVariable: '', datasetVariable: '' });
+	}
 	return result;
 };
 


### PR DESCRIPTION
# Description
- Allow the user to hit a "reset" button to change the state back to it was for its latest output result.
- Calibrate Automap will now return length one with nothing filled in rather than length 0 (screenshot below)

<img width="467" alt="image" src="https://github.com/user-attachments/assets/7a3e19c2-4035-4c42-9982-e2529aa046bc">

