### PR TITLE
Correction To Simulation Pollers

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -264,7 +264,6 @@ watch(
 		if (props.node.state.inProgressForecastId) {
 			const forecastId = props.node.state.inProgressForecastId;
 			response = await pollResult(forecastId);
-			await processResult(id); // Only process and output result for main forecast
 		}
 		if (response?.state !== PollerState.Done) {
 			doneProcess = false;
@@ -276,6 +275,7 @@ watch(
 			state.inProgressForecastId = '';
 			state.inProgressBaseForecastId = '';
 			emit('update-state', state);
+			await processResult(state.forecastId); // Only process and output result for main forecast
 		}
 	},
 	{ immediate: true }

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -257,7 +257,7 @@ watch(
 			const baseForecastId = props.node.state.inProgressBaseForecastId;
 			response = await pollResult(baseForecastId);
 		}
-		if (response?.state !== PollerState.Done) {
+		if (response?.state && response.state !== PollerState.Done) {
 			doneProcess = false;
 		}
 
@@ -265,7 +265,7 @@ watch(
 			const forecastId = props.node.state.inProgressForecastId;
 			response = await pollResult(forecastId);
 		}
-		if (response?.state !== PollerState.Done) {
+		if (response?.state && response.state !== PollerState.Done) {
 			doneProcess = false;
 		}
 		if (doneProcess) {

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -246,33 +246,37 @@ const pollResult = async (runId: string) => {
 	return pollerResults;
 };
 
-async function processPolling(id, propName, inProgressPropName) {
-	const response = await pollResult(id);
-	if (response.state === PollerState.Done) {
-		const state = _.cloneDeep(props.node.state);
-		state[propName] = id;
-		state[inProgressPropName] = '';
-		emit('update-state', state);
-		if (propName === 'forecastId') {
+watch(
+	() => props.node.state.inProgressForecastId + props.node.state.inProgressBaseForecastId,
+	async (id) => {
+		if (!id || id === '') return;
+
+		let doneProcess = true;
+		let response;
+		if (props.node.state.inProgressBaseForecastId) {
+			const baseForecastId = props.node.state.inProgressBaseForecastId;
+			response = await pollResult(baseForecastId);
+		}
+		if (response?.state !== PollerState.Done) {
+			doneProcess = false;
+		}
+
+		if (props.node.state.inProgressForecastId) {
+			const forecastId = props.node.state.inProgressForecastId;
+			response = await pollResult(forecastId);
 			await processResult(id); // Only process and output result for main forecast
 		}
-	}
-}
-
-watch(
-	() => props.node.state.inProgressForecastId,
-	async (id) => {
-		if (!id || id === '') return;
-		await processPolling(id, 'forecastId', 'inProgressForecastId');
-	},
-	{ immediate: true }
-);
-
-watch(
-	() => props.node.state.inProgressBaseForecastId,
-	async (id) => {
-		if (!id || id === '') return;
-		await processPolling(id, 'baseForecastId', 'inProgressBaseForecastId');
+		if (response?.state !== PollerState.Done) {
+			doneProcess = false;
+		}
+		if (doneProcess) {
+			const state = _.cloneDeep(props.node.state);
+			state.forecastId = state.inProgressForecastId;
+			state.baseForecastId = state.inProgressBaseForecastId;
+			state.inProgressForecastId = '';
+			state.inProgressBaseForecastId = '';
+			emit('update-state', state);
+		}
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
# Description
The previous two watchers acting independently both calling `pollResult` was an issue.
This is because `pollResult` overwrites the `pollAction` for our ONE poller. 
This means that whichever watcher was triggered second would be the only simulation we would truly be checking the status for.

# Solution:
As we care about both simulations being completed before moving forward we move forward we can check the status one after the other.
We do not want to create two pollers both spamming the network at the same time 