### PR TITLE
5350 [part 2] fixes permanently disabled "save for reuse" button

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset-transformer/tera-dataset-transformer.vue
@@ -72,7 +72,10 @@ const assets = computed(() =>
 		}))
 );
 const disableSaveForReuse = computed(
-	() => !kernelState.value || props.node.status === OperatorStatus.INVALID || props.node.status === OperatorStatus.ERROR
+	() =>
+		!kernelState.value ||
+		(props.node.status === OperatorStatus.INVALID && props.node.state.selectedOutputs.length) ||
+		props.node.status === OperatorStatus.ERROR
 );
 
 const kernelState = ref(null);

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -244,7 +244,7 @@ export class WorkflowWrapper {
 				state: {}
 			})),
 
-			status: OperatorStatus.INVALID,
+			status: OperatorStatus.DEFAULT,
 			width: nodeSize.width,
 			height: nodeSize.height
 		};

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -244,7 +244,7 @@ export class WorkflowWrapper {
 				state: {}
 			})),
 
-			status: OperatorStatus.DEFAULT,
+			status: OperatorStatus.INVALID,
 			width: nodeSize.width,
 			height: nodeSize.height
 		};


### PR DESCRIPTION
# There are really 3 bugs in https://github.com/DARPA-ASKEM/terarium/issues/5350, I am submitting the fixes for them separately for clarity and ease of review

* Fixes the permanent invalid state of the node to allow saving
* Preserves the ability to disable saving when actually invalid


<img width="904" alt="Screenshot 2024-11-06 at 3 03 52 PM" src="https://github.com/user-attachments/assets/b5dbf5f3-6c20-4ff7-9ea0-0d6779dc0b67">
