### PR TITLE
Ensemble Calibrate fix up stop button

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -47,6 +47,7 @@ export interface CalibrateEnsembleCiemssOperationState extends BaseState {
 	inProgressCalibrationId: string;
 	inProgressPreForecastId: string;
 	inProgressForecastId: string;
+	errorMessage: { name: string; value: string; traceback: string };
 	calibrationId: string;
 	postForecastId: string;
 	preForecastId: string;
@@ -88,6 +89,7 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 			calibrationId: '',
 			postForecastId: '',
 			preForecastId: '',
+			errorMessage: { name: '', value: '', traceback: '' },
 			currentProgress: 0
 		};
 		return init;

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -324,7 +324,12 @@ const isSidebarOpen = ref(true);
 const selectedOutputId = ref<string>();
 const showSpinner = ref(false);
 const isRunDisabled = computed(() => !knobs.value.ensembleMapping[0] || !datasetId.value);
-const cancelRunId = computed(() => props.node.state.inProgressForecastId || props.node.state.inProgressCalibrationId);
+const cancelRunId = computed(
+	() =>
+		props.node.state.inProgressForecastId ||
+		props.node.state.inProgressCalibrationId ||
+		props.node.state.inProgressPreForecastId
+);
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 const inProgressForecastId = computed(() => props.node.state.inProgressForecastId);
 


### PR DESCRIPTION
# Description
- Add error messages to ensemble calibrate if we run into a failure.
- Update cancelId to include all sim ids
- if we stop the poller we do not need to also check for errors. This should be `else if` not `if`
