### PR TITLE
Optimize user guardrails

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -25,19 +25,7 @@
 								:disabled="_.isEmpty(node.outputs[0].value)"
 							/>
 							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
-							<div
-								v-tooltip="{
-									value: `${runButtonMessage}`,
-									pt: {
-										arrow: {
-											style: {
-												borderBottomColor: 'var(--p-primary-color)'
-											}
-										},
-										text: '!bg-primary !text-primary-contrast !font-medium'
-									}
-								}"
-							>
+							<div v-tooltip="runButtonMessage">
 								<Button :disabled="isRunDisabled" label="Run" icon="pi pi-play" @click="runOptimize" />
 							</div>
 						</span>
@@ -62,7 +50,10 @@
 						/>
 					</section>
 					<section class="form-section">
-						<h5>Intervention policy</h5>
+						<h5>
+							Intervention policy
+							<i v-if="!isInterventionReady" v-tooltip="interventionReadyMessage" class="pi pi-exclamation-circle" />
+						</h5>
 						<template v-for="(cfg, idx) in knobs.interventionPolicyGroups">
 							<tera-static-intervention-policy-group
 								v-if="
@@ -531,9 +522,7 @@ const isCriteriaReady = computed(() => {
 	return activeConstraintGroups.length !== 0 && activeConstraintGroups.every((ele) => ele.targetVariable);
 });
 
-const isInterventionReady = computed(
-	() => knobs.value.interventionPolicyGroups.length !== 0 && activePolicyGroups.value.length >= 0
-);
+const isInterventionReady = computed(() => activePolicyGroups.value.length > 0);
 
 const isEndTimeValid = computed(() =>
 	activePolicyGroups.value.every((ele) => {
@@ -549,18 +538,23 @@ const isEndTimeValid = computed(() =>
 );
 
 const isRunDisabled = computed(() => !isCriteriaReady.value || !isInterventionReady.value || !isEndTimeValid.value);
+console.log(isInterventionReady);
+console.log(isRunDisabled);
+const criteriaReadyMessage = computed(() =>
+	!isCriteriaReady.value ? 'All success criteria must be filled in. \n' : ''
+);
+const interventionReadyMessage = computed(() =>
+	!isInterventionReady.value ? 'Must contain at least one active intervention policy that is filled in. \n' : ''
+);
+const endTimeMessage = computed(() =>
+	!isEndTimeValid.value
+		? 'Optimize setting end time must be greater than or equal to all intervention end times. \n'
+		: ''
+);
 
-const criteriaReadyMessage = '-All success criteria must be filled in.';
-const interventionReadyMessage = '-Must contain at least one active intervention policy that is filled in.';
-const endTimeMessage = '-Optimize setting end time must be greater than or equal to all intervention end times';
-
-const runButtonMessage = computed(() => {
-	let aString = '';
-	if (!isCriteriaReady.value) aString = `${aString + criteriaReadyMessage}\n`;
-	if (!isInterventionReady.value) aString = `${aString + interventionReadyMessage}\n`;
-	if (!isEndTimeValid.value) aString = `${aString + endTimeMessage}\n`;
-	return aString;
-});
+const runButtonMessage = computed(
+	() => `${criteriaReadyMessage.value} ${interventionReadyMessage.value} ${endTimeMessage.value}`
+);
 
 const presetType = computed(() => {
 	if (

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -97,7 +97,6 @@
 								label="End time"
 								:start-date="modelConfiguration.temporalContext"
 								:calendar-settings="getCalendarSettingsFromModel(model)"
-								:invalid="!isEndTimeValid"
 								v-model="knobs.endTime"
 							/>
 							<i

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -554,8 +554,8 @@ const endTimeTooltip = computed(() =>
 	!isEndTimeValid.value ? 'End time must be greater than or equal to all intervention policy end times. \n' : ''
 );
 
-const runButtonMessage = computed(
-	() => `${criteriaReadyTooltip.value} ${interventionReadyTooltip.value} ${endTimeTooltip.value}`
+const runButtonMessage = computed(() =>
+	isRunDisabled.value ? `${criteriaReadyTooltip.value} ${interventionReadyTooltip.value} ${endTimeTooltip.value}` : ''
 );
 
 const presetType = computed(() => {

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -100,7 +100,12 @@
 								:invalid="!isEndTimeValid"
 								v-model="knobs.endTime"
 							/>
-							<i v-if="!isEndTimeValid" v-tooltip="endTimeMessage" class="pi pi-exclamation-circle" />
+							<i
+								class="pi pi-exclamation-circle"
+								style="max-width: fit-content"
+								v-if="!isEndTimeValid"
+								v-tooltip="endTimeMessage"
+							/>
 						</div>
 						<div class="input-row">
 							<div class="label-and-input">

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -52,7 +52,7 @@
 					<section class="form-section">
 						<h5>
 							Intervention policy
-							<i v-if="!isInterventionReady" v-tooltip="interventionReadyMessage" class="pi pi-exclamation-circle" />
+							<i v-if="!isInterventionReady" v-tooltip="interventionReadyTooltip" class="pi pi-exclamation-circle" />
 						</h5>
 						<template v-for="(cfg, idx) in knobs.interventionPolicyGroups">
 							<tera-static-intervention-policy-group
@@ -104,7 +104,7 @@
 								class="pi pi-exclamation-circle"
 								style="max-width: fit-content"
 								v-if="!isEndTimeValid"
-								v-tooltip="endTimeMessage"
+								v-tooltip="endTimeTooltip"
 							/>
 						</div>
 						<div class="input-row">
@@ -545,22 +545,17 @@ const isEndTimeValid = computed(() =>
 );
 
 const isRunDisabled = computed(() => !isCriteriaReady.value || !isInterventionReady.value || !isEndTimeValid.value);
-console.log(isInterventionReady);
-console.log(isRunDisabled);
-const criteriaReadyMessage = computed(() =>
-	!isCriteriaReady.value ? 'All success criteria must be filled in. \n' : ''
+
+const criteriaReadyTooltip = computed(() => (!isCriteriaReady.value ? 'Success criteria must be filled in. \n' : ''));
+const interventionReadyTooltip = computed(() =>
+	!isInterventionReady.value ? 'Must contain at least one active intervention policy.\n' : ''
 );
-const interventionReadyMessage = computed(() =>
-	!isInterventionReady.value ? 'Must contain at least one active intervention policy that is filled in. \n' : ''
-);
-const endTimeMessage = computed(() =>
-	!isEndTimeValid.value
-		? 'Optimize setting end time must be greater than or equal to all intervention end times. \n'
-		: ''
+const endTimeTooltip = computed(() =>
+	!isEndTimeValid.value ? 'End time must be greater than or equal to all intervention policy end times. \n' : ''
 );
 
 const runButtonMessage = computed(
-	() => `${criteriaReadyMessage.value} ${interventionReadyMessage.value} ${endTimeMessage.value}`
+	() => `${criteriaReadyTooltip.value} ${interventionReadyTooltip.value} ${endTimeTooltip.value}`
 );
 
 const presetType = computed(() => {

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -97,8 +97,10 @@
 								label="End time"
 								:start-date="modelConfiguration.temporalContext"
 								:calendar-settings="getCalendarSettingsFromModel(model)"
+								:invalid="!isEndTimeValid"
 								v-model="knobs.endTime"
 							/>
+							<i v-if="!isEndTimeValid" v-tooltip="endTimeMessage" class="pi pi-exclamation-circle" />
 						</div>
 						<div class="input-row">
 							<div class="label-and-input">

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-criterion-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-criterion-group-form.vue
@@ -28,7 +28,6 @@
 				option-value="value"
 				v-model="config.targetVariable"
 				placeholder="Select"
-				:invalid="_.isEmpty(config.targetVariable)"
 				@update:model-value="emit('update-self', config)"
 			/>
 			<i v-if="_.isEmpty(config.targetVariable)" class="pi pi-exclamation-circle" v-tooltip="requiredTooltip" />

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-criterion-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-criterion-group-form.vue
@@ -28,8 +28,10 @@
 				option-value="value"
 				v-model="config.targetVariable"
 				placeholder="Select"
+				:invalid="_.isEmpty(config.targetVariable)"
 				@update:model-value="emit('update-self', config)"
 			/>
+			<i v-if="_.isEmpty(config.targetVariable)" class="pi pi-exclamation-circle" v-tooltip="requiredTooltip" />
 			is
 			<Dropdown
 				class="toolbar-button"
@@ -44,6 +46,7 @@
 			/>
 			a threshold of
 			<tera-input-number v-model="config.threshold" @update:model-value="emit('update-self', config)" />
+			<i v-if="!config.threshold" class="pi pi-exclamation-circle" v-tooltip="requiredTooltip" />
 			at
 			<Dropdown
 				:options="[
@@ -56,8 +59,11 @@
 				@update:model-value="emit('update-self', config)"
 			/>
 			in
-			<tera-input-number v-model="config.riskTolerance" @update:model-value="emit('update-self', config)" />% of
-			simulated outcomes
+			<tera-input-number v-model="config.riskTolerance" @update:model-value="emit('update-self', config)" /><i
+				v-if="!config.riskTolerance"
+				class="pi pi-exclamation-circle"
+				v-tooltip="requiredTooltip"
+			/>% of simulated outcomes
 		</div>
 		<div v-else class="section-row">
 			Ensure <b>{{ config.targetVariable }}</b> is <b>{{ config.isMinimized ? 'below' : 'above' }}</b> a threshold of
@@ -84,7 +90,7 @@ const props = defineProps<{
 const emit = defineEmits(['update-self', 'delete-self']);
 
 const config = ref<Criterion>(_.cloneDeep(props.criterion));
-
+const requiredTooltip = 'Required';
 const isEditing = ref<boolean>(false);
 
 const onEdit = () => {


### PR DESCRIPTION
# Description

- [ ] Disable run button when the user has an intervention with an endTime > optimize setting's end time.
- [ ] Add some tooltips on run button to explain why it is disabled (when it is)
- [ ] Add tooltips to fields that are required and filled in incorrectly for the user to better find mistakes they have made

# Looking for opinion
If you have any styling suggestions such as
If you think all of the invalid inputs should be red bordered as in the screenshot below let me know!
<img width="629" alt="image" src="https://github.com/user-attachments/assets/e9ea5aeb-8b70-4fff-928c-5d12f9498220">

# Video
https://github.com/user-attachments/assets/8182c9ab-faa0-4b8e-bfcb-34f56481b908


