### PR TITLE
utility to export svg into html image

### DIFF
--- a/packages/client/hmi-client/src/utils/svg.ts
+++ b/packages/client/hmi-client/src/utils/svg.ts
@@ -9,3 +9,58 @@ export const pointOnPath = (pathEl: SVGPathElement, percent: number) => {
 	const point = pathEl.getPointAtLength(total * percent);
 	return point;
 };
+
+// Note: Being evaluated for now, not in use
+// @ts-ignore
+// eslint-disable-next-line
+const embedExternalStyles = (svgElement: SVGElement) => {
+	const styleSheets = Array.from(document.styleSheets);
+	const styleContent = styleSheets
+		.map((sheet) => {
+			try {
+				return Array.from(sheet.cssRules || [])
+					.map((rule) => rule.cssText)
+					.join('\n');
+			} catch (e) {
+				return '';
+			}
+		})
+		.join('\n');
+	const styleElement = document.createElement('style');
+	styleElement.textContent = styleContent;
+	svgElement.insertBefore(styleElement, svgElement.firstChild);
+	return svgElement;
+};
+
+/**
+ * Converts an SVG to Canvas to Image
+ * Note: css-variables doesn't seem to work very well here
+ * */
+export const svgToImage = (svgElement: SVGElement): Promise<HTMLImageElement> => {
+	const serializer = new XMLSerializer();
+	// embedExternalStyles(svgElement);
+
+	const svgString = serializer.serializeToString(svgElement);
+	const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+	const url = URL.createObjectURL(svgBlob);
+	const img = new Image(svgElement.clientWidth, svgElement.clientHeight);
+	const finalImg = new Image(svgElement.clientWidth, svgElement.clientHeight);
+
+	return new Promise((resolve, reject) => {
+		img.addEventListener('load', (e: any) => {
+			URL.revokeObjectURL(e.target.src);
+			const canvas = document.createElement('canvas');
+			canvas.width = img.width;
+			canvas.height = img.height;
+			const ctx = canvas.getContext('2d');
+			ctx?.drawImage(img, 0, 0);
+			finalImg.src = canvas.toDataURL('image/png');
+			resolve(finalImg);
+		});
+		img.onerror = () => {
+			URL.revokeObjectURL(url);
+			reject(new Error('Failed to load intermediate image'));
+		};
+		img.src = url;
+	});
+};


### PR DESCRIPTION
### Summary
Adds utility functions to convert SVG into image. 

This is not in use for now as where we want to apply SVG=>Image transform (model-diagram), it requires CSS style adjustments and tweaks to the governing logic that are probably better off as a separate PR.


### Testing
You add the this to the end of `renderGraph()` function in tera-model-diagram.vue to test, it appends the image(s) onto the document body. The image(s) are not 100% faithful because of the aforementioned style changes that are not carried over when converting to an image.

```
     const imageTest = await svgToImage(graphElement.value?.querySelector('svg') as any);
     document.body.appendChild(imageTest);
```

<img width="542" alt="image" src="https://github.com/user-attachments/assets/84099ccb-6647-4a80-bb35-2c9dce674164">
