### PR TITLE
vega chart warnings from calibrate operation. For reference only, do not merge.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -866,7 +866,9 @@ const variableCharts = computed(() => {
 			annotations
 		);
 
-		charts[variable].layer.push(...createInterventionChartMarkers(groupedInterventionOutputs.value[variable]));
+		if (groupedInterventionOutputs.value[variable]) {
+			charts[variable].layer.push(...createInterventionChartMarkers(groupedInterventionOutputs.value[variable]));
+		}
 	});
 	return charts;
 });

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -222,8 +222,13 @@ const preparedCharts = computed(() => {
 				dateOptions
 			}
 		);
-		applyForecastChartAnnotations(chart, annotations);
-		chart.layer.push(...createInterventionChartMarkers(groupedInterventionOutputs.value[variable]));
+
+		if (annotations.length > 0) {
+			applyForecastChartAnnotations(chart, annotations);
+		}
+		if (groupedInterventionOutputs.value[variable]) {
+			chart.layer.push(...createInterventionChartMarkers(groupedInterventionOutputs.value[variable]));
+		}
 
 		return chart;
 	});


### PR DESCRIPTION
### Note
This change should be incorporated into https://github.com/DARPA-ASKEM/terarium/pull/5476/files#diff-bd4982fb40ac36aa7db4fb5cac43c6e337de306a235db7350335f02f9e2418ab

Since they are incompatible code wise, the semantics should be incorporated into the refactor PR, once done, this PR will/should be closed.

### Summary
It seems like we are injecting layers where the data or source are null, this crates the `[-infinity, infinity]` warnings in vegalite.  This PR should clean up a good portion of them.