### PR TITLE
Update LaTeX equation style guide to use "*" for multiplication

### DIFF
--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -11,7 +11,7 @@ LATEX_STYLE_GUIDE = """
 8) Avoid non-ASCII characters when possible
 9) Avoid using homoglyphs
 10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
-11) Do not use "\\cdot" or "*" to indicate multiplication. Use whitespace instead.
+11) Use "*" to denote multiplication between scalar quantities
 12) Replace "\\epsilon" with "\\varepsilon" when representing a parameter or variable
 13) If equations are separated by commas, do not include commas in the LaTeX code.
 """


### PR DESCRIPTION
# Description

* Only changed one rule in the style guide
* Use "*" instead of whitespace to denote multiplication (i.e. `a x + b` -> `a * x + b`)
* Necessary to avoid SymPy `parse_latex` edge cases like `a b (1 - g) I(t)` being interpreted as `a * b(t = 1 - g) * I(t)`  (where `b` is a function) instead of `a * b * (1 - g) * I(t)`

Resolves #5811 
