### PR TITLE
disable option for languanage dropdown

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
@@ -68,6 +68,7 @@
 					:model-value="selectedLanguage"
 					placeholder="Select a language"
 					:options="languages"
+					option-disabled="disabled"
 					option-label="name"
 					option-value="value"
 					class="language-dropdown"

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -217,12 +217,13 @@ export const ProgrammingLanguageVersion: { [key in ProgrammingLanguage]: string 
  * The `Zip` programming language is excluded from the options.
  * @returns {Array} An array of options for programming languages.
  */
-export const programmingLanguageOptions = (): { name: string; value: string }[] =>
+export const programmingLanguageOptions = (): { name: string; value: string; disabled: boolean }[] =>
 	Object.values(ProgrammingLanguage)
 		.filter((lang) => lang !== ProgrammingLanguage.Zip)
 		.map((lang) => ({
 			name: lang && `${lang[0].toUpperCase() + lang.slice(1)} (${ProgrammingLanguageVersion[lang]})`,
-			value: ProgrammingLanguageVersion[lang]
+			value: ProgrammingLanguageVersion[lang],
+			disabled: lang === ProgrammingLanguage.Julia
 		}));
 
 export enum CalendarDateType {


### PR DESCRIPTION
### Summary
In data transform, disable langugage = Julia since it was removed from beraker

 
<img width="409" alt="image" src="https://github.com/user-attachments/assets/e81d2fd4-c868-4afd-8cc3-513b7e4ef8a5">

Closes https://github.com/DARPA-ASKEM/terarium/issues/5614