### PR TITLE
Calibrated Configs failing createAMRFromConfiguration

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
@@ -207,9 +207,12 @@ public class ModelConfigurationService
 	}
 
 	public static Model createAMRFromConfiguration(final Model model, final ModelConfiguration modelConfiguration) {
-		setModelParameters(model.getParameters(), modelConfiguration.getParameterSemanticList());
-		setModelInitials(model.getInitials(), modelConfiguration.getInitialSemanticList());
-		setModelObservables(model.getObservables(), modelConfiguration.getObservableSemanticList());
+		// Do not bother setting when we have simulationId as we will use that calibration's inferred parameters.
+		if (modelConfiguration.getSimulationId() == null) {
+			setModelParameters(model.getParameters(), modelConfiguration.getParameterSemanticList());
+			setModelInitials(model.getInitials(), modelConfiguration.getInitialSemanticList());
+			setModelObservables(model.getObservables(), modelConfiguration.getObservableSemanticList());
+		}
 		return model.clone();
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
@@ -210,9 +210,9 @@ public class ModelConfigurationService
 		// Do not bother setting when we have simulationId as we will use that calibration's inferred parameters.
 		if (modelConfiguration.getSimulationId() == null) {
 			setModelParameters(model.getParameters(), modelConfiguration.getParameterSemanticList());
-			setModelInitials(model.getInitials(), modelConfiguration.getInitialSemanticList());
-			setModelObservables(model.getObservables(), modelConfiguration.getObservableSemanticList());
 		}
+		setModelInitials(model.getInitials(), modelConfiguration.getInitialSemanticList());
+		setModelObservables(model.getObservables(), modelConfiguration.getObservableSemanticList());
 		return model.clone();
 	}
 


### PR DESCRIPTION
# Description
When we have a calibrated model configuration we do not necessarily have `matchingConfigParameter.getDistribution().getParameters().value()` which is referenced in `setModelParameters`.
Rather than trying to set the resulting AMR's parameter value just to not use it (as we will use the inferred parameter's value) lets just not try to set it.

# Testing:
Add both this model + model configuration your project.
Try to utilize the model configuration with any operation that relies on /model-configurations/as-configured-model/{id}
or directly hit this endpoint.
Prior to this change you will run into a  `503 - Service Unavailable`

[Model With Date.json](https://github.com/user-attachments/files/18199183/Model.With.Date.json)
[Calibrated Config With Date.json](https://github.com/user-attachments/files/18199184/Calibrated.Config.With.Date.json)



