### PR TITLE
Send workflow sse to all users

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -185,17 +185,21 @@ public class WorkflowController {
 			.build();
 
 		try {
-			final RebacProject rebacProject = new RebacProject(projectId, reBACService);
-			if (rebacProject.isPublic()) {
-				clientEventService.sendToAllUsers(event);
-			} else {
-				final List<String> userIds = projectPermissionsService
-					.getReaders(rebacProject)
-					.stream()
-					.map(Contributor::getUserId)
-					.toList();
-				clientEventService.sendToUsers(event, userIds);
-			}
+			clientEventService.sendToAllUsers(event);
+			// https://github.com/DARPA-ASKEM/terarium/issues/6008
+			// final RebacProject rebacProject = new RebacProject(projectId, reBACService);
+
+			// if (rebacProject.isPublic()) {
+			// 	clientEventService.sendToAllUsers(event);
+			// }
+			// else {
+			// 	final List<String> userIds = projectPermissionsService
+			// 		.getReaders(rebacProject)
+			// 		.stream()
+			// 		.map(Contributor::getUserId)
+			// 		.toList();
+			// 	clientEventService.sendToUsers(event, userIds);
+			// }
 		} catch (final Exception e) {
 			log.error("Unable to notify users of update to workflow", e);
 			// No response status exception here because the workflow was updated successfully, and it's just the update that's failed.

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/ReBACService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/utils/rebac/ReBACService.java
@@ -401,6 +401,7 @@ public class ReBACService {
 	}
 
 	@Observed(name = "function_profile")
+	// https://github.com/DARPA-ASKEM/terarium/issues/6008
 	public PermissionRole getAdminRole() {
 		final RolesResource rolesResource = keycloak.realm(REALM_NAME).roles();
 		for (final RoleRepresentation roleRepresentation : rolesResource.list()) {


### PR DESCRIPTION
# Description
`getAdminRole` check is failing and by the sounds of it we have decided to just broadcast all workflow SSE to all users instead of fix this.
It is failing on this check `if (roleRepresentation.getId().equals(ASKEM_ADMIN_GROUP_ID)) ...`

