### PR TITLE
Calibrate handle large data files

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -438,7 +438,7 @@ import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
 import Column from 'primevue/column';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
-import { CalibrateMap, setupDatasetInput, setupModelInput } from '@/services/calibrate-workflow';
+import { CalibrateMap, setupDatasetInput, setupCsvAsset, setupModelInput } from '@/services/calibrate-workflow';
 import {
 	deleteAnnotation,
 	fetchAnnotations,
@@ -1094,10 +1094,15 @@ const initialize = async () => {
 	modelPartTypesMap.value = modelPartTypes ?? {};
 
 	// dataset input
-	const { filename, csv, datasetOptions } = await setupDatasetInput(datasetId.value);
-	currentDatasetFileName.value = filename;
-	csvAsset.value = csv;
-	datasetColumns.value = datasetOptions;
+	if (datasetId.value) {
+		const { filename, datasetOptions } = await setupDatasetInput(datasetId.value);
+		currentDatasetFileName.value = filename;
+		datasetColumns.value = datasetOptions;
+
+		setupCsvAsset(datasetId.value).then((csv) => {
+			csvAsset.value = csv;
+		});
+	}
 
 	getConfiguredModelConfig();
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -40,7 +40,7 @@ import {
 } from '@/services/models/simulation-service';
 import { getModelConfigurationById, createModelConfiguration } from '@/services/model-configurations';
 import { getModelByModelConfigurationId, getUnitsFromModelParts } from '@/services/model';
-import { setupDatasetInput } from '@/services/calibrate-workflow';
+import { setupCsvAsset } from '@/services/calibrate-workflow';
 import { nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
 import { logger } from '@/utils/logger';
 import { Poller, PollerState } from '@/api/api';
@@ -491,8 +491,9 @@ watch(
 
 		// Dataset used to calibrate
 		const datasetId = props.node.inputs[1]?.value?.[0];
-		const { csv } = await setupDatasetInput(datasetId);
-		csvAsset.value = csv;
+		setupCsvAsset(datasetId).then((csv) => {
+			csvAsset.value = csv;
+		});
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -186,7 +186,7 @@ import AccordionTab from 'primevue/accordiontab';
 import Accordion from 'primevue/accordion';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import Dropdown from 'primevue/dropdown';
-import { setupDatasetInput, setupModelInput } from '@/services/calibrate-workflow';
+import { setupDatasetInput, setupCsvAsset, setupModelInput } from '@/services/calibrate-workflow';
 import TeraSimulateChart from '@/components/workflow/tera-simulate-chart.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
@@ -349,10 +349,14 @@ onMounted(async () => {
 	);
 
 	// dataset input
-	const { filename, csv } = await setupDatasetInput(datasetId.value);
-	currentDatasetFileName.value = filename;
-	csvAsset.value = csv;
-	datasetColumnNames.value = csv?.headers;
+	if (datasetId.value) {
+		const { filename, datasetOptions } = await setupDatasetInput(datasetId.value);
+		currentDatasetFileName.value = filename;
+		datasetColumnNames.value = datasetOptions?.map((ele) => ele.name);
+		setupCsvAsset(datasetId.value).then((csv) => {
+			csvAsset.value = csv;
+		});
+	}
 
 	listModelLabels.value = allModelConfigurations.value.map((ele) => ele.name ?? '');
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -44,7 +44,7 @@ import {
 	getCalibrateBlobURL,
 	makeEnsembleCiemssSimulation
 } from '@/services/models/simulation-service';
-import { setupDatasetInput } from '@/services/calibrate-workflow';
+import { setupCsvAsset } from '@/services/calibrate-workflow';
 import { chartActionsProxy, nodeMetadata, nodeOutputLabel } from '@/components/workflow/util';
 import { logger } from '@/utils/logger';
 
@@ -173,8 +173,9 @@ watch(
 
 		// Dataset used to calibrate
 		const datasetId = props.node.inputs[0]?.value?.[0];
-		const { csv } = await setupDatasetInput(datasetId);
-		csvAsset.value = csv;
+		setupCsvAsset(datasetId.value).then((csv) => {
+			csvAsset.value = csv;
+		});
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -48,7 +48,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 			return {};
 		}
 
-		const filename = dataset?.fileNames?.[0] ?? '';
+		// If our dataset includes a result.csv we will ensure to pick it.
+		const filename = dataset.fileNames?.includes('result.csv') ? 'result.csv' : (dataset?.fileNames?.[0] ?? '');
+
 		const datasetOptions = dataset.columns?.filter((ele) => ele.fileName === filename);
 		// FIXME: We are setting the limit to -1 (i.e. no limit) on the number of rows returned.
 		// This is a temporary fix since the datasets could be very large.

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -47,8 +47,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 			console.log(`Dataset with id:${datasetId} not found`);
 			return {};
 		}
-		const datasetOptions = dataset.columns;
+
 		const filename = dataset?.fileNames?.[0] ?? '';
+		const datasetOptions = dataset.columns?.filter((ele) => ele.fileName === filename);
 		// FIXME: We are setting the limit to -1 (i.e. no limit) on the number of rows returned.
 		// This is a temporary fix since the datasets could be very large.
 		const limit = -1;

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -54,14 +54,9 @@ export const setupDatasetInput = async (datasetId: string | undefined) => {
 		const limit = -1;
 
 		// We are assuming here there is only a single csv file. This may change in the future as the API allows for it.
-		if (dataset.metadata?.format !== 'netcdf' || !dataset.esgfId) {
+		if (!(dataset.metadata?.format === 'netcdf') || !dataset.esgfId) {
 			const csv = (await downloadRawFile(datasetId, filename, limit)) as CsvAsset;
-			// datasetValue.value = csvAsset.value?.csv.map((row) => row.join(',')).join('\n');
-
-			if (csv?.headers) {
-				csv.headers = csv.headers.map((header) => header.trim());
-			}
-
+			csv.headers = csv.headers.map((header) => header.trim());
 			return { filename, csv, datasetOptions };
 		}
 		return {};

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -177,7 +177,11 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 		final Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes.get()));
 		return new CSVParser(
 			reader,
-			CSVFormat.Builder.create(CSVFormat.DEFAULT).setHeader().setSkipHeaderRecord(false).build()
+			CSVFormat.Builder.create(CSVFormat.DEFAULT)
+				.setAllowMissingColumnNames(true)
+				.setHeader()
+				.setSkipHeaderRecord(false)
+				.build()
 		);
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/SimulationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/SimulationService.java
@@ -106,7 +106,7 @@ public class SimulationService extends TerariumAssetServiceWithoutSearch<Simulat
 				throw new IllegalArgumentException("Project not found");
 			}
 
-			final Dataset dataset = datasetService.createAsset(new Dataset(), projectId, permission);
+			Dataset dataset = datasetService.createAsset(new Dataset(), projectId, permission);
 			dataset.setName(datasetName);
 			dataset.setDescription(sim.get().getDescription());
 			dataset.setMetadata(objectMapper.convertValue(Map.of("simulationId", simId.toString()), JsonNode.class));
@@ -121,6 +121,9 @@ public class SimulationService extends TerariumAssetServiceWithoutSearch<Simulat
 
 			// Duplicate the simulation results to a new dataset
 			this.copySimulationResultToDataset(sim.get(), dataset);
+
+			// Set column names:
+			dataset = datasetService.extractColumnsFromFiles(dataset);
 			datasetService.updateAsset(dataset, projectId, permission);
 
 			// Add dataset to project


### PR DESCRIPTION
# Description
When opening a calibration with a large data file it can take a few seconds to download the csv.
This delay should not impact the user from selecting mapping options.

# Solution
Rather than `setupDatasetInput` doing returning `filename, csv, datasetOptions` we will just do `filename, dataset` and have a new `setupCsvAsset` which will be used for the csvAsset 

# Testing
**Before**
https://github.com/user-attachments/assets/416f73b3-bfac-4016-b39a-743c41610434

**After**
https://github.com/user-attachments/assets/063ae9b1-27d3-4a0b-aa88-f65e0060ea45

