### PR TITLE
Ensemble Simulate - same typing as ensemble calibrate

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -46,12 +46,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 	inputs: [{ type: 'modelConfigId', label: 'Model configuration' }],
 	outputs: [{ type: 'datasetId' }],
 	isRunnable: true,
-
-	// TODO: Figure out mapping
-	// Calls API, returns results.
-	action: async (): Promise<void> => {
-		console.log('test');
-	},
+	uniqueInputs: true,
 
 	initState: () => {
 		const init: SimulateEnsembleCiemssOperationState = {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -4,20 +4,14 @@ import { CiemssMethodOptions } from '@/services/models/simulation-service';
 
 const DOCUMENTATION_URL = 'https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L35';
 
-export interface SimulateEnsembleMapEntry {
-	modelConfigId: string;
-	compartmentName: string; // State or Obs that is being mapped to newName
-}
-
 export interface SimulateEnsembleMappingRow {
 	id: string; // uuid that can be used as a row key
 	newName: string; // This is the new name provided by the user.
-	modelConfigurationMappings: SimulateEnsembleMapEntry[];
+	modelConfigurationMappings: { [key: string]: string };
 }
 
-export interface SimulateEnsembleWeight {
-	modelConfigurationId: string;
-	value: number;
+export interface SimulateEnsembleWeights {
+	[key: string]: number;
 }
 
 export const speedValues = Object.freeze({
@@ -33,7 +27,7 @@ export const normalValues = Object.freeze({
 export interface SimulateEnsembleCiemssOperationState extends BaseState {
 	chartConfigs: string[][];
 	mapping: SimulateEnsembleMappingRow[];
-	weights: SimulateEnsembleWeight[];
+	weights: SimulateEnsembleWeights;
 	endTime: number;
 	numSamples: number;
 	method: CiemssMethodOptions;
@@ -63,7 +57,7 @@ export const SimulateEnsembleCiemssOperation: Operation = {
 		const init: SimulateEnsembleCiemssOperationState = {
 			chartConfigs: [],
 			mapping: [],
-			weights: [],
+			weights: {},
 			endTime: 100,
 			numSamples: normalValues.numSamples,
 			method: normalValues.method,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,32 +1,33 @@
 import { EnsembleModelConfigs } from '@/types/Types';
-import { SimulateEnsembleMappingRow, SimulateEnsembleWeight } from './simulate-ensemble-ciemss-operation';
+import { SimulateEnsembleMappingRow, SimulateEnsembleWeights } from './simulate-ensemble-ciemss-operation';
 
 export function formatSimulateModelConfigurations(
 	rows: SimulateEnsembleMappingRow[],
-	weights: SimulateEnsembleWeight[]
+	weights: SimulateEnsembleWeights
 ): EnsembleModelConfigs[] {
 	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
-	// const totalWeight = Object.values(weights).reduce((acc, curr) => acc + curr.value, 0) ?? 1;
-	const totalWeight = weights.map((ele) => ele.value).reduce((acc, curr) => acc + curr, 0);
+	const totalWeight = Object.values(weights).reduce((acc, curr) => acc + curr, 0) ?? 1;
 	// 1. map the weights to the ensemble model configs
-	weights.forEach((weight) => {
+	Object.entries(weights).forEach(([key, value]) => {
 		// return if there is no weight
-		if (!weight.value) return;
+		if (!value) return;
 
 		const ensembleModelConfig: EnsembleModelConfigs = {
-			id: weight.modelConfigurationId,
+			id: key,
 			solutionMappings: {},
-			weight: weight.value / totalWeight
+			weight: value / totalWeight
 		};
 
-		ensembleModelConfigMap[weight.modelConfigurationId] = ensembleModelConfig;
+		ensembleModelConfigMap[key] = ensembleModelConfig;
 	});
 
 	// 2. format the solution mappings
 	rows.forEach((row) => {
-		row.modelConfigurationMappings.forEach((ele) => {
-			if (!ensembleModelConfigMap[ele.modelConfigId]) return;
-			ensembleModelConfigMap[ele.modelConfigId].solutionMappings[row.newName] = ele.compartmentName;
+		Object.entries(row.modelConfigurationMappings).forEach(([key, value]) => {
+			if (!ensembleModelConfigMap[key]) return;
+			ensembleModelConfigMap[key].solutionMappings = {
+				[row.newName]: value
+			};
 		});
 	});
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -40,11 +40,11 @@
 											<td>
 												<tera-input-text v-model="ele.newName" auto-focus class="w-full" placeholder="Add a name" />
 											</td>
-											<td v-for="(row, indx) in ele.modelConfigurationMappings" :key="indx">
+											<td v-for="key in Object.keys(ele.modelConfigurationMappings)" :key="key">
 												<Dropdown
 													class="w-full"
-													:options="allModelOptions[row.modelConfigId]"
-													v-model="row.compartmentName"
+													:options="allModelOptions[key]"
+													v-model="ele.modelConfigurationMappings[key]"
 													placeholder="Select"
 													@change="updateMapping()"
 												/>
@@ -116,12 +116,16 @@
 							<div class="model-weights">
 								<table class="p-datatable-table">
 									<tbody class="p-datatable-tbody">
-										<tr v-for="(ele, indx) in knobs.weights" :key="indx">
+										<tr v-for="key in Object.keys(knobs.weights)" :key="key">
 											<td>
-												{{ modelConfigIdToNameMap[ele.modelConfigurationId] }}
+												{{ modelConfigIdToNameMap[key] }}
 											</td>
 											<td>
-												<tera-signal-bars label="Relative certainty" v-model="ele.value" @change="updateWeights()" />
+												<tera-signal-bars
+													label="Relative certainty"
+													v-model="knobs.weights[key]"
+													@change="updateWeights()"
+												/>
 											</td>
 										</tr>
 									</tbody>
@@ -272,7 +276,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
 	SimulateEnsembleCiemssOperationState,
 	SimulateEnsembleMappingRow,
-	SimulateEnsembleWeight,
+	SimulateEnsembleWeights,
 	speedValues,
 	normalValues
 } from './simulate-ensemble-ciemss-operation';
@@ -285,7 +289,7 @@ const emit = defineEmits(['select-output', 'update-state', 'close']);
 
 interface BasicKnobs {
 	mapping: SimulateEnsembleMappingRow[];
-	weights: SimulateEnsembleWeight[];
+	weights: SimulateEnsembleWeights;
 	numSamples: number;
 	method: CiemssMethodOptions;
 	stepSize: number;
@@ -321,7 +325,7 @@ const presetType = computed(() => {
 // List of each observible + state for each model.
 const allModelOptions = ref<{ [key: string]: string[] }>({});
 const modelConfigurationIds: string[] = props.node.inputs.map((ele) => ele.value?.[0]).filter(Boolean);
-const modelConfigIdToNameMap = ref();
+const modelConfigIdToNameMap = ref<Record<string, string>>({});
 
 const newSolutionMappingKey = ref<string>('');
 const runResults = ref<RunResults>({});
@@ -363,14 +367,18 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 };
 
 const addMapping = () => {
+	// create empty configuration mappings
+	const configMappings = {};
+	modelConfigurationIds.forEach((id) => {
+		configMappings[id as string] = '';
+	});
+
 	knobs.value.mapping.push({
 		id: uuidv4(),
 		newName: newSolutionMappingKey.value,
-		modelConfigurationMappings: modelConfigurationIds.map((id) => ({
-			modelConfigId: id as string,
-			compartmentName: ''
-		}))
+		modelConfigurationMappings: configMappings
 	});
+
 	const state = _.cloneDeep(props.node.state);
 	state.mapping = knobs.value.mapping;
 	emit('update-state', state);
@@ -423,7 +431,7 @@ onMounted(async () => {
 
 	modelConfigIdToNameMap.value = {};
 	allModelConfigurations.forEach((config) => {
-		modelConfigIdToNameMap.value[config.id as string] = config.name;
+		modelConfigIdToNameMap.value[config.id as string] = config.name as string;
 	});
 
 	allModelOptions.value = {};
@@ -435,24 +443,12 @@ onMounted(async () => {
 	}
 	listModelLabels.value = allModelConfigurations.map((ele) => ele.name ?? '');
 
-	const state = _.cloneDeep(props.node.state);
-
-	// Initalize weights:
-	if (
-		!knobs.value.weights ||
-		knobs.value.weights.length === 0 ||
-		knobs.value.weights.length !== modelConfigurationIds.length
-	) {
-		knobs.value.weights = [];
-		modelConfigurationIds.forEach((id) => {
-			knobs.value.weights.push({
-				modelConfigurationId: id,
-				value: 5
-			});
+	// initialze weights
+	if (_.isEmpty(knobs.value.weights)) {
+		allModelConfigurations.forEach((config) => {
+			knobs.value.weights[config.id as string] = 5;
 		});
 	}
-
-	emit('update-state', state);
 });
 
 watch(
@@ -492,7 +488,7 @@ watch(
 		state.stepSize = knobs.value.stepSize;
 		emit('update-state', state);
 	},
-	{ immediate: true }
+	{ deep: true }
 );
 </script>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -40,7 +40,7 @@
 											<td>
 												<tera-input-text v-model="ele.newName" auto-focus class="w-full" placeholder="Add a name" />
 											</td>
-											<td v-for="key in Object.keys(ele.modelConfigurationMappings)" :key="key">
+											<td v-for="key in modelConfigurationIds" :key="key">
 												<Dropdown
 													class="w-full"
 													:options="allModelOptions[key]"
@@ -116,7 +116,7 @@
 							<div class="model-weights">
 								<table class="p-datatable-table">
 									<tbody class="p-datatable-tbody">
-										<tr v-for="key in Object.keys(knobs.weights)" :key="key">
+										<tr v-for="key in modelConfigurationIds" :key="key">
 											<td>
 												{{ modelConfigIdToNameMap[key] }}
 											</td>


### PR DESCRIPTION
# Description
- Ensemble simulate now has the same mapping type as the calibration does.
- Now requires unique inputs
- provide a type for `modelConfigIdToNameMap`
- correct state updater via knobs as `watcher` should be `deep` not `immediate` 
