### PR TITLE
New intervention not working

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
@@ -99,7 +99,7 @@ const onBlur = () => {
 watch(
 	() => props.modelValue,
 	(newValue) => {
-		if (isNaN(newValue)) return;
+		if (isNaN(newValue)) maskedValue.value = '';
 		maskedValue.value = newValue?.toString() ?? '';
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-number.vue
@@ -100,7 +100,7 @@ watch(
 	() => props.modelValue,
 	(newValue) => {
 		if (isNaN(newValue)) maskedValue.value = '';
-		maskedValue.value = newValue?.toString() ?? '';
+		else maskedValue.value = newValue?.toString() ?? '';
 	},
 	{ immediate: true }
 );

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -175,9 +175,9 @@
 		</tera-columnar-panel>
 	</tera-drilldown>
 	<tera-save-asset-modal
-		:initial-name="showCreatePolicyModal ? 'New Intervention Policy' : knobs.transientInterventionPolicy.name"
+		:initial-name="knobs.transientInterventionPolicy.name"
 		:is-visible="showSaveModal"
-		:asset="showCreatePolicyModal ? newBlankInterventionPolicy : knobs.transientInterventionPolicy"
+		:asset="knobs.transientInterventionPolicy"
 		:asset-type="AssetType.InterventionPolicy"
 		@close-modal="showSaveModal = false"
 		@on-save="onSaveAsInterventionPolicy"
@@ -261,12 +261,6 @@ const knobs = ref<BasicKnobs>({
 	}
 });
 
-const newBlankInterventionPolicy = ref({
-	name: '',
-	modelId: '',
-	interventions: [blankIntervention]
-});
-
 interface SelectedIntervention {
 	index: number;
 	name: string;
@@ -285,7 +279,6 @@ const isFetchingPDF = ref(false);
 const pdfData = ref<{ document: DocumentAsset; data: string; isPdf: boolean; name: string }[]>([]);
 
 const showSaveModal = ref(false);
-const showCreatePolicyModal = ref(false);
 const isSidebarOpen = ref(true);
 const filterInterventionsText = ref('');
 const model = ref<Model | null>(null);
@@ -534,7 +527,6 @@ const onResetPolicy = () => {
 };
 
 const onSaveAsInterventionPolicy = (data: InterventionPolicy) => {
-	showCreatePolicyModal.value = false;
 	applyInterventionPolicy(data);
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -397,8 +397,6 @@ const initialize = async (overwriteWithState: boolean = false) => {
 	} else {
 		knobs.value.transientInterventionPolicy = cloneDeep(state.interventionPolicy);
 	}
-
-	console.log(selectedPolicyId.value);
 };
 
 const applyInterventionPolicy = (interventionPolicy: InterventionPolicy) => {
@@ -559,7 +557,15 @@ const onSaveInterventionPolicy = async () => {
 };
 
 const createNewInterventionPolicy = () => {
-	knobs.value.transientInterventionPolicy.interventions = [_.cloneDeep(blankIntervention)];
+	knobs.value.transientInterventionPolicy = {
+		modelId: '',
+		interventions: [blankIntervention]
+	};
+	emit('append-output', {
+		type: InterventionPolicyOperation.outputs[0].type,
+		label: InterventionPolicyOperation.outputs[0].label,
+		value: null
+	});
 };
 
 const extractInterventionPolicyFromInputs = async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -39,7 +39,7 @@
 								:disabled="!props.node.inputs[0]?.value && !props.node.inputs[1]?.value"
 								@click="extractInterventionPolicyFromInputs"
 							/>
-							<Button class="ml-1" label="Create New" :disabled="!model?.id" @click="resetInterventionPolicy" />
+							<Button class="ml-1" label="Create New" :disabled="!model?.id" @click="resetToBlankIntervention" />
 						</nav>
 						<tera-input-text v-model="filterInterventionsText" placeholder="Filter" />
 						<ul v-if="!isFetchingPolicies">
@@ -548,11 +548,14 @@ const onSaveInterventionPolicy = async () => {
 	}
 };
 
-const resetInterventionPolicy = () => {
+const resetToBlankIntervention = () => {
+	const modelId = props.node.inputs[0].value?.[0];
+	if (!modelId) return;
 	knobs.value.transientInterventionPolicy = {
-		modelId: '',
-		interventions: [blankIntervention]
+		modelId,
+		interventions: [_.cloneDeep(blankIntervention)]
 	};
+
 	emit('append-output', {
 		type: InterventionPolicyOperation.outputs[0].type,
 		label: InterventionPolicyOperation.outputs[0].label,

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -39,7 +39,7 @@
 								:disabled="!props.node.inputs[0]?.value && !props.node.inputs[1]?.value"
 								@click="extractInterventionPolicyFromInputs"
 							/>
-							<Button class="ml-1" label="Create New" :disabled="!model?.id" @click="createNewInterventionPolicy" />
+							<Button class="ml-1" label="Create New" :disabled="!model?.id" @click="resetInterventionPolicy" />
 						</nav>
 						<tera-input-text v-model="filterInterventionsText" placeholder="Filter" />
 						<ul v-if="!isFetchingPolicies">
@@ -556,7 +556,7 @@ const onSaveInterventionPolicy = async () => {
 	}
 };
 
-const createNewInterventionPolicy = () => {
+const resetInterventionPolicy = () => {
 	knobs.value.transientInterventionPolicy = {
 		modelId: '',
 		interventions: [blankIntervention]

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -297,8 +297,8 @@ const interventionPoliciesFiltered = computed(() =>
 		.filter((policy) => policy.name?.toLowerCase().includes(filterInterventionsText.value.toLowerCase()))
 		.sort((a, b) => sortDatesDesc(a.createdOn, b.createdOn))
 );
-const selectedOutputId = ref<string>('');
-const selectedPolicyId = computed(() => props.node.outputs.find((o) => o.id === selectedOutputId.value)?.value?.[0]);
+
+const selectedPolicyId = computed(() => props.node.outputs.find((o) => o.id === props.node.active)?.value?.[0]);
 const selectedPolicy = ref<InterventionPolicy | null>(null);
 
 const newDescription = ref('');
@@ -397,6 +397,8 @@ const initialize = async (overwriteWithState: boolean = false) => {
 	} else {
 		knobs.value.transientInterventionPolicy = cloneDeep(state.interventionPolicy);
 	}
+
+	console.log(selectedPolicyId.value);
 };
 
 const applyInterventionPolicy = (interventionPolicy: InterventionPolicy) => {
@@ -557,10 +559,7 @@ const onSaveInterventionPolicy = async () => {
 };
 
 const createNewInterventionPolicy = () => {
-	if (!model.value?.id) return;
-	showCreatePolicyModal.value = true;
-	newBlankInterventionPolicy.value.modelId = model.value.id;
-	showSaveModal.value = true;
+	knobs.value.transientInterventionPolicy.interventions = [_.cloneDeep(blankIntervention)];
 };
 
 const extractInterventionPolicyFromInputs = async () => {
@@ -600,7 +599,6 @@ watch(
 	() => props.node.active,
 	() => {
 		if (props.node.active) {
-			selectedOutputId.value = props.node.active;
 			initialize();
 		}
 	}
@@ -622,7 +620,6 @@ watch(
 
 onMounted(() => {
 	if (props.node.active) {
-		selectedOutputId.value = props.node.active;
 		// setting true will force overwrite the intervention policy with the current state on the node
 		initialize(true);
 	} else {


### PR DESCRIPTION
# Description
Previously the workflow for creating a new intervention is that we would POST a blank intervention and any updates would then allow the user to update this newly created intervention.
This is not a valid workflow as the blank intervention is not a valid intervention (It has no timestep and no value) thus it fails HMIServer's validation.

The new workflow is that we will reset the interface on the frontend and wait for the user to hit `Save` or `Save as...` before trying to POST this intervention 


https://github.com/user-attachments/assets/b273d284-f482-4bca-8e6c-d3749facb795




