### PR TITLE
Update Optimize API optimize_interventions to list

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -754,20 +754,20 @@ const runOptimize = async () => {
 
 	setOutputSettingDefaults();
 
-	const paramNames: string[] = [];
-	const paramValues: number[] = [];
-	const startTime: number[] = [];
+	const optimizeInterventions: OptimizeInterventions[] = [];
 	const listBoundsInterventions: number[][] = [];
-	const initialGuess: number[] = [];
-	const objectiveFunctionOption: string[] = [];
-	const relativeImportance: number[] = [];
 
 	activePolicyGroups.value.forEach((ele) => {
+		const paramNames: string[] = [];
+		const paramValues: number[] = [];
+		const startTime: number[] = [];
+		const initialGuess: number[] = [];
+		const relativeImportance: number[] = [];
+
 		// Only allowed to optimize on interventions that arent grouped aka staticInterventions' length is 1
 		paramNames.push(ele.intervention.staticInterventions[0].appliedTo);
 		paramValues.push(ele.intervention.staticInterventions[0].value);
 		startTime.push(ele.intervention.staticInterventions[0].timestep);
-		objectiveFunctionOption.push(ele.objectiveFunctionOption);
 		relativeImportance.push(ele.relativeImportance);
 
 		if (ele.optimizationType === OptimizationInterventionObjective.startTime) {
@@ -786,21 +786,17 @@ const runOptimize = async () => {
 		} else {
 			console.error(`invalid optimization type used:${ele.optimizationType}`);
 		}
-	});
-	// At the moment we only accept one intervention type. Pyciemss, pyciemss-service and this will all need to be updated.
-	// https://github.com/DARPA-ASKEM/terarium/issues/3909
-	const interventionType = knobs.value.interventionPolicyGroups[0].optimizationType;
 
-	// These are interventions to be optimized over.
-	const optimizeInterventions: OptimizeInterventions = {
-		interventionType,
-		paramNames,
-		startTime,
-		paramValues,
-		initialGuess,
-		objectiveFunctionOption,
-		relativeImportance
-	};
+		optimizeInterventions.push({
+			interventionType: ele.optimizationType,
+			paramNames,
+			startTime,
+			paramValues,
+			initialGuess,
+			objectiveFunctionOption: ele.objectiveFunctionOption,
+			relativeImportance: ele.relativeImportance
+		});
+	});
 
 	// These are interventions to be considered but not optimized over.
 	const fixedInterventions: Intervention[] = _.cloneDeep(inactivePolicyGroups.value.map((ele) => ele.intervention));

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -801,8 +801,8 @@ export interface ModelUnit {
 }
 
 export interface GroundedSemantic {
-    name?: string;
     id: string;
+    name?: string;
     grounding?: ModelGrounding;
 }
 

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -568,7 +568,7 @@ export interface EnsembleSimulationCiemssRequest {
 export interface OptimizeRequestCiemss {
     modelConfigId: string;
     timespan: TimeSpan;
-    optimizeInterventions?: OptimizeInterventions;
+    optimizeInterventions: OptimizeInterventions[];
     fixedInterventions?: Intervention[];
     loggingStepSize?: number;
     qoi: OptimizeQoi[];
@@ -642,9 +642,9 @@ export interface OptimizeInterventions {
     paramNames: string[];
     paramValues?: number[];
     startTime?: number[];
-    objectiveFunctionOption?: string[];
+    objectiveFunctionOption: string;
     initialGuess?: number[];
-    relativeImportance?: number[];
+    relativeImportance: number;
 }
 
 export interface OptimizeQoi {
@@ -801,8 +801,8 @@ export interface ModelUnit {
 }
 
 export interface GroundedSemantic {
-    id: string;
     name?: string;
+    id: string;
     grounding?: ModelGrounding;
 }
 

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -801,9 +801,9 @@ export interface ModelUnit {
 }
 
 export interface GroundedSemantic {
+    grounding?: ModelGrounding;
     id: string;
     name?: string;
-    grounding?: ModelGrounding;
 }
 
 export interface Properties {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/OptimizeRequestCiemss.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/OptimizeRequestCiemss.java
@@ -25,9 +25,8 @@ public class OptimizeRequestCiemss implements Serializable {
 
 	private TimeSpan timespan;
 
-	@TSOptional
 	// https://github.com/DARPA-ASKEM/pyciemss-service/blob/main/service/models/operations/optimize.py#L80
-	private OptimizeInterventions optimizeInterventions;
+	private List<OptimizeInterventions> optimizeInterventions;
 
 	@TSOptional
 	@JsonAlias("fixed_interventions")

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/parts/OptimizeInterventions.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/simulationservice/parts/OptimizeInterventions.java
@@ -30,17 +30,15 @@ public class OptimizeInterventions {
 	@JsonAlias("start_time")
 	private List<Integer> startTime;
 
-	@TSOptional
 	@JsonAlias("objective_function_option")
-	private List<String> objectiveFunctionOption;
+	private String objectiveFunctionOption;
 
 	@TSOptional
 	@JsonAlias("initial_guess")
 	private List<Double> initialGuess;
 
-	@TSOptional
 	@JsonAlias("relative_importance")
-	private List<Double> relativeImportance;
+	private Double relativeImportance;
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
# Issue:
1) It is hard to follow what is going on as we are throwing all optimize interventions into one big blob.
2) Our optimize intervention type (find new start time, param value ect) was being incorrectly assigned when multiple types were given all but the first were ignored.

# Description
- Re-organize how we are sending in the interventions to be optimized.
    - Rather than sending one big messy blob send a list of `InterventionObjective`
- Utilize `intervention_func_combinator` to allow us to intervene on two interventions with different types.
    - Previously if we sent the screenshot below both of the interventions were incorrectly using `new start time`

# Related Required:
https://github.com/DARPA-ASKEM/pyciemss-service/pull/124

# Pictures:
Previously these two inputs settings were incorrectly not treated identically.
<img width="842" alt="image" src="https://github.com/user-attachments/assets/7a45081f-38cf-4d7a-ac7a-e10ccc7f86c7">

<img width="868" alt="image" src="https://github.com/user-attachments/assets/b80857fe-be66-4c0e-a210-c83806fb4529">


