### PR TITLE
Hiding a column in a dataset removes the header, but leaves the data values

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-datatable.vue
@@ -51,13 +51,14 @@
 			:tableStyle="tableStyle ? tableStyle : `width:auto`"
 		>
 			<Column
-				v-for="(colName, index) of selectedColumns"
+				v-for="(colName, index) of rawContent.headers"
 				:key="index"
 				:field="index.toString()"
 				:header="colName"
 				:style="previousHeaders && !previousHeaders.includes(colName) ? 'border-color: green' : ''"
 				sortable
 				:frozen="index == 0"
+				:hidden="selectedColumns.includes(colName) ? false : true"
 			>
 				<template #header v-if="!previewMode && !isEmpty(headerStats) && showSummaries">
 					<!-- column summary charts below -->


### PR DESCRIPTION


# Description

* Must create components for all columns always, then flag them as hidden when not selected. Otherwise it just changes the column header for the different columns and keeps the data unchanged

Resolves #5529
