### PR TITLE
Expand hmi-server heap space

### DIFF
--- a/packages/server/docker/Dockerfile
+++ b/packages/server/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p ./layers \
     && cp ./build/libs/*-SNAPSHOT.jar ./layers
 
 WORKDIR /app/layers
-RUN java -Djarmode=layertools -jar ./*-SNAPSHOT.jar extract
+RUN java -Xms1024m -Xmx4096m -Djarmode=layertools -jar ./*-SNAPSHOT.jar extract
 
 FROM eclipse-temurin:21.0.4_7-jre-noble
 


### PR DESCRIPTION
This pull request includes a change to the `Dockerfile` in the `packages/server/docker` directory, focusing on memory allocation for the Java process during the extraction phase.

Memory allocation update:

* [`packages/server/docker/Dockerfile`](diffhunk://#diff-93508b50dc34e3e2d39091055329099500547273845aa012ace7e65ca07af069L13-R13): Updated the `RUN` command to allocate initial and maximum memory (`-Xms1024m -Xmx4096m`) for the Java process to improve performance during the extraction of the JAR file.