### PR TITLE
Render png for intervention-policy nodes

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -2,7 +2,12 @@
 	<section>
 		<ul v-if="node.state.interventionPolicy.id">
 			<li v-for="(_interventions, appliedTo) in groupedOutputParameters" :key="appliedTo">
-				<vega-chart expandable :are-embed-actions-visible="false" :visualization-spec="preparedCharts[appliedTo]" />
+				<vega-chart
+					expandable
+					:are-embed-actions-visible="false"
+					:visualization-spec="preparedCharts[appliedTo]"
+					:interactive="false"
+				/>
 			</li>
 		</ul>
 		<tera-operator-placeholder :node="node" v-else />


### PR DESCRIPTION
### Summary
- Switch to PNG instead of interactive graph for intervention policy. 
- Make PNG non-interactive to prevent weird dragging effect onto canvas
- Made vegalite watcher immedate, there seem to be cases where it doesn't trigger if we slightly tweak the props because of timing or race issues.

![image](https://github.com/user-attachments/assets/ace9c48c-e61d-4e1b-96f5-b49adf103db2)

