### PR TITLE
Add notebook-session to project-asset for export

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -25,11 +25,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.NotebookSessionService;
+import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
@@ -43,6 +45,7 @@ public class NotebookSessionController {
 	final NotebookSessionService sessionService;
 
 	private final ProjectService projectService;
+	private final ProjectAssetService projectAssetService;
 	private final CurrentUserService currentUserService;
 
 	/**
@@ -119,6 +122,10 @@ public class NotebookSessionController {
 
 		try {
 			sessionService.createAsset(session, projectId, permission);
+
+			final Optional<Project> project = projectService.getProject(projectId);
+			projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+
 			return ResponseEntity.status(HttpStatus.CREATED).body(session);
 		} catch (final IOException e) {
 			final String error = "Unable to create session";

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -28,6 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.NotebookSessionService;
@@ -124,7 +125,7 @@ public class NotebookSessionController {
 			sessionService.createAsset(session, projectId, permission);
 
 			final Optional<Project> project = projectService.getProject(projectId);
-			projectAssetService.createProjectAsset(project.get(), AssetType.SIMULATION, sim.get(), permission);
+			projectAssetService.createProjectAsset(project.get(), AssetType.NOTEBOOK_SESSION, session, permission);
 
 			return ResponseEntity.status(HttpStatus.CREATED).body(session);
 		} catch (final IOException e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/AssetType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/AssetType.java
@@ -15,6 +15,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
@@ -51,6 +52,9 @@ public enum AssetType {
 	@JsonProperty("intervention-policy")
 	INTERVENTION_POLICY,
 
+	@JsonProperty("notebook-session")
+	NOTEBOOK_SESSION,
+
 	@JsonProperty("project")
 	PROJECT;
 
@@ -83,6 +87,8 @@ public enum AssetType {
 			return WORKFLOW;
 		} else if (clazz == InterventionPolicy.class) {
 			return INTERVENTION_POLICY;
+		} else if (clazz == NotebookSession.class) {
+			return NOTEBOOK_SESSION;
 		} else if (clazz == Project.class) {
 			return PROJECT;
 		} else {
@@ -110,6 +116,8 @@ public enum AssetType {
 				return Workflow.class;
 			case INTERVENTION_POLICY:
 				return InterventionPolicy.class;
+			case NOTEBOOK_SESSION:
+				return NotebookSession.class;
 			case PROJECT:
 				return Project.class;
 			default:
@@ -128,7 +136,8 @@ public enum AssetType {
 			SIMULATION,
 			WORKFLOW,
 			PROJECT,
-			INTERVENTION_POLICY
+			INTERVENTION_POLICY,
+			NOTEBOOK_SESSION
 		);
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/NotebookSessionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/NotebookSessionService.java
@@ -52,11 +52,11 @@ public class NotebookSessionService
 		throw new UnsupportedOperationException("Unimplemented");
 	}
 
-	@Override
-	@Observed(name = "function_profile")
-	public Map<String, FileExport> exportAssetFiles(final UUID assetId, final Schema.Permission hasReadPermission) {
-		throw new UnsupportedOperationException("Unimplemented");
-	}
+	// @Override
+	// @Observed(name = "function_profile")
+	// public Map<String, FileExport> exportAssetFiles(final UUID assetId, final Schema.Permission hasReadPermission) {
+	// 	throw new UnsupportedOperationException("Unimplemented");
+	// }
 
 	@Override
 	public Integer uploadFile(final UUID uuid, final String filename, final ContentType contentType, final byte[] data)

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
@@ -14,6 +14,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
+import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
@@ -32,6 +33,7 @@ public class TerariumAssetServices {
 	private final WorkflowService workflowService;
 	private final InterventionService interventionService;
 	private final SimulationService simulationService;
+	private final NotebookSessionService notebookSessionService;
 
 	/**
 	 * Get the service for a given asset type
@@ -51,6 +53,7 @@ public class TerariumAssetServices {
 			case WORKFLOW -> workflowService;
 			case INTERVENTION_POLICY -> interventionService;
 			case SIMULATION -> simulationService;
+			case NOTEBOOK_SESSION -> notebookSessionService;
 			default -> throw new IllegalArgumentException("Invalid asset type: " + type);
 		};
 	}
@@ -80,6 +83,8 @@ public class TerariumAssetServices {
 				return interventionService.updateAsset((InterventionPolicy) asset, projectId, permission);
 			case SIMULATION:
 				return simulationService.updateAsset((Simulation) asset, projectId, permission);
+			case NOTEBOOK_SESSION:
+				return notebookSessionService.updateAsset((NotebookSession) asset, projectId, permission);
 			default:
 				throw new IllegalArgumentException("Invalid asset type: " + type);
 		}

--- a/packages/server/src/main/resources/db/migration/V18__project_asset_constraint2.sql
+++ b/packages/server/src/main/resources/db/migration/V18__project_asset_constraint2.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+ALTER TABLE project_asset
+  DROP CONSTRAINT project_asset_asset_type_check;
+
+ALTER TABLE project_asset
+  ADD CONSTRAINT project_asset_asset_type_check
+  CHECK (asset_type::text = ANY (ARRAY[
+    'WORKFLOW'::character varying,
+    'MODEL'::character varying,
+    'DATASET'::character varying,
+    'SIMULATION'::character varying,
+    'DOCUMENT'::character varying,
+    'CODE'::character varying,
+    'MODEL_CONFIGURATION'::character varying,
+    'ARTIFACT'::character varying,
+    'INTERVENTION_POLICY'::character varying,
+    'NOTEBOOK_SESSION'::character varying
+  ]));
+
+COMMIT;


### PR DESCRIPTION
### Summary
Add notebook session to project-asset so it is picked up when export/import happens



### Testing
- create project ABC
- add in a dataset
- add in a workflow, add in dataset, add data-transform
- run a few cells in the data-transform, eg display first-n rows, plot a graph
- export ABC
- rename ABC to ABC2
- import ABC
- check the data-transform session history is still there