### PR TITLE
Update latex_style_guide.py

### DIFF
--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -1,9 +1,9 @@
 LATEXT_STYLE_GUIDE = """
-1) Derivatives must be written in Leibniz notation (for example, "\\frac{d X}{d t}").
+1) Derivatives must be written in Leibniz notation (for example, "\\frac{d X}{d t}")
     a) Derivatives that are written in other notations, like Newton ("\dot{X}") or Lagrange ("X^\prime" or "X'"), should be converted to Leibniz notation
     b) Partial derivatives of one-variable functions (for example, "\\partial_t X" or "\\frac{\partial X}{\partial t}") should be rewritten as ordinary derivatives ("\\frac{d X}{d t}")
 2) First-order derivative must be on the left of the equal sign
-3) The use of "(t)" should be avoided
+3) All variables have time "t" dependence should be explicitly with "(t)" (for example, "X" should be written as "X(t)")
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{...}"
 6) Avoid parentheses


### PR DESCRIPTION
Change the equation style guide to ensure `(t)` is written explicitly for all time-dependent variables. This `(t)` is necessary for the downstream LaTeX-to-SymPy parser. https://docs.sympy.org/latest/modules/parsing.html

This resolves an issue that @mwdchang encountered while testing the LaTeX-to-SymPy-to-MMT pipeline.