### PR TITLE
don't enable resize-observer in model-diagram if in preview mode

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -243,7 +243,7 @@ watch(
 // Create an observer to re-render the graph when it resizes
 let graphResizeObserver: ResizeObserver;
 onMounted(() => {
-	if (graphElement.value) {
+	if (graphElement.value && props.featureConfig?.isPreview === false) {
 		// FIXME: This debounce prevents the graph from being rendered multiple times in a row.
 		// This happens in cases where there is a slight change in width when a scrollbar is shown or hidden. eg. opening/closing the transitions accordion in the model page
 		graphResizeObserver = observeElementSizeChange(graphElement.value, debounce(renderGraph, 2000));


### PR DESCRIPTION
### Summary
Resize observer causes double rendering pass, often times with no visible changes to the rendering. 
This disables the resize observer in preview mode to speed up loading time in the workflow canvas.


### Testing
If you put a console.log into tera-model-diagram#renderGraph() you can track how many times render happens.