### PR TITLE
parse controller independently of subject/outcome

### DIFF
--- a/packages/client/hmi-client/src/model-representation/mira/mira.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira.ts
@@ -505,15 +505,6 @@ export const convertToIGraph = (
 				points: [],
 				data: {}
 			});
-
-			t.controllers.forEach((controllerName) => {
-				graph.edges.push({
-					source: controllerName,
-					target: t.name,
-					points: [],
-					data: { isController: true }
-				});
-			});
 		}
 		if (t.outcome !== '') {
 			graph.edges.push({
@@ -522,16 +513,16 @@ export const convertToIGraph = (
 				points: [],
 				data: {}
 			});
-
-			// Turn off dual-controller edges as per request - Nov 2024
-			// t.controllers.forEach((controllerName) => {
-			// 	graph.edges.push({
-			// 		source: t.name,
-			// 		target: controllerName,
-			// 		points: [],
-			// 		data: { isController: true }
-			// 	});
-			// });
+		}
+		if (t.controllers && t.controllers.length > 0) {
+			t.controllers.forEach((controllerName) => {
+				graph.edges.push({
+					source: controllerName,
+					target: t.name,
+					points: [],
+					data: { isController: true }
+				});
+			});
 		}
 	});
 


### PR DESCRIPTION
Closes: https://github.com/DARPA-ASKEM/terarium/issues/5785

### Summary
Our parsing assumes assumes number-of-inputs = number-of-outputs and slots controller parsing in one of them, this is not true and controllers should be parsed independently, in order for controlled-group production/degradation to happen.

<img width="701" alt="image" src="https://github.com/user-attachments/assets/2c2ff145-ed11-4774-8c57-a97b9ea9317d">



### Testing
Test model from nelson 
[non_mass_conserved.json](https://github.com/user-attachments/files/18080793/non_mass_conserved.json)
