### PR TITLE
empty mathML workaround

### DIFF
--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -1,6 +1,7 @@
 import sys
 import json
 import traceback
+import time
 
 from taskrunner import TaskRunnerInterface
 from mira.sources.amr import model_from_json
@@ -12,23 +13,44 @@ def main():
     exitCode = 0
 
     try:
+        start = time.time()
         taskrunner = TaskRunnerInterface(description="AMR to MMT")
         taskrunner.on_cancellation(cleanup)
 
         data = taskrunner.read_input_str_with_timeout()
         amr = json.loads(data)
+
+        # Remove any empty mathmls
+        if 'semantics' in amr and "ode" in amr["semantics"]:
+            ode = amr["semantics"]["ode"]
+            if "parameters" in ode:
+                parameters = ode["parameters"]
+                for param in parameters:
+                    if "units" in param and param["units"] and "expression" in param["units"]:
+                        unit_expression = param["units"]["expression"]
+                        if unit_expression == None or unit_expression == "":
+                            del param["units"]
+
         mmt = model_from_json(amr)
+
+        end = time.time()
+        taskrunner.log(f"model from json time since {(end - start) * 1000} ms")
 
         template_params = {}
 
         count = 0
+
+        taskrunner.log("")
+        taskrunner.log(f"number of templates {len(mmt.templates)}");
+
         for tm in mmt.templates:
             # Sanitize
             count = count + 1
             if tm.name == None or tm.name == "":
                 tm.name = "generated-" + str(count)
 
-            params = tm.get_parameter_names()
+            # params = tm.get_parameter_names()
+            params = []
             params = list(params)
 
             subject = None
@@ -50,12 +72,17 @@ def main():
             }
             template_params[tm.name] = entry
 
+
+        end = time.time()
+        taskrunner.log(f"template time since {(end - start) * 1000} ms")
+
         # Summarize observables, extract out concepts
 
         # concept_names = list(map(lambda x: x.name, mmt.get_concepts_map().values()))
         # FIXME: get_concept_map seems to be unreliable, need better/model-agnostic way to parse
         concept_names = list(map(lambda x: x["id"], amr["model"]["states"]))
 
+        taskrunner.log(f"number of observables {len(mmt.observables)}");
         observable_summary = {}
         for ob in mmt.observables.items():
             obKey = ob[0]
@@ -67,12 +94,17 @@ def main():
                 "references": list(obValue.get_parameter_names(concept_names))
             }
 
+        end = time.time()
+        taskrunner.log(f"observable time since {(end - start) * 1000} ms")
+
         result = {
             "template_params": template_params,
             "observable_summary": observable_summary,
             "mmt": json.loads(mmt.json())
         }
         taskrunner.write_output_dict_with_timeout({"response": result})
+        end = time.time()
+        taskrunner.log(f"Conversion of AMR took {(end - start) * 1000} ms")
 
         print("AMR to MMT conversion succeeded")
     except Exception as e:

--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -20,7 +20,7 @@ def main():
         data = taskrunner.read_input_str_with_timeout()
         amr = json.loads(data)
 
-        # Remove any empty mathmls
+        # Remove any empty mathML expressions
         if 'semantics' in amr and "ode" in amr["semantics"]:
             ode = amr["semantics"]["ode"]
             if "parameters" in ode:

--- a/packages/mira/tasks/amr_to_mmt.py
+++ b/packages/mira/tasks/amr_to_mmt.py
@@ -49,8 +49,7 @@ def main():
             if tm.name == None or tm.name == "":
                 tm.name = "generated-" + str(count)
 
-            # params = tm.get_parameter_names()
-            params = []
+            params = tm.get_parameter_names()
             params = list(params)
 
             subject = None


### PR DESCRIPTION
### Summary
A workaround for amr-to-mmt task failing because unit-expressions are blank


### Testing
You need to  run/rebuild mira-taskrunner locally

Goto http://localhost:8080/amr-petri-test and paste in the amr bellow, there should be no errors and the model-diagram should render.

[bad-amr-to-mmt.json](https://github.com/user-attachments/files/17830889/bad-amr-to-mmt.json)

