### PR TITLE
Improve re running compare model

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/model-comparison-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/model-comparison-operation.ts
@@ -11,6 +11,7 @@ export interface ModelComparisonOperationState extends BaseState {
 	comparisonPairs: string[][];
 	goal: string;
 	hasRun: boolean;
+	previousRunId?: string;
 }
 
 export const ModelComparisonOperation: Operation = {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -499,7 +499,7 @@ function updatePreviousRunId() {
 }
 
 function onClickCompare() {
-	// If they are no previous run ID, or the node has already run, update the previous run ID
+	// If there is no previous run ID, or the node has already run, update the previousRunId
 	if (!props.node.state.previousRunId || props.node.state.hasRun) {
 		updatePreviousRunId();
 	}
@@ -512,7 +512,6 @@ const processCompareModels = async () => {
 
 	// Add a unique ID to the request to avoid caching
 	if (!props.node.state.previousRunId) updatePreviousRunId();
-	console.log('RequestID: ', props.node.state.previousRunId);
 	const request = `
   		RequestID: ${props.node.state.previousRunId}
   		${goalQuery.value}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -27,7 +27,7 @@
 										icon="pi pi-sparkles"
 										size="small"
 										:loading="isProcessingComparison"
-										@click.stop="processCompareModels"
+										@click.stop="onClickCompare"
 									/>
 								</div>
 							</template>
@@ -492,10 +492,33 @@ function generateOverview(output: string) {
 	emit('update-status', OperatorStatus.DEFAULT); // This is a custom way of granting a default status to the operator, since it has no output
 }
 
+function updatePreviousRunId() {
+	const state = cloneDeep(props.node.state);
+	state.previousRunId = uuidv4();
+	emit('update-state', state);
+}
+
+function onClickCompare() {
+	// If they are no previous run ID, or the node has already run, update the previous run ID
+	if (!props.node.state.previousRunId || props.node.state.hasRun) {
+		updatePreviousRunId();
+	}
+	processCompareModels();
+}
+
 // Create a task to compare the models
 const processCompareModels = async () => {
 	isProcessingComparison.value = true;
-	const taskRes = await compareModels(modelIds.value, goalQuery.value, props.node.workflowId, props.node.id);
+
+	// Add a unique ID to the request to avoid caching
+	if (!props.node.state.previousRunId) updatePreviousRunId();
+	console.log('RequestID: ', props.node.state.previousRunId);
+	const request = `
+  		RequestID: ${props.node.state.previousRunId}
+  		${goalQuery.value}
+		`;
+
+	const taskRes = await compareModels(modelIds.value, request, props.node.workflowId, props.node.id);
 	compareModelsTaskId = taskRes.id;
 	if (taskRes.status === TaskStatus.Success) {
 		generateOverview(taskRes.output);

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison.vue
@@ -521,6 +521,10 @@ useClientEvent(ClientEventType.TaskGollmCompareModel, (event: ClientEvent<TaskRe
 });
 
 onMounted(async () => {
+	if (props.node.state.hasRun) {
+		processCompareModels();
+	}
+
 	if (!isEmpty(props.node.state.comparisonImageIds)) {
 		isLoadingStructuralComparisons.value = true;
 		structuralComparisons.value = await getImages(props.node.state.comparisonImageIds);
@@ -533,10 +537,7 @@ onMounted(async () => {
 	modelCardsToCompare.value = modelsToCompare.value.map(({ metadata }) => metadata?.gollmCard);
 	fields.value = [...new Set(modelCardsToCompare.value.flatMap((card) => (card ? Object.keys(card) : [])))];
 
-	await buildJupyterContext();
-	if (props.node.state.hasRun) {
-		processCompareModels();
-	}
+	buildJupyterContext();
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
# Description

* Move the rendering of the comparison cached version first onMounted as it is higher priority.
* Bust cache by adding a UUID to the goal query if the user wants a different comparison analysis.
* Keep cache version if the user hasn't requested a new analysis.
