### PR TITLE
Model diagram render png

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -58,8 +58,8 @@ export abstract class Renderer<V, E> extends EventEmitter {
 	}
 
 	initialize(element: HTMLDivElement): void {
-		this.chartSize.width = element.clientWidth;
-		this.chartSize.height = element.clientHeight;
+		this.chartSize.width = element.clientWidth || parseFloat(element.style.width);
+		this.chartSize.height = element.clientHeight || parseFloat(element.style.height);
 		this.svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 		this.svgEl.style.userSelect = 'none';
 		removeChildren(element).appendChild(this.svgEl);

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -163,7 +163,12 @@ async function renderGraph() {
 
 	// If not interactive, convert elem buffer into image
 	if (props.featureConfig?.isPreview && graphElement.value) {
-		const image = await svgToImage(elem?.querySelector('svg') as SVGElement);
+		const svg = elem?.querySelector('svg') as SVGElement;
+
+		// Carry background from container
+		svg.style.background = '#f9fbfa';
+
+		const image = await svgToImage(svg);
 		graphElement.value.innerHTML = '';
 		graphElement.value.appendChild(image);
 		elem = null;

--- a/packages/client/hmi-client/src/utils/svg.ts
+++ b/packages/client/hmi-client/src/utils/svg.ts
@@ -40,12 +40,13 @@ export const svgToImage = (svgElement: SVGElement): Promise<HTMLImageElement> =>
 	const serializer = new XMLSerializer();
 	// embedExternalStyles(svgElement);
 
+	const w = svgElement.clientWidth || parseFloat(svgElement.getAttribute('width') as string);
+	const h = svgElement.clientHeight || parseFloat(svgElement.getAttribute('height') as string);
+
 	const svgString = serializer.serializeToString(svgElement);
 	const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
 	const url = URL.createObjectURL(svgBlob);
 
-	const w = svgElement.clientWidth || parseFloat(svgElement.getAttribute('width') as string);
-	const h = svgElement.clientHeight || parseFloat(svgElement.getAttribute('height') as string);
 	const img = new Image(w, h);
 	const finalImg = new Image(w, h);
 

--- a/packages/client/hmi-client/src/utils/svg.ts
+++ b/packages/client/hmi-client/src/utils/svg.ts
@@ -43,8 +43,11 @@ export const svgToImage = (svgElement: SVGElement): Promise<HTMLImageElement> =>
 	const svgString = serializer.serializeToString(svgElement);
 	const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
 	const url = URL.createObjectURL(svgBlob);
-	const img = new Image(svgElement.clientWidth, svgElement.clientHeight);
-	const finalImg = new Image(svgElement.clientWidth, svgElement.clientHeight);
+
+	const w = svgElement.clientWidth || parseFloat(svgElement.getAttribute('width') as string);
+	const h = svgElement.clientHeight || parseFloat(svgElement.getAttribute('height') as string);
+	const img = new Image(w, h);
+	const finalImg = new Image(w, h);
 
 	return new Promise((resolve, reject) => {
 		img.addEventListener('load', (e: any) => {


### PR DESCRIPTION
### Summary
Make `tera-model-diagram` output either an image or interactive SVG, based on the presence of FeatureConfig.isPreview flag. For the most part this is a performance boost as it can be quite expensive to maintain thousands of DOM-elements in a large workflow or in workflows with big models. 


### Testing
Goto this workflow using `yarn staging` versus directly on staging
- http://localhost:8080/projects/7fbab7f3-9b6a-4fe2-93d4-5d330cc41e7a/workflow/4a952cc4-f4b2-4b37-ab78-1257878868ab
- https://app.staging.terarium.ai/projects/7fbab7f3-9b6a-4fe2-93d4-5d330cc41e7a/workflow/4a952cc4-f4b2-4b37-ab78-1257878868ab

After the workflow is fully loaded (takes a few seconds), pan/zoom the workflows. The former should be noticeably faster/snappier. Alternative we can validate the number of DOM elements present via running this script which prints out the total number of DOM elements.

```
const script = document.createElement('script');
script.src = "https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js";
document.head.appendChild(script)
d3.selectAll('*').size()
```