### PR TITLE
style tweaks for degradation transitions

### DIFF
--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -229,6 +229,10 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 
 		const transitionNodeIds = this.graph.nodes.filter((n) => n.data.type === 'transition').map((n) => n.id);
 
+		const originNodeIds = this.graph.edges.map((edge) => edge.source);
+		const terminalTransitionNodeIds = transitionNodeIds.filter((id) => !originNodeIds.includes(id));
+		// console.log('!!', terminalTransitionNodeIds);
+
 		selection
 			.append('path')
 			.attr('d', (d) => pathFn(d.points))
@@ -244,7 +248,10 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			})
 			.attr('marker-end', (d) => {
 				if (d.data?.isController || d.data?.isObservable) return null;
-				if (transitionNodeIds.includes(d.target as string)) return null;
+
+				// TODO: should check if the transition node is terminal
+				if (transitionNodeIds.includes(d.target as string) && !terminalTransitionNodeIds.includes(d.target))
+					return null;
 				return 'url(#arrowhead)';
 			});
 

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -231,7 +231,6 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 
 		const originNodeIds = this.graph.edges.map((edge) => edge.source);
 		const terminalTransitionNodeIds = transitionNodeIds.filter((id) => !originNodeIds.includes(id));
-		// console.log('!!', terminalTransitionNodeIds);
 
 		selection
 			.append('path')

--- a/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
+++ b/packages/client/hmi-client/src/model-representation/petrinet/petrinet-renderer.ts
@@ -248,7 +248,6 @@ export class PetrinetRenderer extends BasicRenderer<NodeData, EdgeData> {
 			.attr('marker-end', (d) => {
 				if (d.data?.isController || d.data?.isObservable) return null;
 
-				// TODO: should check if the transition node is terminal
 				if (transitionNodeIds.includes(d.target as string) && !terminalTransitionNodeIds.includes(d.target))
 					return null;
 				return 'url(#arrowhead)';


### PR DESCRIPTION
### Summary
Tweak to how a terminal transition (degradation) looks

Before:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/5edc8799-6aa7-487b-852e-dde9ec160e46" />


After:

<img width="386" alt="image" src="https://github.com/user-attachments/assets/5c7fae82-8848-4973-a70c-5400e20bd1fb" />