### PR TITLE
Fix: Calibrate always showing 1%

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -183,7 +183,7 @@ const pollResult = async (runId: string) => {
 				updateLossChartSpec(lossValues);
 			}
 			if (runId === props.node.state.inProgressCalibrationId && data.updates.length > 0) {
-				const checkpoint = _.first(data.updates);
+				const checkpoint = _.last(data.updates);
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
 					state.currentProgress = +((100 * checkpoint.data.progress) / state.numIterations).toFixed(2);


### PR DESCRIPTION
# Description
We are manually sorting the progress coming and then taking the first each time.
Resulting in the first progress % being the only % we see the entire run:

![image](https://github.com/user-attachments/assets/4bced52a-79c2-4879-b46f-34d489d1723a)
