### PR TITLE
fix(model-config-operator): rm guard preventing config select

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -638,9 +638,7 @@ const initialize = async (overwriteWithState: boolean = false) => {
 };
 
 const onSelectConfiguration = async (config: ModelConfiguration) => {
-	if (!config.extractionPage) return;
-
-	if (pdfViewer.value) {
+	if (pdfViewer.value && config.extractionPage) {
 		pdfViewer.value.goToPage(config.extractionPage);
 	}
 	// Checks if there are unsaved changes to current model configuration


### PR DESCRIPTION
# Description
* Model config select in the sidebar wasn't working
* Remove guard expecting a document