### PR TITLE
attempt to resolve vue-warnings/errors in tera-model-diagram

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -26,11 +26,7 @@
 					</span>
 				</template>
 			</Toolbar>
-			<figure ref="graphElement" class="graph-element">
-				<tera-progress-spinner v-if="!renderer" class="spinner" is-centered :font-size="2">
-					Loading...
-				</tera-progress-spinner>
-			</figure>
+			<figure ref="graphElement" class="graph-element"></figure>
 			<ul class="legend" v-if="!isEmpty(graphLegendLabels)">
 				<li v-for="(label, index) in graphLegendLabels" :key="index">
 					<div class="legend-circle" :style="`background: ${graphLegendColors[index]}`" />
@@ -38,11 +34,12 @@
 				</li>
 			</ul>
 		</tera-resizable-panel>
-		<figure v-else-if="model" ref="graphElement" class="graph-element preview" :key="`preview_${model.id}`">
-			<tera-progress-spinner v-if="!renderer" class="spinner" is-centered :font-size="2">
-				Loading...
-			</tera-progress-spinner>
-		</figure>
+		<figure v-else-if="model" ref="graphElement" class="graph-element preview" :key="`preview_${model.id}`"></figure>
+
+		<tera-progress-spinner v-if="mmt.templates.length === 0" class="spinner" is-centered :font-size="2">
+			Loading...
+		</tera-progress-spinner>
+
 		<tera-stratified-matrix-modal
 			v-if="selectedTransitionId"
 			:id="selectedTransitionId"
@@ -51,9 +48,10 @@
 			:stratified-matrix-type="StratifiedMatrix.Rates"
 			@close-modal="selectedTransitionId = ''"
 		/>
-		<template #tooltip-content v-if="isStratified && !isEmpty(hoveredTransitionId)">
+		<template #tooltip-content>
 			<tera-stratified-matrix-preview
 				ref="tooltipContentRef"
+				v-if="isStratified && !isEmpty(hoveredTransitionId)"
 				:mmt="mmt"
 				:mmt-params="mmtParams"
 				:id="hoveredTransitionId"


### PR DESCRIPTION
### Summary
This is an attempt to resolve the insertBefore Vue warnings/errors that can partially break the application in unexpected ways. It seem like the primary culprit is us adding/removing DOM elements that are not inline with how Vue is working. In this PR we perform a couple of clean ups:

- Move the spinner out of the container element for graph-renderer, since graph-renderer will take full control of the element and will not respect Vue components.
- Cleaner way to manage slots

```
chunk-L65O5BSU.js?v=0e6c8aa7:10445 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'insertBefore')
    at insert (chunk-L65O5BSU.js?v=0e6c8aa7:10445:12)
    at processCommentNode (chunk-L65O5BSU.js?v=0e6c8aa7:6789:7)
    at patch (chunk-L65O5BSU.js?v=0e6c8aa7:6692:9)
    at patchBlockChildren (chunk-L65O5BSU.js?v=0e6c8aa7:7082:7)
    at patchElement (chunk-L65O5BSU.js?v=0e6c8aa7:7000:7)
    at processElement (chunk-L65O5BSU.js?v=0e6c8aa7:6859:7)
    at patch (chunk-L65O5BSU.js?v=0e6c8aa7:6716:11)
    at patchKeyedChildren (chunk-L65O5BSU.js?v=0e6c8aa7:7626:9)
    at patchChildren (chunk-L65O5BSU.js?v=0e6c8aa7:7540:11)
    at processFragment (chunk-L65O5BSU.js?v=0e6c8aa7:7186:9)
```


### Testing
Try playing around with models-diagrams in 
- stand alone model page
- workflow
With combinations of unstratified-model, stratified-model. We shouldn't see the insertBefore errors in the console.