### PR TITLE
add new intervention policy in templates

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/intervention-policy-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/intervention-policy-operation.ts
@@ -1,4 +1,4 @@
-import { InterventionPolicy } from '@/types/Types';
+import { InterventionPolicy, InterventionSemanticType } from '@/types/Types';
 import type { BaseState, Operation } from '@/types/workflow';
 import { WorkflowOperationTypes } from '@/types/workflow';
 import { isEqual, omit } from 'lodash';
@@ -57,3 +57,16 @@ export const isInterventionPoliciesValuesEqual = (
 	});
 	return !notEqual;
 };
+
+export const isInterventionPolicyBlank = (policy: InterventionPolicy | null): boolean =>
+	policy?.interventions.length === 1 &&
+	isEqual(policy.interventions[0], {
+		name: 'New Intervention',
+		staticInterventions: [
+			{
+				type: InterventionSemanticType.Parameter,
+				appliedTo: ''
+			}
+		],
+		dynamicInterventions: []
+	});

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -253,7 +253,8 @@ import {
 	InterventionPolicyOperation,
 	InterventionPolicyState,
 	isInterventionPoliciesEqual,
-	isInterventionPoliciesValuesEqual
+	isInterventionPoliciesValuesEqual,
+	isInterventionPolicyBlank
 } from './intervention-policy-operation';
 import TeraInterventionPolicyCard from './tera-intervention-policy-card.vue';
 
@@ -328,6 +329,9 @@ const isSaveDisabled = computed(() => {
 	// Check if the IDs of the transient and selected policies differ
 	const isPolicyIdDifferent = transientPolicyId !== selectedPolicy.value?.id;
 
+	// Check if the selected policy blank
+	const isPolicyBlank = isInterventionPolicyBlank(selectedPolicy.value);
+
 	// Check if the policies themselves are equal
 	const arePoliciesEqual = isInterventionPoliciesEqual(transientPolicy, selectedPolicy.value);
 
@@ -336,7 +340,7 @@ const isSaveDisabled = computed(() => {
 
 	// Disable save if either the policy ID is different, the policies are equal,
 	// or the policy values are not equal
-	return hasSelectedPolicy && (isPolicyIdDifferent || arePoliciesEqual || !arePolicyValuesEqual);
+	return hasSelectedPolicy && !isPolicyBlank && (isPolicyIdDifferent || arePoliciesEqual || !arePolicyValuesEqual);
 });
 
 const documentIds = computed(() =>

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
@@ -79,7 +79,7 @@ export class DecisionMakingScenario extends BaseScenario {
 		this.interventionSpecs.splice(index, 1);
 	}
 
-	setInterventionSpecs(id: string, index: number) {
+	setInterventionSpec(id: string, index: number) {
 		this.interventionSpecs[index].id = id;
 	}
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/tera-decision-making-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/tera-decision-making-template.vue
@@ -36,7 +36,7 @@
 						:options="combinedInterventionPolicies"
 						option-label="name"
 						option-value="id"
-						@update:model-value="scenario.setInterventionSpecs($event, i)"
+						@update:model-value="scenario.setInterventionSpec($event, i)"
 						:disabled="isFetchingModelInformation"
 						:loading="isFetchingModelInformation"
 						filter
@@ -97,11 +97,11 @@ import { isEmpty } from 'lodash';
 import Dropdown from 'primevue/dropdown';
 import MultiSelect from 'primevue/multiselect';
 import Button from 'primevue/button';
-import { v4 as uuidv4 } from 'uuid';
 import { ScenarioHeader } from '../base-scenario';
 import { DecisionMakingScenario } from './decision-making-scenario';
 import TeraScenarioTemplate from '../tera-scenario-template.vue';
 import TeraNewPolicyModal from '../tera-new-policy-modal.vue';
+import { usePolicyModel } from '../scenario-template-utils';
 
 const header: ScenarioHeader = Object.freeze({
 	title: 'Decision Making Template',
@@ -133,23 +133,14 @@ const props = defineProps<{
 	scenario: DecisionMakingScenario;
 }>();
 
-const onOpenPolicyModel = (index: number) => {
-	interventionDropdowns.value[index].hide();
-	policyModalContext.value = index;
-	isPolicyModalVisible.value = true;
-};
-
-const addNewPolicy = (newPolicyName: string) => {
-	if (newPolicyName && policyModalContext.value !== null) {
-		const id = uuidv4();
-		props.scenario.setNewInterventionSpec(id, newPolicyName);
-		props.scenario.setInterventionSpecs(id, policyModalContext.value);
-		isPolicyModalVisible.value = false;
-		policyModalContext.value = null;
-	}
-};
-
 const emit = defineEmits(['save-workflow']);
+
+const { onOpenPolicyModel, addNewPolicy } = usePolicyModel(
+	props,
+	interventionDropdowns,
+	policyModalContext,
+	isPolicyModalVisible
+);
 
 watch(
 	() => props.scenario.modelSpec.id,

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
@@ -26,17 +26,23 @@
 			<label>Select intervention policy (historical)</label>
 			<div v-for="(intervention, i) in scenario.interventionSpecs" :key="i" class="flex">
 				<Dropdown
+					ref="interventionDropdowns"
 					class="flex-1 my-1"
 					:model-value="intervention.id"
-					:options="interventionPolicies"
+					:options="combinedInterventionPolicies"
 					option-label="name"
 					option-value="id"
 					placeholder="Select an intervention policy (optional)"
 					@update:model-value="scenario.setInterventionSpec($event, i)"
 					:key="i"
-					:disabled="isEmpty(interventionPolicies)"
+					:disabled="isFetchingModelInformation"
 					:loading="isFetchingModelInformation"
-				/>
+					filter
+				>
+					<template #filtericon>
+						<Button label="Create new policy" icon="pi pi-plus" size="small" text @click="onOpenPolicyModel(i)" />
+					</template>
+				</Dropdown>
 				<Button
 					v-if="scenario.interventionSpecs.length > 1"
 					size="small"
@@ -119,6 +125,11 @@
 			<img :src="horizon" alt="Horizon scanning chart" class="" />
 		</template>
 	</tera-scenario-template>
+	<tera-new-policy-modal
+		:is-visible="isPolicyModalVisible"
+		@close="isPolicyModalVisible = false"
+		@create="addNewPolicy"
+	/>
 </template>
 
 <script setup lang="ts">
@@ -134,9 +145,11 @@ import { getInterventionPoliciesForModel, getModel, getModelConfigurationsForMod
 import { AssetType, InterventionPolicy, ModelConfiguration, ParameterSemantic } from '@/types/Types';
 import { getModelConfigurationById, getParameter, getParameters } from '@/services/model-configurations';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
+import { v4 as uuidv4 } from 'uuid';
 import { ScenarioHeader } from '../base-scenario';
 import TeraScenarioTemplate from '../tera-scenario-template.vue';
 import { displayParameter } from '../scenario-template-utils';
+import teraNewPolicyModal from '../tera-new-policy-modal.vue';
 
 const header: ScenarioHeader = Object.freeze({
 	title: 'Horizon scanning template',
@@ -160,6 +173,15 @@ const modelParameters = ref<ParameterSemantic[]>([]);
 
 const selectedModelConfiguration = ref<ModelConfiguration | null>(null);
 
+const interventionDropdowns = ref();
+const isPolicyModalVisible = ref(false);
+const policyModalContext = ref<number | null>(null);
+
+const combinedInterventionPolicies = computed(() => [
+	...interventionPolicies.value,
+	...props.scenario.newInterventionSpecs
+]);
+
 const props = defineProps<{
 	scenario: HorizonScanningScenario;
 }>();
@@ -171,6 +193,22 @@ const onParameterSelect = (parameterId: string, index: number) => {
 	const parameter = _.cloneDeep(getParameter(selectedModelConfiguration.value, parameterId));
 	if (!parameter) return;
 	props.scenario.setParameter(parameter, index);
+};
+
+const onOpenPolicyModel = (index: number) => {
+	interventionDropdowns.value[index].hide();
+	policyModalContext.value = index;
+	isPolicyModalVisible.value = true;
+};
+
+const addNewPolicy = (newPolicyName: string) => {
+	if (newPolicyName && policyModalContext.value !== null) {
+		const id = uuidv4();
+		props.scenario.setNewInterventionSpec(id, newPolicyName);
+		props.scenario.setInterventionSpec(id, policyModalContext.value);
+		isPolicyModalVisible.value = false;
+		policyModalContext.value = null;
+	}
 };
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
@@ -145,10 +145,9 @@ import { getInterventionPoliciesForModel, getModel, getModelConfigurationsForMod
 import { AssetType, InterventionPolicy, ModelConfiguration, ParameterSemantic } from '@/types/Types';
 import { getModelConfigurationById, getParameter, getParameters } from '@/services/model-configurations';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
-import { v4 as uuidv4 } from 'uuid';
 import { ScenarioHeader } from '../base-scenario';
 import TeraScenarioTemplate from '../tera-scenario-template.vue';
-import { displayParameter } from '../scenario-template-utils';
+import { displayParameter, usePolicyModel } from '../scenario-template-utils';
 import teraNewPolicyModal from '../tera-new-policy-modal.vue';
 
 const header: ScenarioHeader = Object.freeze({
@@ -188,27 +187,18 @@ const props = defineProps<{
 
 const emit = defineEmits(['save-workflow']);
 
+const { onOpenPolicyModel, addNewPolicy } = usePolicyModel(
+	props,
+	interventionDropdowns,
+	policyModalContext,
+	isPolicyModalVisible
+);
+
 const onParameterSelect = (parameterId: string, index: number) => {
 	if (!selectedModelConfiguration.value) return;
 	const parameter = _.cloneDeep(getParameter(selectedModelConfiguration.value, parameterId));
 	if (!parameter) return;
 	props.scenario.setParameter(parameter, index);
-};
-
-const onOpenPolicyModel = (index: number) => {
-	interventionDropdowns.value[index].hide();
-	policyModalContext.value = index;
-	isPolicyModalVisible.value = true;
-};
-
-const addNewPolicy = (newPolicyName: string) => {
-	if (newPolicyName && policyModalContext.value !== null) {
-		const id = uuidv4();
-		props.scenario.setNewInterventionSpec(id, newPolicyName);
-		props.scenario.setInterventionSpec(id, policyModalContext.value);
-		isPolicyModalVisible.value = false;
-		policyModalContext.value = null;
-	}
 };
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
@@ -2,6 +2,7 @@ import { DistributionType } from '@/services/distribution';
 import { getInitials, getObservables } from '@/services/model-configurations';
 import { ModelConfiguration, ParameterSemantic } from '@/types/Types';
 import { calculateUncertaintyRange } from '@/utils/math';
+import { v4 as uuidv4 } from 'uuid';
 
 export const displayParameter = (parameters: ParameterSemantic[], parameterName: string) => {
 	let value = '';
@@ -45,3 +46,26 @@ const getCompareDatasetVariablePrefixes = (selectedMetrics: string[], modelConfi
 
 export const getMeanCompareDatasetVariables = (selectedMetrics: string[], modelConfiguration: ModelConfiguration) =>
 	getCompareDatasetVariablePrefixes(selectedMetrics, modelConfiguration).map((metric) => `${metric}_mean`);
+
+export function usePolicyModel(props, interventionDropdowns, policyModalContext, isPolicyModalVisible) {
+	const onOpenPolicyModel = (index: number) => {
+		interventionDropdowns.value[index].hide();
+		policyModalContext.value = index;
+		isPolicyModalVisible.value = true;
+	};
+
+	const addNewPolicy = (newPolicyName: string) => {
+		if (newPolicyName && policyModalContext.value !== null) {
+			const id = uuidv4();
+			props.scenario.setNewInterventionSpec(id, newPolicyName);
+			props.scenario.setInterventionSpec(id, policyModalContext.value);
+			isPolicyModalVisible.value = false;
+			policyModalContext.value = null;
+		}
+	};
+
+	return {
+		onOpenPolicyModel,
+		addNewPolicy
+	};
+}

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/tera-new-policy-modal.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/tera-new-policy-modal.vue
@@ -1,0 +1,35 @@
+<template>
+	<tera-modal v-if="isVisible">
+		<template #header> Create a new intervention policy </template>
+		<tera-input-text
+			placeholder="Policy name"
+			v-model="newPolicyName"
+			auto-focus
+			@keydown.enter="emit('create', newPolicyName)"
+		/>
+		<template #footer>
+			<Button label="Create" @click="emit('create', newPolicyName)" />
+			<Button severity="secondary" label="Close" @click="onClose"></Button>
+		</template>
+	</tera-modal>
+</template>
+
+<script setup lang="ts">
+import TeraInputText from '@/components/widgets/tera-input-text.vue';
+import TeraModal from '@/components/widgets/tera-modal.vue';
+import Button from 'primevue/button';
+import { ref } from 'vue';
+
+defineProps<{
+	isVisible: boolean;
+}>();
+
+const emit = defineEmits(['close', 'create']);
+
+const onClose = () => {
+	newPolicyName.value = '';
+	emit('close');
+};
+
+const newPolicyName = ref('');
+</script>

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/tera-value-of-information-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/tera-value-of-information-template.vue
@@ -146,10 +146,9 @@ import { getInterventionPoliciesForModel, getModel, getModelConfigurationsForMod
 import { AssetType, InterventionPolicy, ModelConfiguration, ParameterSemantic } from '@/types/Types';
 import { getModelConfigurationById, getParameter, getParameters } from '@/services/model-configurations';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
-import { v4 as uuidv4 } from 'uuid';
 import { ScenarioHeader } from '../base-scenario';
 import TeraScenarioTemplate from '../tera-scenario-template.vue';
-import { displayParameter } from '../scenario-template-utils';
+import { displayParameter, usePolicyModel } from '../scenario-template-utils';
 import teraNewPolicyModal from '../tera-new-policy-modal.vue';
 
 const header: ScenarioHeader = Object.freeze({
@@ -192,27 +191,18 @@ const props = defineProps<{
 
 const emit = defineEmits(['save-workflow']);
 
+const { onOpenPolicyModel, addNewPolicy } = usePolicyModel(
+	props,
+	interventionDropdowns,
+	policyModalContext,
+	isPolicyModalVisible
+);
+
 const onParameterSelect = (parameterId: string, index: number) => {
 	if (!selectedModelConfiguration.value) return;
 	const parameter = _.cloneDeep(getParameter(selectedModelConfiguration.value, parameterId));
 	if (!parameter) return;
 	props.scenario.setParameter(parameter, index);
-};
-
-const onOpenPolicyModel = (index: number) => {
-	interventionDropdowns.value[index].hide();
-	policyModalContext.value = index;
-	isPolicyModalVisible.value = true;
-};
-
-const addNewPolicy = (newPolicyName: string) => {
-	if (newPolicyName && policyModalContext.value !== null) {
-		const id = uuidv4();
-		props.scenario.setNewInterventionSpec(id, newPolicyName);
-		props.scenario.setInterventionSpec(id, policyModalContext.value);
-		isPolicyModalVisible.value = false;
-		policyModalContext.value = null;
-	}
 };
 
 watch(

--- a/packages/client/hmi-client/src/services/intervention-policy.ts
+++ b/packages/client/hmi-client/src/services/intervention-policy.ts
@@ -21,12 +21,15 @@ export const getInterventionPolicyById = async (policyId: string): Promise<Inter
 	return response?.data ?? null;
 };
 
-export const createInterventionPolicy = async (policy: InterventionPolicy): Promise<InterventionPolicy | null> => {
+export const createInterventionPolicy = async (
+	policy: InterventionPolicy,
+	skipCheck: boolean = false
+): Promise<InterventionPolicy | null> => {
 	try {
 		delete policy.id;
 		delete policy.createdOn;
 		delete policy.updatedOn;
-		const response = await API.post<InterventionPolicy>(`/interventions`, policy);
+		const response = await API.post<InterventionPolicy>(`/interventions?skip-check=${skipCheck}`, policy);
 		if (response.status !== 201) {
 			return null;
 		}

--- a/packages/client/hmi-client/src/utils/date.ts
+++ b/packages/client/hmi-client/src/utils/date.ts
@@ -118,7 +118,7 @@ export function getTimePointString(
 	options: { startDate?: Date; calendarSettings?: CalendarSettings }
 ): string {
 	if (!options.startDate) {
-		return `${timePoint.toString()} day.`;
+		return `${timePoint?.toString()} day.`;
 	}
 
 	const view = options.calendarSettings?.view ?? CalendarDateType.DATE;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
@@ -104,7 +104,7 @@ public class InterventionController {
 	)
 	public ResponseEntity<InterventionPolicy> createIntervention(
 		@RequestBody final InterventionPolicy item,
-		@RequestParam(name = "skip-check", required = false) final boolean skipCheck,
+		@RequestParam(name = "skip-check", required = false, defaultValue = "false") final boolean skipCheck,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
 		final Schema.Permission permission = projectService.checkPermissionCanWrite(


### PR DESCRIPTION
# Description

We can add a new intervention policy within a template:
* open an intervention dropdown
* click create policy button
* policies will not be saved to the project until the create button for the template is pressed AND it is acutally used within the template
* these will be set as blank intervention policies and the user can add the them as needed within the workflow

Added for templates: 
* Value of Information
* Horizontal Scanning
* Decision Making

