### PR TITLE
fix for dropdown not working

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -502,6 +502,16 @@ watch(
 	},
 	{ deep: true }
 );
+
+watch(
+	() => props.node.state?.forecastId,
+	async () => {
+		if (!props.node.state?.forecastId) return;
+
+		const response = await getRunResultCiemss(props.node.state?.forecastId, 'result.csv');
+		runResults.value = response.runResults;
+	}
+);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-simulate-chart.vue
@@ -161,7 +161,7 @@ const CHART_OPTIONS = {
 };
 
 // data for rendering ui
-let stateVariablesList: string[] = [];
+const stateVariablesList = ref<string[]>([]);
 const chartData = ref({});
 
 const selectedVariable = ref<string[]>(props.chartConfig.selectedVariable);
@@ -219,8 +219,8 @@ const watchRunResults = async (runResults) => {
 
 	// assume that the state variables for all runs will be identical
 	// take first run and parse it for state variables
-	if (!stateVariablesList.length) {
-		stateVariablesList = Object.keys(renderedRuns.value[Object.keys(renderedRuns.value)[0]][0]).filter(
+	if (!stateVariablesList.value.length) {
+		stateVariablesList.value = Object.keys(renderedRuns.value[Object.keys(renderedRuns.value)[0]][0]).filter(
 			(key) => key !== 'timestamp'
 		);
 	}


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/41973373-ca8c-4665-bdab-c19cb02c3a67)

Issue:
- Simulate Ensemble Chart dropdown options do not appear without reloading the drill down

Testing
- add 2 model to a workflow
- create 2 model configs
- create a new simulate ensemble 
- add a chart
- dropdown options should appear
 
Resolves #(issue)
