### PR TITLE
Calibration loss chart missing

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -1117,10 +1117,10 @@ const runCalibrate = async () => {
 };
 
 const messageHandler = (event: ClientEvent<any>) => {
-	if (!lossChartRef.value?.view) return;
 	const data = { iter: lossValues.value.length, loss: event.data.loss };
-	lossChartRef.value.view.change(LOSS_CHART_DATA_SOURCE, vega.changeset().insert(data)).resize().run();
 	lossValues.value.push(data);
+	if (!lossChartRef.value?.view) return;
+	lossChartRef.value.view.change(LOSS_CHART_DATA_SOURCE, vega.changeset().insert(data)).resize().run();
 };
 
 const onSelection = (id: string) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -73,7 +73,7 @@
 							</div>
 
 							<Button size="small" text icon="pi pi-plus" label="Add mapping" @click="addMapping" />
-							<!-- 
+							<!--
 						TODO: Add auto mapping here
 						<Button
 							text
@@ -390,10 +390,10 @@ function removeMapping(index: number) {
 }
 
 const messageHandler = (event: ClientEvent<any>) => {
-	if (!lossChartRef.value?.view) return;
 	const data = { iter: lossValues.value.length, loss: event.data.loss };
-	lossChartRef.value.view.change(LOSS_CHART_DATA_SOURCE, vega.changeset().insert(data)).resize().run();
 	lossValues.value.push(data);
+	if (!lossChartRef.value?.view) return;
+	lossChartRef.value.view.change(LOSS_CHART_DATA_SOURCE, vega.changeset().insert(data)).resize().run();
 };
 
 const setPresetValues = (data: CiemssPresetTypes) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -520,7 +520,7 @@ watch(
 			const output = await getRunResultCiemss(state.forecastRunId, 'result.csv');
 			runResults.value = output.runResults;
 			lossValues.value = await getLossValuesFromSimulation(props.node.state.calibrationId);
-			lossChartSpec.value = await updateLossChartSpec(lossValues.value, lossChartSize.value);
+			lossChartSpec.value = updateLossChartSpec(lossValues.value, lossChartSize.value);
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -1,6 +1,10 @@
 <template>
 	<main>
-		<vega-chart v-if="!_.isEmpty(lossValues)" :are-embed-actions-visible="false" :visualization-spec="lossChartSpec" />
+		<vega-chart
+			v-if="(inProgressCalibrationId || inProgressForecastId) && !_.isEmpty(lossValues)"
+			:are-embed-actions-visible="false"
+			:visualization-spec="lossChartSpec"
+		/>
 		<template v-if="!inProgressCalibrationId && !inProgressForecastId && runResults && csvAsset">
 			<tera-simulate-chart
 				v-for="(config, index) of props.node.state.chartConfigs"

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -1,12 +1,7 @@
 <template>
 	<main>
+		<vega-chart v-if="!_.isEmpty(lossValues)" :are-embed-actions-visible="false" :visualization-spec="lossChartSpec" />
 		<template v-if="!inProgressCalibrationId && !inProgressForecastId && runResults && csvAsset">
-			<vega-chart
-				v-if="!_.isEmpty(lossValues)"
-				:are-embed-actions-visible="false"
-				:visualization-spec="lossChartSpec"
-			/>
-
 			<tera-simulate-chart
 				v-for="(config, index) of props.node.state.chartConfigs"
 				:key="index"


### PR DESCRIPTION
# Description
- We had calibration chart `!lossChartRef.value?.view` as well as `v-if="!_.isEmpty(lossValues)"` 
   so we wont fill the data unless we have the reference assigned, but we wont assign the reference unless we have data

- Take loss chart outside of inner result template in the node.
- [Minor]: Do not await a const when using `updateLossChartSpec`
