### PR TITLE
Calibrate ensemble minor UI tweaks for user

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -71,6 +71,7 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 	imageUrl: calibrateEnsembleCiemss,
 	inputs: [
 		{ type: 'datasetId', label: 'Dataset' },
+		{ type: 'modelConfigId', label: 'Model configuration' },
 		{ type: 'modelConfigId', label: 'Model configuration' }
 	],
 	outputs: [{ type: 'datasetId' }],

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -428,7 +428,7 @@ const areNodeInputsFilled = computed(() => datasetId.value && allModelConfigurat
 const isRunDisabled = computed(() => !isMappingfilled.value || !areNodeInputsFilled.value);
 
 const mappingFilledTooltip = computed(() =>
-	!isMappingfilled.value ? 'Must contain a Timestep column and at least one mapping. \n' : ''
+	!isMappingfilled.value ? 'Must contain a Timestamp column and at least one mapping. \n' : ''
 );
 const nodeInputsFilledTooltip = computed(() =>
 	!areNodeInputsFilled.value ? 'Must contain one dataset and at least two model configurations.\n' : ''

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -15,13 +15,15 @@
 				<template #header>
 					<div class="flex gap-2 ml-auto">
 						<tera-pyciemss-cancel-button :simulation-run-id="cancelRunId" />
-						<Button
-							:disabled="isRunDisabled"
-							label="Run"
-							icon="pi pi-play"
-							@click="runEnsemble"
-							:loading="!!inProgressCalibrationId || !!inProgressForecastId"
-						/>
+						<div v-tooltip="runButtonMessage">
+							<Button
+								:disabled="isRunDisabled"
+								label="Run"
+								icon="pi pi-play"
+								@click="runEnsemble"
+								:loading="!!inProgressCalibrationId || !!inProgressForecastId"
+							/>
+						</div>
 					</div>
 				</template>
 				<template #content>
@@ -414,9 +416,28 @@ const currentActiveIndicies = ref([0, 1, 2]);
 
 const isSidebarOpen = ref(true);
 const selectedOutputId = ref<string>();
-const isRunDisabled = computed(
-	() => !knobs.value.ensembleMapping[0] || !datasetId.value || allModelConfigurations.value.length < 2
+
+// Checks for disabling run button:
+const isMappingfilled = computed(
+	() =>
+		knobs.value.ensembleMapping.length !== 0 && knobs.value.ensembleMapping[0].newName && knobs.value.timestampColName
 );
+
+const areNodeInputsFilled = computed(() => datasetId.value && allModelConfigurations.value.length >= 2);
+
+const isRunDisabled = computed(() => !isMappingfilled.value || !areNodeInputsFilled.value);
+
+const mappingFilledTooltip = computed(() =>
+	!isMappingfilled.value ? 'Must contain a Timestep column and at least one mapping. \n' : ''
+);
+const nodeInputsFilledTooltip = computed(() =>
+	!areNodeInputsFilled.value ? 'Must contain one dataset and at least two model configurations.\n' : ''
+);
+
+const runButtonMessage = computed(() =>
+	isRunDisabled.value ? `${mappingFilledTooltip.value} ${nodeInputsFilledTooltip.value}` : ''
+);
+
 const cancelRunId = computed(
 	() =>
 		props.node.state.inProgressForecastId ||

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -64,7 +64,9 @@ const runResults = ref<RunResults>({});
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
 const areInputsFilled = computed(
-	() => props.node.inputs[0].value && props.node.inputs[1].value && props.node.inputs[2].value
+	() =>
+		props.node.inputs[0].value &&
+		props.node.inputs.filter((ele) => ele.type === 'modelConfigId' && ele.value).length >= 2
 );
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 const inProgressForecastId = computed(() => props.node.state.inProgressForecastId);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -16,7 +16,7 @@
 
 		<Button v-if="areInputsFilled" label="Edit" @click="emit('open-drilldown')" severity="secondary" outlined />
 		<tera-operator-placeholder v-else :node="node">
-			Connect a model configuration and dataset
+			Connect at least two model configurations and dataset
 		</tera-operator-placeholder>
 	</main>
 </template>
@@ -63,7 +63,9 @@ const emit = defineEmits(['open-drilldown', 'update-state', 'append-output', 'ap
 const runResults = ref<RunResults>({});
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
-const areInputsFilled = computed(() => props.node.inputs[0].value && props.node.inputs[1].value);
+const areInputsFilled = computed(
+	() => props.node.inputs[0].value && props.node.inputs[1].value && props.node.inputs[2].value
+);
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 const inProgressForecastId = computed(() => props.node.state.inProgressForecastId);
 const lossValues = ref<{ [key: string]: number }[]>([]);


### PR DESCRIPTION
# Description
- [x] Calibrate ensemble has a few conditions as to why the run button can be disabled.
This can lead to user confusion if theyre not familiar with the operator.
We should include tooltips similar to how we have done in the optimize-drilldown to help guide the user.

- [x] could the node just have 2 connections for model configurations on creation? Right now it just shows one and doesn't show the 2nd until the 1st is added. That doesn't really suggest that the 2nd is required

# Screenshots:
New node:
<img width="125" alt="image" src="https://github.com/user-attachments/assets/86db82fe-637f-48c3-8875-3b7d7320c020" />

<img width="984" alt="image" src="https://github.com/user-attachments/assets/3141e98d-ab82-4d69-8570-0c7e2f8bb5af" />
