### PR TITLE
Refactor and improve active chart settings panel and useChartSettings composable 

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -376,8 +376,7 @@
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
 						@delete-annotation="deleteAnnotation"
-						@update-settings-scale="updateChartSettingsScale(activeChartSettings?.id as string, $event)"
-						@update-settings-color="onColorChange"
+						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@close="activeChartSettings = null"
 					/>
 				</template>
@@ -760,8 +759,7 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	updateChartPrimaryColor,
-	updateChartSettingsScale
+	findAndUpdateChartSettingsById
 } = useChartSettings(props, emit);
 
 const {
@@ -1020,10 +1018,6 @@ const getConfiguredModelConfig = async () => {
 	if (configuredModelId) {
 		configuredModelConfig.value = await getModelConfigurationById(configuredModelId);
 	}
-};
-
-const onColorChange = (color: string) => {
-	if (activeChartSettings.value) updateChartPrimaryColor(activeChartSettings.value, color);
 };
 
 onMounted(async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -376,7 +376,7 @@
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
 						@delete-annotation="deleteAnnotation"
-						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
+						@update-settings="updateActiveChartSettings"
 						@close="setActiveChartSettings(null)"
 					/>
 				</template>
@@ -759,7 +759,7 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById,
+	updateActiveChartSettings,
 	setActiveChartSettings
 } = useChartSettings(props, emit);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -377,7 +377,7 @@
 						:generate-annotation="generateAnnotation"
 						@delete-annotation="deleteAnnotation"
 						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
-						@close="activeChartSettings = null"
+						@close="setActiveChartSettings(null)"
 					/>
 				</template>
 				<template #content>
@@ -388,7 +388,7 @@
 							:type="ChartSettingType.DISTRIBUTION_COMPARISON"
 							:select-options="Object.keys(pyciemssMap).filter((c) => modelPartTypesMap[c] === 'parameter')"
 							:selected-options="selectedParameterSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -399,7 +399,7 @@
 							:type="ChartSettingType.INTERVENTION"
 							:select-options="Object.keys(groupedInterventionOutputs)"
 							:selected-options="selectedInterventionSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -412,7 +412,7 @@
 								Object.keys(pyciemssMap).filter((c) => ['state', 'observable'].includes(modelPartTypesMap[c]))
 							"
 							:selected-options="selectedVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -427,7 +427,7 @@
 									.filter((c) => selectedOutputMapping.find((s) => s.modelVariable === c))
 							"
 							:selected-options="selectedErrorVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -442,7 +442,7 @@
 								)
 							"
 							:selected-options="comparisonChartsSettingsSelection"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="comparisonChartsSettingsSelection = $event"
 						/>
@@ -759,7 +759,8 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById
+	findAndUpdateChartSettingsById,
+	setActiveChartSettings
 } = useChartSettings(props, emit);
 
 const {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -264,7 +264,7 @@
 						"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
+						@update-settings="updateActiveChartSettings"
 						@delete-annotation="deleteAnnotation"
 						@close="setActiveChartSettings(null)"
 					/>
@@ -606,7 +606,7 @@ const {
 	selectedEnsembleVariableSettings,
 	selectedErrorVariableSettings,
 	updateEnsembleVariableSettingOption,
-	findAndUpdateChartSettingsById,
+	updateActiveChartSettings,
 	setActiveChartSettings
 } = useChartSettings(props, emit);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -266,7 +266,7 @@
 						:generate-annotation="generateAnnotation"
 						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
-						@close="activeChartSettings = null"
+						@close="setActiveChartSettings(null)"
 					/>
 				</template>
 				<template #content>
@@ -284,7 +284,7 @@
 							:type="ChartSettingType.VARIABLE_ENSEMBLE"
 							:select-options="ensembleVariables"
 							:selected-options="selectedEnsembleVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 							@toggle-ensemble-variable-setting-option="updateEnsembleVariableSettingOption"
@@ -296,7 +296,7 @@
 							:type="ChartSettingType.ERROR_DISTRIBUTION"
 							:select-options="ensembleVariables"
 							:selected-options="selectedErrorVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -606,7 +606,8 @@ const {
 	selectedEnsembleVariableSettings,
 	selectedErrorVariableSettings,
 	updateEnsembleVariableSettingOption,
-	findAndUpdateChartSettingsById
+	findAndUpdateChartSettingsById,
+	setActiveChartSettings
 } = useChartSettings(props, emit);
 
 const {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -262,10 +262,9 @@
 								? getChartAnnotationsByChartId(activeChartSettings?.id ?? '')
 								: undefined
 						"
-						@update-settings-color="onColorChange"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings-scale="updateChartSettingsScale(activeChartSettings?.id as string, $event)"
+						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
 						@close="activeChartSettings = null"
 					/>
@@ -607,8 +606,7 @@ const {
 	selectedEnsembleVariableSettings,
 	selectedErrorVariableSettings,
 	updateEnsembleVariableSettingOption,
-	updateChartSettingsScale,
-	updateChartPrimaryColor
+	findAndUpdateChartSettingsById
 } = useChartSettings(props, emit);
 
 const {
@@ -640,10 +638,6 @@ const ensembleVariableCharts = useEnsembleVariableCharts(selectedEnsembleVariabl
 const weightsDistributionCharts = useWeightsDistributionCharts();
 const { errorCharts, onExpandErrorChart } = useEnsembleErrorCharts(selectedErrorVariableSettings, errorData);
 // --------------------------------------------------------
-
-const onColorChange = (color: string) => {
-	if (activeChartSettings.value) updateChartPrimaryColor(activeChartSettings.value, color);
-};
 
 watch(
 	() => props.node.active,

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -336,7 +336,7 @@
 						:generate-annotation="generateAnnotation"
 						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
-						@close="activeChartSettings = null"
+						@close="setActiveChartSettings(null)"
 					/>
 				</template>
 				<template #content>
@@ -367,7 +367,7 @@
 							:type="ChartSettingType.INTERVENTION"
 							:select-options="_.keys(preProcessedInterventionsData)"
 							:selected-options="selectedInterventionSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -378,7 +378,7 @@
 							:type="ChartSettingType.VARIABLE"
 							:select-options="modelStateAndObsOptions.map((ele) => ele.label)"
 							:selected-options="selectedVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -389,7 +389,7 @@
 							:type="ChartSettingType.VARIABLE_COMPARISON"
 							:select-options="simulationChartOptions"
 							:selected-options="comparisonChartsSettingsSelection"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="comparisonChartsSettingsSelection = $event"
 						/>
@@ -994,7 +994,8 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById
+	findAndUpdateChartSettingsById,
+	setActiveChartSettings
 } = useChartSettings(props, emit);
 
 const {

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -332,10 +332,9 @@
 								? getChartAnnotationsByChartId(activeChartSettings?.id ?? '')
 								: undefined
 						"
-						@update-settings-color="onColorChange"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings-scale="updateChartSettingsScale(activeChartSettings?.id as string, $event)"
+						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
 						@close="activeChartSettings = null"
 					/>
@@ -995,8 +994,7 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	updateChartSettingsScale,
-	updateChartPrimaryColor
+	findAndUpdateChartSettingsById
 } = useChartSettings(props, emit);
 
 const {
@@ -1031,10 +1029,6 @@ const resetState = () => {
 			}
 		}
 	});
-};
-
-const onColorChange = (color: string) => {
-	if (activeChartSettings.value) updateChartPrimaryColor(activeChartSettings.value, color);
 };
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -334,7 +334,7 @@
 						"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
+						@update-settings="updateActiveChartSettings"
 						@delete-annotation="deleteAnnotation"
 						@close="setActiveChartSettings(null)"
 					/>
@@ -994,7 +994,7 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById,
+	updateActiveChartSettings,
 	setActiveChartSettings
 } = useChartSettings(props, emit);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -224,7 +224,7 @@
 						"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
+						@update-settings="updateActiveChartSettings"
 						@delete-annotation="deleteAnnotation"
 						@close="setActiveChartSettings(null)"
 					/>
@@ -529,7 +529,7 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById,
+	updateActiveChartSettings,
 	setActiveChartSettings
 } = useChartSettings(props, emit);
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -226,7 +226,7 @@
 						:generate-annotation="generateAnnotation"
 						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
-						@close="activeChartSettings = null"
+						@close="setActiveChartSettings(null)"
 					/>
 				</template>
 				<template #content>
@@ -237,7 +237,7 @@
 							:type="ChartSettingType.INTERVENTION"
 							:select-options="Object.keys(groupedInterventionOutputs)"
 							:selected-options="selectedInterventionSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -250,7 +250,7 @@
 								Object.keys(pyciemssMap).filter((c) => ['state', 'observable'].includes(modelPartTypesMap[c]))
 							"
 							:selected-options="selectedVariableSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -261,7 +261,7 @@
 							:type="ChartSettingType.VARIABLE_COMPARISON"
 							:select-options="Object.keys(pyciemssMap)"
 							:selected-options="comparisonChartsSettingsSelection"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="comparisonChartsSettingsSelection = $event"
 						/>
@@ -294,7 +294,7 @@
 								Object.keys(pyciemssMap).filter((c) => ['state', 'observable'].includes(modelPartTypesMap[c]))
 							"
 							:selected-options="selectedSensitivityChartSettings.map((s) => s.selectedVariables[0])"
-							@open="activeChartSettings = $event"
+							@open="setActiveChartSettings($event)"
 							@remove="removeChartSettings"
 							@selection-change="updateChartSettings"
 						/>
@@ -529,7 +529,8 @@ const {
 	removeChartSettings,
 	updateChartSettings,
 	addComparisonChartSettings,
-	findAndUpdateChartSettingsById
+	findAndUpdateChartSettingsById,
+	setActiveChartSettings
 } = useChartSettings(props, emit);
 
 const {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -224,8 +224,7 @@
 						"
 						:active-settings="activeChartSettings"
 						:generate-annotation="generateAnnotation"
-						@update-settings-scale="updateChartSettingsScale(activeChartSettings?.id as string, $event)"
-						@update-settings-color="onColorChange"
+						@update-settings="findAndUpdateChartSettingsById(activeChartSettings?.id as string, $event)"
 						@delete-annotation="deleteAnnotation"
 						@close="activeChartSettings = null"
 					/>
@@ -529,9 +528,8 @@ const {
 	comparisonChartsSettingsSelection,
 	removeChartSettings,
 	updateChartSettings,
-	updateChartSettingsScale,
 	addComparisonChartSettings,
-	updateChartPrimaryColor
+	findAndUpdateChartSettingsById
 } = useChartSettings(props, emit);
 
 const {
@@ -743,10 +741,6 @@ watch(
 	},
 	{ immediate: true }
 );
-
-const onColorChange = (color: string) => {
-	if (activeChartSettings.value) updateChartPrimaryColor(activeChartSettings.value, color);
-};
 
 onMounted(() => {
 	buildJupyterContext();

--- a/packages/client/hmi-client/src/composables/useChartSettings.ts
+++ b/packages/client/hmi-client/src/composables/useChartSettings.ts
@@ -117,8 +117,7 @@ export function useChartSettings(
 
 	return {
 		chartSettings,
-		activeChartSettings,
-		// activeChartSettings: computed(() => activeChartSettings.value),
+		activeChartSettings: computed(() => activeChartSettings.value),
 		comparisonChartsSettingsSelection,
 		selectedVariableSettings,
 		selectedEnsembleVariableSettings,

--- a/packages/client/hmi-client/src/composables/useChartSettings.ts
+++ b/packages/client/hmi-client/src/composables/useChartSettings.ts
@@ -115,6 +115,14 @@ export function useChartSettings(
 		}
 	};
 
+	/**
+	 * Update the active chart settings with a partial update.
+	 * @param update - The partial update to apply to the active chart settings.
+	 */
+	const updateActiveChartSettings = (update: Partial<ChartSetting>) => {
+		findAndUpdateChartSettingsById(activeChartSettings.value?.id ?? '', update);
+	};
+
 	return {
 		chartSettings,
 		activeChartSettings: computed(() => activeChartSettings.value),
@@ -127,6 +135,7 @@ export function useChartSettings(
 		selectedComparisonChartSettings,
 		selectedSensitivityChartSettings,
 		setActiveChartSettings,
+		updateActiveChartSettings,
 		removeChartSettings,
 		updateChartSettings,
 		addComparisonChartSettings,

--- a/packages/client/hmi-client/src/composables/useChartSettings.ts
+++ b/packages/client/hmi-client/src/composables/useChartSettings.ts
@@ -1,5 +1,5 @@
 import { cloneDeep } from 'lodash';
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { ChartSetting, ChartSettingEnsembleVariable, ChartSettingType } from '@/types/common';
 import {
 	addMultiVariableChartSetting,
@@ -53,6 +53,18 @@ export function useChartSettings(
 		chartSettings.value.filter((setting) => setting.type === ChartSettingType.SENSITIVITY)
 	);
 
+	watch(chartSettings, (settings) => {
+		// Update active chart settings
+		if (activeChartSettings.value) {
+			const updated = settings.find((setting) => setting.id === activeChartSettings.value?.id);
+			activeChartSettings.value = updated ?? null;
+		}
+	});
+
+	const setActiveChartSettings = (setting: ChartSetting | null) => {
+		activeChartSettings.value = setting;
+	};
+
 	// Methods to manage chart settings
 	const removeChartSettings = (chartId: string) => {
 		emit('update-state', {
@@ -66,20 +78,6 @@ export function useChartSettings(
 			...props.node.state,
 			chartSettings: updateChartSettingsBySelectedVariables(chartSettings.value, type, selectedVariables)
 		});
-	};
-
-	const updateChartSettingsScale = (id: string, useLog: boolean) => {
-		const state = cloneDeep(props.node.state);
-		if (state.chartSettings) {
-			const setting = state.chartSettings.find((settings) => settings.id === id);
-			if (setting) {
-				setting.scale = useLog === true ? 'log' : '';
-				if (activeChartSettings.value) {
-					activeChartSettings.value.scale = setting.scale;
-				}
-				emit('update-state', state);
-			}
-		}
 	};
 
 	const addComparisonChartSettings = () => {
@@ -101,22 +99,26 @@ export function useChartSettings(
 		});
 	};
 
-	const updateChartPrimaryColor = (settings: ChartSetting, color: string) => {
-		const index = chartSettings.value.findIndex((chart) => chart.id === settings.id);
-		if (index !== -1) {
-			const charts = cloneDeep(chartSettings.value);
-			charts[index].primaryColor = color;
-
-			emit('update-state', {
-				...props.node.state,
-				chartSettings: charts
-			});
+	/**
+	 * Find and update a chart setting by its id.
+	 * @param id - The id of the chart setting to update.
+	 * @param update - The partial update to apply to the chart setting.
+	 */
+	const findAndUpdateChartSettingsById = (id: string, update: Partial<ChartSetting>) => {
+		const state = cloneDeep(props.node.state);
+		if (state.chartSettings) {
+			const setting = state.chartSettings.find((settings) => settings.id === id);
+			if (setting) {
+				Object.assign(setting, update);
+				emit('update-state', state);
+			}
 		}
 	};
 
 	return {
 		chartSettings,
 		activeChartSettings,
+		// activeChartSettings: computed(() => activeChartSettings.value),
 		comparisonChartsSettingsSelection,
 		selectedVariableSettings,
 		selectedEnsembleVariableSettings,
@@ -125,11 +127,11 @@ export function useChartSettings(
 		selectedInterventionSettings,
 		selectedComparisonChartSettings,
 		selectedSensitivityChartSettings,
+		setActiveChartSettings,
 		removeChartSettings,
 		updateChartSettings,
-		updateChartPrimaryColor,
-		updateChartSettingsScale,
 		addComparisonChartSettings,
-		updateEnsembleVariableSettingOption
+		updateEnsembleVariableSettingOption,
+		findAndUpdateChartSettingsById
 	};
 }

--- a/packages/client/hmi-client/src/services/chart-settings.ts
+++ b/packages/client/hmi-client/src/services/chart-settings.ts
@@ -9,7 +9,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { b64DecodeUnicode } from '@/utils/binary';
 import { ChartAnnotation } from '@/types/Types';
-import { ForecastChartOptions } from './charts';
+import { CATEGORICAL_SCHEME, ForecastChartOptions } from './charts';
 
 export interface LLMGeneratedChartAnnotation {
 	request: string;
@@ -82,7 +82,8 @@ export function createNewChartSetting(
 		name,
 		selectedVariables,
 		type,
-		scale: ''
+		scale: '',
+		primaryColor: CATEGORICAL_SCHEME[0]
 	};
 	if (isChartSettingEnsembleVariable(setting)) Object.assign(setting, options);
 	return setting;


### PR DESCRIPTION
# Description

Some refactoring related to usChartSettings and active chart settings panel

- Expose `activeChartSettings` as computed property instead of ref to prevent direct modification from components
- `setActiveChartSettings` method to set or unset active chart settings
- `findAndUpdateChartSettingsById` method to find and update chart settings with partial payload instead of having own update method for each chart setting property. 
- Make sure `activeChartSettings` is reactive and updated properly when `chartSettings` update.
- Added default primary color to the new settings

Resolves #(issue)
