### PR TITLE
fix for wrong object being passed

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -155,13 +155,9 @@
 						@update-parameters="setParameterDistributions(knobs.transientModelConfig, $event)"
 						@update-source="setParameterSource(knobs.transientModelConfig, $event.id, $event.value)"
 					/>
-					<Accordion :active-index="observableActiveIndicies" v-if="!isEmpty(calibratedConfigObservables)">
+					<Accordion :active-index="observableActiveIndicies" v-if="!isEmpty(observablesList)">
 						<AccordionTab header="Observables">
-							<tera-model-part
-								class="pl-4"
-								:items="calibratedConfigObservables"
-								:feature-config="{ isPreview: true }"
-							/>
+							<tera-model-part class="pl-4" :items="observablesList" :feature-config="{ isPreview: true }" />
 						</AccordionTab>
 					</Accordion>
 					<!-- vertical spacer at end of page -->
@@ -269,14 +265,15 @@ import {
 } from '@/services/model-configurations';
 import { useToastService } from '@/services/toast';
 import type { Initial, Model, ModelConfiguration, TaskResponse } from '@/types/Types';
-import { AssetType, ModelParameter, Observable } from '@/types/Types';
+import { AssetType, ModelParameter } from '@/types/Types';
 import type { WorkflowNode } from '@/types/workflow';
 import { OperatorStatus } from '@/types/workflow';
 import { logger } from '@/utils/logger';
 import {
 	isModelMissingMetadata,
 	getParameters as getAmrParameters,
-	getInitials as getAmrInitials
+	getInitials as getAmrInitials,
+	createObservablesList
 } from '@/model-representation/service';
 import Message from 'primevue/message';
 import TeraColumnarPanel from '@/components/widgets/tera-columnar-panel.vue';
@@ -330,15 +327,6 @@ interface BasicKnobs {
 const knobs = ref<BasicKnobs>({
 	transientModelConfig: blankModelConfig
 });
-
-const calibratedConfigObservables = computed<Observable[]>(() =>
-	knobs.value.transientModelConfig.observableSemanticList.map(({ referenceId, states, expression }) => ({
-		id: referenceId,
-		name: referenceId,
-		states,
-		expression
-	}))
-);
 
 const getTotalInput = (modelConfiguration: ModelConfiguration) =>
 	modelConfiguration.initialSemanticList.length + modelConfiguration.parameterSemanticList.length;
@@ -517,6 +505,9 @@ const datasetIds = computed(() =>
 		.map((input) => input.value?.[0])
 		.filter((id): id is string => id !== undefined)
 );
+
+const observables = computed(() => model.value?.semantics?.ode?.observables ?? []);
+const observablesList = computed(() => createObservablesList(observables.value));
 
 const modelConfigurations = ref<ModelConfiguration[]>([]);
 


### PR DESCRIPTION
# Description

Issue: 
- The wrong object was being passed to `tera-model-parts.vue` causing the model config to stop functioning correctly
  - the drill down can no longer be closed

Testing:
- using this model create a model config and trying making changes
- [SIR to validate](https://github.com/user-attachments/files/18085187/SIR.to.validate.1.json)
Resolves #(issue)
