### PR TITLE
Calibration Map save on change

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -66,6 +66,7 @@
 										:placeholder="mappingDropdownPlaceholder"
 										v-model="data[field]"
 										:options="modelStateOptions?.map((ele) => ele.referenceId ?? ele.id)"
+										@change="updateMapping()"
 									/>
 								</template>
 							</Column>
@@ -916,6 +917,12 @@ function addMapping() {
 
 	emit('update-state', state);
 }
+
+const updateMapping = () => {
+	const state = _.cloneDeep(props.node.state);
+	state.mapping = mapping.value;
+	emit('update-state', state);
+};
 
 function deleteAllMappings() {
 	mapping.value = [];


### PR DESCRIPTION
# Description

Issue: When a user updates the dropdown value we are not actually saving the state's mapping. We have a watcher on knobs but this does not cover it.

Video of issue:

https://github.com/user-attachments/assets/4376143d-c427-479a-a375-44cce4685b99






