### PR TITLE
Automap string comparison should not care for casing

### DIFF
--- a/packages/client/hmi-client/src/services/concept.ts
+++ b/packages/client/hmi-client/src/services/concept.ts
@@ -213,7 +213,7 @@ const autoEntityMapping = async (sourceEntities: Entity[], targetEntities: Entit
 		targetEntities.forEach((target) => {
 			if (
 				!distinctSources.includes(source.id) &&
-				(target.id.startsWith(source.id) || source.id.startsWith(target.id))
+				(target.id.startsWith(source.id.toLocaleLowerCase()) || source.id.startsWith(target.id.toLocaleLowerCase()))
 			) {
 				result.push({ source: source.id, target: target.id });
 			}


### PR DESCRIPTION
# Description
Allow for the following to successfully automap (note no concepts were used in this automapping)
<img width="448" alt="image" src="https://github.com/user-attachments/assets/aaa5600e-b83c-410d-b03b-a4ce887e1a8d">
