### PR TITLE
fix(funman): no more watcher loop, format json in notebook

### DIFF
--- a/packages/client/hmi-client/src/services/code.ts
+++ b/packages/client/hmi-client/src/services/code.ts
@@ -197,6 +197,16 @@ function setFileExtension(fileName: string, language: ProgrammingLanguage) {
 	return fileName.concat('.').concat(getFileExtension(language));
 }
 
+function formatJSON(jsonString: string): string {
+	try {
+		const jsonObj = JSON.parse(jsonString);
+		return JSON.stringify(jsonObj, null, 2); // Pretty print with 2 spaces indentation
+	} catch (e) {
+		console.error('Invalid JSON string', e);
+		return jsonString; // Return original string if parsing fails
+	}
+}
+
 export {
 	uploadCodeToProject,
 	getCodeFileAsText,
@@ -207,5 +217,6 @@ export {
 	getFileExtension,
 	getProgrammingLanguage,
 	setFileExtension,
-	uploadCodeFromGithubRepo
+	uploadCodeFromGithubRepo,
+	formatJSON
 };

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -111,8 +111,7 @@ export const processFunman = (result: any) => {
 		// Mark boxes with the latest timestep
 		return boxes.map((box) => {
 			const timestep = box?.points?.[0]?.values?.timestep;
-			if (!timestep) return box;
-			box.isAtLatestTimestep = timestep === latestTimestep;
+			if (timestep) box.isAtLatestTimestep = timestep === latestTimestep;
 			return box;
 		});
 	}

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -100,7 +100,9 @@ export const processFunman = (result: any) => {
 
 		// The latest timestep is found in the box with the most keys
 		boxes.forEach((box) => {
-			const keysCount = Object.keys(box.points[0]?.values).length;
+			const points = box?.points?.[0]?.values;
+			if (!points) return;
+			const keysCount = Object.keys(points).length;
 			if (keysCount > maxKeysCount) {
 				maxKeysCount = keysCount;
 				latestTimestep = box.points[0].values.timestep;
@@ -108,7 +110,9 @@ export const processFunman = (result: any) => {
 		});
 		// Mark boxes with the latest timestep
 		return boxes.map((box) => {
-			box.isAtLatestTimestep = box.points[0].values.timestep === latestTimestep;
+			const timestep = box?.points?.[0]?.values?.timestep;
+			if (!timestep) return box;
+			box.isAtLatestTimestep = timestep === latestTimestep;
 			return box;
 		});
 	}


### PR DESCRIPTION
# Description

* Having the `props.node.state.runId` in a watcher array and doing the `update-state` emit within that watcher was infinitely triggering it
* Not having it in an array works fine so I adjusted the logic for it to work
* Also the json is formatted nicely in the notebook tab now 
* Removed an unused watcher and some variables
