### PR TITLE
Update project search

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -9,6 +9,20 @@ export interface ClientConfig {
     sseHeartbeatIntervalMillis: number;
 }
 
+export interface ProjectSearchResult extends Project {
+    score: number;
+    assets: ProjectSearchResultAsset[];
+}
+
+export interface ProjectSearchResultAsset {
+    assetId: string;
+    assetType: AssetType;
+    assetName: string;
+    embeddingContent: string;
+    embeddingType: TerariumAssetEmbeddingType;
+    score: number;
+}
+
 export interface ClientEvent<T> {
     id: string;
     createdAtMs: number;
@@ -1062,6 +1076,12 @@ export enum TaskStatus {
     Cancelled = "CANCELLED",
 }
 
+export enum TerariumAssetEmbeddingType {
+    Overview = "OVERVIEW",
+    Name = "NAME",
+    Description = "DESCRIPTION",
+}
+
 export enum ClientEventType {
     ChartAnnotationCreate = "CHART_ANNOTATION_CREATE",
     ChartAnnotationDelete = "CHART_ANNOTATION_DELETE",
@@ -1207,10 +1227,4 @@ export enum ExtractionAssetType {
     Figure = "FIGURE",
     Table = "TABLE",
     Equation = "EQUATION",
-}
-
-export enum TerariumAssetEmbeddingType {
-    Overview = "OVERVIEW",
-    Name = "NAME",
-    Description = "DESCRIPTION",
 }

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -1213,6 +1213,4 @@ export enum TerariumAssetEmbeddingType {
     Overview = "OVERVIEW",
     Name = "NAME",
     Description = "DESCRIPTION",
-    Metadata = "METADATA",
-    Card = "CARD",
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -284,7 +284,7 @@ public class KnowledgeController {
 				final JsonNode testNode = mapper.readValue(amrString, JsonNode.class);
 				responseAMR = mapper.convertValue(testNode, Model.class);
 			} catch (Exception e) {
-				log.error("failed to convert latex equations to AMR", e);
+				log.error("failed to convert LaTeX equations to AMR", e);
 				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to convert latex equations to AMR");
 			}
 		} else {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/TerariumAssetEmbeddingType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/TerariumAssetEmbeddingType.java
@@ -4,8 +4,7 @@ public enum TerariumAssetEmbeddingType {
 	OVERVIEW("overview"),
 	NAME("name"),
 	DESCRIPTION("description"),
-	METADATA("metadata"),
-	CARD("card");
+	METADATA("metadata");
 
 	private final String text;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/TerariumAssetEmbeddingType.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/TerariumAssetEmbeddingType.java
@@ -3,8 +3,7 @@ package software.uncharted.terarium.hmiserver.models;
 public enum TerariumAssetEmbeddingType {
 	OVERVIEW("overview"),
 	NAME("name"),
-	DESCRIPTION("description"),
-	METADATA("metadata");
+	DESCRIPTION("description");
 
 	private final String text;
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/document/DocumentAsset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/document/DocumentAsset.java
@@ -158,23 +158,4 @@ public class DocumentAsset extends TerariumAsset {
 			throw new RuntimeException("Failed to serialize model embedding text into JSON", e);
 		}
 	}
-
-	@JsonIgnore
-	@TSIgnore
-	public Map<TerariumAssetEmbeddingType, String> getEmbeddingsSourceByType() {
-		final Map<TerariumAssetEmbeddingType, String> sources = super.getEmbeddingsSourceByType();
-
-		try {
-			if (getMetadata() != null && getMetadata().containsKey("gollmCard")) {
-				// update embeddings
-				final JsonNode card = getMetadata().get("gollmCard");
-				final ObjectMapper objectMapper = new ObjectMapper();
-				sources.put(TerariumAssetEmbeddingType.CARD, objectMapper.writeValueAsString(card));
-			}
-		} catch (final Exception e) {
-			log.warn("Failed to serialize card embedding text into JSON", e);
-		}
-
-		return sources;
-	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/Model.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/Model.java
@@ -402,17 +402,7 @@ public class Model extends TerariumAssetThatSupportsAdditionalProperties {
 	public Map<TerariumAssetEmbeddingType, String> getEmbeddingsSourceByType() {
 		final Map<TerariumAssetEmbeddingType, String> sources = super.getEmbeddingsSourceByType();
 
-		try {
-			if (getMetadata() != null && getMetadata().getGollmCard() != null) {
-				// update embeddings
-				final JsonNode card = getMetadata().getGollmCard();
-				final ObjectMapper objectMapper = new ObjectMapper();
-				sources.put(TerariumAssetEmbeddingType.CARD, objectMapper.writeValueAsString(card));
-			}
-		} catch (final Exception e) {
-			log.warn("Failed to serialize card embedding text into JSON", e);
-		}
-
+		// Description are saved as base64 encoded strings, this returns a pure string.
 		if (getDescription() != null) {
 			sources.put(TerariumAssetEmbeddingType.DESCRIPTION, getDescriptionAsReadableString());
 		}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/Model.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/model/Model.java
@@ -382,19 +382,11 @@ public class Model extends TerariumAssetThatSupportsAdditionalProperties {
 	@JsonIgnore
 	@TSIgnore
 	public String getEmbeddingSourceText() {
-		String source = "";
-		try {
-			if (getDescription() != null) {
-				source += getDescriptionAsReadableString();
-			}
-			final ObjectMapper objectMapper = new ObjectMapper();
-			if (getMetadata() != null && getMetadata().getGollmCard() != null) {
-				source += objectMapper.writeValueAsString(getMetadata().getGollmCard());
-			}
-		} catch (final Exception e) {
-			throw new RuntimeException("Failed to serialize model embedding text into JSON", e);
+		if (getMetadata().getDescription() != null) {
+			return getDescriptionAsReadableString();
+		} else {
+			return "";
 		}
-		return source;
 	}
 
 	@JsonIgnore
@@ -403,7 +395,7 @@ public class Model extends TerariumAssetThatSupportsAdditionalProperties {
 		final Map<TerariumAssetEmbeddingType, String> sources = super.getEmbeddingsSourceByType();
 
 		// Description are saved as base64 encoded strings, this returns a pure string.
-		if (getDescription() != null) {
+		if (getMetadata().getDescription() != null) {
 			sources.put(TerariumAssetEmbeddingType.DESCRIPTION, getDescriptionAsReadableString());
 		}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/project/Project.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/project/Project.java
@@ -170,9 +170,6 @@ public class Project extends TerariumAsset {
 		if (overviewContent != null) {
 			sources.put(TerariumAssetEmbeddingType.OVERVIEW, getOverviewAsReadableString());
 		}
-		if (metadata != null) {
-			sources.put(TerariumAssetEmbeddingType.METADATA, metadata.toString());
-		}
 
 		return sources;
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/project/Project.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/project/Project.java
@@ -173,4 +173,21 @@ public class Project extends TerariumAsset {
 
 		return sources;
 	}
+
+	public Project() {
+		super();
+	}
+
+	/**
+	 * Add an extra constructor that takes a project
+	 */
+	public Project(final Project project) {
+		this.userId = project.userId;
+		this.thumbnail = project.thumbnail;
+		this.userName = project.userName;
+		this.authors = project.authors;
+		this.overviewContent = project.overviewContent;
+		this.projectAssets = project.projectAssets;
+		this.sampleProject = project.sampleProject;
+	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectSearchService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ProjectSearchService.java
@@ -352,9 +352,10 @@ public class ProjectSearchService {
 	/**
 	 * Generate asset embeddings for a project
 	 *
-	 * @param projectId
-	 * @param asset
-	 * @return
+	 * @param projectId - the project id
+	 * @param asset - the asset to generate embeddings for
+	 * @param force - force the embedding to be generated even if the asset is temporary
+	 * @return - a future that will be completed when the embedding is generated
 	 */
 	public Future<Void> generateAndUpsertProjectAssetEmbeddings(
 		final UUID projectId,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
@@ -18,6 +18,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
+import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission;
 
 @Service
@@ -34,6 +35,7 @@ public class TerariumAssetServices {
 	private final InterventionService interventionService;
 	private final SimulationService simulationService;
 	private final NotebookSessionService notebookSessionService;
+	private final ProjectService projectService;
 
 	/**
 	 * Get the service for a given asset type
@@ -88,5 +90,22 @@ public class TerariumAssetServices {
 			default:
 				throw new IllegalArgumentException("Invalid asset type: " + type);
 		}
+	}
+
+	public TerariumAsset getAsset(final UUID assetId, final AssetType type) {
+		return switch (type) {
+			case ARTIFACT -> artifactService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case CODE -> codeService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case DATASET -> datasetService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case DOCUMENT -> documentAssetService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case INTERVENTION_POLICY -> interventionService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case MODEL -> modelService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case MODEL_CONFIGURATION -> modelConfigurationService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case NOTEBOOK_SESSION -> notebookSessionService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case SIMULATION -> simulationService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case WORKFLOW -> workflowService.getAsset(assetId, Schema.Permission.READ).orElse(null);
+			case PROJECT -> projectService.getProject(assetId).orElse(null);
+			default -> null;
+		};
 	}
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/elasticsearch/ElasticsearchService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/elasticsearch/ElasticsearchService.java
@@ -344,7 +344,7 @@ public class ElasticsearchService {
 	}
 
 	/**
-	 * Put an component template to the cluster
+	 * Put a component template to the cluster
 	 *
 	 * @param name         The name of the index template
 	 * @param templateJson The component template json string


### PR DESCRIPTION
Enhancements to project search functionality:

* [`Types.ts`](diffhunk://#diff-401d2f2b7e10e894067dc566f3a3c955c6bb70a62a7872a4ab2f416831169a9eR12-R25): Added `ProjectSearchResult` and `ProjectSearchResultAsset` interfaces to represent search results, and `TerariumAssetEmbeddingType` enum to categorize asset embeddings.
* [`ProjectController.java`](diffhunk://#diff-86712ae74e79cfa17607573213ad7f0dd36863a3ef9eac66ef20cdb0c4fecfe7R1020-R1045): Introduced `ProjectSearchResult` and `ProjectSearchResultAsset` classes to encapsulate project search results and their assets. Updated the `projectKnnSearch` method to return a list of `ProjectSearchResult` instead of `ProjectSearchResponse`. 

Refactoring and code improvements:

* [`TerariumAssetEmbeddingType.java`](diffhunk://#diff-f44980fa91f01bc1ebe241260418988971f445ff4984f634227475c4f2b201deL6-R6): Removed unused embedding types `METADATA` and `CARD`.
* [`TerariumAssetServices.java`](diffhunk://#diff-cb035f1f306fd2377bde21926d9286a77b84f1fe585d9866373df961ec035d0aR94-R110): Added a method `getAsset` to retrieve assets based on their type and ID.
* [`Project.java`](diffhunk://#diff-a5608cace8c0017150a2b9ff2994d4b56f98957dd02b6d7912a7164974e2b075L173-R192): Added a constructor to initialize a `Project` object from another `Project` instance.