### PR TITLE
Pyciemss defaults

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -579,7 +579,11 @@ const knobs = ref<BasicKnobs>({
 });
 
 const presetType = computed(() => {
-	if (knobs.value.numSamples === speedPreset.numSamples && knobs.value.method === speedPreset.method) {
+	if (
+		knobs.value.numSamples === speedPreset.numSamples &&
+		knobs.value.method === speedPreset.method &&
+		knobs.value.stepSize === speedPreset.stepSize
+	) {
 		return CiemssPresetTypes.Fast;
 	}
 	if (knobs.value.numSamples === qualityPreset.numSamples && knobs.value.method === qualityPreset.method) {

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -163,7 +163,11 @@
 								</div>
 								<div class="label-and-input">
 									<label for="num-steps">Solver step size</label>
-									<tera-input-number inputId="integeronly" v-model="knobs.stepSize" />
+									<tera-input-number
+										:disabled="knobs.method !== CiemssMethodOptions.euler"
+										:min="0"
+										v-model="knobs.stepSize"
+									/>
 								</div>
 							</div>
 							<div class="spacer m-4" />
@@ -594,7 +598,8 @@ const speedPreset = Object.freeze({
 	numSamples: 1,
 	method: CiemssMethodOptions.euler,
 	numIterations: 10,
-	learningRate: 0.1
+	learningRate: 0.1,
+	stepSize: 0.1
 });
 
 const qualityPreset = Object.freeze({
@@ -681,6 +686,7 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 		knobs.value.method = speedPreset.method;
 		knobs.value.numIterations = speedPreset.numIterations;
 		knobs.value.learningRate = speedPreset.learningRate;
+		knobs.value.stepSize = speedPreset.stepSize;
 	}
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-ciemss-operation.ts
@@ -1,5 +1,5 @@
 import { CiemssMethodOptions } from '@/services/models/simulation-service';
-import { ChartSetting, CiemssPresetTypes } from '@/types/common';
+import { ChartSetting } from '@/types/common';
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import calibrateEnsembleCiemss from '@assets/svg/operator-images/calibrate-ensemble-probabilistic.svg';
 
@@ -9,7 +9,8 @@ export const speedPreset = Object.freeze({
 	numSamples: 1,
 	method: CiemssMethodOptions.euler,
 	numIterations: 10,
-	learningRate: 0.1
+	learningRate: 0.1,
+	stepSize: 0.1
 });
 
 export const qualityPreset = Object.freeze({
@@ -20,7 +21,6 @@ export const qualityPreset = Object.freeze({
 });
 export interface EnsembleCalibrateExtraCiemss {
 	numParticles: number; // The number of particles to use for the inference algorithm. https://github.com/ciemss/pyciemss/blob/1fc62b0d4b0870ca992514ad7a9b7a09a175ce44/pyciemss/interfaces.py#L225
-	presetType: CiemssPresetTypes;
 	solverMethod: CiemssMethodOptions;
 	numIterations: number;
 	endTime: number;
@@ -90,7 +90,6 @@ export const CalibrateEnsembleCiemssOperation: Operation = {
 				solverMethod: speedPreset.method,
 				numParticles: speedPreset.numSamples,
 				numIterations: speedPreset.numIterations,
-				presetType: CiemssPresetTypes.Fast,
 				endTime: 100,
 				stepSize: 1,
 				learningRate: speedPreset.learningRate

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -154,7 +154,11 @@
 									</div>
 									<div class="label-and-input">
 										<label for="num-steps">Solver step size</label>
-										<tera-input-number v-model="knobs.extra.stepSize" />
+										<tera-input-number
+											:disabled="knobs.extra.solverMethod !== CiemssMethodOptions.euler"
+											:min="0"
+											v-model="knobs.extra.stepSize"
+										/>
 									</div>
 								</div>
 								<div class="spacer m-3" />

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -124,7 +124,7 @@
 								<label> Preset </label>
 								<Dropdown
 									class="flex-1"
-									v-model="knobs.extra.presetType"
+									v-model="presetType"
 									placeholder="Select an option"
 									:options="[CiemssPresetTypes.Fast, CiemssPresetTypes.Normal]"
 									@update:model-value="setPresetValues"
@@ -509,6 +509,27 @@ const messageHandler = (event: ClientEvent<any>) => {
 	lossChartRef.value.view.change(LOSS_CHART_DATA_SOURCE, vega.changeset().insert(data)).resize().run();
 };
 
+const presetType = computed(() => {
+	if (
+		knobs.value.extra.numParticles === speedPreset.numSamples &&
+		knobs.value.extra.solverMethod === speedPreset.method &&
+		knobs.value.extra.numIterations === speedPreset.numIterations &&
+		knobs.value.extra.learningRate === speedPreset.learningRate &&
+		knobs.value.extra.stepSize === speedPreset.stepSize
+	) {
+		return CiemssPresetTypes.Fast;
+	}
+	if (
+		knobs.value.extra.numParticles === qualityPreset.numSamples &&
+		knobs.value.extra.solverMethod === qualityPreset.method &&
+		knobs.value.extra.numIterations === qualityPreset.numIterations &&
+		knobs.value.extra.learningRate === qualityPreset.learningRate
+	) {
+		return CiemssPresetTypes.Normal;
+	}
+	return '';
+});
+
 const setPresetValues = (data: CiemssPresetTypes) => {
 	if (data === CiemssPresetTypes.Normal) {
 		knobs.value.extra.numParticles = qualityPreset.numSamples;
@@ -521,6 +542,7 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 		knobs.value.extra.solverMethod = speedPreset.method;
 		knobs.value.extra.numIterations = speedPreset.numIterations;
 		knobs.value.extra.learningRate = speedPreset.learningRate;
+		knobs.value.extra.stepSize = speedPreset.stepSize;
 	}
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -54,6 +54,7 @@ export interface OptimizeCiemssOperationState extends BaseState {
 	// Settings
 	endTime: number;
 	numSamples: number;
+	solverStepSize: number;
 	solverMethod: string;
 	maxiter: number;
 	maxfeval: number;
@@ -136,6 +137,7 @@ export const OptimizeCiemssOperation: Operation = {
 		const init: OptimizeCiemssOperationState = {
 			endTime: 90,
 			numSamples: 100,
+			solverStepSize: 0.1,
 			solverMethod: 'dopri5',
 			maxiter: 5,
 			maxfeval: 25,

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -152,6 +152,16 @@
 										placeholder="Select"
 									/>
 								</div>
+								<div class="label-and-input">
+									<label>Solver Step Size</label>
+									<div>
+										<tera-input-number
+											v-model="knobs.solverStepSize"
+											:disabled="knobs.solverMethod !== CiemssMethodOptions.euler"
+											:min="0"
+										/>
+									</div>
+								</div>
 							</div>
 							<div class="input-row">
 								<h3>Optimizer options</h3>
@@ -511,6 +521,7 @@ enum OutputView {
 interface BasicKnobs {
 	endTime: number;
 	numSamples: number;
+	solverStepSize: number;
 	solverMethod: string;
 	maxiter: number;
 	maxfeval: number;
@@ -524,6 +535,7 @@ interface BasicKnobs {
 const knobs = ref<BasicKnobs>({
 	endTime: props.node.state.endTime ?? 1,
 	numSamples: props.node.state.numSamples ?? 0,
+	solverStepSize: props.node.state.solverStepSize ?? 0.1,
 	solverMethod: props.node.state.solverMethod ?? CiemssMethodOptions.dopri5,
 	maxiter: props.node.state.maxiter ?? 5,
 	maxfeval: props.node.state.maxfeval ?? 25,
@@ -607,7 +619,8 @@ const presetType = computed(() => {
 		knobs.value.numSamples === speedValues.numSamplesToSimModel &&
 		knobs.value.solverMethod === speedValues.method &&
 		knobs.value.maxiter === speedValues.maxiter &&
-		knobs.value.maxfeval === speedValues.maxfeval
+		knobs.value.maxfeval === speedValues.maxfeval &&
+		knobs.value.solverStepSize === speedValues.solverStepSize
 	) {
 		return CiemssPresetTypes.Fast;
 	}
@@ -694,6 +707,7 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 		knobs.value.solverMethod = speedValues.method;
 		knobs.value.maxiter = speedValues.maxiter;
 		knobs.value.maxfeval = speedValues.maxfeval;
+		knobs.value.solverStepSize = speedValues.solverStepSize;
 	}
 };
 
@@ -701,7 +715,8 @@ const speedValues = Object.freeze({
 	numSamplesToSimModel: 1,
 	method: CiemssMethodOptions.euler,
 	maxiter: 0,
-	maxfeval: 1
+	maxfeval: 1,
+	solverStepSize: 0.1
 });
 
 const qualityValues = Object.freeze({
@@ -862,7 +877,7 @@ const runOptimize = async () => {
 			maxfeval: knobs.value.maxfeval,
 			alpha: alphas,
 			solverMethod: knobs.value.solverMethod,
-			solverStepSize: 1
+			solverStepSize: knobs.value.solverStepSize
 		}
 	};
 
@@ -1036,6 +1051,7 @@ watch(
 		const state = _.cloneDeep(props.node.state);
 		state.endTime = knobs.value.endTime;
 		state.numSamples = knobs.value.numSamples;
+		state.solverStepSize = knobs.value.solverStepSize;
 		state.solverMethod = knobs.value.solverMethod;
 		state.maxiter = knobs.value.maxiter;
 		state.maxfeval = knobs.value.maxfeval;

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -134,7 +134,8 @@ const startForecast = async (optimizedInterventions?: InterventionPolicy) => {
 		},
 		extra: {
 			num_samples: props.node.state.numSamples,
-			method: props.node.state.solverMethod
+			method: props.node.state.solverMethod,
+			solver_step_size: props.node.state.solverStepSize
 		},
 		engine: 'ciemss'
 	};

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
@@ -12,6 +12,7 @@ export interface SimulateCiemssOperationState extends BaseState {
 	// state specific to individual simulate runs
 	currentTimespan: TimeSpan;
 	numSamples: number;
+	solverStepSize: number;
 	method: string;
 	forecastId: string; // Completed run's Id
 	baseForecastId: string; // Simulation without intervention
@@ -45,6 +46,7 @@ export const SimulateCiemssOperation: Operation = {
 			chartSettings: null,
 			currentTimespan: { start: 0, end: 100 },
 			numSamples: 100,
+			solverStepSize: 0.1,
 			method: 'dopri5',
 			forecastId: '',
 			baseForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -482,7 +482,8 @@ enum OutputView {
 
 const speedPreset = Object.freeze({
 	numSamples: 10,
-	method: CiemssMethodOptions.euler
+	method: CiemssMethodOptions.euler,
+	stepSize: 0.1
 });
 
 const qualityPreset = Object.freeze({
@@ -546,6 +547,7 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 	if (data === CiemssPresetTypes.Fast) {
 		numSamples.value = speedPreset.numSamples;
 		method.value = speedPreset.method;
+		solverStepSize.value = speedPreset.stepSize;
 	}
 	updateState();
 };

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -523,7 +523,11 @@ const pyciemssMap = ref<Record<string, string>>({});
 const kernelManager = new KernelSessionManager();
 
 const presetType = computed(() => {
-	if (numSamples.value === speedPreset.numSamples && method.value === speedPreset.method) {
+	if (
+		numSamples.value === speedPreset.numSamples &&
+		method.value === speedPreset.method &&
+		solverStepSize.value === speedPreset.stepSize
+	) {
 		return CiemssPresetTypes.Fast;
 	}
 	if (numSamples.value === qualityPreset.numSamples && method.value === qualityPreset.method) {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -75,6 +75,10 @@
 									@update:model-value="updateState"
 								/>
 							</div>
+							<div v-if="method === CiemssMethodOptions.euler" class="label-and-input">
+								<label for="num-samples">Solver Step Size</label>
+								<tera-input-number v-model="solverStepSize" :min="0" @update:model-value="updateState" />
+							</div>
 						</div>
 						<template v-if="interventionPolicy && model">
 							<h4>Intervention Policies</h4>
@@ -468,6 +472,7 @@ const llmQuery = ref('');
 // input params
 const timespan = ref<TimeSpan>(props.node.state.currentTimespan);
 const numSamples = ref<number>(props.node.state.numSamples);
+const solverStepSize = ref<number>(props.node.state.solverStepSize);
 const method = ref(props.node.state.method);
 
 enum OutputView {
@@ -592,6 +597,7 @@ const updateState = () => {
 	state.currentTimespan = timespan.value;
 	state.numSamples = numSamples.value;
 	state.method = method.value;
+	state.solverStepSize = solverStepSize.value;
 	emit('update-state', state);
 };
 
@@ -618,7 +624,7 @@ const makeForecastRequest = async (applyInterventions = true) => {
 		},
 		extra: {
 			solver_method: method.value,
-			solver_step_size: 1,
+			solver_step_size: solverStepSize.value,
 			num_samples: numSamples.value
 		},
 		engine: 'ciemss'
@@ -756,6 +762,7 @@ watch(
 		// Update Wizard form fields with current selected output state
 		timespan.value = props.node.state.currentTimespan;
 		numSamples.value = props.node.state.numSamples;
+		solverStepSize.value = props.node.state.solverStepSize;
 		method.value = props.node.state.method;
 
 		lazyLoadSimulationData(selectedRunId.value);

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -75,9 +75,14 @@
 									@update:model-value="updateState"
 								/>
 							</div>
-							<div v-if="method === CiemssMethodOptions.euler" class="label-and-input">
+							<div class="label-and-input">
 								<label for="num-samples">Solver Step Size</label>
-								<tera-input-number v-model="solverStepSize" :min="0" @update:model-value="updateState" />
+								<tera-input-number
+									v-model="solverStepSize"
+									:disabled="method !== CiemssMethodOptions.euler"
+									:min="0"
+									@update:model-value="updateState"
+								/>
 							</div>
 						</div>
 						<template v-if="interventionPolicy && model">

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/simulate-ensemble-ciemss-operation.ts
@@ -18,7 +18,8 @@ export interface SimulateEnsembleWeights {
 
 export const speedValues = Object.freeze({
 	numSamples: 1,
-	method: CiemssMethodOptions.euler
+	method: CiemssMethodOptions.euler,
+	stepSize: 0.1
 });
 
 export const normalValues = Object.freeze({

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -325,7 +325,11 @@ const showAddMappingInput = ref(false);
 const listModelLabels = ref<string[]>([]);
 
 const presetType = computed(() => {
-	if (knobs.value.numSamples === speedValues.numSamples && knobs.value.method === speedValues.method) {
+	if (
+		knobs.value.numSamples === speedValues.numSamples &&
+		knobs.value.method === speedValues.method &&
+		knobs.value.stepSize === speedValues.stepSize
+	) {
 		return CiemssPresetTypes.Fast;
 	}
 	if (knobs.value.numSamples === normalValues.numSamples && knobs.value.method === normalValues.method) {
@@ -375,6 +379,7 @@ const setPresetValues = (data: CiemssPresetTypes) => {
 	if (data === CiemssPresetTypes.Fast) {
 		knobs.value.numSamples = speedValues.numSamples;
 		knobs.value.method = speedValues.method;
+		knobs.value.stepSize = speedValues.stepSize;
 	}
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -172,7 +172,11 @@
 									</div>
 									<div v-if="knobs.method === CiemssMethodOptions.euler" class="label-and-input">
 										<label>Solver step size</label>
-										<tera-input-number v-model="knobs.stepSize" />
+										<tera-input-number
+											:disabled="knobs.method !== CiemssMethodOptions.euler"
+											:min="0"
+											v-model="knobs.stepSize"
+										/>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
# Description
Update pyciemss operator defaults:
-Fast is always euler with 0.1 step size
-Normal/quality is always dopri5 (no step size required)

- **Add step size to operators that it was missing from (This means some operator states are being updated please be aware demo is finished prior to merge)**
- Disable step size input when euler is not the selected method

Note that stepsize is no longer integer only but is able and in fact defaulted to be 0.1