### PR TITLE
fix model-diagram layout option global bounds

### DIFF
--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -132,7 +132,7 @@ export const rerouteEdges = (nodes: INode<any>[], edges: IEdge<any>[]) => {
 			pointB: { shape: shapeB, side: sideB, distance: 0.5 },
 			shapeMargin: 20,
 			globalBoundsMargin: 10,
-			globalBounds: { left: -8000, top: -8000, width: 8000, height: 8000 },
+			globalBounds: { left: -2000, top: -2000, width: 4000, height: 4000 },
 			obstacles
 		};
 
@@ -151,6 +151,30 @@ export const rerouteEdges = (nodes: INode<any>[], edges: IEdge<any>[]) => {
 		}
 		const path = OrthogonalConnector.route(orthoOptions);
 		edge.points = path;
+
+		// Just in case algorithm fails to return, set manual edge points so
+		// at least it renders
+		if (edge.points.length === 0) {
+			console.warn(`failed ortho edge ${edge.source} => ${edge.target}`);
+			const startX = sideA === 'right' ? shapeA.cx + 0.5 * shapeA.width : shapeA.cx - 0.5 * shapeA.width;
+			const startY = shapeA.cy;
+
+			const endX = sideB === 'right' ? shapeB.cx + 0.5 * shapeB.width : shapeB.cx - 0.5 * shapeB.width;
+			const endY = shapeA.cy;
+
+			edge.points.push({
+				x: startX,
+				y: startY
+			});
+			edge.points.push({
+				x: startX + 0.5 * (endX - startX),
+				y: startY + 0.5 * (endY - startY) + 40
+			});
+			edge.points.push({
+				x: endX,
+				y: endY
+			});
+		}
 
 		sourceNodeCounter.set(edge.source, sourceCounter);
 		targetNodeCounter.set(edge.target, targetCounter);


### PR DESCRIPTION
### Summary
The ortho edge routing's global bound was misconfigured, also added a manual edge-points if algorithm fails.


Before: 
Note D and E ends in transition which is incorrect

<img width="677" alt="image" src="https://github.com/user-attachments/assets/5733c937-6fad-44f0-9898-cd68f21ed1b8">

After:
Now D and E routes back onto themselves (this is location change within the same state)

<img width="672" alt="image" src="https://github.com/user-attachments/assets/e47f4044-f359-4256-bb58-f48d6d410452">


### Test
Use the following, paste the content into http://localhost:8080/amr-petri-test or upload it as a model and view the diagram
[pp-bad-amr-render.json](https://github.com/user-attachments/files/18004396/pp-bad-amr-render.json)
