### PR TITLE
fix for missing count on inferred type

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
@@ -20,10 +20,10 @@
 		<div v-if="inferredDistribution" class="inferred-parameter">
 			<span class="type"><label>Type</label> {{ inferredDistribution.type }}</span>
 			<span class="mean">
-				<label>Mean</label> {{ displayNumber(inferredDistribution?.parameters?.mean.toString()) }}
+				<label>Mean</label> {{ displayNumber(inferredDistribution?.parameters?.mean?.toString()) }}
 			</span>
 			<span class="std">
-				<label>STDDEV</label> {{ displayNumber(inferredDistribution?.parameters?.stddev.toString()) }}
+				<label>STDDEV</label> {{ displayNumber(inferredDistribution?.parameters?.stddev?.toString()) }}
 			</span>
 		</div>
 		<template v-else-if="!featureConfig?.isPreview">
@@ -217,7 +217,7 @@ onMounted(async () => {
 	const identifiers = getParameter(props.model, props.parameterId)?.grounding?.identifiers;
 	if (identifiers) concept.value = await getNameOfCurieCached(getCurieFromGroundingIdentifier(identifiers));
 	const parameter = getParameterDistribution(props.modelConfiguration, props.parameterId, true);
-	isParameterEmpty.value = isParameterInputEmpty(parameter);
+	isParameterEmpty.value = inferredDistribution.value ? false : isParameterInputEmpty(parameter);
 });
 </script>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -535,8 +535,9 @@ const missingInputCount = (modelConfiguration: ModelConfiguration) => {
 	if (selectedConfigId.value === modelConfiguration.id) {
 		return selectedConfigMissingInputCount.value;
 	}
+	const inferredParameterList = modelConfiguration.inferredParameterList?.length ?? 0;
 	const total = amrInitials.value.length + amrParameters.value.length;
-	const amount = total - getTotalInput(modelConfiguration);
+	const amount = total - getTotalInput(modelConfiguration) - inferredParameterList;
 	return getMissingInputsMessage(amount, total);
 };
 
@@ -544,7 +545,8 @@ const selectedConfigMissingInputCount = computed(() => {
 	if (initializing.value) {
 		return '';
 	}
-	const amount = getMissingInputAmount(knobs.value.transientModelConfig);
+	const inferredParameterAmount = knobs.value.transientModelConfig.inferredParameterList?.length ?? 0;
+	const amount = getMissingInputAmount(knobs.value.transientModelConfig) - inferredParameterAmount;
 	const total = getTotalInput(knobs.value.transientModelConfig);
 	return getMissingInputsMessage(amount, total);
 });


### PR DESCRIPTION
# Description

Issue: in model config inferred parameter appear as an empty input
![image](https://github.com/user-attachments/assets/f25933ae-b388-4484-9dfc-97ca4c6ae2ec)

Testing:
- Use the manual test for model calibration

Resolves #(issue)
