### PR TITLE
Fix: Correct getTimespan 

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -618,6 +618,7 @@ const modelParameters = ref<ModelParameter[]>([]);
 const isOutputSettingsPanelOpen = ref(false);
 
 const datasetColumns = ref<DatasetColumn[]>();
+const dataset = shallowRef<Dataset | null>(null);
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 
@@ -891,7 +892,11 @@ const runCalibrate = async () => {
 			lr: knobs.value.learningRate,
 			num_iterations: knobs.value.numIterations
 		},
-		timespan: getTimespan({ dataset: csvAsset.value, mapping: mapping.value }),
+		timespan: getTimespan(
+			dataset.value as Dataset,
+			knobs.value.timestampColName,
+			knobs.value.endTime // Default is simulation End Time
+		),
 		engine: 'ciemss'
 	};
 
@@ -1004,13 +1009,13 @@ const initialize = async () => {
 	// dataset input
 	if (datasetId.value) {
 		// Get dataset
-		const dataset: Dataset | null = await getDataset(datasetId.value);
-		if (dataset) {
-			const { filename, datasetOptions } = await setupDatasetInput(dataset);
+		dataset.value = await getDataset(datasetId.value);
+		if (dataset.value) {
+			const { filename, datasetOptions } = await setupDatasetInput(dataset.value);
 			currentDatasetFileName.value = filename;
 			datasetColumns.value = datasetOptions;
 
-			setupCsvAsset(dataset).then((csv) => {
+			setupCsvAsset(dataset.value).then((csv) => {
 				csvAsset.value = csv;
 			});
 		}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -490,7 +490,7 @@ import DataTable from 'primevue/datatable';
 import Dropdown from 'primevue/dropdown';
 import Column from 'primevue/column';
 import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
-import { CalibrateMap, setupDatasetInput, setupCsvAsset, setupModelInput } from '@/services/calibrate-workflow';
+import { CalibrateMap, getFileName, setupCsvAsset, setupModelInput } from '@/services/calibrate-workflow';
 import { deleteAnnotation, updateChartSettingsBySelectedVariables } from '@/services/chart-settings';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
@@ -504,7 +504,6 @@ import {
 	ClientEvent,
 	ClientEventType,
 	CsvAsset,
-	DatasetColumn,
 	ModelConfiguration,
 	InterventionPolicy,
 	ModelParameter,
@@ -617,8 +616,8 @@ const modelParameters = ref<ModelParameter[]>([]);
 
 const isOutputSettingsPanelOpen = ref(false);
 
-const datasetColumns = ref<DatasetColumn[]>();
 const dataset = shallowRef<Dataset | null>(null);
+const datasetColumns = computed(() => dataset.value?.columns);
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 
@@ -1011,9 +1010,7 @@ const initialize = async () => {
 		// Get dataset
 		dataset.value = await getDataset(datasetId.value);
 		if (dataset.value) {
-			const { filename, datasetOptions } = await setupDatasetInput(dataset.value);
-			currentDatasetFileName.value = filename;
-			datasetColumns.value = datasetOptions;
+			currentDatasetFileName.value = getFileName(dataset.value);
 
 			setupCsvAsset(dataset.value).then((csv) => {
 				csvAsset.value = csv;

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -345,7 +345,7 @@ import TeraInputNumber from '@/components/widgets/tera-input-number.vue';
 import AccordionTab from 'primevue/accordiontab';
 import Accordion from 'primevue/accordion';
 import Dropdown from 'primevue/dropdown';
-import { setupDatasetInput, setupCsvAsset } from '@/services/calibrate-workflow';
+import { getFileName, setupCsvAsset } from '@/services/calibrate-workflow';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraSaveDatasetFromSimulation from '@/components/dataset/tera-save-dataset-from-simulation.vue';
@@ -456,7 +456,7 @@ const isRunInProgress = computed(() => Boolean(inProgressCalibrationId.value || 
 
 const datasetId = computed(() => props.node.inputs[0].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
-const datasetColumnNames = ref<string[]>();
+const datasetColumnNames = computed(() => dataset.value?.columns?.map((col) => col.name) ?? ([] as string[]));
 // Loss Chart:
 const lossChartRef = ref<InstanceType<typeof VegaChart>>();
 const lossChartSpec = ref();
@@ -627,9 +627,8 @@ onMounted(async () => {
 		// Get dataset
 		dataset.value = await getDataset(datasetId.value);
 		if (dataset.value) {
-			const { filename, datasetOptions } = await setupDatasetInput(dataset.value);
-			currentDatasetFileName.value = filename;
-			datasetColumnNames.value = datasetOptions?.map((ele) => ele.name);
+			currentDatasetFileName.value = getFileName(dataset.value);
+
 			setupCsvAsset(dataset.value).then((csv) => {
 				csvAsset.value = csv;
 			});

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -477,6 +477,7 @@ const tableHeaders = computed(() => {
 // List of each observible + state for each model.
 const allModelOptions = ref<any[][]>([]);
 
+const dataset = shallowRef<Dataset | null>(null);
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 
 const onSelection = (id: string) => {
@@ -584,10 +585,11 @@ const runEnsemble = async () => {
 
 	const calibratePayload: EnsembleCalibrationCiemssRequest = {
 		modelConfigs: formatCalibrateModelConfigurations(knobs.value.ensembleMapping, knobs.value.configurationWeights),
-		timespan: getTimespan({
-			dataset: csvAsset.value,
-			timestampColName: knobs.value.timestampColName
-		}),
+		timespan: getTimespan(
+			dataset.value as Dataset,
+			knobs.value.timestampColName,
+			knobs.value.extra.endTime // Default is simulation End Time
+		),
 		dataset: {
 			id: datasetId.value,
 			filename: currentDatasetFileName.value,
@@ -623,12 +625,12 @@ onMounted(async () => {
 	// dataset input
 	if (datasetId.value) {
 		// Get dataset
-		const dataset: Dataset | null = await getDataset(datasetId.value);
-		if (dataset) {
-			const { filename, datasetOptions } = await setupDatasetInput(dataset);
+		dataset.value = await getDataset(datasetId.value);
+		if (dataset.value) {
+			const { filename, datasetOptions } = await setupDatasetInput(dataset.value);
 			currentDatasetFileName.value = filename;
 			datasetColumnNames.value = datasetOptions?.map((ele) => ele.name);
-			setupCsvAsset(dataset).then((csv) => {
+			setupCsvAsset(dataset.value).then((csv) => {
 				csvAsset.value = csv;
 			});
 		}

--- a/packages/client/hmi-client/src/services/calibrate-workflow.ts
+++ b/packages/client/hmi-client/src/services/calibrate-workflow.ts
@@ -40,16 +40,6 @@ export const setupModelInput = async (modelConfigId: string | undefined) => {
 	return {};
 };
 
-// Used in the setup of calibration node and drill down
-// takes a datasetId and grabs relevant objects
-export const setupDatasetInput = async (dataset: Dataset) => {
-	const filename = getFileName(dataset);
-
-	const datasetOptions = dataset.columns?.filter((ele) => ele.fileName === filename);
-
-	return { filename, datasetOptions };
-};
-
 export const setupCsvAsset = async (dataset: Dataset): Promise<CsvAsset | undefined> => {
 	const filename = getFileName(dataset);
 	// FIXME: We are setting the limit to -1 (i.e. no limit) on the number of rows returned.
@@ -59,6 +49,6 @@ export const setupCsvAsset = async (dataset: Dataset): Promise<CsvAsset | undefi
 	return csv ?? undefined;
 };
 
-const getFileName = (dataset: Dataset) =>
+export const getFileName = (dataset: Dataset) =>
 	// If our dataset includes a result.csv we will ensure to pick it.
 	dataset.fileNames?.includes('result.csv') ? 'result.csv' : (dataset?.fileNames?.[0] ?? '');


### PR DESCRIPTION
# Description

1. Calibration and Ensemble-Calibration rely on a helper `getTimespan`. This helper has been made out of date as we are moving away from CsvAsset and we have removed the stats from this type.
2. Remove the useless helper function for cleaning up and to avoid having people use this in the future `setupDatasetInput`
3. As we are now holding dataset in a shallowRef we should update how we are getting and storing the dataset column information to be consistent. 

# Testing
You should be able to 
- [x] create a calibration node as normal
- [x] create add delete mappings as normal
- [x] run as normal
- [x] select output settings as normal