### PR TITLE
remove blank equation

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -463,6 +463,7 @@ async function fetchModel() {
 function getEquations() {
 	const newEquations = multipleEquations.value.split('\n');
 	newEquations.forEach((equation) => {
+		if (!equation.trim().length) return;
 		const index = clonedState.value.equations.length;
 		clonedState.value.equations.push({
 			name: `Equation ${index}`,


### PR DESCRIPTION
# Description

Bug: 
- in the model from equation drill down
- newline characters back to back are being saved as an equation 

Testing:

1. Paste in this list of equations
```
\frac{d S}{d t} = - \beta_w I_w S - \beta_a I_a S - \beta_d I_d S + \mu N - \mu S + \eta_R R_F + \eta_R R_w + \eta_R R_a + \eta_R R_d

\frac{d V_1}{d t} = \omega_1 S - \mu V_1

\frac{d I_w}{d t} = \beta_w I_w S - \gamma_w I_w - \mu_w I_w

\frac{d I_a}{d t} = \beta_a I_a S - \gamma_a I_a - \mu_a I_a

\frac{d I_d}{d t} = \beta_d I_d S - \gamma_d I_d - \mu_a I_a

\frac{d R_w}{d t} = \gamma_w I_w - R_w \beta_{Ra} I_a - R_w \beta_{Rd} I_d - \eta_R R_w - \mu R_w 

\frac{d R_a}{d t} = \gamma_a I_a - R_a \beta_{Rw} I_w - R_a \beta_{Rd} I_d - \eta_R R_a - \mu R_a 

\frac{d R_d}{d t} = \gamma_d I_d - R_d \beta_{Rw} I_w - R_d \beta_{Ra} I_a - \eta_R R_d - \mu R_d 

\frac{d I_{Rw}}{d t} = \beta_{Rw} I_w R_a + \beta_{Rw} I_w R_d - \gamma_w I_{Rw} - \mu_V_w I_{Rw}

\frac{d I_{Ra}}{d t} = \beta_{Ra} I_a R_w + \beta_{Ra} I_a R_d - \gamma_a I_{Ra} - \mu_V_a I_{Ra}

\frac{d I_{Rd}}{d t} = \beta_{Rd} I_d R_w + \beta_{Rd} I_d R_a - \gamma_d I_{Rd} - \mu_V_d I_{Rd}

\frac{d R_F}{d t} = \gamma_w I_{Rw} + \gamma_a I_{Ra} + \gamma_d I_{Rd} - \eta_R R_F - \mu R_F
```
2. Click `Add`

Resolves #(issue)
