### PR TITLE
Ensemble weights to not be normalized

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-signal-bars.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-signal-bars.vue
@@ -7,26 +7,33 @@
 			</template>
 		</Dropdown>
 		<!-- Signal Bars -->
-		<ul>
-			<li v-for="n in numberOfBars" :key="n" :class="{ active: n <= modelValue }" :style="getBarStyle(n)" />
+		<ul v-if="minOption > 0">
+			<li v-for="n in options.length" :key="n" :class="{ active: n <= modelValue }" :style="getBarStyle(n)" />
+		</ul>
+		<ul v-if="minOption <= 0">
+			<li v-for="n in options.length - 1" :key="n" :class="{ active: n <= modelValue }" :style="getBarStyle(n)" />
 		</ul>
 	</div>
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import Dropdown from 'primevue/dropdown';
 import { ref } from 'vue';
 
 const baseDelay = 0.03; // transition delay for each bar
 const barWidth = 2; // width for each bar
-const maxNumberOfBars = 15; // just setting a max number of bars arbitrarily
 
 const props = defineProps({
 	modelValue: {
 		type: Number,
 		required: true
 	},
-	numberOfBars: {
+	minOption: {
+		type: Number,
+		default: 0
+	},
+	maxOption: {
 		type: Number,
 		default: 10
 	},
@@ -39,9 +46,8 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue']);
 
 const previousValue = ref(props.modelValue);
-const numberOfBars = Math.min(props.numberOfBars, maxNumberOfBars);
 
-const options: number[] = Array.from({ length: numberOfBars + 1 }, (_, i) => i);
+const options: number[] = _.range(props.minOption, props.maxOption + 1, 1);
 
 // fun styling for the bars :)
 const getBarStyle = (n: number) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -43,7 +43,6 @@ export function formatCalibrateModelConfigurations(
 	weights: CalibrateEnsembleWeights
 ): EnsembleModelConfigs[] {
 	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
-	const totalWeight = Object.values(weights).reduce((acc, curr) => acc + curr, 0) ?? 1;
 	// 1. map the weights to the ensemble model configs
 	Object.entries(weights).forEach(([key, value]) => {
 		// return if there is no weight
@@ -52,7 +51,7 @@ export function formatCalibrateModelConfigurations(
 		const ensembleModelConfig: EnsembleModelConfigs = {
 			id: key,
 			solutionMappings: {},
-			weight: value / totalWeight
+			weight: value
 		};
 
 		ensembleModelConfigMap[key] = ensembleModelConfig;

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -93,6 +93,7 @@
 								<tera-signal-bars
 									v-if="modelConfiguration?.id"
 									class="ml-auto"
+									:min-option="1"
 									:model-value="knobs.configurationWeights[modelConfiguration.id] ?? 0"
 									@update:model-value="knobs.configurationWeights[modelConfiguration.id] = $event"
 									label="Relative certainty"

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -6,7 +6,6 @@ export function formatSimulateModelConfigurations(
 	weights: SimulateEnsembleWeights
 ): EnsembleModelConfigs[] {
 	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
-	const totalWeight = Object.values(weights).reduce((acc, curr) => acc + curr, 0) ?? 1;
 	// 1. map the weights to the ensemble model configs
 	Object.entries(weights).forEach(([key, value]) => {
 		// return if there is no weight
@@ -15,7 +14,7 @@ export function formatSimulateModelConfigurations(
 		const ensembleModelConfig: EnsembleModelConfigs = {
 			id: key,
 			solutionMappings: {},
-			weight: value / totalWeight
+			weight: value
 		};
 
 		ensembleModelConfigMap[key] = ensembleModelConfig;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -123,6 +123,7 @@
 											<td>
 												<tera-signal-bars
 													label="Relative certainty"
+													:min-option="1"
 													v-model="knobs.weights[key]"
 													@change="updateWeights()"
 												/>


### PR DESCRIPTION
# Description
- Ensemble weighting are `dirichlet_alpha` and should not be normalized.
- They also should not have the option for 0.

In order to accommodate this I have updated `tera-signal-bars` to allow for a min and max number for more flexibility  