### PR TITLE
Simulate - add state units to dynamic intervention

### DIFF
--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -16,9 +16,8 @@
 			<li v-for="(dynamicIntervention, index) in intervention.dynamicInterventions" :key="`dynamic-${index}`">
 				Set {{ dynamicIntervention.type }} <strong>{{ dynamicIntervention.appliedTo }}</strong> to
 				<strong>{{ dynamicIntervention.value }}</strong> when
-				<strong>{{ dynamicIntervention.parameter }}</strong> crosses the threshold&nbsp;<strong>{{
-					dynamicIntervention.threshold
-				}}</strong
+				<strong>{{ dynamicIntervention.parameter }}</strong> crosses the threshold&nbsp;<strong
+					>{{ dynamicIntervention.threshold }} {{ getUnit(dynamicIntervention) }}</strong
 				>.
 			</li>
 		</ul>
@@ -26,15 +25,24 @@
 </template>
 
 <script setup lang="ts">
-import { Intervention } from '@/types/Types';
+import { Intervention, DynamicIntervention } from '@/types/Types';
 import { CalendarSettings, getTimePointString } from '@/utils/date';
 import { isEmpty } from 'lodash';
 
 const props = defineProps<{
 	intervention: Intervention;
+	modelUnits?: any;
 	startDate?: Date;
 	calendarSettings?: CalendarSettings;
 }>();
+
+function getUnit(dynamicIntervention: DynamicIntervention) {
+	let modelUnit = '';
+	if (dynamicIntervention.type === 'state') {
+		modelUnit = props.modelUnits?.[dynamicIntervention.parameter].units.expression ?? '';
+	}
+	return modelUnit;
+}
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -31,7 +31,8 @@ import { isEmpty } from 'lodash';
 
 const props = defineProps<{
 	intervention: Intervention;
-	modelUnits?: string;
+	parameterUnits?: { id: string; units: string } | {};
+	stateUnits?: { id: string; units: string } | {};
 	startDate?: Date;
 	calendarSettings?: CalendarSettings;
 }>();
@@ -39,7 +40,9 @@ const props = defineProps<{
 function getUnit(dynamicIntervention: DynamicIntervention) {
 	let modelUnit = '';
 	if (dynamicIntervention.type === InterventionSemanticType.State) {
-		modelUnit = props.modelUnits?.[dynamicIntervention.parameter]?.units?.expression ?? '';
+		modelUnit = props.stateUnits?.[dynamicIntervention.parameter]?.units ?? '';
+	} else if (dynamicIntervention.type === InterventionSemanticType.Parameter) {
+		modelUnit = props.parameterUnits?.[dynamicIntervention.appliedTo]?.units ?? '';
 	}
 	return modelUnit;
 }

--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -25,21 +25,21 @@
 </template>
 
 <script setup lang="ts">
-import { Intervention, DynamicIntervention } from '@/types/Types';
+import { Intervention, DynamicIntervention, InterventionSemanticType } from '@/types/Types';
 import { CalendarSettings, getTimePointString } from '@/utils/date';
 import { isEmpty } from 'lodash';
 
 const props = defineProps<{
 	intervention: Intervention;
-	modelUnits?: any;
+	modelUnits?: string;
 	startDate?: Date;
 	calendarSettings?: CalendarSettings;
 }>();
 
 function getUnit(dynamicIntervention: DynamicIntervention) {
 	let modelUnit = '';
-	if (dynamicIntervention.type === 'state') {
-		modelUnit = props.modelUnits?.[dynamicIntervention.parameter].units.expression ?? '';
+	if (dynamicIntervention.type === InterventionSemanticType.State) {
+		modelUnit = props.modelUnits?.[dynamicIntervention.parameter]?.units?.expression ?? '';
 	}
 	return modelUnit;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -83,6 +83,7 @@
 								:start-date="modelConfiguration?.temporalContext"
 								:calendar-settings="getCalendarSettingsFromModel(model)"
 								:intervention="intervention"
+								:model-units="modelStateUnits"
 								:key="index"
 							/>
 						</template>
@@ -272,6 +273,7 @@ const codeText = ref('');
 
 const modelConfiguration = ref<ModelConfiguration | null>(null);
 const model = ref<Model | null>(null);
+const modelStateUnits = computed(() => _.keyBy(model.value?.model.states, 'id'));
 
 const policyInterventionId = computed(() => props.node.inputs[1].value?.[0]);
 const interventionPolicy = ref<InterventionPolicy | null>(null);

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -83,7 +83,8 @@
 								:start-date="modelConfiguration?.temporalContext"
 								:calendar-settings="getCalendarSettingsFromModel(model)"
 								:intervention="intervention"
-								:model-units="modelStateUnits"
+								:state-units="modelStateUnits"
+								:parameter-units="modelParameterUnits"
 								:key="index"
 							/>
 						</template>
@@ -324,7 +325,30 @@ const codeText = ref('');
 
 const modelConfiguration = ref<ModelConfiguration | null>(null);
 const model = ref<Model | null>(null);
-const modelStateUnits = computed(() => _.keyBy(model.value?.model.states, 'id'));
+
+const modelStateUnits = computed(() => {
+	const states = model.value?.model.states;
+	let units = {};
+	if (states.length) {
+		units = _.keyBy(
+			states.map((state) => ({ id: state.id, units: state?.units?.expression ?? '' })),
+			'id'
+		);
+	}
+	return units;
+});
+
+const modelParameterUnits = computed(() => {
+	const parametes = model.value?.semantics?.ode?.parameters;
+	let units = {};
+	if (parametes?.length) {
+		units = _.keyBy(
+			parametes.map((parameter) => ({ id: parameter.id, units: parameter?.units?.expression ?? '' })),
+			'id'
+		);
+	}
+	return units;
+});
 
 const policyInterventionId = computed(() => props.node.inputs[1].value?.[0]);
 const interventionPolicy = ref<InterventionPolicy | null>(null);


### PR DESCRIPTION
# Description

Issue: 
The unit value for states when the user switches to the a dynamic intervention was missing.

![image](https://github.com/user-attachments/assets/ed2492d4-8095-4db9-a76e-2727f7cf4d89)

Testing:
- Add a Model
- create a model config
- create a intervention policy with dynamic intervention using state
- connect to simulate

Resolves #(issue)
