### PR TITLE
link simulate with simulate notification event through user id

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
@@ -128,6 +128,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
+			currentUserService,
 			simulationService,
 			sim.get().getId(),
 			projectId,
@@ -174,6 +175,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
+			currentUserService,
 			simulationService,
 			UUID.fromString(res.getSimulationId()),
 			projectId,
@@ -214,6 +216,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
+			currentUserService,
 			simulationService,
 			UUID.fromString(res.getSimulationId()),
 			projectId,
@@ -246,6 +249,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
+			currentUserService,
 			simulationService,
 			UUID.fromString(res.getSimulationId()),
 			projectId,
@@ -278,6 +282,7 @@ public class SimulationRequestController implements SnakeCaseController {
 		new SimulationRequestStatusNotifier(
 			notificationService,
 			clientEventService,
+			currentUserService,
 			simulationService,
 			UUID.fromString(res.getSimulationId()),
 			projectId,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/notification/SimulationRequestStatusNotifier.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/notification/SimulationRequestStatusNotifier.java
@@ -17,6 +17,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simul
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.SimulationEngine;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.SimulationType;
 import software.uncharted.terarium.hmiserver.service.ClientEventService;
+import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.SimulationService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
@@ -50,6 +51,7 @@ public class SimulationRequestStatusNotifier {
 
 	private final ScheduledExecutorService executor;
 	private final ClientEventService clientEventService;
+	private final CurrentUserService currentUserService;
 	private final NotificationService notificationService;
 	private final SimulationService simulationService;
 
@@ -66,6 +68,7 @@ public class SimulationRequestStatusNotifier {
 	public SimulationRequestStatusNotifier(
 		final NotificationService notificationService,
 		final ClientEventService clientEventService,
+		final CurrentUserService currentUserService,
 		final SimulationService simulationService,
 		final UUID simulationId,
 		final UUID projectId,
@@ -73,13 +76,13 @@ public class SimulationRequestStatusNotifier {
 		final JsonNode metadata
 	) {
 		this.clientEventService = clientEventService;
+		this.currentUserService = currentUserService;
 		this.notificationService = notificationService;
 		this.simulationService = simulationService;
 		this.simulationId = simulationId;
 		this.projectId = projectId;
 		this.permission = permission;
 		this.metadata = metadata;
-
 		this.executor = Executors.newScheduledThreadPool(1);
 	}
 
@@ -121,7 +124,7 @@ public class SimulationRequestStatusNotifier {
 			new SimulationNotificationData(this.simulationId, sim.getType(), sim.getEngine(), this.metadata),
 			this.halfTimeSeconds,
 			sim.getId(),
-			null
+			currentUserService.get().getId()
 		);
 		log.info("Starting polling for simulation {} every {} seconds", this.simulationId, this.interval);
 		this.sendStatusMessage(notificationInterface, sim);


### PR DESCRIPTION
### Summary
There is a mismatch where the client-event subscription is by userId, but the simulation notification is setting userId to null

It is not quite clear how the notification system is meant to work, but this will allow simulate event to go through and not spin forever.


### Testing
Run a simulation, it should finish in a timely order and not spin forever.