### PR TITLE
Add default initials and parameter values to model returned by MIRA

### DIFF
--- a/packages/mira/tasks/sympy_to_amr.py
+++ b/packages/mira/tasks/sympy_to_amr.py
@@ -7,6 +7,9 @@ from taskrunner import TaskRunnerInterface
 from mira.sources.sympy_ode import template_model_from_sympy_odes
 from mira.modeling.amr.petrinet import template_model_to_petrinet_json
 
+from mira.metamodel.template_model import Initial, Parameter
+from mira.metamodel.utils import safe_parse_expr
+
 def cleanup():
     pass
 
@@ -31,6 +34,16 @@ def main():
         # SymPy to MMT
         mmt = template_model_from_sympy_odes(globals["equation_output"])
 
+        # Set default values for the model parameters
+        for p, param in mmt.parameters.items():
+            mmt.parameters[p].value = 0.0
+
+        # Initialize the model
+        mmt.initials = mmt.initials | {c: Initial(concept = concept, expression = safe_parse_expr(f'{c}0')) for c, concept in mmt.get_concepts_name_map().items()}
+
+        # Set default values for the initial condition parameters
+        mmt.parameters = mmt.parameters | {f'{c}0': Parameter(name = f'{c}0', display_name = f'{c}0', description = f'Initial condition of state variable {c}', value = 0.0) for c in mmt.get_concepts_name_map().keys()}
+        
         # MMT to AMR
         amr_json = template_model_to_petrinet_json(mmt)
 
@@ -42,6 +55,7 @@ def main():
 
         taskrunner.log(f"Sympy to AMR conversion succeeded")
         taskrunner.write_output_dict_with_timeout({"response": response })
+        
     except Exception as e:
         sys.stderr.write(f"Error: {str(e)}\n")
         sys.stderr.write(traceback.format_exc())


### PR DESCRIPTION
# Description

* Update sympy_to_amr.py 
* Added definition of initials missing in MMT model returned by MIRA
* Set default values to model parameters
* Allows users to not have run a "Edit model" before configuring the model
