### PR TITLE
fix transition accordion lag

### DIFF
--- a/packages/client/hmi-client/src/components/asset/tera-asset.vue
+++ b/packages/client/hmi-client/src/components/asset/tera-asset.vue
@@ -242,6 +242,7 @@ main > section {
 		flex: 1;
 		max-width: 100%;
 		overflow-x: auto;
+		overflow-y: hidden;
 	}
 }
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -1,26 +1,24 @@
 <template>
-	<section>
-		<Accordion multiple :active-index="currentActiveIndexes" v-bind:lazy="true" class="mb-0">
-			<AccordionTab header="Description">
-				<tera-progress-spinner v-if="isGeneratingCard" is-centered> Generating description... </tera-progress-spinner>
-				<Editor v-else v-model="editorContent" />
-			</AccordionTab>
-			<AccordionTab header="Diagram">
-				<tera-model-diagram :model="model" :mmt-data="mmtData" :feature-config="featureConfig" />
-			</AccordionTab>
-			<AccordionTab header="Model equations">
-				<tera-model-equation :model="model" :is-editable="false" @model-updated="emit('update-model')" />
-			</AccordionTab>
-			<AccordionTab v-if="!isEmpty(relatedTerariumArtifacts)" header="Associated resources">
-				<DataTable :value="relatedTerariumModels">
-					<Column field="name" header="Models" />
-				</DataTable>
-				<DataTable :value="relatedTerariumDatasets">
-					<Column field="name" header="Datasets" />
-				</DataTable>
-			</AccordionTab>
-		</Accordion>
-	</section>
+	<Accordion multiple :active-index="currentActiveIndexes" v-bind:lazy="true" class="mb-0">
+		<AccordionTab header="Description">
+			<tera-progress-spinner v-if="isGeneratingCard" is-centered> Generating description... </tera-progress-spinner>
+			<Editor v-else v-model="editorContent" />
+		</AccordionTab>
+		<AccordionTab header="Diagram">
+			<tera-model-diagram :model="model" :mmt-data="mmtData" :feature-config="featureConfig" />
+		</AccordionTab>
+		<AccordionTab header="Model equations">
+			<tera-model-equation :model="model" :is-editable="false" @model-updated="emit('update-model')" />
+		</AccordionTab>
+		<AccordionTab v-if="!isEmpty(relatedTerariumArtifacts)" header="Associated resources">
+			<DataTable :value="relatedTerariumModels">
+				<Column field="name" header="Models" />
+			</DataTable>
+			<DataTable :value="relatedTerariumDatasets">
+				<Column field="name" header="Datasets" />
+			</DataTable>
+		</AccordionTab>
+	</Accordion>
 </template>
 
 <script setup lang="ts">

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, debounce } from 'lodash';
 import { ref, watch, computed, nextTick, onMounted, onUnmounted } from 'vue';
 import Button from 'primevue/button';
 import SelectButton from 'primevue/selectbutton';
@@ -215,7 +215,9 @@ watch(
 let graphResizeObserver: ResizeObserver;
 onMounted(() => {
 	if (graphElement.value) {
-		graphResizeObserver = observeElementSizeChange(graphElement.value, renderGraph);
+		// FIXME: This debounce prevents the graph from being rendered multiple times in a row.
+		// This happens in cases where there is a slight change in width when a scrollbar is shown or hidden. eg. opening/closing the transitions accordion in the model page
+		graphResizeObserver = observeElementSizeChange(graphElement.value, debounce(renderGraph, 2000));
 	}
 });
 onUnmounted(() => {


### PR DESCRIPTION
# Description

A temporary scrollbar spawns while opening/closing the transition accordion causing the model diagram to rerender due to its resize observer. This causes the transition accordion to lag. In order to minimize rerenders I:

* Added a debounce to the model diagram's resize observer
* Removed the uneeded y scrollbar that sometimes gets added to a section in `tera-asset`
