### PR TITLE
Switch between pdfs

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
@@ -1,5 +1,5 @@
 <template>
-	<TabView v-if="pdfs?.length" class="container">
+	<TabView v-if="pdfs?.length" class="container" :active-index="activeTabIndex">
 		<TabPanel :header="pdf.name" v-for="pdf in pdfs" :key="pdf.name">
 			<tera-pdf-embed v-if="pdf.isPdf" ref="pdfRef" :pdf-link="pdf.data" :title="pdf.name || ''" />
 			<tera-text-editor v-else :initial-text="pdf.data" />
@@ -8,7 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { nextTick, onMounted, ref } from 'vue';
+import { keyBy } from 'lodash';
 
 import TabView from 'primevue/tabview';
 import TabPanel from 'primevue/tabpanel';
@@ -30,8 +31,28 @@ const props = defineProps<{
 
 const pdfs = ref<PdfData[]>(props.pdfs);
 const pdfRef = ref(null);
+const activeTabIndex = ref(0);
+const pdfDocs = ref();
 
-defineExpose({ pdfRef });
+async function selectPdf(id) {
+	if (pdfDocs.value[id]) {
+		activeTabIndex.value = pdfDocs.value[id].index;
+		await nextTick();
+	}
+}
+
+onMounted(() => {
+	pdfDocs.value = keyBy(
+		pdfs.value.map((pdf, index) => ({
+			id: pdf.document.id,
+			index,
+			pdf
+		})),
+		'id'
+	);
+});
+
+defineExpose({ pdfRef, selectPdf });
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-pdf-panel.vue
@@ -1,5 +1,10 @@
 <template>
-	<TabView v-if="pdfs?.length" :activeIndex="activeTabIndex" class="container" :class="pdfs?.length < 2 ? 'hide-tab-selectors' : ''">
+	<TabView
+		v-if="pdfs?.length"
+		:activeIndex="activeTabIndex"
+		class="container"
+		:class="pdfs?.length < 2 ? 'hide-tab-selectors' : ''"
+	>
 		<TabPanel :header="pdf.name" v-for="pdf in pdfs" :key="pdf.name">
 			<tera-pdf-embed v-if="pdf.isPdf" ref="pdfRef" :pdf-link="pdf.data" :title="pdf.name || ''" />
 			<tera-text-editor v-else :initial-text="pdf.data" />

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -306,7 +306,7 @@ const selectedConfigMissingInputCount = ref('');
 const currentActiveIndexes = ref([0, 1, 2]);
 const pdfData = ref<{ document: any; data: string; isPdf: boolean; name: string }[]>([]);
 const pdfPanelRef = ref();
-const pdfViewer = computed(() => pdfPanelRef.value?.pdfRef[0]);
+const pdfViewer = computed(() => pdfPanelRef.value?.pdfRef);
 
 const isSidebarOpen = ref(true);
 const isEditingDescription = ref(false);
@@ -652,12 +652,14 @@ const initialize = async (overwriteWithState: boolean = false) => {
 };
 
 const onSelectConfiguration = async (config: ModelConfiguration) => {
+	let tabIndex = 0;
 	if (pdfViewer.value && config.extractionDocumentId) {
-		pdfPanelRef.value.selectPdf(config.extractionDocumentId);
+		tabIndex = await pdfPanelRef.value.selectPdf(config.extractionDocumentId);
+		await nextTick();
 	}
 
 	if (pdfViewer.value && config.extractionPage) {
-		pdfViewer.value.goToPage(config.extractionPage);
+		pdfViewer.value[tabIndex].goToPage(config.extractionPage);
 	}
 
 	const { transientModelConfig } = knobs.value;

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -652,6 +652,10 @@ const initialize = async (overwriteWithState: boolean = false) => {
 };
 
 const onSelectConfiguration = async (config: ModelConfiguration) => {
+	if (pdfViewer.value && config.extractionDocumentId) {
+		pdfPanelRef.value.selectPdf(config.extractionDocumentId);
+	}
+
 	if (pdfViewer.value && config.extractionPage) {
 		pdfViewer.value.goToPage(config.extractionPage);
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -653,7 +653,7 @@ const initialize = async (overwriteWithState: boolean = false) => {
 
 const onSelectConfiguration = async (config: ModelConfiguration) => {
 	let tabIndex = 0;
-	if (pdfViewer.value && config.extractionDocumentId) {
+	if (pdfPanelRef.value && config.extractionDocumentId) {
 		tabIndex = await pdfPanelRef.value.selectPdf(config.extractionDocumentId);
 		await nextTick();
 	}


### PR DESCRIPTION
# Description

https://github.com/user-attachments/assets/1ab6315e-b41e-4747-ba25-808428983cdc

Issue: 
- If there are multiple pdfs when the user selects a model config, the pdf viewer will always stay on the current selected pdf

Testing:
- Add a document & model to a workflow
- create a model config and extract the inputs
-  selecting a different config from different doc to open the correct doc


Resolves #(issue)
