### PR TITLE
Equations engineering UI

### DIFF
--- a/packages/client/hmi-client/src/router/index.ts
+++ b/packages/client/hmi-client/src/router/index.ts
@@ -16,6 +16,7 @@ import JupyterTest from '@/temp/JupyterTest.vue';
 import CustomInputTest from '@/temp/custom-input-test.vue';
 import ClipboardTest from '@/temp/Clipboard.vue';
 import VegaliteTest from '@/temp/Vegalite.vue';
+import EquationsTest from '@/temp/Equations.vue';
 import FunmanDebugger from '@/temp/FunmanDebugger.vue';
 import { RouteName } from './routes';
 
@@ -63,7 +64,8 @@ const routes = [
 	{ path: '/custom-input-test', component: CustomInputTest },
 	{ path: '/clipboard', component: ClipboardTest },
 	{ path: '/vegalite', component: VegaliteTest },
-	{ path: '/funman-debugger', component: FunmanDebugger }
+	{ path: '/funman-debugger', component: FunmanDebugger },
+	{ path: '/equations', component: EquationsTest }
 ];
 
 const router = createRouter({

--- a/packages/client/hmi-client/src/temp/Equations.vue
+++ b/packages/client/hmi-client/src/temp/Equations.vue
@@ -1,25 +1,21 @@
 <template>
 	<section>
 		<div class="row">
-			<h4>
-				<Button @click="latex2latex()" label="Run" size="small"></Button>
-				LaTeX => Cleaned LaTeX
-			</h4>
+			<h4>LaTeX => Cleaned LaTeX</h4>
 			<div style="display: flex; flex-direction: row">
 				<textarea ref="latex1"></textarea>
 				<div class="result" ref="result1"></div>
 			</div>
+			<Button @click="latex2latex()" label="Run" size="small"></Button>
 		</div>
 		<div class="row">
-			<h4>
-				<Button label="Run" size="small"></Button>
-				LaTeX => SymPy String, AMR
-			</h4>
+			<h4>Cleaned LaTeX => SymPy equation strings + AMR json</h4>
 			<div style="display: flex; flex-direction: row">
-				<textarea></textarea>
-				<div class="result"></div>
-				<div class="result"></div>
+				<textarea ref="latex2"></textarea>
+				<pre class="result" ref="resultSympy"></pre>
+				<pre class="result" ref="resultAmr"></pre>
 			</div>
+			<Button @click="latex2amr()" label="Run" size="small"></Button>
 		</div>
 	</section>
 </template>
@@ -30,20 +26,49 @@ import Button from 'primevue/button';
 import API from '@/api/api';
 
 const latex1 = ref<HTMLTextAreaElement | null>(null);
+const latex2 = ref<HTMLTextAreaElement | null>(null);
 const result1 = ref<HTMLDivElement | null>(null);
+const resultSympy = ref<HTMLDivElement | null>(null);
+const resultAmr = ref<HTMLDivElement | null>(null);
 
 const latex2latex = async () => {
 	const inputStr = latex1.value?.value || '[]';
 	const equations = JSON.parse(inputStr);
-	console.log('latex2latex', equations);
+
+	if (result1.value) {
+		result1.value.innerHTML = 'processing...';
+	}
 
 	const resp = await API.post('/knowledge/clean-equations', equations);
 	const respData = resp.data;
-	console.log('resp', respData);
 
 	if (result1.value) {
 		result1.value.innerHTML = '';
 		result1.value.innerHTML = JSON.stringify(respData.cleanedEquations, null, 2);
+	}
+};
+
+const latex2amr = async () => {
+	const inputStr = latex2.value?.value || '[]';
+	const equations = JSON.parse(inputStr);
+
+	if (resultSympy.value) {
+		resultSympy.value.innerHTML = 'processing...';
+	}
+	if (resultAmr.value) {
+		resultAmr.value.innerHTML = 'processing...';
+	}
+
+	const resp = await API.post('/mira/latex-to-amr', equations);
+	const respData = resp.data;
+
+	if (resultSympy.value) {
+		resultSympy.value.innerHTML = '';
+		resultSympy.value.innerHTML = JSON.stringify(respData.response.sympyExprs, null, 2);
+	}
+	if (resultAmr.value) {
+		resultAmr.value.innerHTML = '';
+		resultAmr.value.innerHTML = JSON.stringify(respData.response.amr, null, 2);
 	}
 };
 </script>
@@ -68,5 +93,6 @@ textarea {
 	min-width: 400px;
 	border: 1px solid #bbb;
 	margin-left: 10px;
+	overflow: scroll;
 }
 </style>

--- a/packages/client/hmi-client/src/temp/Equations.vue
+++ b/packages/client/hmi-client/src/temp/Equations.vue
@@ -4,7 +4,7 @@
 			<h4>LaTeX => Cleaned LaTeX</h4>
 			<div style="display: flex; flex-direction: row">
 				<textarea ref="latex1"></textarea>
-				<div class="result" ref="result1"></div>
+				<pre class="result" ref="result1"></pre>
 			</div>
 			<Button @click="latex2latex()" label="Run" size="small"></Button>
 		</div>
@@ -84,13 +84,14 @@ section {
 }
 
 textarea {
-	min-height: 150px;
-	min-width: 450px;
+	height: 200px;
+	width: 450px;
 	font-size: 90%;
 }
 .result {
-	min-height: 150px;
-	min-width: 400px;
+	margin: 0;
+	height: 200px;
+	width: 450px;
 	border: 1px solid #bbb;
 	margin-left: 10px;
 	overflow: scroll;

--- a/packages/client/hmi-client/src/temp/Equations.vue
+++ b/packages/client/hmi-client/src/temp/Equations.vue
@@ -1,0 +1,72 @@
+<template>
+	<section>
+		<div class="row">
+			<h4>
+				<Button @click="latex2latex()" label="Run" size="small"></Button>
+				LaTeX => Cleaned LaTeX
+			</h4>
+			<div style="display: flex; flex-direction: row">
+				<textarea ref="latex1"></textarea>
+				<div class="result" ref="result1"></div>
+			</div>
+		</div>
+		<div class="row">
+			<h4>
+				<Button label="Run" size="small"></Button>
+				LaTeX => SymPy String, AMR
+			</h4>
+			<div style="display: flex; flex-direction: row">
+				<textarea></textarea>
+				<div class="result"></div>
+				<div class="result"></div>
+			</div>
+		</div>
+	</section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import Button from 'primevue/button';
+import API from '@/api/api';
+
+const latex1 = ref<HTMLTextAreaElement | null>(null);
+const result1 = ref<HTMLDivElement | null>(null);
+
+const latex2latex = async () => {
+	const inputStr = latex1.value?.value || '[]';
+	const equations = JSON.parse(inputStr);
+	console.log('latex2latex', equations);
+
+	const resp = await API.post('/knowledge/clean-equations', equations);
+	const respData = resp.data;
+	console.log('resp', respData);
+
+	if (result1.value) {
+		result1.value.innerHTML = '';
+		result1.value.innerHTML = JSON.stringify(respData.cleanedEquations, null, 2);
+	}
+};
+</script>
+
+<style scoped>
+section {
+	display: flex;
+	flex-direction: column;
+	padding: 5px;
+}
+.row {
+	padding-bottom: 15px;
+}
+
+textarea {
+	min-height: 150px;
+	min-width: 450px;
+	font-size: 90%;
+}
+.result {
+	min-height: 150px;
+	min-width: 400px;
+	border: 1px solid #bbb;
+	margin-left: 10px;
+}
+</style>

--- a/packages/mira/tasks/latex_to_amr.py
+++ b/packages/mira/tasks/latex_to_amr.py
@@ -32,8 +32,12 @@ def main():
         # MMT to AMR
         amr_json = template_model_to_petrinet_json(mmt)
 
+        # Gather results
+        response = {}
+        response["sympyExprs"] = list(map(lambda x: str(x), sympy_exprs))
+        response["amr"] = amr_json
         taskrunner.log(f"LaTeX to AMR conversion succeeded")
-        taskrunner.write_output_dict_with_timeout({"response": json.dumps(amr_json)})
+        taskrunner.write_output_dict_with_timeout({"response": response })
 
         print("LaTeX to AMR conversion succeeded")
     except Exception as e:

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -278,11 +278,25 @@ public class KnowledgeController {
 				taskReq.setUserId(currentUserService.get().getId());
 				final TaskResponse taskResp = taskService.runTaskSync(taskReq);
 				final JsonNode taskResponseJSON = mapper.readValue(taskResp.getOutput(), JsonNode.class);
-				final String amrString = taskResponseJSON.get("response").asText();
-				ObjectNode objNode = (ObjectNode) mapper.readTree(amrString);
 
-				final JsonNode testNode = mapper.readValue(amrString, JsonNode.class);
-				responseAMR = mapper.convertValue(testNode, Model.class);
+				System.out.println("");
+				System.out.println("debug 0");
+				System.out.println(taskResponseJSON);
+				System.out.println("");
+				System.out.println("");
+
+				// final String amrString = taskResponseJSON.get("response").get("amr");
+				final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
+
+				System.out.println("");
+				System.out.println("debug 1");
+				System.out.println(amrNode);
+				System.out.println("");
+				System.out.println("");
+
+				// ObjectNode objNode = (ObjectNode) mapper.readTree(amrString);
+				// final JsonNode testNode = mapper.readValue(amrString, JsonNode.class);
+				responseAMR = mapper.convertValue(amrNode, Model.class);
 			} catch (Exception e) {
 				log.error("failed to convert LaTeX equations to AMR", e);
 				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to convert latex equations to AMR");

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -279,23 +279,7 @@ public class KnowledgeController {
 				final TaskResponse taskResp = taskService.runTaskSync(taskReq);
 				final JsonNode taskResponseJSON = mapper.readValue(taskResp.getOutput(), JsonNode.class);
 
-				System.out.println("");
-				System.out.println("debug 0");
-				System.out.println(taskResponseJSON);
-				System.out.println("");
-				System.out.println("");
-
-				// final String amrString = taskResponseJSON.get("response").get("amr");
 				final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
-
-				System.out.println("");
-				System.out.println("debug 1");
-				System.out.println(amrNode);
-				System.out.println("");
-				System.out.println("");
-
-				// ObjectNode objNode = (ObjectNode) mapper.readTree(amrString);
-				// final JsonNode testNode = mapper.readValue(amrString, JsonNode.class);
 				responseAMR = mapper.convertValue(amrNode, Model.class);
 			} catch (Exception e) {
 				log.error("failed to convert LaTeX equations to AMR", e);


### PR DESCRIPTION
### Summary
This PR does two things
- Change the mira taskrunner task to return both the AMR and the string-sympy equations. Also change the format from string to JSON.
- Add in an engineering/debugging interface at `/equations` for debugging/tracing equation-to-amr issues

### Testing
Test that knowledge controller `/equations-to-model` is still working, as it had to accommodate both structural and format change from the task runner. You can try this payload:

```
{
  "equations": [
  "\\frac{d S(t)}{d t} = - b_q S(t) I(t)",
  "\\frac{d E(t)}{d t} = b_q S(t) I(t) - r_X E(t)",
  "\\frac{d I(t)}{d t} = r_X E(t) - g_p_q I(t)",
  "\\frac{d R(t)}{d t} = g_p_q I(t)"
   ]
}

```