### PR TITLE
dont show warning on dataset transformer first open

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset-jupyter-panel.vue
@@ -158,6 +158,7 @@ import { useConfirm } from 'primevue/useconfirm';
 import { useProjects } from '@/composables/project';
 import { programmingLanguageOptions } from '@/types/common';
 import TeraBeakerInput from '@/components/llm/tera-beaker-input.vue';
+import { isEmpty } from 'lodash';
 
 const openDialog = () => {
 	showSaveInput.value = true;
@@ -326,7 +327,10 @@ onMounted(() => {
 				kernelId: jupyterSession.session?.kernel?.id,
 				value: jupyterSession.session?.id
 			};
-			showRerunMessage.value = true;
+			// Show rerun message if there are any cells that have been executed
+			if (props.notebookSession?.data.history?.some((historyItem) => !isEmpty(historyItem.executions))) {
+				showRerunMessage.value = true;
+			}
 		}
 	});
 });


### PR DESCRIPTION
# Description

* show the datset warning banner only when any cell has been executed

