### PR TITLE
Jamie home page style updates

### DIFF
--- a/packages/client/hmi-client/src/components/home/tera-project-card.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-card.vue
@@ -50,8 +50,7 @@
 				<ProgressBar v-if="isCopying" mode="indeterminate" />
 				<section class="details">
 					<div>
-						<div class="author">{{ project?.userName ?? '——' }}</div>
-						<div>{{ formatDdMmmYyyy(project.updatedOn) }}</div>
+						<div>{{ project?.userName ?? '——' }}</div>
 					</div>
 					<div class="description">
 						{{ project.description }}
@@ -230,18 +229,22 @@ section {
 
 .details:not(.skeleton) {
 	overflow: hidden;
-	opacity: 0;
-	height: 0;
-	transition:
-		opacity 0.5s ease,
-		height 0.3s ease;
-	color: var(--text-color-secondary);
-	font-size: var(--font-caption);
+	& .description {
+		opacity: 0;
+		height: 0;
+		transition:
+			opacity 0.5s ease,
+			height 0.3s ease;
+		color: var(--text-color-secondary);
+		font-size: var(--font-caption);
+	}
 }
 
 .p-card:hover .details:not(.skeleton) {
-	opacity: 100;
-	height: auto;
+	& .description {
+		opacity: 100;
+		height: auto;
+	}
 }
 
 .author {

--- a/packages/client/hmi-client/src/components/home/tera-project-table.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-table.vue
@@ -37,8 +37,6 @@
 							<i class="pi pi-user" />
 							{{ data.metadata?.['contributor-count'] ?? 1 }}
 						</span>
-					</div>
-					<div class="stats mt-3">
 						<span
 							v-for="metadataField in Object.keys(metadataCountToAssetNameMap)"
 							:key="metadataField"
@@ -170,7 +168,7 @@ watch(
 
 :deep(.p-datatable-tbody > tr > td),
 :deep(.p-datatable-thead > tr > th) {
-	vertical-align: top;
+	vertical-align: center;
 	padding: var(--gap-3) var(--gap-5);
 }
 
@@ -253,5 +251,7 @@ watch(
 :deep(.p-paginator) {
 	border-radius: 0;
 	padding: var(--gap-2) var(--gap-4);
+	background: var(--surface-glass);
+	backdrop-filter: blur(4px);
 }
 </style>

--- a/packages/client/hmi-client/src/components/home/tera-project-table.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-table.vue
@@ -61,7 +61,8 @@
 			</template>
 		</Column>
 		<template #expansion="{ data }">
-			<div v-for="asset in data.assets" :key="asset.assetId" class="flex align-items-center gap-4">
+			<div v-for="asset in data.assets" :key="asset.assetId" class="flex align-items-center gap-1">
+				<span class="ml-4 pi pi-minus secondary-text"></span>
 				<tera-asset-button
 					v-if="asset.assetType != AssetType.Project"
 					:asset="asset"
@@ -197,7 +198,9 @@ watch(
 
 /* Adjust padding for non-empty expansion rows */
 :deep(.p-datatable-tbody > tr.p-datatable-row-expansion > :not(td:empty)) {
-	padding: var(--gap-2) var(--gap-1);
+	padding: var(--gap-0) var(--gap-1);
+	padding-bottom: var(--gap-4);
+	background: var(--surface-50);
 }
 
 /* Remove padding for empty expansion rows */
@@ -253,5 +256,9 @@ watch(
 	padding: var(--gap-2) var(--gap-4);
 	background: var(--surface-glass);
 	backdrop-filter: blur(4px);
+}
+
+.secondary-text {
+	color: var(--text-color-secondary);
 }
 </style>

--- a/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-input-text.vue
@@ -17,6 +17,7 @@
 				@blur="onBlur"
 				@input="updateValue"
 				@keydown.space.stop
+				autocomplete="off"
 			/>
 		</main>
 		<aside v-if="getErrorMessage"><i class="pi pi-exclamation-circle" /> {{ getErrorMessage }}</aside>

--- a/packages/client/hmi-client/src/page/tera-home.vue
+++ b/packages/client/hmi-client/src/page/tera-home.vue
@@ -40,7 +40,7 @@
 									class="search-input"
 									@keydown.enter="searchedProjects"
 								/>
-								<Button label="Search" @click="searchedProjects" />
+								<Button label="Search" :disabled="searchProjectsQuery.length === 0" @click="searchedProjects" />
 							</span>
 							<Dropdown
 								v-if="view === ProjectsView.Cards"


### PR DESCRIPTION
Four small tweaks to the home page.

1) The Search button in the toolbar shouldn't be primary if the field is empty. Fixed by conditionally disabling it.
![disable-search-button](https://github.com/user-attachments/assets/4393c47b-6264-48b3-8a9c-c5346a6bb671)



2) The Search field shouldn't have a blue background. 
![image](https://github.com/user-attachments/assets/bfc4147d-c8ed-42df-acc0-81754487784d)
Fixed by turning off the browser autocomplete. See above GIF to see the fix.



3) The table view search results had poor alignment. 
![image](https://github.com/user-attachments/assets/cc0063bd-7038-4e35-9009-c320b50d7c60)
Fixed.
![Monosnap Terarium 2024-12-20 13-37-30](https://github.com/user-attachments/assets/8199ec6e-e687-4e41-a806-022c44b28b65)



4) Fixed the project cards so they show the author name by default.
![Monosnap Terarium 2024-12-20 13-40-20](https://github.com/user-attachments/assets/9a1869e4-a196-478b-b4b1-cf0e1ce086cf)
Here's the new:
![project-cards-with-authornames](https://github.com/user-attachments/assets/4ad779a4-ed96-422b-b910-b0464a59d953)
