### PR TITLE
split save and update functions

### DIFF
--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -76,6 +76,7 @@
 		:open-on-save="!isWorkflow"
 		@close-modal="showSaveModal = false"
 		@on-save="onModalSave"
+		@on-update="onModalSave"
 	/>
 </template>
 

--- a/packages/client/hmi-client/src/components/project/tera-save-asset-modal.vue
+++ b/packages/client/hmi-client/src/components/project/tera-save-asset-modal.vue
@@ -63,7 +63,7 @@ const props = defineProps({
 	}
 });
 
-const emit = defineEmits(['close-modal', 'on-save']);
+const emit = defineEmits(['close-modal', 'on-save', 'on-update']);
 
 let newAsset: any = null;
 const newName = ref<string>('');
@@ -77,6 +77,10 @@ const title = computed(() => {
 
 function onSave(data: any) {
 	emit('on-save', data);
+}
+
+function onUpdate(data: any) {
+	emit('on-update', data);
 }
 
 function closeModal() {
@@ -138,7 +142,7 @@ function save() {
 
 	// Save method
 	if (props.isUpdatingAsset) {
-		saveAssetService.updateAddToProject(newAsset, props.assetType, onSave);
+		saveAssetService.updateAddToProject(newAsset, props.assetType, onUpdate);
 	} else {
 		saveAssetService.saveAs(newAsset, props.assetType, props.openOnSave, onSave);
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -301,6 +301,7 @@
 		:asset-type="AssetType.ModelConfiguration"
 		@close-modal="showSaveModal = false"
 		@on-save="onSaveForReuse"
+		@on-update="onSaveForReuse"
 	/>
 </template>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -181,7 +181,7 @@
 		:asset-type="AssetType.InterventionPolicy"
 		@close-modal="showSaveModal = false"
 		@on-save="onSaveAsInterventionPolicy"
-		@on-update="onSaveInterventionPolicy"
+		@on-update="onSaveAsInterventionPolicy"
 	/>
 </template>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -181,6 +181,7 @@
 		:asset-type="AssetType.InterventionPolicy"
 		@close-modal="showSaveModal = false"
 		@on-save="onSaveAsInterventionPolicy"
+		@on-update="onSaveInterventionPolicy"
 	/>
 </template>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -215,6 +215,7 @@
 		:asset-type="AssetType.ModelConfiguration"
 		@close-modal="showSaveModal = false"
 		@on-save="onSaveAsModelConfiguration"
+		@on-update="onSaveAsModelConfiguration"
 	/>
 
 	<!-- Matrix effect easter egg  -->


### PR DESCRIPTION
# Description

* Addressed the attached ticket where we wanted to split the update and save functions from the `tera-save-asset-modal` component.  I've kept the same functionality for all the components that use this component, but we can use different functions for either save or update if we want in the future

