### PR TITLE
5182 bug-multi-add-for-chart-specification-unselects-the-checks-variables

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -41,7 +41,11 @@ const expressionFunctions = {
 		return format(NUMBER_FORMAT)(correctedValue);
 	},
 	// Just show full value in tooltip
-	tooltipFormatter: (value) => fixPrecisionError(value)
+	tooltipFormatter: (value) => {
+		if (value !== undefined) {
+			fixPrecisionError(value);
+		}
+	}
 };
 
 // This config is default for all charts, but can be overridden by individual chart spec


### PR DESCRIPTION
# Tests the existence of `value` before passing to the tooltip number formatter

* Removes large number of errors in console. 
* Associated performance increase makes the bug impossible to reproduce.

Resolves #5182
