### PR TITLE
[Small]: Limit preview on dataset node

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
@@ -3,7 +3,7 @@
 		<template v-if="dataset">
 			<tera-operator-title>{{ dataset.name }}</tera-operator-title>
 			<section class="mb-2">
-				{{ formattedColumnList }}
+				{{ formattedColumnList?.slice(0, 100) }}
 			</section>
 			<Button label="Open" @click="emit('open-drilldown')" severity="secondary" outlined />
 		</template>

--- a/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
@@ -3,7 +3,7 @@
 		<template v-if="dataset">
 			<tera-operator-title>{{ dataset.name }}</tera-operator-title>
 			<section class="mb-2">
-				{{ formattedColumnList?.slice(0, 100) }}
+				{{ formattedColumnList }}
 			</section>
 			<Button label="Open" @click="emit('open-drilldown')" severity="secondary" outlined />
 		</template>
@@ -72,12 +72,16 @@ onMounted(async () => {
 	if (props.node.state.datasetId) getDatasetById(props.node.state.datasetId).then();
 });
 
-const formattedColumnList = computed(() =>
-	dataset.value?.columns
+const formattedColumnList = computed(() => {
+	let formattedString = dataset.value?.columns
 		?.filter((column) => !isEmpty(column.name))
 		.map((column) => column.name)
-		.join(', ')
-);
+		.join(', ');
+	if (formattedString && formattedString.length >= 100) {
+		formattedString = `${formattedString.slice(0, 100)}...`;
+	}
+	return formattedString;
+});
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
@@ -77,6 +77,8 @@ const formattedColumnList = computed(() => {
 		?.filter((column) => !isEmpty(column.name))
 		.map((column) => column.name)
 		.join(', ');
+
+	// Limit size to 100 and add ellipses if need to.
 	if (formattedString && formattedString.length >= 100) {
 		formattedString = `${formattedString.slice(0, 100)}...`;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
@@ -2,9 +2,7 @@
 	<main>
 		<template v-if="dataset">
 			<tera-operator-title>{{ dataset.name }}</tera-operator-title>
-			<section class="mb-2">
-				{{ formattedColumnList }}
-			</section>
+			<tera-show-more-text :text="formattedColumnList" :lines="5" />
 			<Button label="Open" @click="emit('open-drilldown')" severity="secondary" outlined />
 		</template>
 		<template v-else>
@@ -31,6 +29,7 @@ import { getDataset } from '@/services/dataset';
 import { canPropagateResource } from '@/services/workflow';
 import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorTitle from '@/components/operator/tera-operator-title.vue';
+import TeraShowMoreText from '@/components/widgets/tera-show-more-text.vue';
 import { useProjects } from '@/composables/project';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import { DatasetOperationState } from './dataset-operation';
@@ -72,18 +71,13 @@ onMounted(async () => {
 	if (props.node.state.datasetId) getDatasetById(props.node.state.datasetId).then();
 });
 
-const formattedColumnList = computed(() => {
-	let formattedString = dataset.value?.columns
-		?.filter((column) => !isEmpty(column.name))
-		.map((column) => column.name)
-		.join(', ');
-
-	// Limit size to 100 and add ellipses if need to.
-	if (formattedString && formattedString.length >= 100) {
-		formattedString = `${formattedString.slice(0, 100)}...`;
-	}
-	return formattedString;
-});
+const formattedColumnList = computed(
+	() =>
+		dataset.value?.columns
+			?.filter((column) => !isEmpty(column.name))
+			.map((column) => column.name)
+			.join(', ') ?? ''
+);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# Description
There is no limit on the preview in the dataset node.
This leads to HILARIOUS previews that make the node hard to work with and insane.

# Problem:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/fc98976e-d676-4ad7-86ed-4878a1ea0180">

# Solution

https://github.com/user-attachments/assets/556ba80c-52a7-4668-bbe3-68e8fcfb7e7d


