### PR TITLE
modify readers to have admins, evict cache when permissions changed

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/ReBACService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/ReBACService.java
@@ -401,6 +401,35 @@ public class ReBACService {
 	}
 
 	@Observed(name = "function_profile")
+	public PermissionRole getAdminRole() {
+		final RolesResource rolesResource = keycloak.realm(REALM_NAME).roles();
+		for (final RoleRepresentation roleRepresentation : rolesResource.list()) {
+			if (roleRepresentation.getDescription().isBlank()) {
+				if (roleRepresentation.getId().equals(ASKEM_ADMIN_GROUP_ID)) {
+					final RoleResource roleResource = rolesResource.get(roleRepresentation.getName());
+					final List<PermissionUser> users = new ArrayList<>();
+					for (final UserRepresentation userRepresentation : roleResource.getRoleUserMembers()) {
+						if (userRepresentation.getEmail() != null) {
+							final PermissionUser user = new PermissionUser(
+								userRepresentation.getId(),
+								userRepresentation.getFirstName(),
+								userRepresentation.getLastName(),
+								userRepresentation.getEmail()
+								// no roles are acquired (to avoid circular references etc)
+							);
+							users.add(user);
+						}
+					}
+
+					return new PermissionRole(roleRepresentation.getId(), roleRepresentation.getName(), users);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Observed(name = "function_profile")
 	public List<PermissionGroup> getGroups() {
 		final List<PermissionGroup> response = new ArrayList<>();
 


### PR DESCRIPTION
# Description

Should add Admin Group users to reader contributors list (as opposed to the group itself).
Should evict the cached reader's list when permissions for a project change.

This is untested as currently I am failing to connect to S3 (I assume all are failing, but incase you can test without...)

Resolves #(issue)
