### PR TITLE
removed intervention node placeholder illustration

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-node.vue
@@ -10,7 +10,6 @@
 				/>
 			</li>
 		</ul>
-		<tera-operator-placeholder :node="node" v-else />
 		<tera-intervention-summary-card
 			class="intervention-title"
 			v-for="(intervention, index) in node.state.interventionPolicy.interventions"
@@ -33,7 +32,6 @@
 import { computed, ref, watch } from 'vue';
 import { WorkflowNode, WorkflowPortStatus } from '@/types/workflow';
 import Button from 'primevue/button';
-import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import _, { cloneDeep, groupBy } from 'lodash';
 import { blankIntervention, flattenInterventionData } from '@/services/intervention-policy';
 import { createInterventionChart } from '@/services/charts';


### PR DESCRIPTION
# BEFORE
The Create intervention policy node displayed both the placeholder illustration as well as the intervention summary card.
<img width="992" alt="Monosnap Terarium 2025-01-09 13-08-40" src="https://github.com/user-attachments/assets/a3d46723-b392-4b8d-95cf-99541b74331c" />

# AFTER
<img width="669" alt="Monosnap Terarium 2025-01-09 13-12-50" src="https://github.com/user-attachments/assets/92a5e5bb-dfa0-4dd8-a090-2bcda6e3fa70" />
