### PR TITLE
Calibrate handle simulation results

### DIFF
--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -48,7 +48,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 			return {};
 		}
 
-		const filename = dataset?.fileNames?.[0] ?? '';
+		// If our dataset includes a result.csv we will ensure to pick it.
+		const filename = dataset.fileNames?.includes('result.csv') ? 'result.csv' : (dataset?.fileNames?.[0] ?? '');
+
 		const datasetOptions = dataset.columns?.filter((ele) => ele.fileName === filename);
 		// FIXME: We are setting the limit to -1 (i.e. no limit) on the number of rows returned.
 		// This is a temporary fix since the datasets could be very large.

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -47,8 +47,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 			console.log(`Dataset with id:${datasetId} not found`);
 			return {};
 		}
-		const datasetOptions = dataset.columns;
+
 		const filename = dataset?.fileNames?.[0] ?? '';
+		const datasetOptions = dataset.columns?.filter((ele) => ele.fileName === filename);
 		// FIXME: We are setting the limit to -1 (i.e. no limit) on the number of rows returned.
 		// This is a temporary fix since the datasets could be very large.
 		const limit = -1;

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -54,14 +54,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 		const limit = -1;
 
 		// We are assuming here there is only a single csv file. This may change in the future as the API allows for it.
-		if (dataset.metadata?.format !== 'netcdf' || !dataset.esgfId) {
+		if (!(dataset.metadata?.format === 'netcdf') || !dataset.esgfId) {
 			const csv = (await downloadRawFile(datasetId, filename, limit)) as CsvAsset;
-			// datasetValue.value = csvAsset.value?.csv.map((row) => row.join(',')).join('\n');
-
-			if (csv?.headers) {
-				csv.headers = csv.headers.map((header) => header.trim());
-			}
-
+			csv.headers = csv.headers.map((header) => header.trim());
 			return { filename, csv, datasetOptions };
 		}
 		return {};

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -177,7 +177,11 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 		final Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes.get()));
 		return new CSVParser(
 			reader,
-			CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().setSkipHeaderRecord(false).build()
+			CSVFormat.Builder.create(CSVFormat.DEFAULT)
+				.setAllowMissingColumnNames(true)
+				.setHeader()
+				.setSkipHeaderRecord(false)
+				.build()
 		);
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/SimulationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/SimulationService.java
@@ -106,7 +106,7 @@ public class SimulationService extends TerariumAssetServiceWithoutSearch<Simulat
 				throw new IllegalArgumentException("Project not found");
 			}
 
-			final Dataset dataset = datasetService.createAsset(new Dataset(), projectId, permission);
+			Dataset dataset = datasetService.createAsset(new Dataset(), projectId, permission);
 			dataset.setName(datasetName);
 			dataset.setDescription(sim.get().getDescription());
 			dataset.setMetadata(objectMapper.convertValue(Map.of("simulationId", simId.toString()), JsonNode.class));
@@ -121,6 +121,9 @@ public class SimulationService extends TerariumAssetServiceWithoutSearch<Simulat
 
 			// Duplicate the simulation results to a new dataset
 			this.copySimulationResultToDataset(sim.get(), dataset);
+
+			// Set column names:
+			dataset = datasetService.extractColumnsFromFiles(dataset);
 			datasetService.updateAsset(dataset, projectId, permission);
 
 			// Add dataset to project


### PR DESCRIPTION
# Why?
This will allow the user to plug in a simulation node to a calirbation node without it getting permanently stuck on `Please wait...` for the mapping section.

# How?
Previously when we created dataset assets from the simulation results we were not filling in the column metadata field.
This means that our columns field was empty and when we went to get datasetOptions from this we would instead return empty causing our dataset dropdown to never have options for the user to select

# Picture for example scenario
![image](https://github.com/user-attachments/assets/dd6f51c7-7a19-4fe1-917b-afa139595bf1)
