### PR TITLE
exporting project: add simulation to project-assets, cleanup

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import software.uncharted.terarium.hmiserver.controller.SnakeCaseController;
+import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.ProgressState;
@@ -37,6 +38,7 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.ClientEventService;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
+import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.data.SimulationService;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationService;
@@ -56,6 +58,7 @@ public class SimulationRequestController implements SnakeCaseController {
 	private final SimulationCiemssServiceProxy simulationCiemssServiceProxy;
 
 	private final ProjectService projectService;
+	private final ProjectAssetService projectAssetService;
 	private final SimulationService simulationService;
 
 	private final ModelConfigurationService modelConfigService;
@@ -119,16 +122,14 @@ public class SimulationRequestController implements SnakeCaseController {
 			.makeForecastRun(convertObjectToSnakeCaseJsonNode(request.payload))
 			.getBody();
 
-		final Simulation sim = new Simulation();
-
-		sim.setId(UUID.fromString(res.getSimulationId()));
-		sim.setType(SimulationType.SIMULATION);
+		final Optional<Simulation> sim = simulationService.getAsset(UUID.fromString(res.getSimulationId()), permission);
+		final Optional<Project> project = projectService.getProject(projectId);
 
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
 			simulationService,
-			sim.getId(),
+			sim.get().getId(),
 			projectId,
 			permission,
 			request.metadata
@@ -138,22 +139,9 @@ public class SimulationRequestController implements SnakeCaseController {
 			.setHalfTimeSeconds(2.0)
 			.startPolling();
 
-		sim.setExecutionPayload(objectMapper.convertValue(request, JsonNode.class));
-		sim.setStatus(ProgressState.QUEUED);
-		sim.setEngine(SimulationEngine.CIEMSS);
-
-		final Optional<Project> project = projectService.getProject(projectId);
-		if (project.isPresent()) {
-			sim.setProjectId(project.get().getId());
-			sim.setUserId(project.get().getUserId());
-		}
-
 		try {
-			final Optional<Simulation> updated = simulationService.updateAsset(sim, projectId, permission);
-			if (updated.isEmpty()) {
-				return ResponseEntity.notFound().build();
-			}
-			return ResponseEntity.ok(updated.get());
+			projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+			return ResponseEntity.ok(sim.get());
 		} catch (final Exception e) {
 			final String error = "Failed to create simulation";
 			log.error(error, e);
@@ -193,6 +181,10 @@ public class SimulationRequestController implements SnakeCaseController {
 			request.metadata
 		).startPolling();
 
+		final Optional<Simulation> sim = simulationService.getAsset(UUID.fromString(res.getSimulationId()), permission);
+		final Optional<Project> project = projectService.getProject(projectId);
+		projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+
 		return ResponseEntity.ok(res);
 	}
 
@@ -229,6 +221,10 @@ public class SimulationRequestController implements SnakeCaseController {
 			request.metadata
 		).startPolling();
 
+		final Optional<Simulation> sim = simulationService.getAsset(UUID.fromString(res.getSimulationId()), permission);
+		final Optional<Project> project = projectService.getProject(projectId);
+		projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+
 		return ResponseEntity.ok(res);
 	}
 
@@ -246,6 +242,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		final JobResponse res = simulationCiemssServiceProxy
 			.makeEnsembleSimulateCiemssJob(convertObjectToSnakeCaseJsonNode(request.payload))
 			.getBody();
+
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
@@ -255,6 +252,11 @@ public class SimulationRequestController implements SnakeCaseController {
 			permission,
 			request.metadata
 		).startPolling();
+
+		final Optional<Simulation> sim = simulationService.getAsset(UUID.fromString(res.getSimulationId()), permission);
+		final Optional<Project> project = projectService.getProject(projectId);
+		projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+
 		return ResponseEntity.ok(res);
 	}
 
@@ -282,6 +284,10 @@ public class SimulationRequestController implements SnakeCaseController {
 			permission,
 			request.metadata
 		).startPolling();
+
+		final Optional<Simulation> sim = simulationService.getAsset(UUID.fromString(res.getSimulationId()), permission);
+		final Optional<Project> project = projectService.getProject(projectId);
+		projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
 
 		return ResponseEntity.ok(res);
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
@@ -14,6 +14,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission;
@@ -30,6 +31,7 @@ public class TerariumAssetServices {
 	private final ModelService modelService;
 	private final WorkflowService workflowService;
 	private final InterventionService interventionService;
+	private final SimulationService simulationService;
 
 	/**
 	 * Get the service for a given asset type
@@ -48,6 +50,7 @@ public class TerariumAssetServices {
 			case MODEL -> modelService;
 			case WORKFLOW -> workflowService;
 			case INTERVENTION_POLICY -> interventionService;
+			case SIMULATION -> simulationService;
 			default -> throw new IllegalArgumentException("Invalid asset type: " + type);
 		};
 	}
@@ -75,6 +78,8 @@ public class TerariumAssetServices {
 				return workflowService.updateAsset((Workflow) asset, projectId, permission);
 			case INTERVENTION_POLICY:
 				return interventionService.updateAsset((InterventionPolicy) asset, projectId, permission);
+			case SIMULATION:
+				return simulationService.updateAsset((Simulation) asset, projectId, permission);
 			default:
 				throw new IllegalArgumentException("Invalid asset type: " + type);
 		}


### PR DESCRIPTION
### Summary
Project-export is broken, partially because simulations are not extracted into the archive. Moreover they are not a part of project-asset that the exporter iterates over.

This PR adds project-asset entries and does a bit of cleanup of redundant setters


### Testing
- Create project
- Create workflow with model => model-config => simulate, run a simulate, plot some variables
- Export the project into an archive
- Check archive contains the simulation result files (eg result.csv result-summary.csv ... etc), it is just a zip stream, so use whatever extractor is in macos or `unzip -l <archive>` in CLI
- Rename the project
- Import the project, wait 5-10 seconds
- Go into the imported project, verify that workflow is there, we can fetch simulation results and the charts are visible


