### PR TITLE
Intervention node - show summary card and selectable node chart

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/intervention-policy-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/intervention-policy-operation.ts
@@ -6,6 +6,7 @@ import { isEqual, omit } from 'lodash';
 export interface InterventionPolicyState extends BaseState {
 	interventionPolicy: InterventionPolicy;
 	taskIds: string[];
+	selectedCharts?: string[];
 }
 
 export const InterventionPolicyOperation: Operation = {

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -143,6 +143,16 @@
 									:are-embed-actions-visible="false"
 									:visualization-spec="preparedCharts[appliedTo]"
 								/>
+								<span class="flex justify-content-end pr-7 pb-6">
+									<label class="pr-2">Display on node thumbnail</label>
+									<Checkbox
+										v-model="selectedCharts"
+										:input-id="appliedTo"
+										:name="appliedTo"
+										:value="appliedTo"
+										@change="onSelectChartChange"
+									/>
+								</span>
 								<ul>
 									<li
 										class="pb-2"
@@ -226,6 +236,7 @@ import {
 } from '@/services/intervention-policy';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
+import Checkbox from 'primevue/checkbox';
 import Textarea from 'primevue/textarea';
 import EmptySeed from '@/assets/images/lottie-empty-seed.json';
 import { Vue3Lottie } from 'vue3-lottie';
@@ -251,6 +262,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits(['close', 'update-state', 'select-output', 'append-output']);
+
+const selectedCharts = ref<string[] | []>([]);
 
 const confirm = useConfirm();
 
@@ -397,6 +410,7 @@ const initialize = async (overwriteWithState: boolean = false) => {
 	} else {
 		knobs.value.transientInterventionPolicy = cloneDeep(state.interventionPolicy);
 	}
+	selectedCharts.value = state.selectedCharts ?? [];
 };
 
 const applyInterventionPolicy = (interventionPolicy: InterventionPolicy) => {
@@ -590,6 +604,12 @@ const extractInterventionPolicyFromInputs = async () => {
 			}
 		});
 	}
+	emit('update-state', state);
+};
+
+const onSelectChartChange = () => {
+	const state = cloneDeep(props.node.state);
+	state.selectedCharts = selectedCharts.value;
 	emit('update-state', state);
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -11,6 +11,12 @@
 			</li>
 		</ul>
 		<tera-operator-placeholder :node="node" v-else />
+		<tera-intervention-summary-card
+			class="intervention-title"
+			v-for="(intervention, index) in node.state.interventionPolicy.interventions"
+			:intervention="intervention"
+			:key="index"
+		/>
 		<tera-progress-spinner is-centered :font-size="2" v-if="isLoading" />
 		<Button
 			:label="isModelInputConnected ? 'Open' : 'Attach a model'"
@@ -34,6 +40,7 @@ import VegaChart from '@/components/widgets/VegaChart.vue';
 import { useClientEvent } from '@/composables/useClientEvent';
 import { type ClientEvent, ClientEventType, type TaskResponse, TaskStatus } from '@/types/Types';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
+import TeraInterventionSummaryCard from '@/components/intervention-policy/tera-intervention-summary-card.vue';
 import { InterventionPolicyState } from './intervention-policy-operation';
 
 const emit = defineEmits(['open-drilldown', 'update-state']);
@@ -125,5 +132,10 @@ watch(
 <style scoped>
 ul {
 	list-style-type: none;
+}
+.intervention-title {
+	& > :deep(h5) {
+		padding-top: 15px;
+	}
 }
 </style>

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -1,7 +1,7 @@
 <template>
 	<section>
 		<ul v-if="node.state.interventionPolicy.id">
-			<li v-for="(_interventions, appliedTo) in groupedOutputParameters" :key="appliedTo">
+			<li v-for="(_interventions, appliedTo) in selectedOutputParameters" :key="appliedTo">
 				<vega-chart
 					expandable
 					:are-embed-actions-visible="false"
@@ -59,11 +59,18 @@ const isModelInputConnected = computed(() => modelInput?.status === WorkflowPort
 
 const groupedOutputParameters = computed(() =>
 	Object.fromEntries(
-		Object.entries(
-			groupBy(flattenInterventionData(props.node.state.interventionPolicy.interventions), 'appliedTo')
-		).slice(0, 4) // Show a max of 4 charts
+		Object.entries(groupBy(flattenInterventionData(props.node.state.interventionPolicy.interventions), 'appliedTo'))
 	)
 );
+
+const selectedOutputParameters = computed(() => {
+	const charts = {};
+	props.node.state.selectedCharts?.forEach((chart) => {
+		const paramOutput = groupedOutputParameters.value[chart];
+		if (paramOutput) charts[chart] = paramOutput;
+	});
+	return charts;
+});
 
 const preparedCharts = computed(() =>
 	_.mapValues(groupedOutputParameters.value, (interventions, key) =>


### PR DESCRIPTION
# Description

Design Change:
- enable the add the summary cards for the interventions
- enable user to choose which charts to show on the intervention node
- 
![Screenshot 2024-12-04 at 2 06 56 PM](https://github.com/user-attachments/assets/21b648c4-80bf-4a22-a495-2b2ea3a692f7)
![Screenshot 2024-12-04 at 2 07 20 PM](https://github.com/user-attachments/assets/874542a6-6677-496d-ac59-b10e0f13ddfd)

Testing:
- Create a few new interventions
- select the charts you wish to see on the node
- all interventions should appear as summary with the selected charts

Resolves #(issue)
