### PR TITLE
auto config mapping #5381

### DIFF
--- a/packages/client/hmi-client/src/services/concept.ts
+++ b/packages/client/hmi-client/src/services/concept.ts
@@ -239,9 +239,7 @@ const autoCalibrationMapping = async (modelOptions: State[], datasetOptions: Dat
 
 	// Fill targetEntities with datasetOptions
 	datasetOptions.forEach((col) => {
-		const groundings = col.metadata?.groundings?.identifiers
-			? Object.entries(col.metadata.groundings.identifiers).map((ele) => ele.join(':'))
-			: undefined;
+		const groundings = col.grounding?.identifiers?.map((id) => id.curie);
 		targetEntities.push({ id: col.name, groundings });
 	});
 


### PR DESCRIPTION
# Description

Fixing the automap.
note that currently models are set up to use the `DKG` class(es) while dataset is set up to use `Identifier` which are basically the same thing. Going to look into cleaning this up soon

Resolves #5381 
