### PR TITLE
use gollm=>mira equation to amr pipeline

### DIFF
--- a/packages/client/hmi-client/src/temp/Equations.vue
+++ b/packages/client/hmi-client/src/temp/Equations.vue
@@ -64,7 +64,7 @@ const latex2amr = async () => {
 		resultAmr.value.innerHTML = 'processing...';
 	}
 
-	const resp = await API.post('/mira/latex-to-amr', equations);
+	const resp = await API.post('/knowledge/equations-to-model-debug', equations);
 	const respData = resp.data;
 
 	if (resultCode.value) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -302,22 +302,6 @@ public class KnowledgeController {
 				log.error("failed to convert LaTeX equations to AMR", e);
 				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to convert latex equations to AMR");
 			}
-			// final TaskRequest taskReq = new TaskRequest();
-			// final String latex = req.get("equations").toString();
-			// taskReq.setType(TaskType.MIRA);
-			// try {
-			// 	taskReq.setInput(latex.getBytes());
-			// 	taskReq.setScript(LatexToAMRResponseHandler.NAME);
-			// 	taskReq.setUserId(currentUserService.get().getId());
-			// 	final TaskResponse taskResp = taskService.runTaskSync(taskReq);
-			// 	final JsonNode taskResponseJSON = mapper.readValue(taskResp.getOutput(), JsonNode.class);
-
-			// 	final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
-			// 	responseAMR = mapper.convertValue(amrNode, Model.class);
-			// } catch (Exception e) {
-			// 	log.error("failed to convert LaTeX equations to AMR", e);
-			// 	throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to convert latex equations to AMR");
-			// }
 		} else {
 			try {
 				// Create a request for SKEMA with the cleaned-up equations.

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -887,6 +887,95 @@ public class KnowledgeController {
 		return ResponseEntity.accepted().build();
 	}
 
+	@PostMapping("/equations-to-model-debug")
+	@Secured(Roles.USER)
+	@Operation(summary = "Generate AMR from latex ODE equations, DEBUGGING only")
+	@ApiResponses(
+		value = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "Dispatched successfully",
+				content = @Content(
+					mediaType = "application/json",
+					schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = TaskResponse.class)
+				)
+			),
+			@ApiResponse(responseCode = "500", description = "There was an issue dispatching the request", content = @Content)
+		}
+	)
+	/**
+	 * This is similiar to /equations-to-model endpoint, but rather than
+	 * directly creating a model asset it returns artifact at different intersections
+	 * and handoff for debugging
+	 **/
+	public ResponseEntity<JsonNode> latexToAMR(@RequestBody final String latex) {
+		////////////////////////////////////////////////////////////////////////////////
+		// 1. Convert latex string to python sympy code string
+		//
+		// Note this is a gollm string => string task
+		////////////////////////////////////////////////////////////////////////////////
+		final TaskRequest latexToSympyRequest = new TaskRequest();
+		final TaskResponse latexToSympyResponse;
+		String code = null;
+
+		try {
+			latexToSympyRequest.setType(TaskType.GOLLM);
+			latexToSympyRequest.setInput(latex.getBytes());
+			latexToSympyRequest.setScript(LatexToSympyResponseHandler.NAME);
+			latexToSympyRequest.setUserId(currentUserService.get().getId());
+			latexToSympyResponse = taskService.runTaskSync(latexToSympyRequest);
+
+			final JsonNode node = mapper.readValue(latexToSympyResponse.getOutput(), JsonNode.class);
+			code = node.get("response").asText();
+		} catch (final TimeoutException e) {
+			log.warn("Timeout while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, messages.get("task.gollm.timeout"));
+		} catch (final InterruptedException e) {
+			log.warn("Interrupted while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.interrupted"));
+		} catch (final ExecutionException e) {
+			log.error("Error while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.execution-failure"));
+		} catch (final Exception e) {
+			log.error("Unexpected error", e);
+		}
+
+		if (code == null) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.execution-failure"));
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
+		// 2. Convert python sympy code string to amr
+		//
+		// This returns the AMR json, and intermediate data representations for debugging
+		////////////////////////////////////////////////////////////////////////////////
+		final TaskRequest sympyToAMRRequest = new TaskRequest();
+		final TaskResponse sympyToAMRResponse;
+		final JsonNode response;
+
+		try {
+			sympyToAMRRequest.setType(TaskType.MIRA);
+			sympyToAMRRequest.setInput(code.getBytes());
+			sympyToAMRRequest.setScript(SympyToAMRResponseHandler.NAME);
+			sympyToAMRRequest.setUserId(currentUserService.get().getId());
+			sympyToAMRResponse = taskService.runTaskSync(sympyToAMRRequest);
+			response = mapper.readValue(sympyToAMRResponse.getOutput(), JsonNode.class);
+			return ResponseEntity.ok().body(response);
+		} catch (final TimeoutException e) {
+			log.warn("Timeout while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, messages.get("task.mira.timeout"));
+		} catch (final InterruptedException e) {
+			log.warn("Interrupted while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.interrupted"));
+		} catch (final ExecutionException e) {
+			log.error("Error while waiting for task response", e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.execution-failure"));
+		} catch (final Exception e) {
+			log.error("Unexpected error", e);
+		}
+		throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("generic.io-error.read"));
+	}
+
 	private ResponseStatusException handleSkemaFeignException(final FeignException e) {
 		final HttpStatus statusCode = HttpStatus.resolve(e.status());
 		if (statusCode != null && statusCode.is4xxClientError()) {


### PR DESCRIPTION
# Summary
Replace `latex => sympy.parse_latex => mira` pipeline with `latex => gollm => mira` pipeline.
This is the 2nd part to: https://github.com/DARPA-ASKEM/terarium/pull/5846

This PR also clean up the mira-endpoint.
`/mira/latex-to-amr` => `/knowledge/equations-to-model-debug`


### Testing
POST `/knowledge/equations-to-model` should return a model-id, which in turn should reflect the equations.

```
{
  "equations": [
  "\\frac{d S(t)}{d t} = - b_q S(t) I(t)",
  "\\frac{d E(t)}{d t} = b_q S(t) I(t) - r_X E(t)",
  "\\frac{d I(t)}{d t} = r_X E(t) - g_p_q I(t)",
  "\\frac{d R(t)}{d t} = g_p_q I(t)"
   ]
}
```
