### PR TITLE
Validate config katex layout

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-constraint-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-constraint-group-form.vue
@@ -31,6 +31,7 @@
 				@update:model-value="emit('update-self', { key: 'constraint', value: $event })"
 			/>
 			<MultiSelect
+				:maxSelectedLabels="5"
 				:model-value="config.variables"
 				placeholder="Select variables"
 				:options="variableOptions"
@@ -151,9 +152,9 @@
 			/>
 		</div>
 		<katex-element
-			class="mt-3"
+			class="expression-constraint"
 			v-else-if="config.constraintType !== ConstraintType.Following"
-			:expression="stringToLatexExpression(generateConstraintExpression(config))"
+			:expression="stringToLatexExpression(expression)"
 		/>
 	</section>
 </template>
@@ -203,9 +204,26 @@ const variableOptions = computed(() => {
 			return [];
 	}
 });
+
+const expression = computed(() => {
+	if (props.config) {
+		return generateConstraintExpression(props.config);
+	}
+	return '';
+});
 </script>
 
 <style scoped>
+.expression-constraint {
+	max-height: 150px;
+	overflow: auto;
+	margin-top: var(--gap-4);
+	margin-bottom: var(--gap-4);
+	padding: var(--gap-1) 0 var(--gap-1) 0;
+	border: 1px solid var(--surface-border-light);
+	border-radius: var(--border-radius);
+}
+
 section {
 	display: flex;
 	padding: var(--gap-4);

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -43,20 +43,12 @@
 												<InputSwitch class="mr-3" v-model="knobs.compartmentalConstraint.isActive" />
 											</div>
 										</header>
+										<div class="flex flex-column pb-4 align-items-left gap-6">
+											<katex-element :expression="expression" />
+										</div>
 										<div class="flex align-items-center gap-6">
 											<katex-element
-												:expression="
-													stringToLatexExpression(
-														stateIds
-															.map((s, index) => `${s}${index === stateIds.length - 1 ? `\\geq 0` : ','}`)
-															.join('')
-													)
-												"
-											/>
-											<katex-element
-												:expression="
-													stringToLatexExpression(`${stateIds.join('+')} = ${displayNumber(mass)} \\ \\forall \\ t`)
-												"
+												:expression="stringToLatexExpression(`${stateIds.join('+')} = ${massScientificNotation}`)"
 											/>
 										</div>
 									</section>
@@ -394,7 +386,7 @@ import { pythonInstance } from '@/python/PyodideController';
 import TeraConstraintGroupForm from '@/components/workflow/ops/funman/tera-constraint-group-form.vue';
 import { DrilldownTabs, ChartSetting, ChartSettingType } from '@/types/common';
 import { stringToLatexExpression, getModel, getMMT } from '@/services/model';
-import { displayNumber } from '@/utils/number';
+import { toScientificNotation } from '@/utils/number';
 import { removeChartSettingById, updateChartSettingsBySelectedVariables } from '@/services/chart-settings';
 import { nodeOutputLabel } from '@/components/workflow/util';
 import { formatJSON } from '@/services/code';
@@ -922,6 +914,19 @@ async function prepareOutput() {
 	processedFunmanResult.value = processFunman(funmanResult);
 	renderCharts();
 }
+
+const expression = computed(() =>
+	stringToLatexExpression(
+		stateIds.value
+			.map((s, index) => `${s}${index === stateIds.value.length - 1 ? `\\geq 0` : ',\\geq 0 \\newline '}`)
+			.join('')
+	)
+);
+
+const massScientificNotation = computed(() => {
+	const notation = toScientificNotation(parseFloat(mass.value));
+	return `${notation.mantissa} \\times 10^${notation.exponent}`;
+});
 
 watch(
 	() => props.node.state.runId,

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -43,14 +43,11 @@
 												<InputSwitch class="mr-3" v-model="knobs.compartmentalConstraint.isActive" />
 											</div>
 										</header>
-										<div class="flex flex-column pb-4 align-items-left gap-6">
-											<katex-element :expression="expression" />
-										</div>
-										<div class="flex align-items-center gap-6">
-											<katex-element
-												:expression="stringToLatexExpression(`${stateIds.join('+')} = ${massScientificNotation}`)"
-											/>
-										</div>
+										<katex-element class="expression-constraint" :expression="expression" />
+										<katex-element
+											class="expression-constraint"
+											:expression="stringToLatexExpression(`${stateIds.join('+')} = ${massScientificNotation}`)"
+										/>
 									</section>
 								</li>
 								<li v-for="(cfg, index) in node.state.constraintGroups" :key="index">
@@ -918,7 +915,7 @@ async function prepareOutput() {
 const expression = computed(() =>
 	stringToLatexExpression(
 		stateIds.value
-			.map((s, index) => `${s}${index === stateIds.value.length - 1 ? `\\geq 0` : ',\\geq 0 \\newline '}`)
+			.map((s, index) => `${s}${index === stateIds.value.length - 1 ? `\\geq 0` : '\\geq 0 \\newline '}`)
 			.join('')
 	)
 );
@@ -935,6 +932,16 @@ watch(
 </script>
 
 <style scoped>
+.expression-constraint {
+	max-height: 150px;
+	overflow: auto;
+	margin-top: var(--gap-4);
+	margin-bottom: var(--gap-4);
+	padding: var(--gap-1) 0 var(--gap-1) 0;
+	border: 1px solid var(--surface-border-light);
+	border-radius: var(--border-radius);
+}
+
 .top-toolbar {
 	display: flex;
 	align-items: center;

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -79,7 +79,7 @@ export function generateConstraintExpression(config: ConstraintGroup) {
 			expressionPart += constraintType === ConstraintType.Increasing ? '0' : `${interval?.lb ?? 0}`;
 		}
 		// Adding the "for all in timepoints" in the same expression helps with text alignment
-		expression += `${expressionPart}  \\ \\forall \\ t \\in [${timepoints.lb}, ${timepoints.ub}] \\newline `;
+		expression += `${expressionPart} \\ \\forall \\ t \\in [${timepoints.lb}, ${timepoints.ub}] \\newline `;
 	}
 	return expression;
 }

--- a/packages/client/hmi-client/src/services/models/funman-service.ts
+++ b/packages/client/hmi-client/src/services/models/funman-service.ts
@@ -67,25 +67,21 @@ export function generateConstraintExpression(config: ConstraintGroup) {
 		if (constraintType === ConstraintType.Increasing || constraintType === ConstraintType.Decreasing) {
 			expressionPart = `d/dt ${expressionPart}`;
 		}
-		if (i === variables.length - 1) {
-			if (
-				constraintType === ConstraintType.LessThan ||
-				constraintType === ConstraintType.LessThanOrEqualTo ||
-				constraintType === ConstraintType.Decreasing
-			) {
-				expressionPart += constraintType === ConstraintType.LessThan ? `<` : `\\leq`;
-				expressionPart += constraintType === ConstraintType.Decreasing ? '0' : `${interval?.ub ?? 0}`;
-			} else {
-				expressionPart += constraintType === ConstraintType.GreaterThan ? `>` : `\\geq`;
-				expressionPart += constraintType === ConstraintType.Increasing ? '0' : `${interval?.lb ?? 0}`;
-			}
+		if (
+			constraintType === ConstraintType.LessThan ||
+			constraintType === ConstraintType.LessThanOrEqualTo ||
+			constraintType === ConstraintType.Decreasing
+		) {
+			expressionPart += constraintType === ConstraintType.LessThan ? `<` : `\\leq`;
+			expressionPart += constraintType === ConstraintType.Decreasing ? '0' : `${interval?.ub ?? 0}`;
 		} else {
-			expressionPart += ',';
+			expressionPart += constraintType === ConstraintType.GreaterThan ? `>` : `\\geq`;
+			expressionPart += constraintType === ConstraintType.Increasing ? '0' : `${interval?.lb ?? 0}`;
 		}
-		expression += expressionPart;
+		// Adding the "for all in timepoints" in the same expression helps with text alignment
+		expression += `${expressionPart}  \\ \\forall \\ t \\in [${timepoints.lb}, ${timepoints.ub}] \\newline `;
 	}
-	// Adding the "for all in timepoints" in the same expression helps with text alignment
-	return `${expression} \\ \\forall \\ t \\in [${timepoints.lb}, ${timepoints.ub}]`;
+	return expression;
 }
 
 export const processFunman = (result: any) => {

--- a/packages/client/hmi-client/src/utils/number.ts
+++ b/packages/client/hmi-client/src/utils/number.ts
@@ -140,3 +140,11 @@ export function scrubAndParse(v) {
 	} else if (Number(parts[0])) return true;
 	return false;
 }
+
+export function toScientificNotation(num: number) {
+	if (num === 0) return { A: 0, B: 0 };
+	const exponent = Math.floor(Math.log10(Math.abs(num)));
+	const mantissa = num / 10 ** exponent;
+
+	return { mantissa, exponent };
+}

--- a/packages/client/hmi-client/tests/unit/services/funman-constraint-expression.spec.ts
+++ b/packages/client/hmi-client/tests/unit/services/funman-constraint-expression.spec.ts
@@ -20,7 +20,8 @@ describe('generateConstraintExpression', () => {
 			constraintType: ConstraintType.GreaterThanOrEqualTo,
 			weights: [1, 1]
 		};
-		const expected = 'I(t),R(t)\\geq0 \\ \\forall \\ t \\in [0, 100]';
+		const expected =
+			'I(t)\\geq0 \\ \\forall \\ t \\in [0, 100] \\newline R(t)\\geq0 \\ \\forall \\ t \\in [0, 100] \\newline ';
 		const result = generateConstraintExpression(constraint);
 		expect(result).toEqual(expected);
 	});
@@ -42,7 +43,8 @@ describe('generateConstraintExpression', () => {
 			constraintType: ConstraintType.LessThanOrEqualTo,
 			weights: [1, 1]
 		};
-		const expected = 'I(t),R(t)\\leq100 \\ \\forall \\ t \\in [0, 100]';
+		const expected =
+			'I(t)\\leq100 \\ \\forall \\ t \\in [0, 100] \\newline R(t)\\leq100 \\ \\forall \\ t \\in [0, 100] \\newline ';
 		const result = generateConstraintExpression(constraint);
 		expect(result).toEqual(expected);
 	});
@@ -64,7 +66,8 @@ describe('generateConstraintExpression', () => {
 			constraintType: ConstraintType.LessThan,
 			weights: [1, 1]
 		};
-		const expected = 'I(t),R(t)<100 \\ \\forall \\ t \\in [0, 100]';
+		const expected =
+			'I(t)<100 \\ \\forall \\ t \\in [0, 100] \\newline R(t)<100 \\ \\forall \\ t \\in [0, 100] \\newline ';
 		const result = generateConstraintExpression(constraint);
 		expect(result).toEqual(expected);
 	});
@@ -86,7 +89,8 @@ describe('generateConstraintExpression', () => {
 			weights: [1, 1, 1],
 			constraintType: ConstraintType.Increasing
 		};
-		const expected = 'd/dt S(t),d/dt I(t),d/dt R(t)\\geq0 \\ \\forall \\ t \\in [0, 100]';
+		const expected =
+			'd/dt S(t)\\geq0 \\ \\forall \\ t \\in [0, 100] \\newline d/dt I(t)\\geq0 \\ \\forall \\ t \\in [0, 100] \\newline d/dt R(t)\\geq0 \\ \\forall \\ t \\in [0, 100] \\newline ';
 		const result = generateConstraintExpression(constraint);
 		expect(result).toEqual(expected);
 	});
@@ -108,7 +112,8 @@ describe('generateConstraintExpression', () => {
 			weights: [1, 1, 1],
 			constraintType: ConstraintType.Decreasing
 		};
-		const expected = 'd/dt S(t),d/dt I(t),d/dt R(t)\\leq0 \\ \\forall \\ t \\in [0, 100]';
+		const expected =
+			'd/dt S(t)\\leq0 \\ \\forall \\ t \\in [0, 100] \\newline d/dt I(t)\\leq0 \\ \\forall \\ t \\in [0, 100] \\newline d/dt R(t)\\leq0 \\ \\forall \\ t \\in [0, 100] \\newline ';
 		const result = generateConstraintExpression(constraint);
 		expect(result).toEqual(expected);
 	});


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/4cd41160-6db9-42dd-80fd-c5ac49139c2b)
![image](https://github.com/user-attachments/assets/df93964b-dfda-4494-b72f-363d42e9a9aa)

Issue: 
- The list of parameters & initial states were not following the layout and just printing in a single line.
- Same would happen to the dropdown when selecting multiple options

![image](https://github.com/user-attachments/assets/38f22a98-3d61-4e87-999a-4d27089d181c)


Testing:
- Create a model-config with a large amount of parameters
- Create a new Validate configuration
- They should list the items and stay within the layout

Resolves #(issue)
