### PR TITLE
Calibrate does not show old errors

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -236,6 +236,10 @@
 						@click="showSaveModal = true"
 					/>
 				</template>
+				<tera-notebook-error
+					v-if="!_.isEmpty(node.state?.errorMessage?.traceback) && !isLoading"
+					v-bind="node.state.errorMessage"
+				/>
 				<tera-operator-output-summary
 					v-if="node.state.summaryId && !isLoading"
 					class="p-3"
@@ -255,7 +259,7 @@
 						</div>
 					</AccordionTab>
 				</Accordion>
-				<div v-if="!isLoading && _.isEmpty(node.state?.errorMessage?.traceback)">
+				<div v-if="!isLoading">
 					<section class="pb-3" ref="outputPanel" v-if="modelConfig && csvAsset">
 						<Accordion multiple :active-index="[0, 1, 2, 3, 4]" class="px-2">
 							<AccordionTab header="Parameter distributions">
@@ -341,10 +345,7 @@
 						<p class="helpMessage">Connect a model configuration and dataset</p>
 					</section>
 				</div>
-				<tera-notebook-error
-					v-else-if="!_.isEmpty(node.state?.errorMessage?.traceback) && !isLoading"
-					v-bind="node.state.errorMessage"
-				/>
+
 				<section v-else class="emptyState">
 					<tera-progress-spinner :font-size="2" is-centered style="height: 12rem" />
 					<p>Processing...{{ props.node.state.currentProgress }}%</p>

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -255,7 +255,7 @@
 						</div>
 					</AccordionTab>
 				</Accordion>
-				<div v-if="!isLoading">
+				<div v-if="!isLoading && _.isEmpty(node.state?.errorMessage?.traceback)">
 					<section class="pb-3" ref="outputPanel" v-if="modelConfig && csvAsset">
 						<Accordion multiple :active-index="[0, 1, 2, 3, 4]" class="px-2">
 							<AccordionTab header="Parameter distributions">
@@ -341,11 +341,14 @@
 						<p class="helpMessage">Connect a model configuration and dataset</p>
 					</section>
 				</div>
+				<tera-notebook-error
+					v-else-if="!_.isEmpty(node.state?.errorMessage?.traceback) && !isLoading"
+					v-bind="node.state.errorMessage"
+				/>
 				<section v-else class="emptyState">
 					<tera-progress-spinner :font-size="2" is-centered style="height: 12rem" />
 					<p>Processing...{{ props.node.state.currentProgress }}%</p>
 				</section>
-				<tera-notebook-error v-if="!_.isEmpty(node.state?.errorMessage?.traceback)" v-bind="node.state.errorMessage" />
 			</tera-drilldown-section>
 			<!-- Empty state if calibrate hasn't been run yet -->
 			<section v-else class="output-section-empty-state">

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -674,9 +674,7 @@ const mappingDropdownPlaceholder = computed(() => {
 const showOutputSection = computed(
 	() =>
 		lossValues.value.length > 0 ||
-		selectedErrorVariableSettings.value.length > 0 ||
-		selectedVariableSettings.value.length > 0 ||
-		selectedParameterSettings.value.length > 0 ||
+		!_.isEmpty(chartSettings.value) ||
 		isLoading.value ||
 		!_.isEmpty(props.node.state?.errorMessage?.traceback)
 );


### PR DESCRIPTION
# Description

* Calibrate will not show old errors when loading or running new calibrations

