### PR TITLE
Ensemble simulate prep

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -6,12 +6,12 @@ const DOCUMENTATION_URL = 'https://github.com/ciemss/pyciemss/blob/main/pyciemss
 
 export interface SimulateEnsembleMapEntry {
 	modelConfigId: string;
-	value: string; // This is the new name provided by the user.
+	compartmentName: string; // State or Obs that is being mapped to newName
 }
 
 export interface SimulateEnsembleMappingRow {
 	id: string; // uuid that can be used as a row key
-	name: string;
+	newName: string; // This is the new name provided by the user.
 	modelConfigurationMappings: SimulateEnsembleMapEntry[];
 }
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -1,12 +1,29 @@
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
-import type { EnsembleModelConfigs, TimeSpan } from '@/types/Types';
+import type { TimeSpan } from '@/types/Types';
 import simulateEnsembleCiemss from '@assets/svg/operator-images/simulate-ensemble-probabilistic.svg';
 
 const DOCUMENTATION_URL = 'https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35';
 
+export interface SimulateEnsembleMapEntry {
+	modelConfigId: string;
+	value: string; // This is the new name provided by the user.
+}
+
+export interface SimulateEnsembleMappingRow {
+	id: string; // uuid that can be used as a row key
+	name: string;
+	modelConfigurationMappings: SimulateEnsembleMapEntry[];
+}
+
+export interface SimulateEnsembleWeight {
+	modelConfigurationId: string;
+	value: number;
+}
+
 export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
-	mapping: EnsembleModelConfigs[];
+	mapping: SimulateEnsembleMappingRow[];
+	weights: SimulateEnsembleWeight[];
 	timeSpan: TimeSpan;
 	numSamples: number;
 	inProgressForecastId: string;
@@ -34,6 +51,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 		const init: SimulateEnsembleCiemssOperationState = {
 			chartConfigs: [],
 			mapping: [],
+			weights: [],
 			timeSpan: { start: 0, end: 40 },
 			numSamples: 40,
 			inProgressForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,0 +1,11 @@
+import { EnsembleModelConfigs } from '@/types/Types';
+import { SimulateEnsembleMappingRow, SimulateEnsembleWeight } from './simulate-ensemble-ciemss-operation';
+
+export function clientMappingToCiemssMapping(
+	mapping: SimulateEnsembleMappingRow[],
+	weights: SimulateEnsembleWeight[]
+): EnsembleModelConfigs[] {
+	console.log(mapping);
+	console.log(weights);
+	return [] as EnsembleModelConfigs[];
+}

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,11 +1,34 @@
 import { EnsembleModelConfigs } from '@/types/Types';
 import { SimulateEnsembleMappingRow, SimulateEnsembleWeight } from './simulate-ensemble-ciemss-operation';
 
-export function clientMappingToCiemssMapping(
-	mapping: SimulateEnsembleMappingRow[],
+export function formatSimulateModelConfigurations(
+	rows: SimulateEnsembleMappingRow[],
 	weights: SimulateEnsembleWeight[]
 ): EnsembleModelConfigs[] {
-	console.log(mapping);
-	console.log(weights);
-	return [] as EnsembleModelConfigs[];
+	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
+	// const totalWeight = Object.values(weights).reduce((acc, curr) => acc + curr.value, 0) ?? 1;
+	const totalWeight = weights.map((ele) => ele.value).reduce((acc, curr) => acc + curr, 0);
+	// 1. map the weights to the ensemble model configs
+	weights.forEach((weight) => {
+		// return if there is no weight
+		if (!weight.value) return;
+
+		const ensembleModelConfig: EnsembleModelConfigs = {
+			id: weight.modelConfigurationId,
+			solutionMappings: {},
+			weight: weight.value / totalWeight
+		};
+
+		ensembleModelConfigMap[weight.modelConfigurationId] = ensembleModelConfig;
+	});
+
+	// 2. format the solution mappings
+	rows.forEach((row) => {
+		row.modelConfigurationMappings.forEach((ele) => {
+			if (!ensembleModelConfigMap[ele.modelConfigId]) return;
+			ensembleModelConfigMap[ele.modelConfigId].solutionMappings[row.newName] = ele.compartmentName;
+		});
+	});
+
+	return [...Object.values(ensembleModelConfigMap)];
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -278,7 +278,6 @@ const onSelection = (id: string) => {
 };
 
 const addMapping = () => {
-	console.log('Add mapping');
 	knobs.value.mapping.push({
 		id: uuidv4(),
 		newName: newSolutionMappingKey.value,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -85,7 +85,7 @@
 									auto-focus
 									class="w-full"
 									placeholder="Add a name"
-									@keydown.enter="
+									@keydown.enter.stop.prevent="
 										addMapping();
 										showAddMappingInput = false;
 									"
@@ -278,6 +278,7 @@ const onSelection = (id: string) => {
 };
 
 const addMapping = () => {
+	console.log('Add mapping');
 	knobs.value.mapping.push({
 		id: uuidv4(),
 		newName: newSolutionMappingKey.value,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -48,12 +48,12 @@
 										</th>
 									</tr>
 									<tr v-for="(ele, indx) in knobs.mapping" :key="indx">
-										<td>{{ ele.name }}</td>
+										<td>{{ ele.newName }}</td>
 										<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
 											<Dropdown
 												class="w-full"
 												:options="allModelOptions[row.modelConfigId]"
-												v-model="ele.modelConfigurationMappings[row.modelConfigId]"
+												v-model="row.compartmentName"
 												placeholder="Select a variable"
 											/>
 										</td>
@@ -279,8 +279,11 @@ const onSelection = (id: string) => {
 const addMapping = () => {
 	knobs.value.mapping.push({
 		id: uuidv4(),
-		name: newSolutionMappingKey.value,
-		modelConfigurationMappings: modelConfigurationIds.value.map((id) => ({ modelConfigId: id as string, value: '' }))
+		newName: newSolutionMappingKey.value,
+		modelConfigurationMappings: modelConfigurationIds.value.map((id) => ({
+			modelConfigId: id as string,
+			compartmentName: ''
+		}))
 	});
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = knobs.value.mapping;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -27,7 +27,7 @@
 											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
 										</td>
 										<td>
-											<tera-input-number v-model="ele.value" />
+											<tera-input-number v-model="ele.value" @change="updateWeights" />
 										</td>
 									</tr>
 								</tbody>
@@ -55,6 +55,7 @@
 												:options="allModelOptions[row.modelConfigId]"
 												v-model="row.compartmentName"
 												placeholder="Select a variable"
+												@change="updateMapping"
 											/>
 										</td>
 										<td>
@@ -290,12 +291,24 @@ const addMapping = () => {
 	emit('update-state', state);
 };
 
-function deleteMappingRow(id: string) {
+const deleteMappingRow = (id: string) => {
 	knobs.value.mapping = knobs.value.mapping.filter((ele) => ele.id !== id);
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = knobs.value.mapping;
 	emit('update-state', state);
-}
+};
+
+const updateMapping = () => {
+	const state = _.cloneDeep(props.node.state);
+	state.mapping = knobs.value.mapping;
+	emit('update-state', state);
+};
+
+const updateWeights = () => {
+	const state = _.cloneDeep(props.node.state);
+	state.weights = knobs.value.weights;
+	emit('update-state', state);
+};
 
 const runEnsemble = async () => {
 	const modelConfigs = formatSimulateModelConfigurations(knobs.value.mapping, knobs.value.weights);
@@ -379,7 +392,7 @@ watch(
 
 watch(
 	() => knobs.value,
-	async () => {
+	() => {
 		const state = _.cloneDeep(props.node.state);
 		state.mapping = knobs.value.mapping;
 		state.weights = knobs.value.weights;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -240,9 +240,7 @@ const listModelLabels = ref<string[]>([]);
 
 // List of each observible + state for each model.
 const allModelOptions = ref<{ [key: string]: string[] }>({});
-const modelConfigurationIds = ref<string[]>(
-	props.node.inputs.filter((ele) => ele.value?.[0]).map((ele) => ele.value?.[0])
-);
+const modelConfigurationIds: string[] = props.node.inputs.map((ele) => ele.value?.[0]).filter(Boolean);
 const modelConfigIdToNameMap = ref();
 
 const newSolutionMappingKey = ref<string>('');

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -5,7 +5,7 @@
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"
 	>
-		<section :tabName="Tabs.Wizard" class="ml-3 mr-2 pt-3">
+		<section :tabName="DrilldownTabs.Wizard" class="ml-3 mr-2 pt-3">
 			<tera-drilldown-section>
 				<template #header-controls-right>
 					<Button label="Run" icon="pi pi-play" @click="runEnsemble" :disabled="false" />
@@ -145,7 +145,7 @@
 				</Accordion>
 			</tera-drilldown-section>
 		</section>
-		<section :tabName="Tabs.Notebook">
+		<section :tabName="DrilldownTabs.Notebook">
 			<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
 		</section>
 		<template #preview>
@@ -205,6 +205,7 @@ import { chartActionsProxy, drilldownChartSize, nodeMetadata } from '@/component
 import type { WorkflowNode } from '@/types/workflow';
 import type { TimeSpan, EnsembleSimulationCiemssRequest } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
+import { DrilldownTabs } from '@/types/common';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -218,11 +219,6 @@ const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
 }>();
 const emit = defineEmits(['select-output', 'update-state', 'close']);
-
-enum Tabs {
-	Wizard = 'Wizard',
-	Notebook = 'Notebook'
-}
 
 interface BasicKnobs {
 	mapping: SimulateEnsembleMappingRow[];

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -24,7 +24,7 @@
 									<!-- Index matching listModelLabels and mapping-->
 									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
 										<td>
-											{{ ele.modelConfigurationId }}
+											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
 										</td>
 										<td>
 											<tera-input-number v-model="ele.value" />
@@ -246,6 +246,7 @@ const allModelOptions = ref<{ [key: string]: string[] }>({});
 const modelConfigurationIds = ref<string[]>(
 	props.node.inputs.filter((ele) => ele.value?.[0]).map((ele) => ele.value?.[0])
 );
+const modelConfigIdToNameMap = ref();
 
 const newSolutionMappingKey = ref<string>('');
 const runResults = ref<RunResults>({});
@@ -314,6 +315,11 @@ onMounted(async () => {
 	const allModelConfigurations = await Promise.all(
 		modelConfigurationIds.value.map((id) => getModelConfigurationById(id))
 	);
+
+	modelConfigIdToNameMap.value = {};
+	allModelConfigurations.forEach((config) => {
+		modelConfigIdToNameMap.value[config.id as string] = config.name;
+	});
 
 	allModelOptions.value = {};
 	for (let i = 0; i < allModelConfigurations.length; i++) {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -27,7 +27,7 @@
 											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
 										</td>
 										<td>
-											<tera-input-number v-model="ele.value" @change="updateWeights" />
+											<tera-input-number v-model="ele.value" @change="updateWeights()" />
 										</td>
 									</tr>
 								</tbody>
@@ -55,7 +55,7 @@
 												:options="allModelOptions[row.modelConfigId]"
 												v-model="row.compartmentName"
 												placeholder="Select a variable"
-												@change="updateMapping"
+												@change="updateMapping()"
 											/>
 										</td>
 										<td>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -275,7 +275,7 @@ const addMapping = () => {
 	knobs.value.mapping.push({
 		id: uuidv4(),
 		newName: newSolutionMappingKey.value,
-		modelConfigurationMappings: modelConfigurationIds.value.map((id) => ({
+		modelConfigurationMappings: modelConfigurationIds.map((id) => ({
 			modelConfigId: id as string,
 			compartmentName: ''
 		}))
@@ -320,10 +320,8 @@ const runEnsemble = async () => {
 };
 
 onMounted(async () => {
-	if (!modelConfigurationIds.value) return;
-	const allModelConfigurations = await Promise.all(
-		modelConfigurationIds.value.map((id) => getModelConfigurationById(id))
-	);
+	if (!modelConfigurationIds) return;
+	const allModelConfigurations = await Promise.all(modelConfigurationIds.map((id) => getModelConfigurationById(id)));
 
 	modelConfigIdToNameMap.value = {};
 	allModelConfigurations.forEach((config) => {
@@ -345,10 +343,10 @@ onMounted(async () => {
 	if (
 		!knobs.value.weights ||
 		knobs.value.weights.length === 0 ||
-		knobs.value.weights.length !== modelConfigurationIds.value.length
+		knobs.value.weights.length !== modelConfigurationIds.length
 	) {
 		knobs.value.weights = [];
-		modelConfigurationIds.value.forEach((id) => {
+		modelConfigurationIds.forEach((id) => {
 			knobs.value.weights.push({
 				modelConfigurationId: id,
 				value: 5

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -311,7 +311,6 @@ const runEnsemble = async () => {
 
 onMounted(async () => {
 	if (!modelConfigurationIds.value) return;
-	console.log(modelConfigurationIds.value);
 	const allModelConfigurations = await Promise.all(
 		modelConfigurationIds.value.map((id) => getModelConfigurationById(id))
 	);
@@ -336,8 +335,6 @@ onMounted(async () => {
 	if (knobs.value.weights.length === 0 || knobs.value.weights.length !== modelConfigurationIds.value.length) {
 		knobs.value.weights = [];
 		modelConfigurationIds.value.forEach((id) => {
-			console.log('Id:');
-			console.log(id);
 			knobs.value.weights.push({
 				modelConfigurationId: id,
 				value: 5

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -211,7 +211,7 @@ import {
 	SimulateEnsembleMappingRow,
 	SimulateEnsembleWeight
 } from './simulate-ensemble-ciemss-operation';
-import { clientMappingToCiemssMapping } from './simulate-ensemble-util';
+import { formatSimulateModelConfigurations } from './simulate-ensemble-util';
 
 const props = defineProps<{
 	node: WorkflowNode<SimulateEnsembleCiemssOperationState>;
@@ -298,7 +298,7 @@ function deleteMappingRow(id: string) {
 }
 
 const runEnsemble = async () => {
-	const modelConfigs = clientMappingToCiemssMapping(knobs.value.mapping, knobs.value.weights);
+	const modelConfigs = formatSimulateModelConfigurations(knobs.value.mapping, knobs.value.weights);
 	const params: EnsembleSimulationCiemssRequest = {
 		modelConfigs,
 		timespan: knobs.value.timeSpan,
@@ -335,7 +335,11 @@ onMounted(async () => {
 	const state = _.cloneDeep(props.node.state);
 
 	// Initalize weights:
-	if (knobs.value.weights.length === 0 || knobs.value.weights.length !== modelConfigurationIds.value.length) {
+	if (
+		!knobs.value.weights ||
+		knobs.value.weights.length === 0 ||
+		knobs.value.weights.length !== modelConfigurationIds.value.length
+	) {
 		knobs.value.weights = [];
 		modelConfigurationIds.value.forEach((id) => {
 			knobs.value.weights.push({


### PR DESCRIPTION
# Description
- Update our mapping to new type to clean -> The same will be done with ensemble calibrate shortly.
- Add weights as its own object -> The same will be done with ensemble calibrate shortly.
- Utilize Cole's new type -> pyciemss-service payload converter
- adding knobs for cleaner reading

# Testing
You should be able to run an ensemble simulate as before, there should be no functional differences