### PR TITLE
Add error message to ensemble calibrate drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -232,6 +232,7 @@
 					<tera-progress-spinner v-if="isRunInProgress" :font-size="2" is-centered style="height: 100%">
 						{{ node.state.currentProgress }}%
 					</tera-progress-spinner>
+					<tera-notebook-error v-bind="node.state.errorMessage" />
 				</section>
 			</tera-drilldown-section>
 		</template>
@@ -325,7 +326,7 @@ import TeraCheckbox from '@/components/widgets/tera-checkbox.vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import TeraSignalBars from '@/components/widgets/tera-signal-bars.vue';
 import TeraTimestepCalendar from '@/components/widgets/tera-timestep-calendar.vue';
-
+import TeraNotebookError from '@/components/drilldown/tera-notebook-error.vue';
 import { getTimespan, nodeMetadata } from '@/components/workflow/util';
 import type {
 	CsvAsset,

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -96,20 +96,19 @@ const pollResult = async (runId: string) => {
 			}
 		});
 	const pollerResults = await poller.start();
+	const state = _.cloneDeep(props.node.state);
+	state.errorMessage = { name: '', value: '', traceback: '' };
 
 	if (pollerResults.state === PollerState.Cancelled) {
-		const state = _.cloneDeep(props.node.state);
 		state.currentProgress = 0;
 		state.inProgressForecastId = '';
 		state.inProgressCalibrationId = '';
 		poller.stop();
-		emit('update-state', state);
 	} else if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
 		// throw if there are any failed runs for now
 		logger.error(`Calibration: ${runId} has failed`, {
 			toastTitle: 'Error - Pyciemss'
 		});
-		const state = _.cloneDeep(props.node.state);
 		const simulation = await getSimulation(runId);
 		if (simulation?.status && simulation?.statusMessage) {
 			state.inProgressCalibrationId = '';
@@ -125,6 +124,7 @@ const pollResult = async (runId: string) => {
 		emit('update-state', state);
 		throw Error('Failed Runs');
 	}
+	emit('update-state', state);
 	return pollerResults;
 };
 


### PR DESCRIPTION
# Description
- When we have an error message in our state we should show it as we are doing in other nodes
- Reset error message when we start polling aka new run

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/3065eb23-6bb5-48d3-8533-7ea8b25c59e0">
