### PR TITLE
Simulate With Interventions correction

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -253,6 +253,9 @@ async function processPolling(id, propName, inProgressPropName) {
 		state[propName] = id;
 		state[inProgressPropName] = '';
 		emit('update-state', state);
+		if (propName === 'forecastId') {
+			await processResult(id); // Only process and output result for main forecast
+		}
 	}
 }
 
@@ -261,7 +264,6 @@ watch(
 	async (id) => {
 		if (!id || id === '') return;
 		await processPolling(id, 'forecastId', 'inProgressForecastId');
-		await processResult(id); // Only process and output result for main forecast
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
# Description
This will fix simulations that have interventions connected to them

- When running simulate we should only `processResult` for `forecastId`. The previous set up was not waiting for the poller to be done correctly.


# Testing:
- Run a simulation with intervention plugged in. With main you will see 404 error if the base forecast finishes first (it should on vast majority of runs)
- Run again with this branch - no longer 404 as well as seeing 1 result added to the output node that can correctly be worked with