### PR TITLE
Change project sample to be reversible

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,7 @@ module.exports = {
 		'vuejs-accessibility/click-events-have-key-events': 'off',
 		'vuejs-accessibility/label-has-for': 'off',
 		'vuejs-accessibility/form-control-has-label': 'off',
+		'vuejs-accessibility/no-autofocus': 'off',
 		'vue/require-toggle-inside-transition': 'off',
 		'vue/multi-word-component-names': 'off',
 		'import/prefer-default-export': 'off',

--- a/packages/client/hmi-client/src/components/home/tera-project-menu.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-menu.vue
@@ -22,13 +22,7 @@ const props = defineProps<{ project: Project | null }>();
 const emit = defineEmits(['copied-project']);
 
 // Triggers modals from tera-common-modal-dialogs.vue to open
-const {
-	isShareDialogVisible,
-	isRemoveDialogVisible,
-	isProjectConfigDialogVisible,
-	isMakeSampleDialogVisible,
-	menuProject
-} = useProjectMenu();
+const { isShareDialogVisible, isRemoveDialogVisible, isProjectConfigDialogVisible, menuProject } = useProjectMenu();
 
 const isCopying = ref(false);
 
@@ -91,14 +85,6 @@ const downloadMenuItem = {
 	}
 };
 
-const makeSampleMenuItem = {
-	label: 'Make a sample',
-	icon: 'pi pi-star',
-	command: () => {
-		isMakeSampleDialogVisible.value = true;
-	}
-};
-
 const projectMenuItems = computed(() => {
 	// Basic access to a public and reader project
 	const items: MenuItem[] = [copyMenuItem, downloadMenuItem];
@@ -111,11 +97,6 @@ const projectMenuItems = computed(() => {
 	// Creator of the project, or an admin
 	if (props.project?.userPermission === 'creator' || useAuthStore().isAdmin) {
 		items.push(removeMenuItem);
-	}
-
-	// Admin only
-	if (useAuthStore().isAdmin && props.project?.sampleProject === false) {
-		items.push(makeSampleMenuItem);
 	}
 
 	return items;

--- a/packages/client/hmi-client/src/components/home/tera-project-menu.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-menu.vue
@@ -12,22 +12,28 @@ import { isEmpty } from 'lodash';
 import Button from 'primevue/button';
 import Menu from 'primevue/menu';
 import { computed, ref } from 'vue';
-import { exportProjectAsFile, setSample } from '@/services/project';
+import { exportProjectAsFile } from '@/services/project';
 import { AcceptedExtensions } from '@/types/common';
 import { MenuItem } from 'primevue/menuitem';
 import useAuthStore from '@/stores/auth';
-import { useToastService } from '@/services/toast';
 
 const props = defineProps<{ project: Project | null }>();
 
 const emit = defineEmits(['copied-project']);
 
 // Triggers modals from tera-common-modal-dialogs.vue to open
-const { isShareDialogVisible, isRemoveDialogVisible, isProjectConfigDialogVisible, menuProject } = useProjectMenu();
+const {
+	isShareDialogVisible,
+	isRemoveDialogVisible,
+	isProjectConfigDialogVisible,
+	isMakeSampleDialogVisible,
+	menuProject
+} = useProjectMenu();
 
 const isCopying = ref(false);
 
 const menu = ref();
+
 const editDetailsMenuItem = {
 	label: 'Edit details',
 	icon: 'pi pi-pencil',
@@ -35,6 +41,7 @@ const editDetailsMenuItem = {
 		isProjectConfigDialogVisible.value = true;
 	}
 };
+
 const shareMenuItem = {
 	label: 'Share',
 	icon: 'pi pi-user-plus',
@@ -42,6 +49,7 @@ const shareMenuItem = {
 		isShareDialogVisible.value = true;
 	}
 };
+
 const removeMenuItem = {
 	label: 'Delete',
 	icon: 'pi pi-trash',
@@ -49,6 +57,7 @@ const removeMenuItem = {
 		isRemoveDialogVisible.value = true;
 	}
 };
+
 const copyMenuItem = {
 	label: 'Copy',
 	icon: 'pi pi-clone',
@@ -86,14 +95,7 @@ const makeSampleMenuItem = {
 	label: 'Make a sample',
 	icon: 'pi pi-star',
 	command: () => {
-		setSample(props.project?.id).then((response) => {
-			if (response) {
-				useToastService().success(undefined, 'Project set as sample');
-				useProjects().refresh();
-			} else {
-				useToastService().error(undefined, 'Error setting project as sample');
-			}
-		});
+		isMakeSampleDialogVisible.value = true;
 	}
 };
 
@@ -119,7 +121,7 @@ const projectMenuItems = computed(() => {
 	return items;
 });
 
-function toggle(event) {
+function toggle(event: any) {
 	menu.value.toggle(event);
 }
 </script>

--- a/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
+++ b/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
@@ -39,6 +39,7 @@
 					class="p-dropdown-sm accessibility"
 					:loading="isUpdatingAccessibility"
 					@update:model-value="changeAccessibility"
+					:disabled="isSample"
 				>
 					<template #value="slotProps">
 						<div class="general-access-option">
@@ -56,10 +57,14 @@
 				<div class="text-sm">{{ generalAccessCaption }}</div>
 			</section>
 			<section v-if="useAuthStore().isAdmin">
-				<i v-if="isSampleLoading" class="pi pi-spin pi-spinner" style="color: var(--primary-color)" />
-				<input v-else type="checkbox" id="sample-project" v-model="isSample" class="m-0" />
-				<strong class="ml-2">Sample project</strong>
-				<p class="pt-1 text-sm">A sample project is public and only editable by an <em>administrator</em>.</p>
+				<label for="sample-project" class="cursor-pointer block">
+					<i v-if="isSampleLoading" class="pi pi-spin pi-spinner" style="color: var(--primary-color)" />
+					<input v-else type="checkbox" id="sample-project" v-model="isSample" class="m-0" />
+					<strong class="ml-2">Sample project</strong>
+					<span class="block pt-1 text-sm"
+						>A sample project is public and only editable by an <em>administrator</em>.</span
+					>
+				</label>
 			</section>
 		</main>
 		<template #footer>
@@ -119,7 +124,6 @@ const generalAccessCaption = computed(() => {
 });
 
 function onDone() {
-	useProjects().getAll();
 	setPermissions();
 }
 
@@ -243,6 +247,7 @@ watch(
 		existingUsers.value = new Set();
 		users.value = (await getUsers()) ?? [];
 		isSample.value = props.project.sampleProject ?? false;
+		publicGeneralAccess.value = props.project.publicProject;
 	},
 	{ immediate: true }
 );
@@ -276,7 +281,11 @@ watch(isSample, (value) => {
 			.setSample(props.project.id, value)
 			.then((done) => {
 				isSampleLoading.value = false;
-				if (!done) isSample.value = !value;
+				if (done) {
+					useProjects().getAll();
+				} else {
+					isSample.value = !value;
+				}
 			});
 	}
 });

--- a/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
+++ b/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
@@ -63,7 +63,7 @@
 			</section>
 		</main>
 		<template #footer>
-			<Button label="Done" @click="setPermissions" />
+			<Button label="Done" @click="onDone" />
 		</template>
 	</Dialog>
 </template>
@@ -118,6 +118,11 @@ const generalAccessCaption = computed(() => {
 	}
 	return 'Anyone can view and copy this project.';
 });
+
+function onDone() {
+	useProjects().getAll();
+	setPermissions();
+}
 
 async function changeAccessibility({ label }: { label: Accessibility }) {
 	isUpdatingAccessibility.value = true;
@@ -238,6 +243,7 @@ watch(
 	async () => {
 		existingUsers.value = new Set();
 		users.value = (await getUsers()) ?? [];
+		isSample.value = props.project.sampleProject ?? false;
 	},
 	{ immediate: true }
 );
@@ -261,16 +267,19 @@ watch(
 /**
  * Sample project
  */
-const isSample = ref(props.project.sampleProject ?? false);
+const isSample = ref<boolean>(props.project.sampleProject ?? false);
 const isSampleLoading = ref<boolean>(false);
 watch(isSample, (value) => {
-	isSampleLoading.value = true;
-	useProjects()
-		.setSample(props.project.id, value)
-		.then((done) => {
-			isSampleLoading.value = false;
-			if (!done) isSample.value = !value;
-		});
+	// When the user decides to change the sample project status
+	if (props.project.sampleProject !== value) {
+		isSampleLoading.value = true;
+		useProjects()
+			.setSample(props.project.id, value)
+			.then((done) => {
+				isSampleLoading.value = false;
+				if (!done) isSample.value = !value;
+			});
+	}
 });
 </script>
 

--- a/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
+++ b/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
@@ -1,14 +1,14 @@
 <template>
 	<Dialog
-		v-model:visible="visible"
 		modal
-		:closable="false"
 		header="Share project"
-		@hide="$emit('update:modelValue', false)"
+		style="width: 30rem"
+		v-model:visible="visible"
+		:closable="false"
 		@after-hide="onAfterHide"
-		:style="{ width: '35rem' }"
+		@hide="$emit('update:modelValue', false)"
 	>
-		<section class="mr-2">
+		<main>
 			<Dropdown
 				v-model="selectedUser"
 				:options="usersMenu"
@@ -55,9 +55,15 @@
 				</Dropdown>
 				<div class="caption">{{ generalAccessCaption }}</div>
 			</section>
-		</section>
+			<section>
+				<h6>Sample project</h6>
+				<input type="checkbox" id="sample-project" v-model="isSample" />
+				<p>This will make the project public and only editable by <em>administrator</em>.</p>
+				<span>{{}}</span>
+			</section>
+		</main>
 		<template #footer>
-			<Button label="Done" @click="setPermissions" size="large" />
+			<Button label="Done" @click="setPermissions" />
 		</template>
 	</Dialog>
 </template>
@@ -249,6 +255,26 @@ watch(
 		visible.value = props.modelValue;
 	}
 );
+
+/**
+ * Sample project
+ */
+const isSample = ref(props.project.sampleProject ?? false);
+const isSampleLoading = ref<boolean>(false);
+const isSampleMessage = ref<string>('');
+watch(isSample, (value) => {
+	useProjects()
+		.setSample(props.project.id, value)
+		.then((response) => {
+			isSampleLoading.value = false;
+
+			// In the case of an error, reset the value and show a message
+			if (!response) {
+				isSample.value = !value;
+				isSampleMessage.value = 'An error occurred while updating the sample project status. Please try again later.';
+			}
+		});
+});
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
+++ b/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
@@ -2,7 +2,7 @@
 	<Dialog
 		modal
 		header="Share project"
-		style="width: 30rem"
+		style="width: 35rem"
 		v-model:visible="visible"
 		:closable="false"
 		@after-hide="onAfterHide"
@@ -53,13 +53,13 @@
 						</div>
 					</template>
 				</Dropdown>
-				<div class="caption">{{ generalAccessCaption }}</div>
+				<div class="text-sm">{{ generalAccessCaption }}</div>
 			</section>
-			<section>
-				<h6>Sample project</h6>
-				<input type="checkbox" id="sample-project" v-model="isSample" />
-				<p>This will make the project public and only editable by <em>administrator</em>.</p>
-				<span>{{}}</span>
+			<section v-if="useAuthStore().isAdmin">
+				<tera-progress-spinner v-if="isSampleLoading">Updating project</tera-progress-spinner>
+				<input v-else type="checkbox" id="sample-project" v-model="isSample" class="m-0" />
+				<strong class="ml-2">Sample project</strong>
+				<p class="pt-1 text-sm">A sample project is public and only editable by an <em>administrator</em>.</p>
 			</section>
 		</main>
 		<template #footer>
@@ -76,6 +76,8 @@ import Button from 'primevue/button';
 import { getUsers } from '@/services/user';
 import type { PermissionRelationships, PermissionUser, Project } from '@/types/Types';
 import { useProjects } from '@/composables/project';
+import useAuthStore from '@/stores/auth';
+import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import TeraUserCard from './tera-user-card.vue';
 
 enum Accessibility {
@@ -261,28 +263,23 @@ watch(
  */
 const isSample = ref(props.project.sampleProject ?? false);
 const isSampleLoading = ref<boolean>(false);
-const isSampleMessage = ref<string>('');
 watch(isSample, (value) => {
+	isSampleLoading.value = true;
 	useProjects()
 		.setSample(props.project.id, value)
-		.then((response) => {
+		.then((done) => {
 			isSampleLoading.value = false;
-
-			// In the case of an error, reset the value and show a message
-			if (!response) {
-				isSample.value = !value;
-				isSampleMessage.value = 'An error occurred while updating the sample project status. Please try again later.';
-			}
+			if (!done) isSample.value = !value;
 		});
 });
 </script>
 
 <style scoped>
-section {
-	padding-top: var(--gap-2);
+section + section {
+	margin-top: var(--gap-3);
 }
 
-section > section {
+main > section {
 	padding-top: var(--gap-4);
 }
 

--- a/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
+++ b/packages/client/hmi-client/src/components/widgets/share-project/tera-share-project.vue
@@ -56,7 +56,7 @@
 				<div class="text-sm">{{ generalAccessCaption }}</div>
 			</section>
 			<section v-if="useAuthStore().isAdmin">
-				<tera-progress-spinner v-if="isSampleLoading">Updating project</tera-progress-spinner>
+				<i v-if="isSampleLoading" class="pi pi-spin pi-spinner" style="color: var(--primary-color)" />
 				<input v-else type="checkbox" id="sample-project" v-model="isSample" class="m-0" />
 				<strong class="ml-2">Sample project</strong>
 				<p class="pt-1 text-sm">A sample project is public and only editable by an <em>administrator</em>.</p>
@@ -77,7 +77,6 @@ import { getUsers } from '@/services/user';
 import type { PermissionRelationships, PermissionUser, Project } from '@/types/Types';
 import { useProjects } from '@/composables/project';
 import useAuthStore from '@/stores/auth';
-import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 import TeraUserCard from './tera-user-card.vue';
 
 enum Accessibility {

--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -21,7 +21,7 @@
 		<p>Are you sure?</p>
 		<template #footer>
 			<Button label="Cancel" class="p-button-secondary" @click="isRemoveDialogVisible = false" />
-			<Button label="Delete project" severity="danger" @click="removeProject" />
+			<Button label="Delete project" severity="danger" @click="removeProject" autofocus />
 		</template>
 	</Dialog>
 	<tera-share-project v-if="menuProject" v-model="isShareDialogVisible" :project="menuProject" />

--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -25,17 +25,6 @@
 		</template>
 	</Dialog>
 	<tera-share-project v-if="menuProject" v-model="isShareDialogVisible" :project="menuProject" />
-	<Dialog modal header="Make a sample project" style="max-width: 65ch" v-model:visible="isMakeSampleDialogVisible">
-		<p>
-			This irreversible action will change <strong>{{ menuProject?.name }}</strong> into sample a project publicly
-			accessible.
-		</p>
-		<p>Only Terarium <strong>administrators</strong> can edit sample projects.</p>
-		<template #footer>
-			<Button label="Cancel" class="p-button-secondary" @click="isMakeSampleDialogVisible = false" />
-			<Button label="Make a sample project" severity="danger" @click="makeSampleProject" />
-		</template>
-	</Dialog>
 </template>
 
 <script setup lang="ts">
@@ -50,21 +39,13 @@ import { RoutePath, useCurrentRoute } from '@/router/index';
 import { RouteName } from '@/router/routes';
 import { useProjects } from '@/composables/project';
 import { useProjectMenu } from '@/composables/project-menu';
-import { setSample } from '@/services/project';
-import { useToastService } from '@/services/toast';
 
 const router = useRouter();
 const currentRoute = useCurrentRoute();
 
 // For now, we just use project-menu.ts to manage modals related to projects
 // For non-project related modals we may want to create new composable or abstract project-menu.ts into a modal manager
-const {
-	isShareDialogVisible,
-	isRemoveDialogVisible,
-	isProjectConfigDialogVisible,
-	isMakeSampleDialogVisible,
-	menuProject
-} = useProjectMenu();
+const { isShareDialogVisible, isRemoveDialogVisible, isProjectConfigDialogVisible, menuProject } = useProjectMenu();
 
 const removeProject = async () => {
 	if (!menuProject.value) return;
@@ -76,21 +57,6 @@ const removeProject = async () => {
 		logger.info(`The project ${name} was removed`, { showToast: true });
 		if (currentRoute.value.name !== RouteName.Home) router.push(RoutePath.Home);
 	}
-};
-
-const makeSampleProject = async () => {
-	if (!menuProject.value) return;
-	const { id } = menuProject.value;
-
-	setSample(id).then((response) => {
-		if (response) {
-			useToastService().success(undefined, 'Project set as sample');
-			useProjects().getAll();
-		} else {
-			useToastService().error(undefined, 'Error setting project as sample');
-		}
-		isMakeSampleDialogVisible.value = false;
-	});
 };
 </script>
 

--- a/packages/client/hmi-client/src/composables/project-menu.ts
+++ b/packages/client/hmi-client/src/composables/project-menu.ts
@@ -4,7 +4,6 @@ import { Project } from '@/types/Types';
 const isShareDialogVisible = ref(false);
 const isRemoveDialogVisible = ref(false);
 const isProjectConfigDialogVisible = ref(false);
-const isMakeSampleDialogVisible = ref(false);
 const menuProject = ref<Project | null>(null);
 
 export function useProjectMenu() {
@@ -12,7 +11,6 @@ export function useProjectMenu() {
 		isShareDialogVisible,
 		isRemoveDialogVisible,
 		isProjectConfigDialogVisible,
-		isMakeSampleDialogVisible,
 		menuProject
 	};
 }

--- a/packages/client/hmi-client/src/composables/project-menu.ts
+++ b/packages/client/hmi-client/src/composables/project-menu.ts
@@ -4,6 +4,7 @@ import { Project } from '@/types/Types';
 const isShareDialogVisible = ref(false);
 const isRemoveDialogVisible = ref(false);
 const isProjectConfigDialogVisible = ref(false);
+const isMakeSampleDialogVisible = ref(false);
 const menuProject = ref<Project | null>(null);
 
 export function useProjectMenu() {
@@ -11,6 +12,7 @@ export function useProjectMenu() {
 		isShareDialogVisible,
 		isRemoveDialogVisible,
 		isProjectConfigDialogVisible,
+		isMakeSampleDialogVisible,
 		menuProject
 	};
 }

--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -11,6 +11,7 @@ import * as ProjectService from '@/services/project';
 import type { PermissionRelationships, Project, ProjectAsset } from '@/types/Types';
 import { AssetType } from '@/types/Types';
 import { shallowRef } from 'vue';
+import { useToastService } from '@/services/toast';
 
 const TIMEOUT_MS = 100;
 
@@ -214,6 +215,24 @@ export function useProjects() {
 		}
 	}
 
+	/**
+	 * Make a project a sample project
+	 * @param {Project['id]} projectId - the id of the project to set as a sample project
+	 * @param {boolean} isSample - true if the project should be a sample project, false otherwise
+	 */
+	async function setSample(projectId: Project['id'], isSample: boolean): Promise<boolean> {
+		const projectToUpdate = allProjects.value?.find((project) => project.id === projectId);
+		if (projectToUpdate) {
+			const response = await ProjectService.setSample(projectId, isSample);
+			if (response) {
+				projectToUpdate.sampleProject = isSample;
+				return true;
+			}
+			useToastService().error(undefined, 'Error changing the sample status of the project');
+		}
+		return false;
+	}
+
 	async function getPermissions(projectId: Project['id']): Promise<PermissionRelationships | null> {
 		return ProjectService.getPermissions(projectId);
 	}
@@ -270,6 +289,7 @@ export function useProjects() {
 		remove,
 		refresh,
 		setAccessibility,
+		setSample,
 		getPermissions,
 		hasAssetInActiveProject,
 		hasEditPermission,

--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -224,10 +224,7 @@ export function useProjects() {
 		const projectToUpdate = allProjects.value?.find((project) => project.id === projectId);
 		if (projectToUpdate) {
 			const response = await ProjectService.setSample(projectId, isSample);
-			if (response) {
-				projectToUpdate.sampleProject = isSample;
-				return true;
-			}
+			if (response) return true;
 			useToastService().error(undefined, 'Error changing the sample status of the project');
 		}
 		return false;

--- a/packages/client/hmi-client/src/page/Home.vue
+++ b/packages/client/hmi-client/src/page/Home.vue
@@ -234,12 +234,10 @@ const searchedAndFilterProjects = computed(() => {
 		tabProjects = tabProjects.filter(
 			({ userPermission, publicProject }) =>
 				// I can edit the project, or I can view a non-public project
-				['creator', 'writer'].includes(userPermission ?? '') || (userPermission === 'reader' && publicProject === false)
+				['creator', 'writer'].includes(userPermission ?? '') || (userPermission === 'reader' && !publicProject)
 		);
 	} else if (activeTabIndex.value === 1) {
-		tabProjects = tabProjects.filter(
-			({ publicProject, sampleProject }) => publicProject === true && sampleProject === false
-		);
+		tabProjects = tabProjects.filter(({ publicProject, sampleProject }) => publicProject === true && !sampleProject);
 	} else if (activeTabIndex.value === 2) {
 		tabProjects = tabProjects.filter(({ sampleProject }) => sampleProject === true);
 	}

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -158,7 +158,7 @@ async function setSample(projectId: Project['id'], isSample: boolean): Promise<b
 		const response = await API.put(`projects/set-sample/${projectId}/${isSample}`);
 		return response?.status === 200;
 	} catch (error) {
-		console.error(error);
+		console.error('Unable to update Project sample status', error);
 		return false;
 	}
 }

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -153,12 +153,12 @@ async function setAccessibility(projectId: Project['id'], isPublic: boolean): Pr
 	}
 }
 
-async function setSample(projectId: Project['id']): Promise<boolean> {
+async function setSample(projectId: Project['id'], isSample: boolean): Promise<boolean> {
 	try {
-		const response = await API.post(`projects/set-sample/${projectId}`);
+		const response = await API.post(`projects/set-sample/${projectId}`, { sample: isSample });
 		return response?.status === 200;
 	} catch (error) {
-		console.error(`The project was not made a sample project, ${error}`);
+		console.error(error);
 		return false;
 	}
 }

--- a/packages/client/hmi-client/src/services/project.ts
+++ b/packages/client/hmi-client/src/services/project.ts
@@ -155,7 +155,7 @@ async function setAccessibility(projectId: Project['id'], isPublic: boolean): Pr
 
 async function setSample(projectId: Project['id'], isSample: boolean): Promise<boolean> {
 	try {
-		const response = await API.post(`projects/set-sample/${projectId}`, { sample: isSample });
+		const response = await API.put(`projects/set-sample/${projectId}/${isSample}`);
 		return response?.status === 200;
 	} catch (error) {
 		console.error(error);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -1246,15 +1246,31 @@ public class ProjectController {
 					// When we make a project a sample project,
 					// Update all user permissions to READER only
 					if (isSample) {
-						rebacUser.removeAllRelationsExceptOne(rebacProject, Schema.Relationship.READER);
+						projectPermissionsService.removeProjectPermissions(
+							rebacProject,
+							rebacUser,
+							Schema.Relationship.CREATOR.toString()
+						);
+						projectPermissionsService.removeProjectPermissions(
+							rebacProject,
+							rebacUser,
+							Schema.Relationship.WRITER.toString()
+						);
+						projectPermissionsService.setProjectPermissions(
+							rebacProject,
+							rebacUser,
+							Schema.Relationship.READER.toString()
+						);
 					}
 
 					// When we revert a project to a non-sample project, and
 					// the user is the same as the project creator it will become the creator of the project once more
 					if (!isSample && contributor.getUserId().equals(project.get().getUserId())) {
-						try {
-							rebacUser.createCreatorRelationship(rebacProject);
-						} catch (final RelationshipAlreadyExistsException ignore) {}
+						projectPermissionsService.setProjectPermissions(
+							rebacProject,
+							rebacUser,
+							Schema.Relationship.CREATOR.toString()
+						);
 					}
 				}
 			}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -1264,7 +1264,7 @@ public class ProjectController {
 					}
 
 					// When we revert a project to a non-sample project, and
-					// the user is the same as the project creator it will become the creator of the project once more
+					// the user is the same as the project author it will become the creator of the project once more
 					if (!isSample && contributor.getUserId().equals(project.get().getUserId())) {
 						projectPermissionsService.setProjectPermissions(
 							rebacProject,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/askem/RebacUser.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/askem/RebacUser.java
@@ -91,6 +91,31 @@ public class RebacUser extends RebacObject {
 		reBACService.removeRelationship(getSchemaObject(), rebacObject.getSchemaObject(), Schema.Relationship.READER);
 	}
 
+	/**
+	 * Remove all relationships between this group and the given object.
+	 * Except the provided relationship, if it doesn't exist, it will be added
+	 */
+	public void removeAllRelationsExceptOne(
+		final RebacObject rebacObject,
+		final Schema.Relationship relationshipToIgnore
+	) throws Exception {
+		final Schema.Relationship[] relationships = {
+			Schema.Relationship.READER,
+			Schema.Relationship.WRITER,
+			Schema.Relationship.CREATOR,
+			Schema.Relationship.ADMIN
+		};
+		for (Schema.Relationship relationship : relationships) {
+			if (relationship == relationshipToIgnore) {
+				try {
+					reBACService.createRelationship(getSchemaObject(), rebacObject.getSchemaObject(), relationship);
+				} catch (RelationshipAlreadyExistsException ignore) {}
+			} else {
+				reBACService.removeRelationship(getSchemaObject(), rebacObject.getSchemaObject(), relationship);
+			}
+		}
+	}
+
 	public PermissionGroup createGroup(final String name) throws Exception, RelationshipAlreadyExistsException {
 		final PermissionGroup group = reBACService.createGroup(name);
 		reBACService.createRelationship(

--- a/packages/server/src/main/resources/messages.properties
+++ b/packages/server/src/main/resources/messages.properties
@@ -64,6 +64,7 @@ projects.unable-to-delete = We couldn't delete the project. Please try again lat
 projects.unable-to-get-permissions = We couldn't verify your read/write permissions. For safety reasons, we can't show results. Please try again later.
 projects.unable-to-update = We couldn't update the project. Please try again later.
 projects.import-parse-failure = We couldn't parse the import file. Please verify that the file is correctly formatted and try again.
+projects.already-sample = The project is already set as a sample project.
 
 rebac.permissions.unable-to-set = We couldn't set project permissions. Please try again later.
 rebac.relationship-already-exists = You already have permission to access this resource. Contact the system administrator to upgrade permissions.


### PR DESCRIPTION
### Sample Project Handling:

* Added a new method `setSample` to the `useProjects` composable to handle marking projects as sample projects.
* Updated the `ProjectController` to handle setting and unsetting sample projects via a new `PUT` endpoint.

### UI Updates:

* Modified the `tera-share-project` component to include a checkbox for marking projects as sample projects, visible only to admins.
* Removed the `makeSampleMenuItem` from the project menu and adjusted the project menu items accordingly.
* Updated the `tera-common-modal-dialogs` component to improve the UI for the delete project dialog.