### PR TITLE
dataset transformer rerun header fix

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
@@ -85,6 +85,10 @@
 				/>
 			</div>
 		</div>
+		<div v-if="showRerunMessage" class="rerun-message">
+			Re-run all the cells to restore the context if you need to make any changes or use them downstream.
+			<Button icon="pi pi-times" text rounded aria-label="Close" @click="showRerunMessage = false" />
+		</div>
 
 		<!-- Jupyter Chat -->
 		<tera-jupyter-chat
@@ -185,6 +189,7 @@ const props = defineProps<{
 	sampleAgentQuestions: string[];
 }>();
 
+const showRerunMessage = ref(false);
 const languages = programmingLanguageOptions();
 const selectedLanguage = computed(() => props.programmingLanguage || languages[0].value);
 
@@ -308,6 +313,7 @@ watch(
 
 onMounted(() => {
 	// for admin panel
+
 	jupyterSession.ready.then(() => {
 		if (jupyterSession.session) {
 			const sessions = getSessionManager().running();
@@ -322,6 +328,7 @@ onMounted(() => {
 				kernelId: jupyterSession.session?.kernel?.id,
 				value: jupyterSession.session?.id
 			};
+			showRerunMessage.value = true;
 		}
 	});
 });
@@ -481,10 +488,15 @@ const onAddCodeCell = () => {
 };
 
 const onRunAllCells = () => {
-	if (window.confirm('Are you sure you want to rerun all cells?')) {
-		const event = new Event('run-all-cells');
-		window.dispatchEvent(event);
-	}
+	confirm.require({
+		message: 'Are you sure you want to rerun all cells?',
+		header: 'Rerun all cells',
+		accept: () => {
+			const event = new Event('run-all-cells');
+			window.dispatchEvent(event);
+			showRerunMessage.value = false;
+		}
+	});
 };
 
 /* Download dataset feature has been removed, but keeping this code here in case it returns */
@@ -631,5 +643,13 @@ const onDownloadResponse = (payload) => {
 	grid-row: 2;
 	grid-column: 1 / span 6;
 	color: var(--text-color-subdued);
+}
+
+.rerun-message {
+	display: flex;
+	background-color: var(--surface-warning);
+	justify-content: space-between;
+	align-items: center;
+	padding: var(--gap-2);
 }
 </style>

--- a/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell.vue
@@ -38,7 +38,7 @@ const props = defineProps<{
 	index: Number;
 }>();
 
-const emit = defineEmits(['deleteRequested', 'code-dirty']);
+const emit = defineEmits(['deleteRequested']);
 
 const confirm = useConfirm();
 
@@ -58,7 +58,6 @@ const code = computed(() => props.jupyterMessage.content.code);
 const editor = ref<VAceEditorInstance['_editor'] | null>(null);
 const initialize = (editorInstance) => {
 	editor.value = editorInstance;
-	editorInstance.getSession().on('change', () => emit('code-dirty'));
 };
 
 const enter = () => {

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-chat.vue
@@ -8,10 +8,6 @@
 			tabindex="0"
 			class="message-container"
 		>
-			<div v-if="showRerunMessage" class="rerun-message" @click="closeRerunMessage">
-				Re-run all the cells to restore the context if you need to make any changes or use them downstream.
-				<Button class="close-mask" icon="pi pi-times" text rounded aria-label="Close" />
-			</div>
 			<tera-jupyter-response
 				@keydown.stop
 				v-for="(msg, index) in filteredNotebookItems"
@@ -30,7 +26,6 @@
 				@delete-prompt="handleDeletePrompt"
 				@re-run-prompt="handleRerunPrompt"
 				@edit-prompt="reRunPrompt"
-				@code-dirty="() => (isRerunMessageRelevant = true)"
 				@click="selectedCellId = msg.query_id"
 				@on-selected="handleUpdateSelectedOutput(msg.query_id)"
 			/>
@@ -66,8 +61,6 @@ const selectedCellId = ref();
 const filteredNotebookItems = computed<INotebookItem[]>(() =>
 	notebookItems.value.filter((item) => !isEmpty(item.messages))
 );
-const hideRerunMessage = ref(false);
-const isRerunMessageRelevant = ref(false);
 
 const emit = defineEmits([
 	'new-message',
@@ -77,8 +70,7 @@ const emit = defineEmits([
 	'new-model-saved',
 	'update-kernel-state',
 	'update-language',
-	'update-selected-outputs',
-	'code-dirty'
+	'update-selected-outputs'
 ]);
 
 const props = defineProps<{
@@ -95,8 +87,6 @@ const props = defineProps<{
 	notebookSession?: NotebookSession;
 	defaultPreview?: string;
 }>();
-
-const showRerunMessage = computed<boolean>(() => !hideRerunMessage.value && isRerunMessageRelevant.value);
 
 const iopubMessageHandler = (_session, message) => {
 	if (message.header.msg_type === 'status') {
@@ -415,10 +405,6 @@ const clearOutputs = () => {
 	}
 };
 
-const closeRerunMessage = () => {
-	hideRerunMessage.value = true;
-};
-
 onUnmounted(() => {
 	messagesHistory.value = [];
 });
@@ -505,12 +491,5 @@ section {
 	height: calc(100% - 3.5rem);
 	overflow-y: auto;
 	background: var(--surface-100);
-}
-.rerun-message {
-	display: flex;
-	background-color: var(--surface-warning);
-	justify-content: space-between;
-	align-items: center;
-	padding: var(--gap-2);
 }
 </style>

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
@@ -79,7 +79,6 @@
 							:lang="language"
 							:index="index"
 							@deleteRequested="onDeleteRequested(m.header.msg_id)"
-							@code-dirty="() => emit('code-dirty')"
 						/>
 					</div>
 					<div
@@ -120,8 +119,7 @@ const emit = defineEmits([
 	're-run-prompt',
 	'delete-prompt',
 	'delete-message',
-	'on-selected',
-	'code-dirty'
+	'on-selected'
 ]);
 
 const props = defineProps<{


### PR DESCRIPTION
# Description
- moved the warning message from the tera-beaker-chat to tera-dataset-jupyter-panel

New
Show rerun cells header when:
- each time the dataset transformer is opened (everytime it is opened a new session starts)
- pressing the reset kernel button

Close when:
- explicitly pressing the close button on the header
- pressing the re-run cells button 

