### PR TITLE
clearer unsaved changes message in model config

### DIFF
--- a/packages/client/hmi-client/src/assets/css/theme/_variables.scss
+++ b/packages/client/hmi-client/src/assets/css/theme/_variables.scss
@@ -643,7 +643,7 @@ $dialogHeaderTextColor: $textColor;
 $dialogHeaderFontWeight: $fontWeightSemiBold;
 $dialogHeaderFontSize: $fontBodyLarge;
 $dialogHeaderPadding: 1rem 1.33rem 0rem 1.33rem;
-$dialogContentPadding: 0 1.33rem 1.33rem 1.33rem;
+$dialogContentPadding: 1.33rem;
 $dialogFooterBorder: 0 none;
 $dialogFooterPadding: 1rem 1.33rem;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -63,7 +63,7 @@
 				</template>
 			</tera-slider-panel>
 		</template>
-		<tera-drilldown-section :is-loading="initializing" :tabName="ConfigTabs.Wizard" class="px-3 mb-10">
+		<tera-drilldown-section :is-loading="initializing" :tabName="DrilldownTabs.Wizard" class="px-3 mb-10">
 			<template #header-controls-left>
 				<tera-toggleable-input
 					v-if="typeof knobs.transientModelConfig.name === 'string'"
@@ -167,7 +167,7 @@
 				</template>
 			</template>
 		</tera-drilldown-section>
-		<tera-columnar-panel :tabName="ConfigTabs.Notebook">
+		<tera-columnar-panel :tabName="DrilldownTabs.Notebook">
 			<tera-drilldown-section class="notebook-section">
 				<div class="toolbar">
 					<Suspense>
@@ -280,6 +280,7 @@ import { useProjects } from '@/composables/project';
 import TeraPdfPanel from '@/components/widgets/tera-pdf-panel.vue';
 import Calendar from 'primevue/calendar';
 import { CalendarSettings } from '@/utils/date';
+import { DrilldownTabs } from '@/types/common';
 import {
 	blankModelConfig,
 	isModelConfigsEqual,
@@ -289,14 +290,11 @@ import {
 } from './model-config-operation';
 import TeraModelConfigurationItem from './tera-model-configuration-item.vue';
 
-enum ConfigTabs {
-	Wizard = 'Wizard',
-	Notebook = 'Notebook'
-}
-
 const props = defineProps<{
 	node: WorkflowNode<ModelConfigOperationState>;
 }>();
+
+const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
 
 const isFetchingPDF = ref(false);
 const isDocViewerOpen = ref(true);
@@ -311,7 +309,7 @@ const isEditingDescription = ref(false);
 const newDescription = ref('');
 const descriptionTextareaRef = ref<ComponentPublicInstance<typeof Textarea> | null>(null);
 
-const emit = defineEmits(['append-output', 'update-state', 'select-output', 'close']);
+let originalConfig: ModelConfiguration | null = null;
 
 interface BasicKnobs {
 	transientModelConfig: ModelConfiguration;
@@ -331,16 +329,14 @@ const calibratedConfigObservables = computed<Observable[]>(() =>
 );
 
 // Check if the model configuration is the same as the original
-const isModelConfigChanged = computed(
-	() => !isModelConfigsEqual(originalConfig.value, knobs.value.transientModelConfig)
-);
+const isModelConfigChanged = computed(() => !isModelConfigsEqual(originalConfig, knobs.value.transientModelConfig));
 
 // Save button is disabled if the model configuration name is empty, the values have changed, or the configuration is the same as the original
 const isSaveDisabled = computed(
 	() =>
 		knobs.value.transientModelConfig.name === '' ||
-		isModelConfigsEqual(originalConfig.value, knobs.value.transientModelConfig) ||
-		!isModelConfigValuesEqual(originalConfig.value, knobs.value.transientModelConfig)
+		isModelConfigsEqual(originalConfig, knobs.value.transientModelConfig) ||
+		!isModelConfigValuesEqual(originalConfig, knobs.value.transientModelConfig)
 );
 
 const kernelManager = new KernelSessionManager();
@@ -493,7 +489,6 @@ const extractConfigurationsFromInputs = async () => {
 
 const selectedOutputId = ref<string>('');
 const selectedConfigId = computed(() => props.node.outputs.find((o) => o.id === selectedOutputId.value)?.value?.[0]);
-const originalConfig = ref<ModelConfiguration | null>(null);
 
 const documentIds = computed(() =>
 	props.node.inputs
@@ -609,9 +604,9 @@ const initialize = async (overwriteWithState: boolean = false) => {
 		// Apply a configuration if one hasn't been applied yet
 		applyConfigValues(modelConfigurations.value[0]);
 	} else {
-		originalConfig.value = await getModelConfigurationById(selectedConfigId.value);
+		originalConfig = await getModelConfigurationById(selectedConfigId.value);
 		if (!overwriteWithState) {
-			knobs.value.transientModelConfig = cloneDeep(originalConfig.value);
+			knobs.value.transientModelConfig = cloneDeep(originalConfig);
 		} else {
 			knobs.value.transientModelConfig = cloneDeep(state.transientModelConfig);
 		}
@@ -639,15 +634,28 @@ const onSelectConfiguration = async (config: ModelConfiguration) => {
 	if (pdfViewer.value && config.extractionPage) {
 		pdfViewer.value.goToPage(config.extractionPage);
 	}
-	// Checks if there are unsaved changes to current model configuration
-	if (isModelConfigsEqual(originalConfig.value, knobs.value.transientModelConfig)) {
+	// If no changes were made switch right away
+	if (isModelConfigsEqual(originalConfig, knobs.value.transientModelConfig)) {
 		applyConfigValues(config);
 		return;
 	}
 
+	const lostItems: string[] = [];
+
+	if (!isModelConfigValuesEqual(originalConfig, knobs.value.transientModelConfig)) lostItems.push('values');
+	if (knobs.value.transientModelConfig.name !== originalConfig?.name) lostItems.push('name');
+	if (knobs.value.transientModelConfig.description !== originalConfig?.description) lostItems.push('description');
+
+	let lostItemsStr = '';
+	if (lostItems.length > 1) {
+		lostItemsStr = `${lostItems.slice(0, -1).join(', ')} and ${lostItems.slice(-1)}`;
+	} else {
+		lostItemsStr = lostItems[0];
+	}
+
 	confirm.require({
-		header: 'Are you sure you want to select this configuration?',
-		message: `This will apply the configuration "${config.name}" to the model.  All current values will be replaced.`,
+		header: `Unsaved changes`,
+		message: `Changes made to the ${lostItemsStr} will be lost.`,
 		accept: () => {
 			applyConfigValues(config);
 		},
@@ -696,10 +704,10 @@ const onConfirmEditDescription = () => {
 
 const resetConfiguration = () => {
 	confirm.require({
-		header: 'Are you sure you want to reset the configuration?',
-		message: 'This will reset all values original values of the configuration.',
+		header: 'Reset configuration',
+		message: 'This will reset all values to their original ones.',
 		accept: () => {
-			if (originalConfig.value) knobs.value.transientModelConfig = cloneDeep(originalConfig.value);
+			if (originalConfig) knobs.value.transientModelConfig = cloneDeep(originalConfig);
 		},
 		acceptLabel: 'Confirm',
 		rejectLabel: 'Cancel'

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -705,7 +705,7 @@ const onConfirmEditDescription = () => {
 const resetConfiguration = () => {
 	confirm.require({
 		header: 'Reset configuration',
-		message: 'This will reset all values to their original ones.',
+		message: 'All edits done to this configuration will be reverted.',
 		accept: () => {
 			if (originalConfig) knobs.value.transientModelConfig = cloneDeep(originalConfig);
 		},

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -281,6 +281,7 @@ import TeraPdfPanel from '@/components/widgets/tera-pdf-panel.vue';
 import Calendar from 'primevue/calendar';
 import { CalendarSettings } from '@/utils/date';
 import { DrilldownTabs } from '@/types/common';
+import { formatListWithConjunction } from '@/utils/text';
 import {
 	blankModelConfig,
 	isModelConfigsEqual,
@@ -634,28 +635,23 @@ const onSelectConfiguration = async (config: ModelConfiguration) => {
 	if (pdfViewer.value && config.extractionPage) {
 		pdfViewer.value.goToPage(config.extractionPage);
 	}
+
+	const { transientModelConfig } = knobs.value;
 	// If no changes were made switch right away
-	if (isModelConfigsEqual(originalConfig, knobs.value.transientModelConfig)) {
+	if (isModelConfigsEqual(originalConfig, transientModelConfig)) {
 		applyConfigValues(config);
 		return;
 	}
 
 	const lostItems: string[] = [];
 
-	if (!isModelConfigValuesEqual(knobs.value.transientModelConfig, originalConfig)) lostItems.push('values');
-	if (knobs.value.transientModelConfig.name !== originalConfig?.name) lostItems.push('name');
-	if (knobs.value.transientModelConfig.description !== originalConfig?.description) lostItems.push('description');
-
-	let lostItemsStr = '';
-	if (lostItems.length > 1) {
-		lostItemsStr = `${lostItems.slice(0, -1).join(', ')} and ${lostItems.slice(-1)}`;
-	} else {
-		lostItemsStr = lostItems[0];
-	}
+	if (!isModelConfigValuesEqual(transientModelConfig, originalConfig)) lostItems.push('values');
+	if (transientModelConfig.name !== originalConfig?.name) lostItems.push('name');
+	if (transientModelConfig.description !== originalConfig?.description) lostItems.push('description');
 
 	confirm.require({
 		header: `Unsaved changes`,
-		message: `Changes made to the ${lostItemsStr} will be lost.`,
+		message: `Changes made to the ${formatListWithConjunction(lostItems)} will be lost.`,
 		accept: () => {
 			applyConfigValues(config);
 		},

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -642,9 +642,11 @@ const onSelectConfiguration = async (config: ModelConfiguration) => {
 
 	const lostItems: string[] = [];
 
-	if (!isModelConfigValuesEqual(originalConfig, knobs.value.transientModelConfig)) lostItems.push('values');
+	if (!isModelConfigValuesEqual(knobs.value.transientModelConfig, originalConfig)) lostItems.push('values');
 	if (knobs.value.transientModelConfig.name !== originalConfig?.name) lostItems.push('name');
-	if (knobs.value.transientModelConfig.description !== originalConfig?.description) lostItems.push('description');
+	if (knobs.value.transientModelConfig.description?.trim() !== originalConfig?.description?.trim()) {
+		lostItems.push('description');
+	}
 
 	let lostItemsStr = '';
 	if (lostItems.length > 1) {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -644,9 +644,7 @@ const onSelectConfiguration = async (config: ModelConfiguration) => {
 
 	if (!isModelConfigValuesEqual(knobs.value.transientModelConfig, originalConfig)) lostItems.push('values');
 	if (knobs.value.transientModelConfig.name !== originalConfig?.name) lostItems.push('name');
-	if (knobs.value.transientModelConfig.description?.trim() !== originalConfig?.description?.trim()) {
-		lostItems.push('description');
-	}
+	if (knobs.value.transientModelConfig.description !== originalConfig?.description) lostItems.push('description');
 
 	let lostItemsStr = '';
 	if (lostItems.length > 1) {

--- a/packages/client/hmi-client/src/utils/text.ts
+++ b/packages/client/hmi-client/src/utils/text.ts
@@ -37,4 +37,20 @@ function snakeToCapitalSentence(snakeCaseString: string) {
 	return startCase(toLower(snakeCaseString));
 }
 
-export { highlightText as highlight, pascalCaseToCapitalSentence, snakeToCapitalized, snakeToCapitalSentence };
+function formatListWithConjunction(stringList: string[]) {
+	let formattedString = '';
+	if (stringList.length > 1) {
+		formattedString = `${stringList.slice(0, -1).join(', ')} and ${stringList.slice(-1)}`;
+	} else if (stringList[0]) {
+		formattedString = stringList[0];
+	}
+	return formattedString;
+}
+
+export {
+	highlightText as highlight,
+	pascalCaseToCapitalSentence,
+	snakeToCapitalized,
+	snakeToCapitalSentence,
+	formatListWithConjunction
+};


### PR DESCRIPTION
# Description

- User will know if they will lose changes to name and description now. Also I decided to make the wording more concise and clear
- As a side cleanup I changed `originalModelConfig` to a regular variable instead of a `ref`


https://github.com/user-attachments/assets/ba14ca6c-f4b0-4c29-afe1-422f6f4647a0

