### PR TITLE
Remove hack to have CSS custom properties

### DIFF
--- a/packages/client/hmi-client/src/main.ts
+++ b/packages/client/hmi-client/src/main.ts
@@ -82,10 +82,3 @@ router.beforeEach(async (to, _from, next) => {
 });
 
 useNotificationManager().init();
-
-// Allow the use of CSS custom properties
-declare module '@vue/runtime-dom' {
-	export interface CSSProperties {
-		[key: `--${string}`]: string | undefined;
-	}
-}


### PR DESCRIPTION
This hack is not necessary anymore, two years later, vite and vue caught up.