### PR TITLE
column info isn't duplicated when dataset is transferred to another project

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -59,7 +59,6 @@
 				<tera-column-info
 					v-for="(column, index) in columnInformation"
 					:key="index"
-					class="column-info"
 					:column="column"
 					:feature-config="{ isPreview: false }"
 					@update-column="updateColumn(index, $event.key, $event.value)"

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -82,7 +82,11 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 	@Observed(name = "function_profile")
 	public Dataset createAsset(final Dataset asset, final UUID projectId, final Schema.Permission hasWritePermission)
 		throws IOException {
-		extractColumns(asset);
+		System.out.println("\n\nCreating asset\n\n");
+		// If the columns are already set, don't add them again (happens when copying a dataset to another project).
+		if (asset.getColumns() == null || asset.getColumns().isEmpty()) {
+			extractColumns(asset);
+		}
 		verifyColumnRelationship(asset);
 		return super.createAsset(asset, projectId, hasWritePermission);
 	}
@@ -152,10 +156,6 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 	 */
 	@Observed(name = "function_profile")
 	public static void addDatasetColumns(final Dataset dataset, final String fileName, final List<String> headers) {
-		// If the columns are already set, don't add them again (happens when copying a dataset to another project).
-		if (dataset.getColumns() != null && !dataset.getColumns().isEmpty()) {
-			return;
-		}
 		if (dataset.getColumns() == null) {
 			dataset.setColumns(new ArrayList<>());
 		}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -152,6 +152,10 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 	 */
 	@Observed(name = "function_profile")
 	public static void addDatasetColumns(final Dataset dataset, final String fileName, final List<String> headers) {
+		// If the columns are already set, don't add them again (happens when transferring a dataset between projects).
+		if (dataset.getColumns() != null && !dataset.getColumns().isEmpty()) {
+			return;
+		}
 		if (dataset.getColumns() == null) {
 			dataset.setColumns(new ArrayList<>());
 		}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -82,7 +82,6 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 	@Observed(name = "function_profile")
 	public Dataset createAsset(final Dataset asset, final UUID projectId, final Schema.Permission hasWritePermission)
 		throws IOException {
-		System.out.println("\n\nCreating asset\n\n");
 		// If the columns are already set, don't add them again (happens when copying a dataset to another project).
 		if (asset.getColumns() == null || asset.getColumns().isEmpty()) {
 			extractColumns(asset);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/DatasetService.java
@@ -152,7 +152,7 @@ public class DatasetService extends TerariumAssetServiceWithSearch<Dataset, Data
 	 */
 	@Observed(name = "function_profile")
 	public static void addDatasetColumns(final Dataset dataset, final String fileName, final List<String> headers) {
-		// If the columns are already set, don't add them again (happens when transferring a dataset between projects).
+		// If the columns are already set, don't add them again (happens when copying a dataset to another project).
 		if (dataset.getColumns() != null && !dataset.getColumns().isEmpty()) {
 			return;
 		}


### PR DESCRIPTION
# Description

* Column info used to be generated every time a dataset was added
* Now if it is already set we don't readd it
