### PR TITLE
fix model config initial error state

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-initial-entry.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-initial-entry.vue
@@ -61,12 +61,7 @@ import { isEmpty } from 'lodash';
 import { computed, ref, onMounted } from 'vue';
 import { DistributionType } from '@/services/distribution';
 import { Model, ModelConfiguration } from '@/types/Types';
-import {
-	getInitialExpression,
-	getInitialSource,
-	getOtherValues,
-	isNumberInputEmpty
-} from '@/services/model-configurations';
+import { getInitialExpression, getInitialSource, getOtherValues } from '@/services/model-configurations';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import TeraInitialOtherValueModal from '@/components/model/petrinet/tera-initial-other-value-modal.vue';
 import Button from 'primevue/button';
@@ -92,7 +87,7 @@ const emit = defineEmits(['update-expression', 'update-source']);
 const name = getInitialName(props.model, props.initialId);
 const unit = getInitialUnits(props.model, props.initialId);
 const description = getInitialDescription(props.model, props.initialId);
-const isExpressionEmpty = ref(false);
+const isExpressionEmpty = computed(() => isEmpty(getInitialExpression(props.modelConfiguration, props.initialId)));
 
 const concept = ref('');
 const sourceOpen = ref(false);
@@ -102,11 +97,7 @@ const expression = ref('');
 const getOtherValuesLabel = computed(() => `Other values (${otherValueList.value?.length})`);
 
 function onExpressionChange(value) {
-	isExpressionEmpty.value = isNumberInputEmpty(value);
-	expression.value = value;
-	if (!isExpressionEmpty.value) {
-		emit('update-expression', { id: props.initialId, value });
-	}
+	emit('update-expression', { id: props.initialId, value });
 }
 
 function getExpression() {
@@ -125,7 +116,6 @@ function getSourceLabel(initialId) {
 onMounted(async () => {
 	const identifiers = getStates(props.model).find((state) => state.id === props.initialId)?.grounding?.identifiers;
 	if (identifiers) concept.value = await getNameOfCurieCached(getCurieFromGroundingIdentifier(identifiers));
-	isExpressionEmpty.value = isNumberInputEmpty(getInitialExpression(props.modelConfiguration, props.initialId));
 });
 </script>
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-initial-entry.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-initial-entry.vue
@@ -22,7 +22,7 @@
 						label="Expression"
 						error-empty
 						:model-value="getExpression()"
-						@update:model-value="onExpressionChange($event)"
+						@blur="onExpressionChange($event)"
 					/>
 				</span>
 				<Button :label="getSourceLabel(initialId)" text size="small" @click="sourceOpen = !sourceOpen" />

--- a/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
@@ -101,6 +101,13 @@ const onFocus = (event) => {
 };
 const onBlur = (event) => {
 	isFocused.value = false;
+	const target = event.target as HTMLInputElement;
+	if (props.charactersToReject && !isEmpty(props.charactersToReject)) {
+		const start = target.selectionStart;
+		const end = target.selectionEnd;
+		target.value = target.value.replace(new RegExp(`[${props.charactersToReject.join('')}]`, 'g'), ''); // Create a regex pattern from charactersToReject to remove them
+		target.setSelectionRange(start, end); // Maintain cursor position, is needed if we are entering in the middle of the input
+	}
 	emit('blur', event.target.value);
 };
 

--- a/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
@@ -101,7 +101,7 @@ const onFocus = (event) => {
 };
 const onBlur = (event) => {
 	isFocused.value = false;
-	emit('blur', event);
+	emit('blur', event.target.value);
 };
 
 onMounted(() => {

--- a/packages/client/hmi-client/src/services/model-configurations.ts
+++ b/packages/client/hmi-client/src/services/model-configurations.ts
@@ -233,7 +233,7 @@ export function isNumberInputEmpty(value: string) {
 export function getMissingInputAmount(modelConfiguration: ModelConfiguration) {
 	let missingInputs = 0;
 	modelConfiguration.initialSemanticList.forEach((initial) => {
-		if (isNumberInputEmpty(initial.expression)) {
+		if (isEmpty(initial.expression)) {
 			missingInputs++;
 		}
 	});


### PR DESCRIPTION
# Description

* It looks like initials were forced to be evaluated as numbers, I've lifted that restriction in this PR
* Initials will only be "empty" when there is no value
* initial now updated on blur, which should reduce some api calls

