### PR TITLE
send user id for workflow update client-events

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -14,6 +14,7 @@ export interface ClientEvent<T> {
     type: ClientEventType;
     projectId?: string;
     notificationGroupId?: string;
+    userId?: string;
     data: T;
 }
 
@@ -798,10 +799,10 @@ export interface ModelUnit {
 }
 
 export interface GroundedSemantic {
-    id: string;
     name?: string;
-    description?: string;
+    id: string;
     grounding?: ModelGrounding;
+    description?: string;
 }
 
 export interface Properties {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -154,10 +154,8 @@ public class WorkflowController {
 		@RequestBody final Workflow workflow,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
+		final String userId = currentUserService.get().getId();
+		final Schema.Permission permission = projectService.checkPermissionCanWrite(userId, projectId);
 
 		workflow.setId(id);
 		final Optional<Workflow> updated;
@@ -183,6 +181,7 @@ public class WorkflowController {
 		final ClientEvent<Workflow> event = ClientEvent.<Workflow>builder()
 			.type(ClientEventType.WORKFLOW_UPDATE)
 			.data(updated.get())
+			.userId(userId)
 			.build();
 
 		try {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/ClientEvent.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/ClientEvent.java
@@ -26,5 +26,8 @@ public class ClientEvent<T> implements Serializable {
 	@TSOptional
 	private UUID notificationGroupId;
 
+	@TSOptional
+	private String userId; // Event created by or due to userId
+
 	private T data;
 }


### PR DESCRIPTION
### Summary
This is an attempt to get around workflow collab/sync problems, where slowness in server response can cause a modeler's prior action to overwrite their current action.

We can kind of get around this problem, by selectively updating the UI with only events not from the same modeler. 