### PR TITLE
improve error message; fix typo

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -300,8 +300,8 @@ public class KnowledgeController {
 				final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
 				responseAMR = mapper.convertValue(amrNode, Model.class);
 			} catch (final Exception e) {
-				log.error("failed to convert LaTeX equations to AMR", e);
-				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to convert latex equations to AMR");
+				log.error(messages.get("task.mira.internal-error"), e);
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.internal-error"));
 			}
 		} else {
 			try {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/TaskService.java
@@ -722,7 +722,7 @@ public class TaskService {
 
 			notificationService.createNotificationGroup(group);
 		} catch (final Exception e) {
-			log.error("Failed to create notificaiton group for id: {}", req.getId(), e);
+			log.error("Failed to create notification group for id: {}", req.getId(), e);
 		}
 
 		// now send request

--- a/packages/server/src/main/resources/messages.properties
+++ b/packages/server/src/main/resources/messages.properties
@@ -98,6 +98,7 @@ task.mira.json-processing = We couldn't process domain knowledge service (MIRA) 
 task.mira.timeout = We terminated our domain knowledge service (MIRA) because it took too long to complete. Please try again later. If this problem continues, please contact support.
 task.mira.interrupted = The task sent to our domain knowledge service (MIRA) was interrupted and didn't finish.
 task.mira.execution-failure = Our domain knowledge service (MIRA) couldn't perform the selected task. Please try again later. If this problem continues, please contact support.
+task.mira.internal-error =  We couldn't produce a valid model representation based on the selected resource. Please verify that the resource is valid and try again.
 
 task.funman.json-processing = We couldn't process task data for our model validation service (FUNMAN). Please verify the data is valid and try again.
 task.funman.timeout = We terminated our model validation service (FUNMAN) because it took too long to complete. Please try again later. If this problem persists, please contact support.


### PR DESCRIPTION
# Description

* Improves the error message when MIRA fails to create a model from equasions, made to be the same as SKEMA

Resolves #5902
