### PR TITLE
create notebook session when cloning

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -259,6 +259,11 @@ public class NotebookSessionController {
 				projectId,
 				permission
 			);
+
+			final Optional<Project> project = projectService.getProject(projectId);
+
+			projectAssetService.createProjectAsset(project.get(), AssetType.NOTEBOOK_SESSION, newNotebookSession, permission);
+
 			return ResponseEntity.status(HttpStatus.OK).body(newNotebookSession);
 		} catch (final Exception e) {
 			final String error = "Unable to clone notebook session";

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -255,7 +254,12 @@ public class NotebookSessionController {
 			if (session.isEmpty()) {
 				return ResponseEntity.notFound().build();
 			}
-			return ResponseEntity.status(HttpStatus.OK).body(session.get().clone());
+			final NotebookSession newNotebookSession = sessionService.createAsset(
+				session.get().clone(),
+				projectId,
+				permission
+			);
+			return ResponseEntity.status(HttpStatus.OK).body(newNotebookSession);
 		} catch (final Exception e) {
 			final String error = "Unable to clone notebook session";
 			log.error(error, e);


### PR DESCRIPTION
# Description

* When duplicating a data transform the notebook clone call would not actually create a new notebook session but just send back a clone of the session, nothing was done with this.  Now we are creating the new notebook session and sending it back