### PR TITLE
manually sort loss data points

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -140,10 +140,12 @@ async function updateLossChartWithSimulation() {
 	if (props.node.active) {
 		const simulationObj = await getSimulation(props.node.state.calibrationId);
 		if (simulationObj?.updates) {
-			lossValues = simulationObj?.updates.map((d, i) => ({
-				iter: i,
-				loss: d.data.loss
-			}));
+			lossValues = simulationObj?.updates
+				.sort((a, b) => a.data.progress - b.data.progress)
+				.map((d, i) => ({
+					iter: i,
+					loss: d.data.loss
+				}));
 			updateLossChartSpec(lossValues);
 		}
 	}
@@ -279,10 +281,12 @@ const pollResult = async (runId: string) => {
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
 			if (data?.updates?.length) {
-				lossValues = data?.updates.map((d, i) => ({
-					iter: i,
-					loss: d.data.loss
-				}));
+				lossValues = data?.updates
+					.sort((a, b) => a.data.progress - b.data.progress)
+					.map((d, i) => ({
+						iter: i,
+						loss: d.data.loss
+					}));
 				updateLossChartSpec(lossValues);
 			}
 			if (runId === props.node.state.inProgressCalibrationId && data.updates.length > 0) {


### PR DESCRIPTION
### Summary
Just sort the data points with respect to progression manually, as they are still coming back in seemingly random order

Instead of


<img width="211" alt="image" src="https://github.com/user-attachments/assets/a9b397c9-907b-4afb-8a0b-e548e36eff54">


We should have

<img width="303" alt="image" src="https://github.com/user-attachments/assets/2c63f2c1-77b4-44f9-9b38-13fb1744a546">
