### PR TITLE
Ensemble map from model_# to uuid

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,3 +1,4 @@
+import { getSimulation } from '@/services/models/simulation-service';
 import { EnsembleModelConfigs } from '@/types/Types';
 import { SimulateEnsembleMappingRow, SimulateEnsembleWeights } from './simulate-ensemble-ciemss-operation';
 
@@ -29,4 +30,27 @@ export function formatSimulateModelConfigurations(
 	});
 
 	return [...Object.values(ensembleModelConfigMap)];
+}
+
+// The result files from ensemble simulate have column headers such as model_#/column_name
+// This can be used to trace what model configuration is what model_# in a given run.
+export async function getResultModelConfigMap(runId: string) {
+	interface EnsembleModelConfigsSnakeCase {
+		id: string;
+		solution_mappings: { [index: string]: string };
+		weight: number;
+	}
+	const resultMap: { [key: string]: string } = {};
+
+	// Get Simulation Execution Run:
+	const simulationRun = await getSimulation(runId);
+	if (!simulationRun) {
+		console.error(`Could not find simulation ${runId}`);
+		return null;
+	}
+	const modelConfigs: EnsembleModelConfigsSnakeCase[] = simulationRun.executionPayload.model_configs;
+	for (let i = 0; i < modelConfigs.length; i++) {
+		resultMap[`model_${i}`] = modelConfigs[i].id;
+	}
+	return resultMap;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-util.ts
@@ -1,4 +1,3 @@
-import { getSimulation } from '@/services/models/simulation-service';
 import { EnsembleModelConfigs } from '@/types/Types';
 import { SimulateEnsembleMappingRow, SimulateEnsembleWeights } from './simulate-ensemble-ciemss-operation';
 
@@ -30,27 +29,4 @@ export function formatSimulateModelConfigurations(
 	});
 
 	return [...Object.values(ensembleModelConfigMap)];
-}
-
-// The result files from ensemble simulate have column headers such as model_#/column_name
-// This can be used to trace what model configuration is what model_# in a given run.
-export async function getResultModelConfigMap(runId: string) {
-	interface EnsembleModelConfigsSnakeCase {
-		id: string;
-		solution_mappings: { [index: string]: string };
-		weight: number;
-	}
-	const resultMap: { [key: string]: string } = {};
-
-	// Get Simulation Execution Run:
-	const simulationRun = await getSimulation(runId);
-	if (!simulationRun) {
-		console.error(`Could not find simulation ${runId}`);
-		return null;
-	}
-	const modelConfigs: EnsembleModelConfigsSnakeCase[] = simulationRun.executionPayload.model_configs;
-	for (let i = 0; i < modelConfigs.length; i++) {
-		resultMap[`model_${i}`] = modelConfigs[i].id;
-	}
-	return resultMap;
 }

--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -361,3 +361,26 @@ export const convertToCsvAsset = (data: Record<string, any>[], keys: string[]) =
 	});
 	return csvData;
 };
+
+// The result files from ensemble simulate have column headers such as model_#/column_name
+// This can be used to trace what model configuration is what model_# in a given run.
+export async function getEnsembleResultModelConfigMap(runId: string) {
+	interface EnsembleModelConfigsSnakeCase {
+		id: string;
+		solution_mappings: { [index: string]: string };
+		weight: number;
+	}
+	const resultMap: { [key: string]: string } = {};
+
+	// Get Simulation Execution Run:
+	const simulationRun = await getSimulation(runId);
+	if (!simulationRun) {
+		console.error(`Could not find simulation ${runId}`);
+		return null;
+	}
+	const modelConfigs: EnsembleModelConfigsSnakeCase[] = simulationRun.executionPayload.model_configs;
+	for (let i = 0; i < modelConfigs.length; i++) {
+		resultMap[`model_${i}`] = modelConfigs[i].id;
+	}
+	return resultMap;
+}


### PR DESCRIPTION
# Description
This will help us map ensemble output to our model configurations provided
The issue this is solving is that the output for ensemble is `model_0/S` and we have no reference to what model 0 is, this will provide a map from model_0 -> the model configurations uuid

If you believe this should be written somewhere else please let me know
