### PR TITLE
Open calibrate loss tab on run

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -836,8 +836,8 @@ const initDefaultChartSettings = (state: CalibrationOperationStateCiemss) => {
 	);
 };
 
-const updateLossTab = (activeTab: number | null) => {
-	lossActiveIndex.value = activeTab;
+const updateLossTab = (activeTab: number | undefined) => {
+	lossActiveIndex.value = activeTab ?? null;
 };
 
 const runCalibrate = async () => {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -252,7 +252,7 @@
 					class="p-3"
 					:summary-id="node.state.summaryId"
 				/>
-				<Accordion :active-index="lossActiveIndex" class="px-2">
+				<Accordion :active-index="lossActiveIndex" @update:active-index="updateLossTab" class="px-2">
 					<AccordionTab header="Loss">
 						<!-- Loss chart -->
 						<div ref="lossChartContainer">
@@ -616,7 +616,7 @@ const datasetColumns = ref<DatasetColumn[]>();
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 
-const lossActiveIndex = ref(0);
+const lossActiveIndex = ref<number | null>(0);
 const currentActiveIndicies = ref([0, 1, 2, 3, 4]);
 
 const modelConfig = ref<ModelConfiguration | null>(null);
@@ -836,7 +836,12 @@ const initDefaultChartSettings = (state: CalibrationOperationStateCiemss) => {
 	);
 };
 
+const updateLossTab = (activeTab: number | null) => {
+	lossActiveIndex.value = activeTab;
+};
+
 const runCalibrate = async () => {
+	lossActiveIndex.value = 0; // ensure loss tab open on run
 	if (!modelConfigId.value || !datasetId.value || !currentDatasetFileName.value) return;
 
 	const formattedMap: { [index: string]: string } = {};

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -616,7 +616,7 @@ const datasetColumns = ref<DatasetColumn[]>();
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 
-const lossActiveIndex = ref([0]);
+const lossActiveIndex = ref(0);
 const currentActiveIndicies = ref([0, 1, 2, 3, 4]);
 
 const modelConfig = ref<ModelConfiguration | null>(null);


### PR DESCRIPTION
# Description
When we run we should ensure that the loss chart is open
Not only is it weird to have it stay closed as then we have nothing to look at, but it has also caused confusion to user