### PR TITLE
Intervention service minor update

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -250,7 +250,10 @@ export async function getOptimizedInterventions(optimizeRunId: string) {
  *
  *
  */
-export async function createInterventionPolicyFromOptimize(modelConfigId: string, optimizeRunId: string) {
+export async function createInterventionPolicyFromOptimize(
+	modelConfigId: string,
+	optimizeRunId: string
+): Promise<InterventionPolicy | null> {
 	const modelId = await getModelIdFromModelConfigurationId(modelConfigId);
 	const optimizedInterventions = await getOptimizedInterventions(optimizeRunId);
 
@@ -260,6 +263,6 @@ export async function createInterventionPolicyFromOptimize(modelConfigId: string
 		temporary: true,
 		interventions: optimizedInterventions
 	};
-	const newInterventionPolicy: InterventionPolicy = await createInterventionPolicy(newIntervention);
+	const newInterventionPolicy: InterventionPolicy | null = await createInterventionPolicy(newIntervention);
 	return newInterventionPolicy;
 }

--- a/packages/client/hmi-client/src/services/intervention-policy.ts
+++ b/packages/client/hmi-client/src/services/intervention-policy.ts
@@ -27,7 +27,6 @@ export const createInterventionPolicy = async (policy: InterventionPolicy): Prom
 		delete policy.createdOn;
 		delete policy.updatedOn;
 		const response = await API.post<InterventionPolicy>(`/interventions`, policy);
-		console.log(response);
 		if (response.status !== 201) {
 			return null;
 		}

--- a/packages/client/hmi-client/src/services/intervention-policy.ts
+++ b/packages/client/hmi-client/src/services/intervention-policy.ts
@@ -1,6 +1,7 @@
 import API from '@/api/api';
 import type { Intervention, InterventionPolicy } from '@/types/Types';
 import { InterventionSemanticType } from '@/types/Types';
+import { logger } from '@/utils/logger';
 
 export const blankIntervention: Intervention = {
 	name: 'New Intervention',
@@ -20,12 +21,21 @@ export const getInterventionPolicyById = async (policyId: string): Promise<Inter
 	return response?.data ?? null;
 };
 
-export const createInterventionPolicy = async (policy: InterventionPolicy): Promise<InterventionPolicy> => {
-	delete policy.id;
-	delete policy.createdOn;
-	delete policy.updatedOn;
-	const response = await API.post<InterventionPolicy>(`/interventions`, policy);
-	return response?.data ?? null;
+export const createInterventionPolicy = async (policy: InterventionPolicy): Promise<InterventionPolicy | null> => {
+	try {
+		delete policy.id;
+		delete policy.createdOn;
+		delete policy.updatedOn;
+		const response = await API.post<InterventionPolicy>(`/interventions`, policy);
+		console.log(response);
+		if (response.status !== 201) {
+			return null;
+		}
+		return response.data ?? null;
+	} catch (error) {
+		logger.error(error);
+		return null;
+	}
 };
 
 export const deleteInterventionPolicy = async (policyId: string) => {


### PR DESCRIPTION
# Description
As the hmiserver can fail to create an intervention it is important that our client's service can as well.
This update is propagated to optimize as well where technically the result can be failed to create
This will now better handle this fail case