### PR TITLE
bug: stop image from being dragged off of node

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell-output.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell-output.vue
@@ -25,6 +25,10 @@ const renderOutputs = (outputs) => {
 	});
 
 	if (outputAreaRef.value) {
+		const imgElement = outputArea.node.querySelector('img');
+		if (imgElement) {
+			imgElement.draggable = false;
+		}
 		outputAreaRef.value.replaceChildren(outputArea.node);
 	}
 };


### PR DESCRIPTION
# Description


https://github.com/user-attachments/assets/1ca90e53-10f9-40bc-8349-59b6664099ba

Issues: Images in the Dataset Transformation node could be dragged, and would create a new node.

Testing: 
- https://github.com/DARPA-ASKEM/terarium/blob/main/testing/manual/transform-dataset.md

- Create a new dataset transformation and show a graph image on the node
- Try dragging image

Resolves #(issue)
