### PR TITLE
Simulate Ensemble UI Updates

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -1,6 +1,7 @@
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import type { TimeSpan } from '@/types/Types';
 import simulateEnsembleCiemss from '@assets/svg/operator-images/simulate-ensemble-probabilistic.svg';
+import { CiemssMethodOptions } from '@/services/models/simulation-service';
 
 const DOCUMENTATION_URL = 'https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35';
 
@@ -26,6 +27,7 @@ export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	weights: SimulateEnsembleWeight[];
 	timeSpan: TimeSpan;
 	numSamples: number;
+	method: CiemssMethodOptions;
 	inProgressForecastId: string;
 	forecastId: string; // Completed run's Id
 	errorMessage: { name: string; value: string; traceback: string };
@@ -54,6 +56,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 			weights: [],
 			timeSpan: { start: 0, end: 40 },
 			numSamples: 40,
+			method: CiemssMethodOptions.dopri5,
 			inProgressForecastId: '',
 			forecastId: '',
 			errorMessage: { name: '', value: '', traceback: '' }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -21,6 +21,16 @@ export interface SimulateEnsembleWeight {
 	value: number;
 }
 
+export const speedValues = Object.freeze({
+	numSamples: 1,
+	method: CiemssMethodOptions.euler
+});
+
+export const normalValues = Object.freeze({
+	numSamples: 100,
+	method: CiemssMethodOptions.dopri5
+});
+
 export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
 	mapping: SimulateEnsembleMappingRow[];
@@ -55,8 +65,8 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 			mapping: [],
 			weights: [],
 			timeSpan: { start: 0, end: 40 },
-			numSamples: 40,
-			method: CiemssMethodOptions.dopri5,
+			numSamples: normalValues.numSamples,
+			method: normalValues.method,
 			inProgressForecastId: '',
 			forecastId: '',
 			errorMessage: { name: '', value: '', traceback: '' }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -1,5 +1,4 @@
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
-import type { TimeSpan } from '@/types/Types';
 import simulateEnsembleCiemss from '@assets/svg/operator-images/simulate-ensemble-probabilistic.svg';
 import { CiemssMethodOptions } from '@/services/models/simulation-service';
 
@@ -35,7 +34,7 @@ export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
 	mapping: SimulateEnsembleMappingRow[];
 	weights: SimulateEnsembleWeight[];
-	timeSpan: TimeSpan;
+	endTime: number;
 	numSamples: number;
 	method: CiemssMethodOptions;
 	inProgressForecastId: string;
@@ -64,7 +63,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 			chartConfigs: [],
 			mapping: [],
 			weights: [],
-			timeSpan: { start: 0, end: 40 },
+			endTime: 100,
 			numSamples: normalValues.numSamples,
 			method: normalValues.method,
 			inProgressForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -193,7 +193,17 @@
 				</section>
 			</tera-drilldown-preview>
 		</template>
-		<template #footer> </template>
+		<template #sidebar-right>
+			<tera-slider-panel
+				v-model:is-open="isOutputSettingsPanelOpen"
+				direction="right"
+				class="input-config"
+				header="Output Settings"
+				content-width="360px"
+			>
+				<!-- TODO Chart options here -->
+			</tera-slider-panel>
+		</template>
 	</tera-drilldown>
 </template>
 
@@ -249,6 +259,7 @@ const knobs = ref<BasicKnobs>({
 });
 
 const isSidebarOpen = ref(true);
+const isOutputSettingsPanelOpen = ref(false);
 const showSpinner = ref(false);
 const showAddMappingInput = ref(false);
 const listModelLabels = ref<string[]>([]);
@@ -416,23 +427,31 @@ watch(
 	padding-bottom: 0;
 }
 
+.output-settings-panel {
+	padding: var(--gap-4);
+	display: flex;
+	flex-direction: column;
+	gap: var(--gap-2);
+	hr {
+		border: 0;
+		border-top: 1px solid var(--surface-border-alt);
+		width: 100%;
+	}
+}
+
+/* Override grid template so output expands when sidebar is closed */
+.overlay-container:deep(section.scale main) {
+	grid-template-columns: auto 1fr;
+}
+
 .subheader {
 	color: var(--text-color-subdued);
 	margin-bottom: var(--gap-4);
 }
 
-.ensemble-calibration-graph {
-	height: 100px;
-}
-
 .model-weights {
 	display: flex;
 	align-items: start;
-}
-
-.ensemble-header {
-	display: flex;
-	margin: 1em;
 }
 
 th {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -11,7 +11,7 @@
 			<tera-slider-panel
 				class="input-config"
 				v-model:is-open="isSidebarOpen"
-				header="Simulation settings"
+				header="Simulation ensemble settings"
 				content-width="420px"
 			>
 				<template #content>
@@ -26,7 +26,7 @@
 					<Accordion :multiple="true" :active-index="activeAccordionIndicies">
 						<!-- Mapping -->
 						<AccordionTab header="Mapping">
-							<p class="subheader">Map the variables from the models to the ensemble variables.</p>
+							<p class="subheader">All variables mapped should be normalized (could use observables)</p>
 							<template v-if="knobs.mapping.length > 0">
 								<table class="w-full mb-2">
 									<tbody>
@@ -175,7 +175,7 @@
 			<tera-slider-panel
 				class="input-config"
 				v-model:is-open="isSidebarOpen"
-				header="Simulation settings"
+				header="Simulation ensemble settings"
 				content-width="420px"
 			>
 				<template #content>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -128,16 +128,6 @@
 						<!-- Other Settings -->
 						<AccordionTab header="Other Settings">
 							<div class="form-section" v-if="isSidebarOpen">
-								<!-- Presets -->
-								<div class="label-and-input">
-									<label>Preset (optional)</label>
-									<!-- <Dropdown
-										v-model="presetType"
-										placeholder="Select an option"
-										:options="[CiemssPresetTypes.Fast, CiemssPresetTypes.Normal]"
-										@update:model-value="setPresetValues"
-									/> -->
-								</div>
 								<div class="input-row">
 									<div class="label-and-input">
 										<label>Start time</label>
@@ -148,7 +138,16 @@
 										<tera-input-number v-model="knobs.timeSpan.end" />
 									</div>
 								</div>
-
+								<!-- Presets -->
+								<div class="label-and-input">
+									<label>Preset (optional)</label>
+									<Dropdown
+										v-model="presetType"
+										placeholder="Select an option"
+										:options="[CiemssPresetTypes.Fast, CiemssPresetTypes.Normal]"
+										@update:model-value="setPresetValues"
+									/>
+								</div>
 								<!-- Number of Samples & Method -->
 								<div class="input-row">
 									<div class="label-and-input">
@@ -258,7 +257,7 @@ import { chartActionsProxy, drilldownChartSize, nodeMetadata } from '@/component
 import type { WorkflowNode } from '@/types/workflow';
 import type { TimeSpan, EnsembleSimulationCiemssRequest } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
-import { DrilldownTabs } from '@/types/common';
+import { DrilldownTabs, CiemssPresetTypes } from '@/types/common';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import TeraSignalBars from '@/components/widgets/tera-signal-bars.vue';
 import TeraSliderPanel from '@/components/widgets/tera-slider-panel.vue';
@@ -266,7 +265,9 @@ import { v4 as uuidv4 } from 'uuid';
 import {
 	SimulateEnsembleCiemssOperationState,
 	SimulateEnsembleMappingRow,
-	SimulateEnsembleWeight
+	SimulateEnsembleWeight,
+	speedValues,
+	normalValues
 } from './simulate-ensemble-ciemss-operation';
 import { formatSimulateModelConfigurations } from './simulate-ensemble-util';
 
@@ -297,6 +298,16 @@ const isOutputSettingsPanelOpen = ref(false);
 const showSpinner = ref(false);
 const showAddMappingInput = ref(false);
 const listModelLabels = ref<string[]>([]);
+
+const presetType = computed(() => {
+	if (knobs.value.numSamples === speedValues.numSamples && knobs.value.method === speedValues.method) {
+		return CiemssPresetTypes.Fast;
+	}
+	if (knobs.value.numSamples === normalValues.numSamples && knobs.value.method === normalValues.method) {
+		return CiemssPresetTypes.Normal;
+	}
+	return '';
+});
 
 // List of each observible + state for each model.
 const allModelOptions = ref<{ [key: string]: string[] }>({});
@@ -329,6 +340,17 @@ const chartProxy = chartActionsProxy(props.node, (state: SimulateEnsembleCiemssO
 
 const onSelection = (id: string) => {
 	emit('select-output', id);
+};
+
+const setPresetValues = (data: CiemssPresetTypes) => {
+	if (data === CiemssPresetTypes.Normal) {
+		knobs.value.numSamples = normalValues.numSamples;
+		knobs.value.method = normalValues.method;
+	}
+	if (data === CiemssPresetTypes.Fast) {
+		knobs.value.numSamples = speedValues.numSamples;
+		knobs.value.method = speedValues.method;
+	}
 };
 
 const addMapping = () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -4,149 +4,162 @@
 		@update:selection="onSelection"
 		@on-close-clicked="emit('close')"
 		@update-state="(state: any) => emit('update-state', state)"
+		class="drilldown"
 	>
-		<section :tabName="DrilldownTabs.Wizard" class="ml-3 mr-2 pt-3">
-			<tera-drilldown-section>
-				<template #header-controls-right>
-					<Button label="Run" icon="pi pi-play" @click="runEnsemble" :disabled="false" />
-					<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
-				</template>
-				<Accordion :multiple="true" :active-index="[0, 1, 2]">
-					<!-- Mapping -->
-					<AccordionTab header="Mapping">
-						<p class="subheader">Map the variables from the models to the ensemble variables.</p>
-						<template v-if="knobs.mapping.length > 0">
-							<table class="w-full mb-2">
-								<tbody>
-									<tr>
-										<th>Ensemble variables</th>
-										<th v-for="(element, i) in listModelLabels" :key="i">
-											{{ element }}
-										</th>
-									</tr>
-									<tr v-for="(ele, indx) in knobs.mapping" :key="indx">
-										<td>{{ ele.newName }}</td>
-										<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
-											<Dropdown
-												class="w-full"
-												:options="allModelOptions[row.modelConfigId]"
-												v-model="row.compartmentName"
-												placeholder="Select a variable"
-												@change="updateMapping()"
-											/>
-										</td>
-										<td>
-											<Button class="p-button-sm" icon="pi pi-times" rounded text @click="deleteMappingRow(ele.id)" />
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</template>
-						<section class="add-mapping">
-							<Button
-								v-if="!showAddMappingInput"
-								outlined
-								:style="{ marginRight: 'auto' }"
-								label="Add mapping"
-								size="small"
-								severity="secondary"
-								icon="pi pi-plus"
-								@click="
-									newSolutionMappingKey = '';
-									showAddMappingInput = true;
-								"
-							/>
-							<div v-if="showAddMappingInput" class="flex items-center">
-								<tera-input-text
-									v-model="newSolutionMappingKey"
-									auto-focus
-									class="w-full"
-									placeholder="Add a name"
-									@keydown.enter.stop.prevent="
-										addMapping();
-										showAddMappingInput = false;
-									"
-								/>
+		<tera-drilldown-section :tabName="DrilldownTabs.Wizard" class="wizard">
+			<tera-slider-panel
+				class="input-config"
+				v-model:is-open="isSidebarOpen"
+				header="Simulation settings"
+				content-width="420px"
+			>
+				<template #content>
+					<div class="toolbar">
+						<p>Click Run to start the simulation.</p>
+						<span class="flex gap-2">
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
+							<Button label="Run" icon="pi pi-play" @click="runEnsemble" :disabled="false" />
+						</span>
+					</div>
+
+					<Accordion :multiple="true" :active-index="[0, 1, 2]">
+						<!-- Mapping -->
+						<AccordionTab header="Mapping">
+							<p class="subheader">Map the variables from the models to the ensemble variables.</p>
+							<template v-if="knobs.mapping.length > 0">
+								<table class="w-full mb-2">
+									<tbody>
+										<tr>
+											<th>Ensemble variables</th>
+											<th v-for="(element, i) in listModelLabels" :key="i">
+												{{ element }}
+											</th>
+										</tr>
+										<tr v-for="(ele, indx) in knobs.mapping" :key="indx">
+											<td>{{ ele.newName }}</td>
+											<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
+												<Dropdown
+													class="w-full"
+													:options="allModelOptions[row.modelConfigId]"
+													v-model="row.compartmentName"
+													placeholder="Select a variable"
+													@change="updateMapping()"
+												/>
+											</td>
+											<td>
+												<Button class="p-button-sm" icon="pi pi-times" rounded text @click="deleteMappingRow(ele.id)" />
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</template>
+							<section class="add-mapping">
 								<Button
-									class="p-button-sm p-button-outlined w-2 ml-2"
+									v-if="!showAddMappingInput"
+									outlined
+									:style="{ marginRight: 'auto' }"
+									label="Add mapping"
+									size="small"
 									severity="secondary"
-									icon="pi pi-times"
-									label="Cancel"
+									icon="pi pi-plus"
 									@click="
 										newSolutionMappingKey = '';
-										showAddMappingInput = false;
+										showAddMappingInput = true;
 									"
 								/>
-								<Button
-									:disabled="!newSolutionMappingKey"
-									class="p-button-sm p-button-outlined w-2 ml-2"
-									icon="pi pi-check"
-									label="Add"
-									@click="
-										addMapping();
-										showAddMappingInput = false;
-									"
-								/>
-							</div>
-						</section>
-					</AccordionTab>
+								<div v-if="showAddMappingInput" class="flex items-center">
+									<tera-input-text
+										v-model="newSolutionMappingKey"
+										auto-focus
+										class="w-full"
+										placeholder="Add a name"
+										@keydown.enter.stop.prevent="
+											addMapping();
+											showAddMappingInput = false;
+										"
+									/>
+									<Button
+										class="p-button-sm p-button-outlined w-2 ml-2"
+										severity="secondary"
+										icon="pi pi-times"
+										label="Cancel"
+										@click="
+											newSolutionMappingKey = '';
+											showAddMappingInput = false;
+										"
+									/>
+									<Button
+										:disabled="!newSolutionMappingKey"
+										class="p-button-sm p-button-outlined w-2 ml-2"
+										icon="pi pi-check"
+										label="Add"
+										@click="
+											addMapping();
+											showAddMappingInput = false;
+										"
+									/>
+								</div>
+							</section>
+						</AccordionTab>
 
-					<!-- Model weights -->
-					<AccordionTab header="Model weights">
-						<p class="subheader">
-							This encodes your relative confidence for each model. These are the alpha parameters of a Dirichlet
-							distribution.
-						</p>
-						<div class="model-weights">
-							<table class="p-datatable-table">
+						<!-- Model weights -->
+						<AccordionTab header="Model weights">
+							<p class="subheader">
+								This encodes your relative confidence for each model. These are the alpha parameters of a Dirichlet
+								distribution.
+							</p>
+							<div class="model-weights">
+								<table class="p-datatable-table">
+									<tbody class="p-datatable-tbody">
+										<tr v-for="(ele, indx) in knobs.weights" :key="indx">
+											<td>
+												{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
+											</td>
+											<td>
+												<tera-signal-bars label="Relative certainty" v-model="ele.value" @change="updateWeights()" />
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</div>
+						</AccordionTab>
+
+						<!-- Other Settings -->
+						<AccordionTab header="Other Settings">
+							<p class="subheader">Set the time span and number of samples for the ensemble simulation.</p>
+							<table class="w-full">
+								<thead class="p-datatable-thead">
+									<tr>
+										<th>Units</th>
+										<th>Start Step</th>
+										<th>End Step</th>
+										<th>Number of Samples</th>
+									</tr>
+								</thead>
 								<tbody class="p-datatable-tbody">
-									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
+									<tr>
+										<td class="w-2">Steps</td>
 										<td>
-											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
+											<tera-input-number class="w-full" v-model="knobs.timeSpan.start" />
 										</td>
 										<td>
-											<tera-signal-bars label="Relative certainty" v-model="ele.value" @change="updateWeights()" />
+											<tera-input-number class="w-full" v-model="knobs.timeSpan.end" />
+										</td>
+										<td>
+											<tera-input-number class="w-full" v-model="knobs.numSamples" />
 										</td>
 									</tr>
 								</tbody>
 							</table>
-						</div>
-					</AccordionTab>
+						</AccordionTab>
+					</Accordion>
+				</template>
+			</tera-slider-panel>
+		</tera-drilldown-section>
 
-					<!-- Other Settings -->
-					<AccordionTab header="Other Settings">
-						<p class="subheader">Set the time span and number of samples for the ensemble simulation.</p>
-						<table class="w-full">
-							<thead class="p-datatable-thead">
-								<tr>
-									<th>Units</th>
-									<th>Start Step</th>
-									<th>End Step</th>
-									<th>Number of Samples</th>
-								</tr>
-							</thead>
-							<tbody class="p-datatable-tbody">
-								<tr>
-									<td class="w-2">Steps</td>
-									<td>
-										<tera-input-number class="w-full" v-model="knobs.timeSpan.start" />
-									</td>
-									<td>
-										<tera-input-number class="w-full" v-model="knobs.timeSpan.end" />
-									</td>
-									<td>
-										<tera-input-number class="w-full" v-model="knobs.numSamples" />
-									</td>
-								</tr>
-							</tbody>
-						</table>
-					</AccordionTab>
-				</Accordion>
-			</tera-drilldown-section>
-		</section>
-		<section :tabName="DrilldownTabs.Notebook">
+		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="notebook-section">
 			<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
-		</section>
+		</tera-drilldown-section>
 		<template #preview>
 			<tera-drilldown-preview
 				title="Simulation output"
@@ -207,6 +220,7 @@ import { RunResults } from '@/types/SimulateConfig';
 import { DrilldownTabs } from '@/types/common';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import TeraSignalBars from '@/components/widgets/tera-signal-bars.vue';
+import TeraSliderPanel from '@/components/widgets/tera-slider-panel.vue';
 import { v4 as uuidv4 } from 'uuid';
 import {
 	SimulateEnsembleCiemssOperationState,
@@ -234,6 +248,7 @@ const knobs = ref<BasicKnobs>({
 	timeSpan: props.node.state.timeSpan
 });
 
+const isSidebarOpen = ref(true);
 const showSpinner = ref(false);
 const showAddMappingInput = ref(false);
 const listModelLabels = ref<string[]>([]);
@@ -397,6 +412,24 @@ watch(
 </script>
 
 <style scoped>
+.wizard .toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: var(--gap-1) var(--gap-4);
+	gap: var(--gap-2);
+}
+
+/* Notebook */
+.notebook-section {
+	width: calc(50vw - 4rem);
+}
+
+.notebook-section:deep(main) {
+	gap: var(--gap-2);
+	position: relative;
+}
+
 .subheader {
 	color: var(--text-color-subdued);
 	margin-bottom: var(--gap-4);

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -437,6 +437,14 @@ watch(
 </script>
 
 <style scoped>
+.toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: var(--gap-1) var(--gap-4);
+	gap: var(--gap-2);
+}
+
 .input-config:deep(.content-wrapper) {
 	padding-bottom: 0;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -213,6 +213,9 @@
 				header="Output Settings"
 				content-width="360px"
 			>
+				<template #content>
+					<div class="mt-3 ml-4 mr-2">Under construction.</div>
+				</template>
 				<!-- TODO Chart options here -->
 			</tera-slider-panel>
 		</template>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -12,29 +12,6 @@
 					<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
 				</template>
 				<Accordion :multiple="true" :active-index="[0, 1, 2]">
-					<!-- Model weights -->
-					<AccordionTab header="Model weights">
-						<p class="subheader">
-							How do you want to distribute weights of the attached models? You can distribute them equally or set
-							custom weights using the input boxes.
-						</p>
-						<div class="model-weights">
-							<table class="p-datatable-table">
-								<tbody class="p-datatable-tbody">
-									<!-- Index matching listModelLabels and mapping-->
-									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
-										<td>
-											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
-										</td>
-										<td>
-											<tera-input-number v-model="ele.value" @change="updateWeights()" />
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</div>
-					</AccordionTab>
-
 					<!-- Mapping -->
 					<AccordionTab header="Mapping">
 						<p class="subheader">Map the variables from the models to the ensemble variables.</p>
@@ -112,6 +89,29 @@
 								/>
 							</div>
 						</section>
+					</AccordionTab>
+
+					<!-- Model weights -->
+					<AccordionTab header="Model weights">
+						<p class="subheader">
+							How do you want to distribute weights of the attached models? You can distribute them equally or set
+							custom weights using the input boxes.
+						</p>
+						<div class="model-weights">
+							<table class="p-datatable-table">
+								<tbody class="p-datatable-tbody">
+									<!-- Index matching listModelLabels and mapping-->
+									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
+										<td>
+											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
+										</td>
+										<td>
+											<tera-input-number v-model="ele.value" @change="updateWeights()" />
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
 					</AccordionTab>
 
 					<!-- Time span -->

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -1,5 +1,6 @@
 <template>
 	<tera-drilldown
+		v-bind="$attrs"
 		:node="node"
 		@update:selection="onSelection"
 		@on-close-clicked="emit('close')"
@@ -160,8 +161,9 @@
 		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="input-config">
 			<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
 		</tera-drilldown-section>
+
 		<template #preview>
-			<tera-drilldown-preview
+			<tera-drilldown-section
 				title="Simulation output"
 				:options="outputs"
 				v-model:output="selectedOutputId"
@@ -191,8 +193,9 @@
 						icon="pi pi-plus"
 					/>
 				</section>
-			</tera-drilldown-preview>
+			</tera-drilldown-section>
 		</template>
+
 		<template #sidebar-right>
 			<tera-slider-panel
 				v-model:is-open="isOutputSettingsPanelOpen"
@@ -218,7 +221,6 @@ import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import Dropdown from 'primevue/dropdown';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
-import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraPyciemssCancelButton from '@/components/pyciemss/tera-pyciemss-cancel-button.vue';
 import TeraSimulateChart from '@/components/workflow/tera-simulate-chart.vue';
 import { getRunResultCiemss, makeEnsembleCiemssSimulation } from '@/services/models/simulation-service';
@@ -427,21 +429,14 @@ watch(
 	padding-bottom: 0;
 }
 
-.output-settings-panel {
-	padding: var(--gap-4);
-	display: flex;
-	flex-direction: column;
-	gap: var(--gap-2);
-	hr {
-		border: 0;
-		border-top: 1px solid var(--surface-border-alt);
-		width: 100%;
-	}
+/* Override grid template so output expands when sidebar is closed */
+.overlay-container:deep(section.drilldown main) {
+	grid-template-columns: auto 1fr;
 }
 
-/* Override grid template so output expands when sidebar is closed */
-.overlay-container:deep(section.scale main) {
-	grid-template-columns: auto 1fr;
+/* Override top and bottom padding of content-container */
+.overlay-container:deep(section.drilldown main .content-container) {
+	padding: 0 var(--gap-4);
 }
 
 .subheader {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -103,10 +103,11 @@
 									<!-- Index matching listModelLabels and mapping-->
 									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
 										<td>
-											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
-										</td>
-										<td>
-											<tera-input-number v-model="ele.value" @change="updateWeights()" />
+											<tera-signal-bars
+												:label="modelConfigIdToNameMap[ele.modelConfigurationId]"
+												v-model="ele.value"
+												@change="updateWeights()"
+											/>
 										</td>
 									</tr>
 								</tbody>
@@ -114,8 +115,8 @@
 						</div>
 					</AccordionTab>
 
-					<!-- Time span -->
-					<AccordionTab header="Time span">
+					<!-- Other Settings -->
+					<AccordionTab header="Other Settings">
 						<p class="subheader">Set the time span and number of samples for the ensemble simulation.</p>
 						<table class="w-full">
 							<thead class="p-datatable-thead">
@@ -207,6 +208,7 @@ import type { TimeSpan, EnsembleSimulationCiemssRequest } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
 import { DrilldownTabs } from '@/types/common';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
+import TeraSignalBars from '@/components/widgets/tera-signal-bars.vue';
 import { v4 as uuidv4 } from 'uuid';
 import {
 	SimulateEnsembleCiemssOperationState,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -45,7 +45,7 @@
 													class="w-full"
 													:options="allModelOptions[row.modelConfigId]"
 													v-model="row.compartmentName"
-													placeholder="Select a variable"
+													placeholder="Select"
 													@change="updateMapping()"
 												/>
 											</td>
@@ -70,7 +70,7 @@
 										showAddMappingInput = true;
 									"
 								/>
-								<div v-if="showAddMappingInput" class="flex items-center">
+								<div v-if="showAddMappingInput" class="flex">
 									<tera-input-text
 										v-model="newSolutionMappingKey"
 										auto-focus
@@ -81,26 +81,28 @@
 											showAddMappingInput = false;
 										"
 									/>
-									<Button
-										class="p-button-sm p-button-outlined w-2 ml-2"
-										severity="secondary"
-										icon="pi pi-times"
-										label="Cancel"
-										@click="
-											newSolutionMappingKey = '';
-											showAddMappingInput = false;
-										"
-									/>
-									<Button
-										:disabled="!newSolutionMappingKey"
-										class="p-button-sm p-button-outlined w-2 ml-2"
-										icon="pi pi-check"
-										label="Add"
-										@click="
-											addMapping();
-											showAddMappingInput = false;
-										"
-									/>
+									<span class="flex gap-2">
+										<Button
+											class="p-button-sm p-button-outlined ml-2"
+											severity="secondary"
+											icon="pi pi-times"
+											label="Cancel"
+											@click="
+												newSolutionMappingKey = '';
+												showAddMappingInput = false;
+											"
+										/>
+										<Button
+											:disabled="!newSolutionMappingKey"
+											class="p-button-sm p-button-outlined ml-2"
+											icon="pi pi-check"
+											label="Add"
+											@click="
+												addMapping();
+												showAddMappingInput = false;
+											"
+										/>
+									</span>
 								</div>
 							</section>
 						</AccordionTab>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -94,13 +94,12 @@
 					<!-- Model weights -->
 					<AccordionTab header="Model weights">
 						<p class="subheader">
-							How do you want to distribute weights of the attached models? You can distribute them equally or set
-							custom weights using the input boxes.
+							This encodes your relative confidence for each model. These are the alpha parameters of a Dirichlet
+							distribution.
 						</p>
 						<div class="model-weights">
 							<table class="p-datatable-table">
 								<tbody class="p-datatable-tbody">
-									<!-- Index matching listModelLabels and mapping-->
 									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
 										<td>
 											<tera-signal-bars

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -6,7 +6,7 @@
 		@update-state="(state: any) => emit('update-state', state)"
 		class="drilldown"
 	>
-		<tera-drilldown-section :tabName="DrilldownTabs.Wizard" class="wizard">
+		<tera-drilldown-section :tabName="DrilldownTabs.Wizard" class="input-config">
 			<tera-slider-panel
 				class="input-config"
 				v-model:is-open="isSidebarOpen"
@@ -157,7 +157,7 @@
 			</tera-slider-panel>
 		</tera-drilldown-section>
 
-		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="notebook-section">
+		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="input-config">
 			<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
 		</tera-drilldown-section>
 		<template #preview>
@@ -412,22 +412,8 @@ watch(
 </script>
 
 <style scoped>
-.wizard .toolbar {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: var(--gap-1) var(--gap-4);
-	gap: var(--gap-2);
-}
-
-/* Notebook */
-.notebook-section {
-	width: calc(50vw - 4rem);
-}
-
-.notebook-section:deep(main) {
-	gap: var(--gap-2);
-	position: relative;
+.input-config:deep(.content-wrapper) {
+	padding-bottom: 0;
 }
 
 .subheader {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -23,7 +23,7 @@
 						</span>
 					</div>
 
-					<Accordion :multiple="true" :active-index="[0, 1, 2]">
+					<Accordion :multiple="true" :active-index="activeAccordionIndicies">
 						<!-- Mapping -->
 						<AccordionTab header="Mapping">
 							<p class="subheader">Map the variables from the models to the ensemble variables.</p>
@@ -37,7 +37,7 @@
 											</th>
 										</tr>
 										<tr v-for="(ele, indx) in knobs.mapping" :key="indx">
-											<td>{{ ele.newName }}</td>
+											<tera-input-text v-model="ele.newName" auto-focus class="w-full" placeholder="Add a name" />
 											<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
 												<Dropdown
 													class="w-full"
@@ -272,6 +272,7 @@ const knobs = ref<BasicKnobs>({
 	timeSpan: props.node.state.timeSpan
 });
 
+const activeAccordionIndicies = ref([1, 2, 3]);
 const isSidebarOpen = ref(true);
 const isOutputSettingsPanelOpen = ref(false);
 const showSpinner = ref(false);

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -159,7 +159,16 @@
 		</tera-drilldown-section>
 
 		<tera-drilldown-section :tabName="DrilldownTabs.Notebook" class="input-config">
-			<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
+			<tera-slider-panel
+				class="input-config"
+				v-model:is-open="isSidebarOpen"
+				header="Simulation settings"
+				content-width="420px"
+			>
+				<template #content>
+					<div class="mt-3 ml-4 mr-2">Under construction. Use the wizard for now.</div>
+				</template>
+			</tera-slider-panel>
 		</tera-drilldown-section>
 
 		<template #preview>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -153,13 +153,12 @@
 								<!-- Number of Samples & Method -->
 								<div class="input-row">
 									<div class="label-and-input">
-										<label for="num-samples">Number of samples</label>
-										<tera-input-number id="num-samples" v-model="knobs.numSamples" inputId="integeronly" :min="1" />
+										<label>Number of samples</label>
+										<tera-input-number v-model="knobs.numSamples" inputId="integeronly" :min="1" />
 									</div>
 									<div class="label-and-input">
-										<label for="solver-method">Solver method</label>
+										<label>Solver method</label>
 										<Dropdown
-											id="solver-method"
 											v-model="knobs.method"
 											:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
 										/>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -102,11 +102,10 @@
 								<tbody class="p-datatable-tbody">
 									<tr v-for="(ele, indx) in knobs.weights" :key="indx">
 										<td>
-											<tera-signal-bars
-												:label="modelConfigIdToNameMap[ele.modelConfigurationId]"
-												v-model="ele.value"
-												@change="updateWeights()"
-											/>
+											{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
+										</td>
+										<td>
+											<tera-signal-bars label="Relative certainty" v-model="ele.value" @change="updateWeights()" />
 										</td>
 									</tr>
 								</tbody>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -37,7 +37,9 @@
 											</th>
 										</tr>
 										<tr v-for="(ele, indx) in knobs.mapping" :key="indx">
-											<tera-input-text v-model="ele.newName" auto-focus class="w-full" placeholder="Add a name" />
+											<td>
+												<tera-input-text v-model="ele.newName" auto-focus class="w-full" placeholder="Add a name" />
+											</td>
 											<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
 												<Dropdown
 													class="w-full"
@@ -54,7 +56,7 @@
 									</tbody>
 								</table>
 							</template>
-							<section class="add-mapping">
+							<section>
 								<Button
 									v-if="!showAddMappingInput"
 									outlined

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -135,11 +135,11 @@
 								<div class="input-row">
 									<div class="label-and-input">
 										<label>Start time</label>
-										<tera-input-number class="w-12" v-model="knobs.timeSpan.start" />
+										<tera-input-number class="w-12" disabled :model-value="0" />
 									</div>
 									<div class="label-and-input">
 										<label>End time</label>
-										<tera-input-number v-model="knobs.timeSpan.end" />
+										<tera-input-number v-model="knobs.endTime" />
 									</div>
 								</div>
 								<!-- Presets -->
@@ -258,7 +258,7 @@ import {
 import { getModelConfigurationById, getObservables, getInitials } from '@/services/model-configurations';
 import { chartActionsProxy, drilldownChartSize, nodeMetadata } from '@/components/workflow/util';
 import type { WorkflowNode } from '@/types/workflow';
-import type { TimeSpan, EnsembleSimulationCiemssRequest } from '@/types/Types';
+import type { EnsembleSimulationCiemssRequest } from '@/types/Types';
 import { RunResults } from '@/types/SimulateConfig';
 import { DrilldownTabs, CiemssPresetTypes } from '@/types/common';
 import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
@@ -284,7 +284,7 @@ interface BasicKnobs {
 	weights: SimulateEnsembleWeight[];
 	numSamples: number;
 	method: CiemssMethodOptions;
-	timeSpan: TimeSpan;
+	endTime: number;
 }
 
 const knobs = ref<BasicKnobs>({
@@ -292,7 +292,7 @@ const knobs = ref<BasicKnobs>({
 	weights: props.node.state.weights,
 	numSamples: props.node.state.numSamples,
 	method: props.node.state.method,
-	timeSpan: props.node.state.timeSpan
+	endTime: props.node.state.endTime
 });
 
 const activeAccordionIndicies = ref([0, 1, 2]);
@@ -393,7 +393,7 @@ const runEnsemble = async () => {
 	const modelConfigs = formatSimulateModelConfigurations(knobs.value.mapping, knobs.value.weights);
 	const params: EnsembleSimulationCiemssRequest = {
 		modelConfigs,
-		timespan: knobs.value.timeSpan,
+		timespan: { start: 0, end: knobs.value.endTime },
 		engine: 'ciemss',
 		extra: {
 			num_samples: knobs.value.numSamples,
@@ -476,7 +476,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.mapping = knobs.value.mapping;
 		state.weights = knobs.value.weights;
-		state.timeSpan = knobs.value.timeSpan;
+		state.endTime = knobs.value.endTime;
 		state.numSamples = knobs.value.numSamples;
 		state.method = knobs.value.method;
 		emit('update-state', state);

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -104,12 +104,7 @@ const processResult = async (simulationId: string) => {
 		type: SimulateEnsembleCiemssOperation.outputs[0].type,
 		label: nodeOutputLabel(props.node, `${portLabel} Result`),
 		value: [datasetResult.id],
-		state: {
-			mapping: state.mapping,
-			timeSpan: state.timeSpan,
-			numSamples: state.numSamples,
-			forecastId: simulationId
-		},
+		state,
 		isSelected: false
 	});
 };


### PR DESCRIPTION
# Description
- Adding sliders for input and output panels
- Updating weights UI 
- Updating Mapping UI
- Update Other Settings UI (formatting/presets/ect)
- minor corrections

# Follow up PRS:
- update pyciemss and EnsembleSimulationCiemssRequest to not take a timespan but just an endTime.
- update output panel
- update charts
- update `SimulateEnsembleMappingRow` type so that `modelConfigurationMappings` is a `map` not a `list`

# Screenshots of UI
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/796662c9-0965-49a8-bad2-b447f2171bc5">
<img width="458" alt="image" src="https://github.com/user-attachments/assets/2a5e42cf-4894-49a4-9614-fb4f3e391eb2">

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/f4dbddbd-344d-4bd1-b1d3-384ac7711591">

