### PR TITLE
Ensure EnsembleModelConfigs[] is ordered

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -38,34 +38,40 @@ export const updateLossChartSpec = (data: string | Record<string, any>[], size: 
 		}
 	);
 
+// Note that the order of the result matters as it will help us understand the output's ordering
 export function formatCalibrateModelConfigurations(
+	inputModelConfigsOrder: string[],
 	rows: CalibrateEnsembleMappingRow[],
 	weights: CalibrateEnsembleWeights
 ): EnsembleModelConfigs[] {
-	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
+	const ensembleModelConfigList: EnsembleModelConfigs[] = [];
+
+	inputModelConfigsOrder.forEach((configId) => {
+		const newConfig: EnsembleModelConfigs = {
+			id: configId,
+			solutionMappings: {},
+			weight: 0
+		};
+		ensembleModelConfigList.push(newConfig);
+	});
+
 	// 1. map the weights to the ensemble model configs
 	Object.entries(weights).forEach(([key, value]) => {
 		// return if there is no weight
 		if (!value) return;
-
-		const ensembleModelConfig: EnsembleModelConfigs = {
-			id: key,
-			solutionMappings: {},
-			weight: value
-		};
-
-		ensembleModelConfigMap[key] = ensembleModelConfig;
+		const index = ensembleModelConfigList.findIndex((ele) => ele.id === key) as number;
+		ensembleModelConfigList[index].weight = value;
 	});
 
 	// 2. format the solution mappings
 	rows.forEach((row) => {
 		Object.entries(row.modelConfigurationMappings).forEach(([key, value]) => {
-			if (!ensembleModelConfigMap[key]) return;
-			ensembleModelConfigMap[key].solutionMappings = {
+			const index = ensembleModelConfigList.findIndex((ele) => ele.id === key) as number;
+			ensembleModelConfigList[index].solutionMappings = {
 				[row.datasetMapping]: value
 			};
 		});
 	});
 
-	return [...Object.values(ensembleModelConfigMap)];
+	return ensembleModelConfigList;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -337,6 +337,10 @@ const lossChartContainer = ref(null);
 const lossChartSize = useDrilldownChartSize(lossChartContainer);
 const LOSS_CHART_DATA_SOURCE = 'lossData';
 // Model:
+const modelConfigurationIds: string[] = props.node.inputs
+	.filter((ele) => ele.type === 'modelConfigId')
+	.map((ele) => ele.value?.[0])
+	.filter(Boolean);
 const listModelLabels = ref<string[]>([]);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
 
@@ -427,7 +431,11 @@ const runEnsemble = async () => {
 	});
 
 	const calibratePayload: EnsembleCalibrationCiemssRequest = {
-		modelConfigs: formatCalibrateModelConfigurations(knobs.value.ensembleMapping, knobs.value.configurationWeights),
+		modelConfigs: formatCalibrateModelConfigurations(
+			modelConfigurationIds,
+			knobs.value.ensembleMapping,
+			knobs.value.configurationWeights
+		),
 		timespan: getTimespan({
 			dataset: csvAsset.value,
 			timestampColName: knobs.value.timestampColName
@@ -458,10 +466,6 @@ const runEnsemble = async () => {
 
 onMounted(async () => {
 	allModelConfigurations.value = [];
-	const modelConfigurationIds: string[] = [];
-	props.node.inputs.forEach((ele) => {
-		if (ele.value && ele.type === 'modelConfigId') modelConfigurationIds.push(ele.value[0]);
-	});
 	if (!modelConfigurationIds) return;
 
 	// Model configuration input

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -16,6 +16,7 @@
 				}"
 				:mapping="
 					formatCalibrateModelConfigurations(
+						modelConfigurationIds,
 						props.node.state.ensembleMapping,
 						props.node.state.configurationWeights
 					) as any
@@ -86,6 +87,10 @@ const runResults = ref<RunResults>({});
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
 const areInputsFilled = computed(() => props.node.inputs[0].value && props.node.inputs[1].value);
+const modelConfigurationIds: string[] = props.node.inputs
+	.filter((ele) => ele.type === 'modelConfigId')
+	.map((ele) => ele.value?.[0])
+	.filter(Boolean);
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 const inProgressForecastId = computed(() => props.node.state.inProgressForecastId);
 const lossValues = ref<{ [key: string]: number }[]>([]);
@@ -167,6 +172,7 @@ watch(
 			const state = _.cloneDeep(props.node.state);
 			const baseRequestPayload: EnsembleSimulationCiemssRequest = {
 				modelConfigs: formatCalibrateModelConfigurations(
+					modelConfigurationIds,
 					props.node.state.ensembleMapping,
 					props.node.state.configurationWeights
 				),

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,34 +1,40 @@
 import { EnsembleModelConfigs } from '@/types/Types';
 import { SimulateEnsembleMappingRow, SimulateEnsembleWeights } from './simulate-ensemble-ciemss-operation';
 
+// Note that the order of the result matters as it will help us understand the output's ordering
 export function formatSimulateModelConfigurations(
+	inputModelConfigsOrder: string[],
 	rows: SimulateEnsembleMappingRow[],
 	weights: SimulateEnsembleWeights
 ): EnsembleModelConfigs[] {
-	const ensembleModelConfigMap: { [key: string]: EnsembleModelConfigs } = {};
+	const ensembleModelConfigList: EnsembleModelConfigs[] = [];
+
+	inputModelConfigsOrder.forEach((configId) => {
+		const newConfig: EnsembleModelConfigs = {
+			id: configId,
+			solutionMappings: {},
+			weight: 0
+		};
+		ensembleModelConfigList.push(newConfig);
+	});
+
 	// 1. map the weights to the ensemble model configs
 	Object.entries(weights).forEach(([key, value]) => {
 		// return if there is no weight
 		if (!value) return;
-
-		const ensembleModelConfig: EnsembleModelConfigs = {
-			id: key,
-			solutionMappings: {},
-			weight: value
-		};
-
-		ensembleModelConfigMap[key] = ensembleModelConfig;
+		const index = ensembleModelConfigList.findIndex((ele) => ele.id === key) as number;
+		ensembleModelConfigList[index].weight = value;
 	});
 
 	// 2. format the solution mappings
 	rows.forEach((row) => {
 		Object.entries(row.modelConfigurationMappings).forEach(([key, value]) => {
-			if (!ensembleModelConfigMap[key]) return;
-			ensembleModelConfigMap[key].solutionMappings = {
+			const index = ensembleModelConfigList.findIndex((ele) => ele.id === key) as number;
+			ensembleModelConfigList[index].solutionMappings = {
 				[row.newName]: value
 			};
 		});
 	});
 
-	return [...Object.values(ensembleModelConfigMap)];
+	return ensembleModelConfigList;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -405,7 +405,11 @@ const updateWeights = () => {
 };
 
 const runEnsemble = async () => {
-	const modelConfigs = formatSimulateModelConfigurations(knobs.value.mapping, knobs.value.weights);
+	const modelConfigs = formatSimulateModelConfigurations(
+		modelConfigurationIds,
+		knobs.value.mapping,
+		knobs.value.weights
+	);
 	const params: EnsembleSimulationCiemssRequest = {
 		modelConfigs,
 		timespan: {


### PR DESCRIPTION
# Description
As our ensemble output has outputs in the form of `model_0/Column Name`, `model_1/column_name` we need to ensure that our model configs we send in our request are in the same order every time in order to understand what model_0 is.
We will use the node's input order for this.

# Draft:
Will reach out to ciemss team to update this to uuid rather than model_{i}