### PR TITLE
Update latex_style_guide.py to accommodate overzealous LaTeX spellchecker

### DIFF
--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -3,7 +3,7 @@ LATEX_STYLE_GUIDE = """
     a) Derivatives that are written in other notations, like Newton ("\dot{X}") or Lagrange ("X^\prime" or "X'"), should be converted to Leibniz notation
     b) Partial derivatives of one-variable functions (for example, "\\partial_t X" or "\\frac{\partial X}{\partial t}") should be rewritten as ordinary derivatives ("\\frac{d X}{d t}")
 2) First-order derivative must be on the left of the equal sign
-3) All variables have time "t" dependence should be explicitly with "(t)" (for example, "X" should be written as "X(t)")
+3) All variables that have time "t" dependence should be written with an explicit "(t)" (for example, "X" should be written as "X(t)")
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{...}"
 6) Avoid parentheses
@@ -11,7 +11,7 @@ LATEX_STYLE_GUIDE = """
 8) Avoid non-ASCII characters when possible
 9) Avoid using homoglyphs
 10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
-11) Use "*" to denote multiplication between scalar quantities
+11) Use " * " to denote multiplication between scalar quantities
 12) Replace "\\epsilon" with "\\varepsilon" when representing a parameter or variable
 13) If equations are separated by commas, do not include commas in the LaTeX code.
 """


### PR DESCRIPTION
Minor change to ensure that the multiplication `*` is bracketed by whitespace (` * `). This would avoid the LaTeX spellchecker in Terarium from putting red underlines in expressions like `a*b` (as opposed to `a * b`).
