### PR TITLE
fix: check if transition is a base part

### DIFF
--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -418,8 +418,10 @@ export function createPartsList(parts, model, partType) {
 					};
 		if (partType === PartType.TRANSITION) {
 			base.templateId = `${id}`;
-			base.input = basePart.input.join(', ');
-			base.output = basePart.output.join(', ');
+			if (basePart) {
+				base.input = basePart.input.join(', ');
+				base.output = basePart.output.join(', ');
+			}
 		}
 
 		return { base, children, isParent };


### PR DESCRIPTION
# Description

* This used to be checked before the refactor but it forgot to be added in
* Some model pages won't appear without this fix
