### PR TITLE
Jamie style updates nov 13

### DIFF
--- a/packages/client/hmi-client/src/assets/css/style.scss
+++ b/packages/client/hmi-client/src/assets/css/style.scss
@@ -104,6 +104,11 @@
 		font-weight: var(--font-weight);
 	}
 
+	/* Make tab font size same as body */
+	.p-tabview-title {
+		font-size: var(--font-size);
+	}
+
 	/* Fixing the confirm dialog text placement and reject button styling */
 	.p-confirm-dialog-message {
 		margin-left: 0 !important;

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
@@ -84,7 +84,7 @@ header .tabs-row:deep(.p-tabview .p-tabview-panels) {
 }
 
 a {
-	height: 3rem;
+	height: 2.75rem;
 	display: flex;
 	align-items: center;
 	color: var(--primary-color);

--- a/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
@@ -101,7 +101,7 @@ section {
 	}
 
 	& > .p-inputtext {
-		font-size: var(--font-caption);
+		padding-top: 0.325rem;
 	}
 
 	&.in-node {

--- a/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-annotation.vue
@@ -96,7 +96,6 @@ section {
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
-		font-size: var(--font-caption);
 		color: var(--text-color-primary);
 		cursor: text;
 	}

--- a/packages/client/hmi-client/src/components/operator/tera-operator-output-summary.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-output-summary.vue
@@ -136,7 +136,6 @@ section {
 	& > .summary {
 		display: flex;
 		width: 100%;
-		font-size: var(--font-caption);
 		color: var(--text-color-primary);
 		cursor: text;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,7 +1,7 @@
 <template>
 	<section>
-		<div v-if="!isEmpty(node.state.transientModelConfig.id)" class="pl-2 pr-2 pb-3">
-			<h6 class="pb-2">{{ node.state.transientModelConfig.name }}</h6>
+		<div v-if="!isEmpty(node.state.transientModelConfig.id)" class="pb-3">
+			<h6 class="pb-1 line-wrap">{{ node.state.transientModelConfig.name }}</h6>
 			<p>{{ node.state.transientModelConfig.description }}</p>
 		</div>
 		<tera-operator-placeholder v-else :node="node" />
@@ -126,7 +126,13 @@ watch(
 );
 </script>
 <style scoped>
+.line-wrap {
+	white-space: normal;
+	overflow-wrap: break-word;
+	word-break: break-word;
+	max-width: 100%;
+}
 h6 + p {
-	color: var(--text-color-subdued);
+	color: var(--text-color);
 }
 </style>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -53,7 +53,7 @@
 			</div>
 			<div class="warning-banner" :class="{ visible: warningBanner && hasInvalidNodes }">
 				A yellow header indicates that the node is stale due to upstream changes. Rerun to update.
-				<a class="ml-auto mr-4 underline" @click="dontShowAgain">Don't show this again</a
+				<a class="ml-auto mr-4" @click="dontShowAgain">Don't show this again</a
 				><Button class="mr-2" icon="pi pi-times" text @click="warningBanner = false" />
 			</div>
 		</template>
@@ -1056,6 +1056,8 @@ onUnmounted(() => {
 
 .warning-banner {
 	width: 100%;
+	font-size: var(--font-caption);
+	border-bottom: 1px solid var(--surface-border-light);
 	display: flex;
 	align-items: center;
 	background-color: var(--surface-warning);


### PR DESCRIPTION
Minor style updates, mostly relating to font sizes and padding.

### Annotation font sizes - NODE
Before:
<img width="427" alt="annotation font size - node - before" src="https://github.com/user-attachments/assets/2e9a335c-571c-4578-af65-a55cf5b30d85">

After:
<img width="310" alt="annotation font size - node - after" src="https://github.com/user-attachments/assets/5a729b39-4e5e-4abc-8d86-b676e7e84628">

---------------------------------------------
### Annotation font sizes - DRILLDOWN
Before:
<img width="1370" alt="annotation font size - drilldown - before" src="https://github.com/user-attachments/assets/fcf9ff60-8591-4f99-9d5f-da6087bc1427">

After:
<img width="1418" alt="annotation font size - drilldown - after" src="https://github.com/user-attachments/assets/e60d61ed-da84-478f-b102-2bf1ab96a8b9">

---------------------------------------------
### Configuration name text overflow
Before:
<img width="508" alt="Configuration name text overflow - before" src="https://github.com/user-attachments/assets/1fae05f2-8e94-40e8-97c8-ad683add4b7b">

After:
<img width="285" alt="Configuration name text overflow - after" src="https://github.com/user-attachments/assets/8afe0437-8e9a-47d4-a780-e55becc17b29">


---------------------------------------------
### Summary font size
Before:
<img width="1778" alt="Summary font size - before" src="https://github.com/user-attachments/assets/32f1838c-f17f-40da-8bf2-22110360e67e">

After:
<img width="1777" alt="Summary font size - after" src="https://github.com/user-attachments/assets/955b5068-d874-41e0-9bd5-f0ebf20c7297">




---------------------------------------------
### Tab font sizes
Before:
<img width="704" alt="Tab font size - before" src="https://github.com/user-attachments/assets/715b54ad-96ee-47be-80f6-2fb0a2fb37a1">

After:
<img width="1065" alt="Tab font size - after" src="https://github.com/user-attachments/assets/baa031e1-4224-44b3-8379-e69c7a51e03a">


---------------------------------------------
### Warning banner font sizes
Before:
I didn't take a screenshot... font size was 14px. 

After: 
It's now caption.
<img width="1147" alt="Warning banner - reduced font size, removed underline" src="https://github.com/user-attachments/assets/7be1f3f3-f95a-4fe7-946d-e3bdb7e54ad6">
