### PR TITLE
Hard refresh brings back the first project on a users list.

### DIFF
--- a/packages/client/hmi-client/src/api/api.ts
+++ b/packages/client/hmi-client/src/api/api.ts
@@ -4,6 +4,7 @@ import { EventSource } from 'extended-eventsource';
 import { ServerError } from '@/types/ServerError';
 import { Ref, ref } from 'vue';
 import { activeProjectId } from '@/composables/activeProject';
+import { isEmpty } from 'lodash';
 import useAuthStore from '../stores/auth';
 
 export class FatalError extends Error {}
@@ -27,7 +28,7 @@ API.interceptors.request.use(
 		const auth = useAuthStore();
 		config.headers.setAuthorization(`Bearer ${auth.getToken()}`);
 		// ActiveProjectId is often not available when the API is called from a global context or immediately after pages are hard refreshed, so we need to check the URL for the project id
-		const projectId = activeProjectId.value || getProjectIdFromUrl();
+		const projectId = isEmpty(activeProjectId.value) ? getProjectIdFromUrl() : activeProjectId.value;
 		if (projectId) {
 			if (config.params) {
 				config.params['project-id'] = projectId;


### PR DESCRIPTION
The issue looks like `activeProjectId` might return an empty string which does not trigger the `||` OR condition when loading the page on an hard refresh.

I added an `isEmtpty` test to make sure we do not have an empty string.