### PR TITLE
Update LaTeX style guide to better standardize the glyph variants of Greek letters (`\var<...>` vs. `\<...>`)

### DIFF
--- a/packages/gollm/gollm_openai/prompts/latex_style_guide.py
+++ b/packages/gollm/gollm_openai/prompts/latex_style_guide.py
@@ -12,6 +12,6 @@ LATEX_STYLE_GUIDE = """
 9) Avoid using homoglyphs
 10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
 11) Use " * " to denote multiplication between scalar quantities
-12) Replace "\\epsilon" with "\\varepsilon" when representing a parameter or variable
-13) If equations are separated by commas, do not include commas in the LaTeX code.
+12) Replace any variant form of Greek letters to their main form when representing a variable or parameter; "\\varepsilon" -> "\\epsilon", "\\vartheta" -> "\\theta", "\\varpi" -> "\\pi", "\\varrho" -> "\\rho",  "\\varsigma" -> "\\sigma", "\\varphi" -> "\\phi"
+13) If equations are separated by punctuation (like comma, period, semicolon), do not include the punctuation in the LaTeX code.
 """


### PR DESCRIPTION
Update the style guide rule about variant glyphs of Greek letters; instruct the agent to use the main glyph (`\varepsilon` -> `\epsilon`, etc.).

# Description

* Resolves the issue where the LaTeX math expression uses `\varepsilon` and the model ends up with a parameter named `varepsilon` and the user doesn't know what that is (as opposed to just `epsilon`).
* Ditto for other Greek letters with such glyph variants
* Further reading: https://tex.stackexchange.com/questions/98013/varepsilon-vs-epsilon
* Also tweaks the wording for removing all punctuations, not just commas between equations (e.g. `equation1, equation2; equation3. equation4`)
