### PR TITLE
Jamie consolidate node preview design tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -54,7 +54,7 @@ function getUnit(dynamicIntervention: DynamicIntervention) {
 .intervention-card {
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
-	border-radius: var(--border-radius-medium);
+	border-radius: var(--border-radius);
 	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
 	overflow: hidden;
 }
@@ -64,7 +64,7 @@ function getUnit(dynamicIntervention: DynamicIntervention) {
 	padding-right: var(--gap-2);
 	padding-bottom: var(--gap-3);
 	padding-left: var(--gap-2-5);
-	border-left: 5px solid var(--surface-400);
+	border-left: 4px solid var(--surface-400);
 }
 
 ul {

--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -1,26 +1,28 @@
 <template>
-	<div>
-		<aside>{{ !isEmpty(intervention.dynamicInterventions) ? 'Dynamic' : 'Static' }} intervention</aside>
-		<h6 class="pt-1 line-wrap">{{ intervention.name }}</h6>
-		<ul class="text-sm">
-			<li v-for="(staticIntervention, index) in intervention.staticInterventions" :key="`static-${index}`">
-				Set {{ staticIntervention.type }} <strong>{{ staticIntervention.appliedTo }}</strong> to
-				<strong>{{ staticIntervention.value }}</strong> starting at
-				<strong>{{
-					getTimePointString(staticIntervention.timestep, {
-						startDate: props.startDate,
-						calendarSettings: props.calendarSettings
-					})
-				}}</strong>
-			</li>
-			<li v-for="(dynamicIntervention, index) in intervention.dynamicInterventions" :key="`dynamic-${index}`">
-				Set {{ dynamicIntervention.type }} <strong>{{ dynamicIntervention.appliedTo }}</strong> to
-				<strong>{{ dynamicIntervention.value }}</strong> when
-				<strong>{{ dynamicIntervention.parameter }}</strong> crosses the threshold&nbsp;<strong
-					>{{ dynamicIntervention.threshold }} {{ getUnit(dynamicIntervention) }}</strong
-				>.
-			</li>
-		</ul>
+	<div class="intervention-card">
+		<div class="content">
+			<aside>{{ !isEmpty(intervention.dynamicInterventions) ? 'Dynamic' : 'Static' }} intervention</aside>
+			<h6 class="pt-1 line-wrap">{{ intervention.name }}</h6>
+			<ul class="text-sm">
+				<li v-for="(staticIntervention, index) in intervention.staticInterventions" :key="`static-${index}`">
+					Set {{ staticIntervention.type }} <strong>{{ staticIntervention.appliedTo }}</strong> to
+					<strong>{{ staticIntervention.value }}</strong> starting at
+					<strong>{{
+						getTimePointString(staticIntervention.timestep, {
+							startDate: props.startDate,
+							calendarSettings: props.calendarSettings
+						})
+					}}</strong>
+				</li>
+				<li v-for="(dynamicIntervention, index) in intervention.dynamicInterventions" :key="`dynamic-${index}`">
+					Set {{ dynamicIntervention.type }} <strong>{{ dynamicIntervention.appliedTo }}</strong> to
+					<strong>{{ dynamicIntervention.value }}</strong> when
+					<strong>{{ dynamicIntervention.parameter }}</strong> crosses the threshold&nbsp;<strong
+						>{{ dynamicIntervention.threshold }} {{ getUnit(dynamicIntervention) }}</strong
+					>.
+				</li>
+			</ul>
+		</div>
 	</div>
 </template>
 
@@ -49,12 +51,20 @@ function getUnit(dynamicIntervention: DynamicIntervention) {
 </script>
 
 <style scoped>
-div {
+.intervention-card {
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius-medium);
-	padding: var(--gap-2) var(--gap-3) var(--gap-3) var(--gap-3);
 	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
+	overflow: hidden;
+}
+
+.intervention-card .content {
+	padding-top: var(--gap-2);
+	padding-right: var(--gap-2);
+	padding-bottom: var(--gap-3);
+	padding-left: var(--gap-2-5);
+	border-left: 5px solid var(--surface-400);
 }
 
 ul {

--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -2,7 +2,7 @@
 	<div>
 		<aside>{{ !isEmpty(intervention.dynamicInterventions) ? 'Dynamic' : 'Static' }} intervention</aside>
 		<h6 class="pt-1 line-wrap">{{ intervention.name }}</h6>
-		<ul>
+		<ul class="text-sm">
 			<li v-for="(staticIntervention, index) in intervention.staticInterventions" :key="`static-${index}`">
 				Set {{ staticIntervention.type }} <strong>{{ staticIntervention.appliedTo }}</strong> to
 				<strong>{{ staticIntervention.value }}</strong> starting at
@@ -53,10 +53,8 @@ div {
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius-medium);
-	padding: var(--gap-2) var(--gap-3);
-	box-shadow:
-		0 2px 2px -1px rgba(0, 0, 0, 0.06),
-		0 2px 4px -1px rgba(0, 0, 0, 0.08);
+	padding: var(--gap-2) var(--gap-3) var(--gap-3) var(--gap-3);
+	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
 }
 
 ul {
@@ -72,5 +70,11 @@ aside {
 	color: var(--text-color-subdued);
 	font-size: var(--font-caption);
 	font-style: italic;
+}
+.line-wrap {
+	white-space: normal;
+	overflow-wrap: break-word;
+	word-break: break-word;
+	max-width: 100%;
 }
 </style>

--- a/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
+++ b/packages/client/hmi-client/src/components/intervention-policy/tera-intervention-summary-card.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<aside>{{ !isEmpty(intervention.dynamicInterventions) ? 'Dynamic' : 'Static' }}</aside>
-		<h5>{{ intervention.name }}</h5>
+		<aside>{{ !isEmpty(intervention.dynamicInterventions) ? 'Dynamic' : 'Static' }} intervention</aside>
+		<h6 class="pt-1 line-wrap">{{ intervention.name }}</h6>
 		<ul>
 			<li v-for="(staticIntervention, index) in intervention.staticInterventions" :key="`static-${index}`">
 				Set {{ staticIntervention.type }} <strong>{{ staticIntervention.appliedTo }}</strong> to
@@ -53,7 +53,7 @@ div {
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius-medium);
-	padding: var(--gap-4) var(--gap-5);
+	padding: var(--gap-2) var(--gap-3);
 	box-shadow:
 		0 2px 2px -1px rgba(0, 0, 0, 0.06),
 		0 2px 4px -1px rgba(0, 0, 0, 0.08);
@@ -61,7 +61,7 @@ div {
 
 ul {
 	list-style: none;
-	margin-top: var(--gap-2);
+	margin-top: var(--gap-1);
 }
 
 li + li {
@@ -71,6 +71,6 @@ li + li {
 aside {
 	color: var(--text-color-subdued);
 	font-size: var(--font-caption);
-	float: right;
+	font-style: italic;
 }
 </style>

--- a/packages/client/hmi-client/src/components/operator/tera-operator-model-preview.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-model-preview.vue
@@ -30,6 +30,12 @@ const handleChange = (event) => {
 </script>
 
 <style scoped>
+.container {
+	border: 1px solid var(--surface-border-light);
+	border-radius: var(--border-radius);
+	overflow: hidden;
+}
+
 .p-selectbutton {
 	width: 100%;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -24,6 +24,7 @@
 			severity="secondary"
 			outlined
 			:disabled="!isModelInputConnected"
+			class="mt-2"
 		/>
 	</section>
 </template>

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,8 +1,8 @@
 <template>
 	<section>
-		<div v-if="!isEmpty(node.state.transientModelConfig.id)" class="pb-3">
+		<div v-if="!isEmpty(node.state.transientModelConfig.id)" class="configuration-card">
 			<h6 class="pb-1 line-wrap">{{ node.state.transientModelConfig.name }}</h6>
-			<p>{{ node.state.transientModelConfig.description }}</p>
+			<p class="text-sm">{{ node.state.transientModelConfig.description }}</p>
 		</div>
 		<tera-operator-placeholder v-else :node="node" />
 
@@ -126,6 +126,14 @@ watch(
 );
 </script>
 <style scoped>
+.configuration-card {
+	background: var(--surface-section);
+	border: 1px solid var(--surface-border-light);
+	border-radius: var(--border-radius-medium);
+	padding: var(--gap-2) var(--gap-3) var(--gap-3) var(--gap-3);
+	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
+}
+
 .line-wrap {
 	white-space: normal;
 	overflow-wrap: break-word;

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -131,7 +131,7 @@ watch(
 .configuration-card {
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
-	border-radius: var(--border-radius-medium);
+	border-radius: var(--border-radius);
 	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
 	overflow: hidden;
 	margin-bottom: var(--gap-1);
@@ -142,7 +142,7 @@ watch(
 	padding-right: var(--gap-2);
 	padding-bottom: var(--gap-3);
 	padding-left: var(--gap-2-5);
-	border-left: 5px solid var(--primary-color);
+	border-left: 4px solid var(--primary-color);
 }
 
 .line-wrap {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -1,8 +1,10 @@
 <template>
 	<section>
 		<div v-if="!isEmpty(node.state.transientModelConfig.id)" class="configuration-card">
-			<h6 class="pb-1 line-wrap">{{ node.state.transientModelConfig.name }}</h6>
-			<p class="text-sm">{{ node.state.transientModelConfig.description }}</p>
+			<div class="content">
+				<h6 class="pb-1 line-wrap">{{ node.state.transientModelConfig.name }}</h6>
+				<p class="text-sm">{{ node.state.transientModelConfig.description }}</p>
+			</div>
 		</div>
 		<tera-operator-placeholder v-else :node="node" />
 
@@ -130,8 +132,17 @@ watch(
 	background: var(--surface-section);
 	border: 1px solid var(--surface-border-light);
 	border-radius: var(--border-radius-medium);
-	padding: var(--gap-2) var(--gap-3) var(--gap-3) var(--gap-3);
 	box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.08);
+	overflow: hidden;
+	margin-bottom: var(--gap-1);
+}
+
+.configuration-card .content {
+	padding-top: var(--gap-2);
+	padding-right: var(--gap-2);
+	padding-bottom: var(--gap-3);
+	padding-left: var(--gap-2-5);
+	border-left: 5px solid var(--primary-color);
 }
 
 .line-wrap {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-node.vue
@@ -1,6 +1,6 @@
 <template>
 	<section>
-		<tera-operator-model-preview v-if="model" :model="model" />
+		<tera-operator-model-preview v-if="model" :model="model" class="container" />
 		<tera-operator-placeholder v-else :node="node">
 			<template v-if="!node.inputs[0].value">Attach a model</template>
 		</tera-operator-placeholder>


### PR DESCRIPTION
## Subtle design tweaks for node previews

### Intervention node
**BEFORE**
<img width="602" alt="Monosnap Terarium 2024-12-12 11-00-46" src="https://github.com/user-attachments/assets/4889ada9-c0b4-4a1f-b421-87d9163865cf" />

**AFTER**
<img width="344" alt="Monosnap Terarium 2024-12-12 11-15-14" src="https://github.com/user-attachments/assets/fa0a0b83-a7e1-4b1d-ae31-36f2593e22f2" />

------------------------------------------------------------------------
### Configuration node
**BEFORE**
<img width="491" alt="Monosnap Terarium 2024-12-12 11-02-33" src="https://github.com/user-attachments/assets/a2e52bfb-4432-4eee-85a3-5a29c42d222a" />

**AFTER**
<img width="408" alt="Monosnap Terarium 2024-12-12 11-09-17" src="https://github.com/user-attachments/assets/be94f1db-e2a7-4068-9895-115e125f6e1a" />

------------------------------------------------------------------------
### Edit model && Create model from equations

**BEFORE**
<img width="493" alt="Monosnap Terarium 2024-12-12 11-04-36" src="https://github.com/user-attachments/assets/7c5c8dc3-305c-4bff-b094-2e4204b43cc4" />

**AFTER**
<img width="589" alt="Monosnap Terarium 2024-12-12 11-07-45" src="https://github.com/user-attachments/assets/5379155b-71a5-4287-b42a-79ca71946b4d" />
