### PR TITLE
Add guard against unnecessary workflow updates

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -186,8 +186,11 @@ const pollResult = async (runId: string) => {
 				const checkpoint = _.last(data.updates);
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
-					state.currentProgress = +((100 * checkpoint.data.progress) / state.numIterations).toFixed(2);
-					emit('update-state', state);
+					const newProgress = +((100 * checkpoint.data.progress) / state.numIterations).toFixed(2);
+					if (newProgress > state.currentProgress) {
+						state.currentProgress = newProgress;
+						emit('update-state', state);
+					}
 				}
 			}
 		});

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -187,7 +187,7 @@ const pollResult = async (runId: string) => {
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
 					const newProgress = +((100 * checkpoint.data.progress) / state.numIterations).toFixed(2);
-					if (newProgress > state.currentProgress) {
+					if (newProgress !== state.currentProgress) {
 						state.currentProgress = newProgress;
 						emit('update-state', state);
 					}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -140,8 +140,11 @@ const pollResult = async (runId: string) => {
 				const checkpoint = _.last(data.updates);
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
-					state.currentProgress = +((100 * checkpoint.data.progress) / state.extra.numIterations).toFixed(2);
-					emit('update-state', state);
+					const newProgress = +((100 * checkpoint.data.progress) / state.extra.numIterations).toFixed(2);
+					if (newProgress > state.currentProgress) {
+						state.currentProgress = newProgress;
+						emit('update-state', state);
+					}
 				}
 			}
 		});

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -141,7 +141,7 @@ const pollResult = async (runId: string) => {
 				if (checkpoint) {
 					const state = _.cloneDeep(props.node.state);
 					const newProgress = +((100 * checkpoint.data.progress) / state.extra.numIterations).toFixed(2);
-					if (newProgress > state.currentProgress) {
+					if (newProgress !== state.currentProgress) {
 						state.currentProgress = newProgress;
 						emit('update-state', state);
 					}

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -108,7 +108,7 @@ const pollResult = async (runId: string) => {
 				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
 					const newProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(2);
-					if (newProgress > state.currentProgress) {
+					if (newProgress !== state.currentProgress) {
 						state.currentProgress = newProgress;
 						emit('update-state', state);
 					}

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -103,13 +103,15 @@ const pollResult = async (runId: string) => {
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
+				// TODO: Need to check if "first" is actually the latest update
 				const checkpointData = _.first(data.updates)?.data as CiemssOptimizeStatusUpdate;
 				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
-					state.currentProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(
-						2
-					);
-					emit('update-state', state);
+					const newProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(2);
+					if (newProgress > state.currentProgress) {
+						state.currentProgress = newProgress;
+						emit('update-state', state);
+					}
 				}
 			}
 		});

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -103,8 +103,8 @@ const pollResult = async (runId: string) => {
 		.setPollAction(async () => pollAction(runId))
 		.setProgressAction((data: Simulation) => {
 			if (runId === props.node.state.inProgressOptimizeId && data.updates.length > 0) {
-				// TODO: Need to check if "first" is actually the latest update
-				const checkpointData = _.first(data.updates)?.data as CiemssOptimizeStatusUpdate;
+				data.updates.sort((a, b) => a.data.progress - b.data.progress);
+				const checkpointData = _.last(data.updates)?.data as CiemssOptimizeStatusUpdate;
 				if (checkpointData) {
 					const state = _.cloneDeep(props.node.state);
 					const newProgress = +((100 * checkpointData.progress) / checkpointData.totalPossibleIterations).toFixed(2);


### PR DESCRIPTION
### Summary
We are queuing up workflow-update actions regardless of whether there are progress changes or not, this is wasteful. This PR adds guards to only update if progress actually changed.


### Testing
Run any of Calibrate, Optimize, Ensemble-Calibrate and check the network tab, we should only send updates if progress changes.