### PR TITLE
Intervention pdf goto page

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
@@ -1,14 +1,14 @@
 <template>
 	<TabView v-if="pdfs?.length" class="container">
 		<TabPanel :header="pdf.name" v-for="pdf in pdfs" :key="pdf.name">
-			<tera-pdf-embed v-if="pdf.isPdf" :pdf-link="pdf.data" :title="pdf.name || ''" />
+			<tera-pdf-embed v-if="pdf.isPdf" ref="pdfRef" :pdf-link="pdf.data" :title="pdf.name || ''" />
 			<tera-text-editor v-else :initial-text="pdf.data" />
 		</TabPanel>
 	</TabView>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
 
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
@@ -24,11 +24,16 @@ interface PdfData {
 	name: string;
 }
 
+const emit = defineEmits(['pdf-ref']);
+
 const props = defineProps<{
 	pdfs: PdfData[];
 }>();
 
 const pdfs = ref<PdfData[]>(props.pdfs);
+const pdfRef = ref(null);
+
+onMounted(() => emit('pdf-ref', pdfRef));
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -15,7 +15,7 @@
 			>
 				<template #content>
 					<tera-drilldown-section :is-loading="isFetchingPDF">
-						<tera-pdf-panel :pdfs="pdfData" />
+						<tera-pdf-panel :pdfs="pdfData" @pdf-ref="getPdfRef" />
 					</tera-drilldown-section>
 				</template>
 			</tera-slider-panel>
@@ -65,8 +65,16 @@
 					<Button outlined severity="secondary" label="Reset" @click="onResetPolicy" />
 				</template>
 				<ul class="flex flex-column gap-2">
-					<li v-for="(intervention, index) in knobs.transientInterventionPolicy.interventions" :key="index">
+					<li
+						v-for="(intervention, index) in knobs.transientInterventionPolicy.interventions"
+						:key="index"
+						@click="selectInterventionPolicy(intervention, index)"
+					>
 						<tera-intervention-card
+							class="intervention"
+							:class="{
+								selected: selectedIntervention?.name === intervention?.name && selectedIntervention?.index === index
+							}"
 							:intervention="intervention"
 							:parameterOptions="parameterOptions"
 							:stateOptions="stateOptions"
@@ -192,6 +200,8 @@ import {
 	Intervention,
 	InterventionPolicy,
 	Model,
+	DynamicIntervention,
+	StaticIntervention,
 	type TaskResponse,
 	type DocumentAsset
 } from '@/types/Types';
@@ -255,6 +265,18 @@ const newBlankInterventionPolicy = ref({
 	modelId: '',
 	interventions: [blankIntervention]
 });
+
+interface SelectedIntervention {
+	index: number;
+	name: string;
+	extractionDocumentId?: string;
+	extractionPage?: number;
+	staticInterventions: StaticIntervention[];
+	dynamicInterventions: DynamicIntervention[];
+}
+
+const pdfViewer = ref();
+const selectedIntervention = ref<SelectedIntervention | null>(null);
 
 const isPdfSidebarOpen = ref(true);
 const isFetchingPDF = ref(false);
@@ -405,6 +427,19 @@ const fetchInterventionPolicies = async (modelId: string) => {
 	isFetchingPolicies.value = true;
 	interventionsPolicyList.value = await getInterventionPoliciesForModel(modelId);
 	isFetchingPolicies.value = false;
+};
+
+const getPdfRef = (pdfRef) => {
+	pdfViewer.value = pdfRef.value[0];
+};
+
+const selectInterventionPolicy = (intervention: Intervention, index: number) => {
+	selectedIntervention.value = { ...intervention, index };
+	if (!intervention?.extractionPage) return;
+
+	if (pdfViewer.value) {
+		pdfViewer.value.goToPage(selectedIntervention.value.extractionPage);
+	}
 };
 
 const onUpdateInterventionCard = (intervention: Intervention, index: number) => {
@@ -667,6 +702,20 @@ button.start-edit {
 
 	& > .pi {
 		color: var(--text-color-subdued);
+	}
+}
+
+.intervention {
+	background-color: var(--gray-0);
+	border-left: 4px solid var(--surface-300);
+
+	&.selected {
+		border-left-color: var(--primary-color);
+	}
+
+	&,
+	&.selected {
+		transition: border-left-color 250ms;
 	}
 }
 

--- a/packages/gollm/gollm_openai/prompts/config_from_document.py
+++ b/packages/gollm/gollm_openai/prompts/config_from_document.py
@@ -26,7 +26,7 @@ For each condition, create a model configuration JSON object that satisfies the 
 5.	For each parameter specified in the AMR model, extract information from the text and create a parameter semantic object. Do not create new parameter semantic objects for parameters that are not included in the original AMR model. If you cannot find a constant value or distribution for the parameter, do not create a parameter semantic object.
 6. `observableSemanticList` should be an empty list.
 7. `inferredParameterList` should be an empty list.
-8. Determine what page that the majority of information was extracted from and set the `extractionPage` value to that page number. If the page number cannot be determined, set it to 0.
+8. Determine what page the information was extracted from and set the `extractionPage` value to that page number. If the page number cannot be determined, set it to 0. Only pick one page number. Do not provide a range.
 
 Do not respond in full sentences; only create a JSON object that satisfies the JSON schema specified in the response format. Make sure you follow the JSON standard for the data types and format.
 

--- a/packages/gollm/gollm_openai/prompts/interventions_from_document.py
+++ b/packages/gollm/gollm_openai/prompts/interventions_from_document.py
@@ -1,5 +1,5 @@
 INTERVENTIONS_FROM_DOCUMENT_PROMPT = """
-You are a helpful agent designed to find intervention policies for a given AMR model described in a research paper.
+You are a helpful agent designed to find intervention policies described in a research paper for a given AMR model.
 For context, intervention policies can include multiple interventions that include only static interventions or dynamic interventions.
 Static interventions are applied at a specific point in time and permanently change the value of a specific parameter or state.
 Dynamic interventions are applied when the value of a state crosses a threshold value.
@@ -26,8 +26,8 @@ For each policy described in the paper, create an interventionPolicy object. To 
 3. `model_id` id a UUID. If the AMR model has an id, you can use it. Otherwise, you can set as the nil UUID "00000000-0000-0000-0000-000000000000".
 4. For each intervention specified in the policy create an intervention object with the following rules.
     a. Create a value for `name` from the user-provided text.
-    b. Determine what page that the majority of information was extracted from and set the `extractionPage` value to that page number. If the page number cannot be determined, set it to 0.
-    c. create a list of either static or dynamic interventions, but not both. The other list should be empty.
+    b. Determine what page the information was extracted from and set the `extractionPage` value to that page number. If the page number cannot be determined, set it to 0. Only pick one page number. Do not provide a range.
+    c. Create a list of either static or dynamic interventions, but not both. The other list should be empty.
         i. `appliedTo` should reference the id of a parameter or state in the AMR Model. If you cannot find a state or parameter in the AMR model that matches, do not create an intervention object.
         ii. `type` should be either "state" or "parameter" depending on what the intervention is applied to.
         iii. For dynamic interventions, `parameter` should be the id of a state that the threshold is applied to.


### PR DESCRIPTION
# Description

Design Change

- For interventions with page number, clicking on them will jump to the matching the page in the PDF

Testing:
- connect a document to the intervention's drill down
- extract from inputs\
- select a policy and click on an intervention

Resolves #(issue)
