### PR TITLE
5350 [part 1] fixes the add a cell button

### DIFF
--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
@@ -242,7 +242,6 @@ const reRunPrompt = (queryId: string, query?: string) => {
 	isExecutingCode.value = true;
 };
 
-// here
 const addCodeCell = (isDefaultCell: boolean = false, isNextCell: boolean = true) => {
 	const msgId = createMessageId('code_cell');
 	const date = new Date().toISOString();
@@ -463,9 +462,8 @@ watch(
 defineExpose({
 	clearHistory,
 	clearOutputs,
-	submitQuery
-
-	// here
+	submitQuery,
+	addCodeCell
 });
 </script>
 


### PR DESCRIPTION
# There are really 3 bugs in #5350, I am submitting the fixes for them separately for clarity and ease of review

* The `+ Add a cell` button towards the top of the Transform Dataset drill down works as expected again

<img width="676" alt="Screenshot 2024-11-06 at 2 54 44 PM" src="https://github.com/user-attachments/assets/ab42c65b-36af-48d2-99cc-58a16f289677">
