### PR TITLE
prevent nested groups from going over prestashed circle pack limits

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/nested-petrinet-renderer.ts
@@ -188,6 +188,21 @@ export class NestedPetrinetRenderer extends PetrinetRenderer {
 			}
 
 			const nestedNodesLen = Object.keys(node).filter((d) => d !== '_key').length;
+			if (nestedNodesLen >= CIRCLE_PACKING_CHILD_NORMALIZED_VECTORS.length) {
+				select(g[idx])
+					.append('text')
+					.classed('latex-font', true)
+					.attr('y', parentRadius)
+					.style('font-size', 0.6 * parentRadius)
+					.attr('stroke-width', '0.5px')
+					.style('text-anchor', 'middle')
+					.style('paint-order', 'stroke')
+					.style('fill', 'var(--text-color-primary)')
+					.style('pointer-events', 'none')
+					.text(`${nestedNodesLen} groups`);
+
+				return;
+			}
 
 			Object.entries(node).forEach((kvPair, i) => {
 				if (kvPair[0] === '_key') return;


### PR DESCRIPTION
### Summary
We precomputed circle pack up to 75 groups, so if we go higher the renderer will fail. 
This PR adds a cap condition check and exits if we exceed the threshold, here is diagram showing 190+ groups.

![image](https://github.com/user-attachments/assets/c220a36a-f41e-4ba6-9737-875911a3e9ea)


Note: While we can go higher in terms of the precompute it will increase the size of the application/payload non-linearly.