### PR TITLE
Add output settings and AI annotations to Optimize operator

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -352,7 +352,11 @@
 			>
 				<template #overlay>
 					<tera-chart-settings-panel
-						:annotations="activeChartSettings?.type === ChartSettingType.VARIABLE ? chartAnnotations : undefined"
+						:annotations="
+							activeChartSettings?.type === ChartSettingType.VARIABLE
+								? getChartAnnotationsByChartId(activeChartSettings.id)
+								: undefined
+						"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
 						@delete-annotation="deleteAnnotation"
@@ -436,7 +440,6 @@ import {
 } from '@/services/calibrate-workflow';
 import {
 	deleteAnnotation,
-	fetchAnnotations,
 	generateForecastChartAnnotation,
 	removeChartSettingById,
 	saveAnnotation,
@@ -459,7 +462,6 @@ import {
 	CsvAsset,
 	DatasetColumn,
 	ModelConfiguration,
-	ChartAnnotation,
 	InterventionPolicy,
 	ModelParameter,
 	AssetType,
@@ -495,7 +497,6 @@ import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import { displayNumber } from '@/utils/number';
 import TeraPyciemssCancelButton from '@/components/pyciemss/tera-pyciemss-cancel-button.vue';
 import TeraSaveSimulationModal from '@/components/project/tera-save-simulation-modal.vue';
-import { useClientEvent } from '@/composables/useClientEvent';
 import { useDrilldownChartSize } from '@/composables/useDrilldownChartSize';
 import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import TeraInterventionSummaryCard from '@/components/intervention-policy/tera-intervention-summary-card.vue';
@@ -503,6 +504,7 @@ import { getParameters } from '@/model-representation/service';
 import TeraTimestepCalendar from '@/components/widgets/tera-timestep-calendar.vue';
 import { getDataset } from '@/services/dataset';
 import { getCalendarSettingsFromModel, getVegaDateOptions } from '@/services/model';
+import { useChartAnnotations } from '@/composables/useChartAnnotations';
 import type { CalibrationOperationStateCiemss } from './calibrate-operation';
 import { renameFnGenerator, mergeResults, getErrorData } from './calibrate-utils';
 
@@ -691,13 +693,7 @@ const selectedErrorVariableSettings = computed(() =>
 );
 
 // --- Handle chart annotations
-const chartAnnotations = ref<ChartAnnotation[]>([]);
-const updateChartAnnotations = async () => {
-	chartAnnotations.value = await fetchAnnotations(props.node.id);
-};
-onMounted(() => updateChartAnnotations());
-useClientEvent([ClientEventType.ChartAnnotationCreate, ClientEventType.ChartAnnotationDelete], updateChartAnnotations);
-
+const { getChartAnnotationsByChartId } = useChartAnnotations(props.node.id);
 const generateAnnotation = async (setting: ChartSetting, query: string) => {
 	// Note: Currently llm generated chart annotations are supported for the forecast chart only
 	if (!preparedChartInputs.value) return null;
@@ -772,7 +768,7 @@ const preparedCharts = computed(() => {
 	// Simulate Charts:
 	selectedVariableSettings.value.forEach((settings) => {
 		const variable = settings.selectedVariables[0];
-		const annotations = chartAnnotations.value.filter((annotation) => annotation.chartId === settings.id);
+		const annotations = getChartAnnotationsByChartId(settings.id);
 		const datasetVariables: string[] = [];
 		const mapObj = state.mapping.find((d) => d.modelVariable === variable);
 		if (mapObj) {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -104,7 +104,7 @@ const chartSize = { width: 180, height: 120 };
 let lossValues: { [key: string]: number }[] = [];
 
 const selectedVariableSettings = computed(() =>
-	(props.node.state.chartSettings ?? []).filter((setting) => setting.type === ChartSettingType.VARIABLE_COMPARISON)
+	(props.node.state.chartSettings ?? []).filter((setting) => setting.type === ChartSettingType.VARIABLE)
 );
 
 const lossChartSpec = ref();

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -58,8 +58,6 @@ import {
 	ModelConfiguration,
 	SemanticType,
 	InferredParameterSemantic,
-	ChartAnnotation,
-	ClientEventType,
 	InterventionPolicy,
 	Dataset
 } from '@/types/Types';
@@ -70,9 +68,8 @@ import VegaChart from '@/components/widgets/VegaChart.vue';
 import * as stats from '@/utils/stats';
 import { createDatasetFromSimulationResult, getDataset } from '@/services/dataset';
 import { useProjects } from '@/composables/project';
-import { fetchAnnotations } from '@/services/chart-settings';
-import { useClientEvent } from '@/composables/useClientEvent';
 import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
+import { useChartAnnotations } from '@/composables/useChartAnnotations';
 import type { CalibrationOperationStateCiemss } from './calibrate-operation';
 import { CalibrationOperationCiemss } from './calibrate-operation';
 import { renameFnGenerator, mergeResults } from './calibrate-utils';
@@ -185,7 +182,7 @@ const preparedCharts = computed(() => {
 		if (mapObj) {
 			datasetVariables.push(mapObj.datasetVariable);
 		}
-		const annotations = chartAnnotations.value.filter((annotation) => annotation.chartId === setting.id);
+		const annotations = getChartAnnotationsByChartId(setting.id);
 
 		// variable chart
 		const chart = createForecastChart(
@@ -255,14 +252,7 @@ const preparedCharts = computed(() => {
 	return { variableCharts, interventionCharts };
 });
 
-// --- Handle chart annotations
-const chartAnnotations = ref<ChartAnnotation[]>([]);
-const updateChartAnnotations = async () => {
-	chartAnnotations.value = await fetchAnnotations(props.node.id);
-};
-onMounted(() => updateChartAnnotations());
-useClientEvent([ClientEventType.ChartAnnotationCreate, ClientEventType.ChartAnnotationDelete], updateChartAnnotations);
-// ---
+const { getChartAnnotationsByChartId } = useChartAnnotations(props.node.id);
 
 const poller = new Poller();
 const pollResult = async (runId: string) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -4,6 +4,7 @@ import { getRunResult, getSimulation } from '@/services/models/simulation-servic
 import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
 import { createInterventionPolicy, blankIntervention } from '@/services/intervention-policy';
 import optimizeModel from '@assets/svg/operator-images/optimize-model.svg';
+import { ChartSetting } from '@/types/common';
 
 const DOCUMENTATION_URL = 'https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L747';
 
@@ -63,6 +64,7 @@ export interface OptimizeCiemssOperationState extends BaseState {
 	constraintGroups: Criterion[];
 	selectedInterventionVariables: string[];
 	selectedSimulationVariables: string[];
+	chartSettings: ChartSetting[] | null; // null indicates that the chart settings have not been set yet
 	inProgressOptimizeId: string;
 	inProgressPreForecastId: string;
 	preForecastRunId: string;
@@ -144,6 +146,7 @@ export const OptimizeCiemssOperation: Operation = {
 			constraintGroups: [defaultCriterion],
 			selectedInterventionVariables: [],
 			selectedSimulationVariables: [],
+			chartSettings: null,
 			inProgressOptimizeId: '',
 			inProgressPostForecastId: '',
 			inProgressPreForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -50,13 +50,14 @@ import {
 } from '@/types/Types';
 import { createLLMSummary } from '@/services/summary-service';
 import VegaChart from '@/components/widgets/VegaChart.vue';
-import { createForecastChart } from '@/services/charts';
+import { applyForecastChartAnnotations, createForecastChart } from '@/services/charts';
 import { mergeResults, renameFnGenerator } from '@/components/workflow/ops/calibrate-ciemss/calibrate-utils';
 import { getModelByModelConfigurationId, getUnitsFromModelParts, getVegaDateOptions } from '@/services/model';
 import { getModelConfigurationById } from '@/services/model-configurations';
 import { createDatasetFromSimulationResult } from '@/services/dataset';
 import { useProjects } from '@/composables/project';
 import { ChartSettingType } from '@/types/common';
+import { useChartAnnotations } from '@/composables/useChartAnnotations';
 import {
 	OptimizeCiemssOperationState,
 	OptimizeCiemssOperation,
@@ -82,6 +83,8 @@ const chartSettings = computed(() => props.node.state.chartSettings ?? []);
 const selectedVariableSettings = computed(() =>
 	chartSettings.value.filter((setting) => setting.type === ChartSettingType.VARIABLE)
 );
+
+const { getChartAnnotationsByChartId } = useChartAnnotations(props.node.id);
 
 let pyciemssMap: Record<string, string> = {};
 
@@ -167,33 +170,37 @@ const preparedCharts = computed(() => {
 
 	return selectedVariableSettings.value.map((setting) => {
 		const variable = setting.selectedVariables[0];
-		return createForecastChart(
-			{
-				data: result,
-				variables: [`${pyciemssMap[variable]}:pre`, pyciemssMap[variable]],
-				timeField: 'timepoint_id',
-				groupField: 'sample_id'
-			},
-			{
-				data: resultSummary,
-				variables: [`${pyciemssMap[variable]}_mean:pre`, `${pyciemssMap[variable]}_mean`],
-				timeField: 'timepoint_id'
-			},
-			null,
-			{
-				width: 180,
-				height: 120,
-				legend: true,
-				xAxisTitle: modelVarUnits.value._time || 'Time',
-				yAxisTitle: modelVarUnits.value[variable] || '',
-				translationMap: {
-					[`${pyciemssMap[variable]}_mean:pre`]: `${variable} before optimization`,
-					[`${pyciemssMap[variable]}_mean`]: `${variable} after optimization`
+		const annotations = getChartAnnotationsByChartId(setting.id);
+		return applyForecastChartAnnotations(
+			createForecastChart(
+				{
+					data: result,
+					variables: [`${pyciemssMap[variable]}:pre`, pyciemssMap[variable]],
+					timeField: 'timepoint_id',
+					groupField: 'sample_id'
 				},
-				title: '',
-				colorscheme: ['#AAB3C6', '#1B8073'],
-				dateOptions
-			}
+				{
+					data: resultSummary,
+					variables: [`${pyciemssMap[variable]}_mean:pre`, `${pyciemssMap[variable]}_mean`],
+					timeField: 'timepoint_id'
+				},
+				null,
+				{
+					width: 180,
+					height: 120,
+					legend: true,
+					xAxisTitle: modelVarUnits.value._time || 'Time',
+					yAxisTitle: modelVarUnits.value[variable] || '',
+					translationMap: {
+						[`${pyciemssMap[variable]}_mean:pre`]: `${variable} before optimization`,
+						[`${pyciemssMap[variable]}_mean`]: `${variable} after optimization`
+					},
+					title: '',
+					colorscheme: ['#AAB3C6', '#1B8073'],
+					dateOptions
+				}
+			),
+			annotations
 		);
 	});
 });

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -512,14 +512,11 @@ useClientEvent([ClientEventType.ChartAnnotationCreate, ClientEventType.ChartAnno
 const generateAnnotation = async (setting: ChartSetting, query: string) => {
 	// Note: Currently llm generated chart annotations are supported for the forecast chart only
 	if (!preparedChartInputs.value) return null;
-
-	const selectedVars = setting.selectedVariables;
-	const { statLayerVariables, options } = getForecastChartOptions(selectedVars, preparedChartInputs.value.reverseMap);
-	const annotationLayerSpec = await generateForecastChartAnnotation(query, 'timepoint_id', statLayerVariables, {
-		translationMap: options.translationMap,
-		xAxisTitle: options.xAxisTitle,
-		yAxisTitle: options.yAxisTitle
-	});
+	const { statLayerVariables, options } = getForecastChartOptions(
+		setting.selectedVariables,
+		preparedChartInputs.value.reverseMap
+	);
+	const annotationLayerSpec = await generateForecastChartAnnotation(query, 'timepoint_id', statLayerVariables, options);
 	const saved = await saveAnnotation(annotationLayerSpec, props.node.id, setting.id);
 	return saved;
 };

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -34,7 +34,12 @@ import { nodeOutputLabel } from '@/components/workflow/util';
 import type { WorkflowNode } from '@/types/workflow';
 import { createLLMSummary } from '@/services/summary-service';
 import { useProjects } from '@/composables/project';
-import { createForecastChart, createInterventionChartMarkers, ForecastChartOptions } from '@/services/charts';
+import {
+	applyForecastChartAnnotations,
+	createForecastChart,
+	createInterventionChartMarkers,
+	ForecastChartOptions
+} from '@/services/charts';
 import { createDatasetFromSimulationResult } from '@/services/dataset';
 import VegaChart from '@/components/widgets/VegaChart.vue';
 import {
@@ -53,6 +58,7 @@ import { addMultiVariableChartSetting } from '@/services/chart-settings';
 import { ChartSettingType } from '@/types/common';
 import { useClientEvent } from '@/composables/useClientEvent';
 import { getModelConfigurationById } from '@/services/model-configurations';
+import { useChartAnnotations } from '@/composables/useChartAnnotations';
 import { SimulateCiemssOperationState, SimulateCiemssOperation } from './simulate-ciemss-operation';
 import { mergeResults, renameFnGenerator } from '../calibrate-ciemss/calibrate-utils';
 
@@ -77,6 +83,8 @@ const interventionPolicyId = computed(() => props.node.inputs[1].value?.[0]);
 const interventionPolicy = ref<InterventionPolicy | null>(null);
 
 const chartSettings = computed(() => props.node.state.chartSettings ?? []);
+
+const { getChartAnnotationsByChartId } = useChartAnnotations(props.node.id);
 
 let pyciemssMap: Record<string, string> = {};
 
@@ -181,20 +189,24 @@ const preparedCharts = computed(() => {
 			options.colorscheme = ['#AAB3C6', '#1B8073'];
 		}
 
-		const chart = createForecastChart(
-			{
-				data: result,
-				variables: setting.selectedVariables.map((d) => pyciemssMap[d]),
-				timeField: 'timepoint_id',
-				groupField: 'sample_id'
-			},
-			{
-				data: resultSummary,
-				variables: statLayerVariables,
-				timeField: 'timepoint_id'
-			},
-			null,
-			options
+		const annotations = getChartAnnotationsByChartId(setting.id);
+		const chart = applyForecastChartAnnotations(
+			createForecastChart(
+				{
+					data: result,
+					variables: setting.selectedVariables.map((d) => pyciemssMap[d]),
+					timeField: 'timepoint_id',
+					groupField: 'sample_id'
+				},
+				{
+					data: resultSummary,
+					variables: statLayerVariables,
+					timeField: 'timepoint_id'
+				},
+				null,
+				options
+			),
+			annotations
 		);
 		if (interventionPolicy.value) {
 			_.keys(groupedInterventionOutputs.value).forEach((key) => {

--- a/packages/client/hmi-client/src/composables/useChartAnnotations.ts
+++ b/packages/client/hmi-client/src/composables/useChartAnnotations.ts
@@ -1,0 +1,24 @@
+import { fetchAnnotations } from '@/services/chart-settings';
+import { ChartAnnotation, ClientEventType } from '@/types/Types';
+import { onMounted, ref } from 'vue';
+import { useClientEvent } from './useClientEvent';
+
+export function useChartAnnotations(nodeId: string) {
+	const chartAnnotations = ref<ChartAnnotation[]>([]);
+	const updateChartAnnotations = async () => {
+		chartAnnotations.value = await fetchAnnotations(nodeId);
+	};
+	onMounted(() => updateChartAnnotations());
+	useClientEvent(
+		[ClientEventType.ChartAnnotationCreate, ClientEventType.ChartAnnotationDelete],
+		updateChartAnnotations
+	);
+
+	const getChartAnnotationsByChartId = (id: string) =>
+		chartAnnotations.value.filter((annotation) => annotation.chartId === id);
+
+	return {
+		chartAnnotations,
+		getChartAnnotationsByChartId
+	};
+}

--- a/packages/client/hmi-client/src/composables/useChartAnnotations.ts
+++ b/packages/client/hmi-client/src/composables/useChartAnnotations.ts
@@ -3,6 +3,11 @@ import { ChartAnnotation, ClientEventType } from '@/types/Types';
 import { onMounted, ref } from 'vue';
 import { useClientEvent } from './useClientEvent';
 
+/**
+ * Fetches chart annotations for a given node id and stores them in a ref.
+ * The ref is updated when a new annotation is created or deleted and can be accessed by getChartAnnotationsByChartId getter function.
+ * @param nodeId
+ */
 export function useChartAnnotations(nodeId: string) {
 	const chartAnnotations = ref<ChartAnnotation[]>([]);
 	const updateChartAnnotations = async () => {
@@ -18,7 +23,6 @@ export function useChartAnnotations(nodeId: string) {
 		chartAnnotations.value.filter((annotation) => annotation.chartId === id);
 
 	return {
-		chartAnnotations,
 		getChartAnnotationsByChartId
 	};
 }


### PR DESCRIPTION
# Description

![Screenshot 2024-10-30 at 8 14 08 PM](https://github.com/user-attachments/assets/98aa8a85-b0a7-4ba5-8c62-9fd120d9b3cb)
![Screenshot 2024-10-31 at 10 08 43 AM](https://github.com/user-attachments/assets/d92106ba-32ab-4835-82fe-fe89c869ff28)

- For optimize drilldown, added output settings panel and moved output settings over to it.
- Added AI annotations to optimize node and drilldown
- Refactored and pulled repeated common logic about fetching and updating chart annotations out of the components and moved it as its own composable. 


Resolves #5272, #5037  