### PR TITLE
Minor poll updates

### DIFF
--- a/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
+++ b/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import Button from 'primevue/button';
 import { cancelCiemssJob } from '@/services/models/simulation-service';
 import { logger } from '@/utils/logger';
@@ -12,10 +12,14 @@ const props = defineProps<{
 	simulationRunId?: string | string[];
 }>();
 
-const disabled = computed(() => props.simulationRunId === '' || props.simulationRunId?.length === 0);
+const isCancelling = ref(false);
+const disabled = computed(
+	() => props.simulationRunId === '' || props.simulationRunId?.length === 0 || isCancelling.value
+);
 
 const cancelSimulation = async () => {
 	if (!props.simulationRunId) return;
+	isCancelling.value = true;
 	const cancelIds = Array.isArray(props.simulationRunId) ? props.simulationRunId : [props.simulationRunId];
 	cancelIds.forEach(async (id) => {
 		if (!id) return;

--- a/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
+++ b/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script setup lang="ts">
+import _ from 'lodash';
 import { computed, ref } from 'vue';
 import Button from 'primevue/button';
 import { cancelCiemssJob } from '@/services/models/simulation-service';
@@ -13,9 +14,7 @@ const props = defineProps<{
 }>();
 
 const isCancelling = ref(false);
-const disabled = computed(
-	() => props.simulationRunId === '' || props.simulationRunId?.length === 0 || isCancelling.value
-);
+const disabled = computed(() => _.isEmpty(props.simulationRunId) || isCancelling.value);
 
 const cancelSimulation = async () => {
 	if (!props.simulationRunId) return;

--- a/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
+++ b/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 	simulationRunId?: string | string[];
 }>();
 
-const disabled = computed(() => props.simulationRunId === '');
+const disabled = computed(() => props.simulationRunId === '' || props.simulationRunId?.length === 0);
 
 const cancelSimulation = async () => {
 	if (!props.simulationRunId) return;

--- a/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
+++ b/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
@@ -25,6 +25,7 @@ const cancelSimulation = async () => {
 		await cancelCiemssJob(id);
 		logger.success(`Simulation ${id} has been cancelled.`);
 	});
+	isCancelling.value = false;
 };
 </script>
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -201,11 +201,14 @@ const pollResult = async (runId: string) => {
 		state.inProgressBaseForecastId = '';
 		poller.stop();
 	} else if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
+		state.inProgressForecastId = '';
+		state.inProgressBaseForecastId = '';
 		// throw if there are any failed runs for now
 		logger.error(`Simulate: ${runId} has failed`, {
 			toastTitle: 'Error - Pyciemss'
 		});
 	}
+	emit('update-state', state);
 	return pollerResults;
 };
 


### PR DESCRIPTION
# Description
This addresses a few minor things
- [X] Simulation polling updates did not include the `update-state` required when polling status is cancelled.
- [X] If simulation fails grab the error message
- [X] Simulation provides a list of Ids to `pyciemss-cancel-button`. We should include this check for our disable logic.
- [X] Add `isCancelling` flag to prevent user from double clicking cancel.