### PR TITLE
get all csv rows of result_summary and not sample data for compare dataset

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
@@ -329,8 +329,11 @@ function findDuplicates(strings: string[]): string[] {
 async function generateChartData() {
 	if (datasets.value.length <= 1) return;
 
-	const rawContents = await Promise.all(datasets.value.map((dataset) => getRawContent(dataset)));
+	const rawContents = await Promise.all(datasets.value.map((dataset) => getRawContent(dataset, 162)));
 	const transposedRawContents = rawContents.map((content) => ({ ...content, csv: transposeArrays(content?.csv) }));
+
+	console.log(datasets.value);
+	console.log(rawContents);
 
 	// Collect common header names if not done yet
 	if (isEmpty(commonHeaderNames.value)) {

--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
@@ -329,11 +329,17 @@ function findDuplicates(strings: string[]): string[] {
 async function generateChartData() {
 	if (datasets.value.length <= 1) return;
 
-	const rawContents = await Promise.all(datasets.value.map((dataset) => getRawContent(dataset, 162)));
-	const transposedRawContents = rawContents.map((content) => ({ ...content, csv: transposeArrays(content?.csv) }));
+	const rawContents = await Promise.all(
+		datasets.value.map((dataset) => {
+			// Compare the summaries so find its csv file like this
+			let summaryIndex = dataset?.fileNames?.findIndex((name) => name === 'result_summary.csv');
+			// If the summary isn't found, use the first file (it could be the first one if you downloaded the summary csv)
+			if (!summaryIndex || summaryIndex === -1) summaryIndex = 0;
+			return getRawContent(dataset, -1, summaryIndex); // Setting the csv row limit to -1 to get all rows
+		})
+	);
 
-	console.log(datasets.value);
-	console.log(rawContents);
+	const transposedRawContents = rawContents.map((content) => ({ ...content, csv: transposeArrays(content?.csv) }));
 
 	// Collect common header names if not done yet
 	if (isEmpty(commonHeaderNames.value)) {

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -305,7 +305,8 @@ export function useCharts(
 							height: chartSize.value.height,
 							xAxisTitle: getUnit('_time') || 'Time',
 							yAxisTitle: capitalize(selectedPlotType.value),
-							scale: settings.scale
+							scale: settings.scale,
+							legendProperties: { direction: 'vertical', columns: 3 }
 						}
 					),
 					annotations

--- a/packages/client/hmi-client/src/services/dataset.ts
+++ b/packages/client/hmi-client/src/services/dataset.ts
@@ -239,12 +239,12 @@ async function createDatasetFromSimulationResult(
 	projectId: string,
 	simulationId: string,
 	datasetName: string | null,
-	addtoProject?: boolean
+	addToProject?: boolean
 ): Promise<Dataset | null> {
-	if (addtoProject === undefined) addtoProject = true;
+	if (addToProject === undefined) addToProject = true;
 	try {
 		const response: AxiosResponse<Dataset> = await API.post(
-			`/simulations/${simulationId}/create-result-as-dataset/${projectId}?dataset-name=${datasetName}&add-to-project=${addtoProject}`
+			`/simulations/${simulationId}/create-result-as-dataset/${projectId}?dataset-name=${datasetName}&add-to-project=${addToProject}`
 		);
 		return response.data as Dataset;
 	} catch (error) {
@@ -348,17 +348,21 @@ const getCsvColumnStats = (csvColumn: number[]): CsvColumnStats => {
 	return { bins, minValue, maxValue, mean, median, sd };
 };
 
-async function getRawContent(dataset: Dataset, limit: number = 100): Promise<CsvAsset | null> {
+async function getRawContent(
+	dataset: Dataset,
+	limit: number = 100,
+	fileNameIndex: number = 0
+): Promise<CsvAsset | null> {
 	// If it's an ESGF dataset or a NetCDF file, we don't want to download the raw content
 	if (!dataset?.id || dataset.esgfId || dataset.metadata?.format === 'netcdf') return null;
 	// We are assuming here there is only a single csv file.
 	if (
 		dataset.fileNames &&
 		!isEmpty(dataset.fileNames) &&
-		!isEmpty(dataset.fileNames[0]) &&
-		dataset.fileNames[0].endsWith('.csv')
+		!isEmpty(dataset.fileNames[fileNameIndex]) &&
+		dataset.fileNames[fileNameIndex].endsWith('.csv')
 	) {
-		const response = await downloadRawFile(dataset.id, dataset.fileNames[0], limit);
+		const response = await downloadRawFile(dataset.id, dataset.fileNames[fileNameIndex], limit);
 		return response;
 	}
 	return null;

--- a/packages/client/hmi-client/src/services/dataset.ts
+++ b/packages/client/hmi-client/src/services/dataset.ts
@@ -104,6 +104,7 @@ async function getBulkDatasets(datasetIDs: string[]) {
  */
 async function downloadRawFile(datasetId: string, filename: string, limit: number = 100): Promise<CsvAsset | null> {
 	const URL = `/datasets/${datasetId}/download-csv?filename=${filename}&limit=${limit}`;
+	console.log('URL', URL);
 	const response = await API.get(URL).catch((error) => {
 		logger.error(`Error: data-service was not able to retrieve the dataset's rawfile ${error}`);
 	});
@@ -347,7 +348,7 @@ const getCsvColumnStats = (csvColumn: number[]): CsvColumnStats => {
 	return { bins, minValue, maxValue, mean, median, sd };
 };
 
-async function getRawContent(dataset: Dataset) {
+async function getRawContent(dataset: Dataset, limit: number = 100): Promise<CsvAsset | null> {
 	// If it's an ESGF dataset or a NetCDF file, we don't want to download the raw content
 	if (!dataset?.id || dataset.esgfId || dataset.metadata?.format === 'netcdf') return null;
 	// We are assuming here there is only a single csv file.
@@ -357,7 +358,7 @@ async function getRawContent(dataset: Dataset) {
 		!isEmpty(dataset.fileNames[0]) &&
 		dataset.fileNames[0].endsWith('.csv')
 	) {
-		const response = await downloadRawFile(dataset.id, dataset.fileNames[0]);
+		const response = await downloadRawFile(dataset.id, dataset.fileNames[0], limit);
 		return response;
 	}
 	return null;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -271,7 +271,7 @@ public class DatasetController {
 		@RequestParam("filename") final String filename,
 		@RequestParam(name = "limit", defaultValue = "" + DEFAULT_CSV_LIMIT, required = false) final Integer limit
 	) {
-		CSVParser csvParser;
+		final CSVParser csvParser;
 		try {
 			csvParser = datasetService.getCSVFileParser(filename, datasetId);
 			if (csvParser == null) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -289,15 +289,6 @@ public class DatasetController {
 			);
 		}
 
-		// Count the number of rows in the CSV file
-		// int totalRowCount = 0;
-		// for (CSVRecord record : csvParser.getRecords()) {
-		// 		System.out.println("Total row count: " + totalRowCount);
-		// 		totalRowCount++;
-		// }
-
-		// System.out.println("Total row count: " + csvParser.getRecords().size());
-
 		// We have a parser over our CSV file. Now for the front end we need to create a matrix of strings
 		// to represent the CSV file up to our limit. Then we need to calculate the column statistics.
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -271,7 +271,7 @@ public class DatasetController {
 		@RequestParam("filename") final String filename,
 		@RequestParam(name = "limit", defaultValue = "" + DEFAULT_CSV_LIMIT, required = false) final Integer limit
 	) {
-		final CSVParser csvParser;
+		CSVParser csvParser;
 		try {
 			csvParser = datasetService.getCSVFileParser(filename, datasetId);
 			if (csvParser == null) {
@@ -288,6 +288,15 @@ public class DatasetController {
 				messages.get("postgres.service-unavailable")
 			);
 		}
+
+		// Count the number of rows in the CSV file
+		// int totalRowCount = 0;
+		// for (CSVRecord record : csvParser.getRecords()) {
+		// 		System.out.println("Total row count: " + totalRowCount);
+		// 		totalRowCount++;
+		// }
+
+		// System.out.println("Total row count: " + csvParser.getRecords().size());
 
 		// We have a parser over our CSV file. Now for the front end we need to create a matrix of strings
 		// to represent the CSV file up to our limit. Then we need to calculate the column statistics.


### PR DESCRIPTION
# Description

* the result_summary is read in the compare dataset instead of the beginning of the sample results
* Improved dataset downloading
<img width="862" alt="Screenshot 2024-12-17 at 1 19 17 AM" src="https://github.com/user-attachments/assets/d52b227a-9097-4b9c-9809-284f9c1957a9" />

