### PR TITLE
remove dataset transformer from sensitivity analysis scenario

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
@@ -3,7 +3,6 @@ import * as workflowService from '@/services/workflow';
 import { operation as ModelOp } from '@/components/workflow/ops/model/mod';
 import { operation as ModelConfigOp } from '@/components/workflow/ops/model-config/mod';
 import { operation as SimulateCiemssOp } from '@/components/workflow/ops/simulate-ciemss/mod';
-import { operation as TransformDatasetOp } from '@/components/workflow/ops/dataset-transformer/mod';
 import { OperatorNodeSize } from '@/services/workflow';
 import {
 	createModelConfiguration,
@@ -142,14 +141,6 @@ export class SensitivityAnalysisScenario extends BaseScenario {
 			}
 		);
 
-		const datasetTransformerNode = wf.addNode(
-			TransformDatasetOp,
-			{ x: 0, y: 0 },
-			{
-				size: OperatorNodeSize.medium
-			}
-		);
-
 		// 2. Add edges
 		wf.addEdge(modelNode.id, modelNode.outputs[0].id, modelConfigNode.id, modelConfigNode.inputs[0].id, [
 			{ x: 0, y: 0 },
@@ -159,16 +150,6 @@ export class SensitivityAnalysisScenario extends BaseScenario {
 			{ x: 0, y: 0 },
 			{ x: 0, y: 0 }
 		]);
-		wf.addEdge(
-			simulateNode.id,
-			simulateNode.outputs[0].id,
-			datasetTransformerNode.id,
-			datasetTransformerNode.inputs[0].id,
-			[
-				{ x: 0, y: 0 },
-				{ x: 0, y: 0 }
-			]
-		);
 
 		// 3. Setting node states/outputs
 		wf.updateNode(modelNode, {


### PR DESCRIPTION
# Description

* Since we have the sensitivity analysis charts in the simulate node, the dataset transformer is no longer needed in the template creation

