### PR TITLE
default chart settings for the compare dataset operator

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -424,9 +424,9 @@ const modelConfiguration = ref<ModelConfiguration | null>(null);
 const model = ref<Model | null>(null);
 
 const lastTimepoint = computed<number>(() => {
-	if (!runResults.value || !selectedRunId.value) return 0;
+	if (isEmpty(runResults.value) || !selectedRunId.value) return 0;
 	const lastResult = _.last(runResults.value[selectedRunId.value]);
-	return lastResult!.timepoint_id ?? 0;
+	return lastResult?.timepoint_id ?? 0;
 });
 const modelStateUnits = computed(() => {
 	const states = model.value?.model.states;

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
@@ -11,6 +11,7 @@ import { OperatorNodeSize } from '@/services/workflow';
 import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
 import { ChartSetting, ChartSettingType } from '@/types/common';
 import { updateChartSettingsBySelectedVariables } from '@/services/chart-settings';
+import { getMeanCompareDatasetVariables } from '../scenario-template-utils';
 
 export class DecisionMakingScenario extends BaseScenario {
 	public static templateId = 'decision-making';
@@ -159,6 +160,13 @@ export class DecisionMakingScenario extends BaseScenario {
 			this.simulateSpec.ids
 		);
 
+		let compareDatasetChartSettings: ChartSetting[] = [];
+		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
+			compareDatasetChartSettings,
+			ChartSettingType.VARIABLE,
+			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+		);
+
 		// 2. Add base simulation (no interventions) and connect it to the compare datasets node
 		const baseSimulateNode = wf.addNode(
 			SimulateOp,
@@ -176,6 +184,12 @@ export class DecisionMakingScenario extends BaseScenario {
 		wf.updateNode(baseSimulateNode, {
 			state: {
 				chartSettings: simulateChartSettings
+			}
+		});
+
+		wf.updateNode(compareDatasetNode, {
+			state: {
+				chartSettings: compareDatasetChartSettings
 			}
 		});
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
@@ -15,6 +15,7 @@ import { DistributionType } from '@/services/distribution';
 import { calculateUncertaintyRange } from '@/utils/math';
 import { getInterventionPolicyById } from '@/services/intervention-policy';
 import { useProjects } from '@/composables/project';
+import { getMeanCompareDatasetVariables } from '../scenario-template-utils';
 
 export interface HorizonScanningParameter {
 	id: string;
@@ -208,6 +209,19 @@ export class HorizonScanningScenario extends BaseScenario {
 			ChartSettingType.VARIABLE,
 			this.simulateSpec.ids
 		);
+
+		let compareDatasetChartSettings: ChartSetting[] = [];
+		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
+			compareDatasetChartSettings,
+			ChartSettingType.VARIABLE,
+			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+		);
+
+		wf.updateNode(compareDatasetNode, {
+			state: {
+				chartSettings: compareDatasetChartSettings
+			}
+		});
 
 		// 2. create model config nodes for each paramter for both the low and high values and attach them to the model node
 		const modelConfigPromises = this.parameters.flatMap(async (parameter) => {

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
@@ -1,5 +1,6 @@
 import { DistributionType } from '@/services/distribution';
-import { ParameterSemantic } from '@/types/Types';
+import { getInitials, getObservables } from '@/services/model-configurations';
+import { ModelConfiguration, ParameterSemantic } from '@/types/Types';
 import { calculateUncertaintyRange } from '@/utils/math';
 
 export const displayParameter = (parameters: ParameterSemantic[], parameterName: string) => {
@@ -32,3 +33,15 @@ export const switchToUniformDistribution = (parameter: ParameterSemantic) => {
 		parameter.distribution.parameters = { minimum, maximum };
 	}
 };
+
+const getCompareDatasetVariablePrefixes = (selectedMetrics: string[], modelConfiguration: ModelConfiguration) =>
+	selectedMetrics.map((metric) => {
+		const state = getInitials(modelConfiguration).some((i) => i.target === metric);
+		if (state) return `${metric}_state`;
+		const observable = getObservables(modelConfiguration).some((o) => o.referenceId === metric);
+		if (observable) return `${metric}_observable_state`;
+		return metric;
+	});
+
+export const getMeanCompareDatasetVariables = (selectedMetrics: string[], modelConfiguration: ModelConfiguration) =>
+	getCompareDatasetVariablePrefixes(selectedMetrics, modelConfiguration).map((metric) => `${metric}_mean`);

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
@@ -17,7 +17,7 @@ import { updateChartSettingsBySelectedVariables } from '@/services/chart-setting
 import { AssetType, ParameterSemantic } from '@/types/Types';
 import { getInterventionPolicyById } from '@/services/intervention-policy';
 import { useProjects } from '@/composables/project';
-import { switchToUniformDistribution } from '../scenario-template-utils';
+import { getMeanCompareDatasetVariables, switchToUniformDistribution } from '../scenario-template-utils';
 
 /*
  * Value of information scenario
@@ -194,6 +194,19 @@ export class ValueOfInformationScenario extends BaseScenario {
 			ChartSettingType.VARIABLE,
 			this.simulateSpec.ids
 		);
+
+		let compareDatasetChartSettings: ChartSetting[] = [];
+		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
+			compareDatasetChartSettings,
+			ChartSettingType.VARIABLE,
+			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+		);
+
+		wf.updateNode(compareDatasetNode, {
+			state: {
+				chartSettings: compareDatasetChartSettings
+			}
+		});
 
 		// 2. create model config nodes for each paramter and attach them to the model node
 		const modelConfigPromises = this.parameters.map(async (parameter) => {


### PR DESCRIPTION
# Description

* default compare dataset charts when creating a scenario template.  This is included in the decision making, horizon scanning, and value of information templates.
* it will be default select the `mean` variables so:
 state -> {metric}_state_mean
 observable -> {metric}_observable_state_mean

