### PR TITLE
fix transition input/output not showing up, add fixme note

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -12,7 +12,7 @@
 				/>
 			</span>
 			<span class="unit" :class="{ time: isTimePart }">
-				<template v-if="input && output">
+				<template v-if="input || output">
 					<span><label>Input:</label> {{ input }}</span>
 					<span><label>Output:</label> {{ output }}</span>
 				</template>

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -360,6 +360,7 @@ export enum PartType {
 
 // FIXME: should refactor so typing is explicit and clear
 // Note "model" is both an AMR model, or it can be a list of transition templates
+// FIXME: Nelson recommended we show subject/outcome/controllers instead of input/output
 export function createPartsList(parts, model, partType) {
 	return Array.from(parts.keys()).map((id) => {
 		const childTargets = parts.get(id) ?? [];

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -358,6 +358,8 @@ export enum PartType {
 	TRANSITION = 'TRANSITION'
 }
 
+// FIXME: should refactor so typing is explicit and clear
+// Note "model" is both an AMR model, or it can be a list of transition templates
 export function createPartsList(parts, model, partType) {
 	return Array.from(parts.keys()).map((id) => {
 		const childTargets = parts.get(id) ?? [];


### PR DESCRIPTION
Closes: https://github.com/DARPA-ASKEM/terarium/issues/5882

### Summary
The predicate `input && output` is incorrect because the sides can be imbalanced. A transition does not necessarily need to have an input (a production) or an output (a degradation). Added a fixme note to address the disjunctive typings.

Before, note the "units" are showing for some transitions, which doesn't make sense as units are on the states.

<img width="631" alt="image" src="https://github.com/user-attachments/assets/04512d01-cb0a-44dd-8caf-4f0832d7d587" />


After:

<img width="535" alt="image" src="https://github.com/user-attachments/assets/8b9ffd0f-4419-45e8-9db9-826cefb8b6ec" />



### Testing
View the transition table for the model here, that has a a mix up production and degradation transitions:
[non_mass_conserved.json](https://github.com/user-attachments/files/18294121/non_mass_conserved.json)
