### PR TITLE
funman: add onFailure hook, fix update-hook python error

### DIFF
--- a/packages/funman/tasks/validate_modelconfig.py
+++ b/packages/funman/tasks/validate_modelconfig.py
@@ -35,13 +35,14 @@ def run_validate(model: PetrinetModel, request, taskrunner):
         request=request,
         parameter_space=ParameterSpace(),
     )
+    current_results.start()
 
     # Update callback
     def update_current_results(scenario: AnalysisScenario, results: ParameterSpace) -> FunmanProgress:
         progress = current_results.update_parameter_space(scenario, results)
 
         # write_progress_dict_with_timeout(self, progress: dict, timeout_seconds: int):
-        print("update hook", progress)
+        print(f"update hook: progress={progress.progress} coverage={progress.coverage_of_search_space}")
         if taskrunner is not None:
             progress_dict = { "progress": progress.progress, "coverage_of_search_space": progress.coverage_of_search_space }
             taskrunner.write_progress_dict_with_timeout(progress_dict, 5)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
@@ -166,7 +166,7 @@ public class SimulationController {
 					(sim.getStatus().equals(ProgressState.FAILED) || sim.getStatus().equals(ProgressState.ERROR)) &&
 					(sim.getStatusMessage() == null || sim.getStatusMessage().isEmpty())
 				) {
-					if (sim.getEngine().equals(SimulationEngine.CIEMSS)) {
+					if (sim.getEngine() != null && sim.getEngine().equals(SimulationEngine.CIEMSS)) {
 						// Pyciemss can give us a nice error message. Attempt to get it.
 						final ResponseEntity<SimulationStatusMessage> statusResponse = simulationCiemssServiceProxy.getRunStatus(
 							sim.getId().toString()


### PR DESCRIPTION
### Summary
Tidy up Funman task runner to be more complete, and update the python task as it seemed like the interface we are hitting against had changed a little bit.
- Add a onFailure to mark the funman-simulation as failed
- Fix python update datetime error in validation task's update hook, there is a date comparison that needs start_time to be initialized

@shawnyama The progression may not be "smooth" but you should have some progress number coming back after this PR, you just need to hook it up, it is part of the simulation object being polled. `simulation.progress` field. 

<img width="723" alt="image" src="https://github.com/user-attachments/assets/95ff28f8-8a09-4133-bfad-34171956a936">


### Testing
Run funman process to validate a model-configuration. Note you may need to exec into the funman-taskrunner container and do:

```
cd /funman_task/
pip install  -e .
```
To refresh the installed tasks.


If funman runs successfully, the funman log should be free of errors such as 
```
2024-10-18 21:15:04 [WARN] [1f6971c9-15c4-4293-ac8d-c9173ed91840] stderr:     time_delta = now - self.start_time [software.uncharted.terarium.taskrunner.service.Task:415]
```

If funman fails, the UI should stop and not be doing infinite polling