### PR TITLE
show negative timesteps as invalid in the intervention policy drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
@@ -34,6 +34,7 @@ const props = defineProps<{
 	disabled?: boolean;
 	placeholder?: string;
 	autoWidth?: boolean;
+	invalidateNegative?: boolean;
 }>();
 const emit = defineEmits(['update:model-value', 'focusout']);
 const inputField = ref<HTMLInputElement | null>(null);
@@ -63,7 +64,7 @@ const updateValue = (event: Event) => {
 	const value = (event.target as HTMLInputElement).value;
 	maskedValue.value = value;
 	const numValue = toNumber(value);
-	error.value = isNaN(numValue) ? 'Invalid number' : '';
+	error.value = isNaN(numValue) || (props.invalidateNegative && numValue < 0) ? 'Invalid number' : '';
 };
 
 function displayValue() {

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -28,8 +28,8 @@
 				Starting at day
 				<tera-input-number
 					auto-width
+					invalidate-negative
 					:model-value="intervention.staticInterventions[0].timestep"
-					:invalidate-negative="true"
 					@update:model-value="(val) => onUpdateThreshold(val, 0)"
 					placeholder="timestep"
 				/>

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -29,6 +29,7 @@
 				<tera-input-number
 					auto-width
 					:model-value="intervention.staticInterventions[0].timestep"
+					:invalidate-negative="true"
 					@update:model-value="(val) => onUpdateThreshold(val, 0)"
 					placeholder="timestep"
 				/>

--- a/testing/manual/intervention-policy.md
+++ b/testing/manual/intervention-policy.md
@@ -23,7 +23,7 @@ Report any issues into GitHub: [open an issue](https://github.com/DARPA-ASKEM/te
 2. Edit the default intervention card, name it `Static Parameters` and leave it as _Static_.
 3. Set Parameter `beta` to value `0.0001` starting at timestep `20`.
 4. Click `+ Add`.
-5. Set the Parameter gamma to 0.5
+5. Set the Parameter gamma to `0.5`
 6. Check that the charts reflect the intervention
 
 ### 5. Try to create an invalid intervention
@@ -42,7 +42,7 @@ Report any issues into GitHub: [open an issue](https://github.com/DARPA-ASKEM/te
 ### 7. Create a static state criteria
 1. Click `+ Add intervention`
 2. Name it `Static State` and leave it as _Static_.
-3. Set State `I` to value `600` starting at timestep 40`.
+3. Set State `I` to value `600` starting at timestep `40`.
 
 ### 8. Create a dynamic state criteria
 1. Click `+ Add intervention`


### PR DESCRIPTION

# Description

* Expands the element validation to some negative timesteps as invalid
* Also fixes some formatting in the test description

<img width="519" alt="Screenshot 2024-10-24 at 1 32 26 PM" src="https://github.com/user-attachments/assets/3f306f22-00f0-4424-8801-b914f31e1f2b">
