### PR TITLE
fix model diagram pan/zoom in create model from equations op

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-preview.vue
@@ -40,7 +40,6 @@ header {
 
 .content-container > main {
 	overflow-y: auto;
-	padding: var(--gap-4);
 	flex-grow: 1;
 	padding-top: 0;
 	padding-left: 0;

--- a/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider-panel.vue
@@ -146,8 +146,8 @@ header:not(.tab) {
 		background: color-mix(in srgb, var(--surface-100) 80%, transparent 20%);
 	}
 
-	& :deep(.slider-content),
-	& :deep(.slider-tab) {
+	& :deep(.content),
+	& :deep(.tab) {
 		background-color: var(--surface-100);
 		border-right: 1px solid var(--surface-border-light);
 	}

--- a/packages/client/hmi-client/src/components/widgets/tera-slider.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-slider.vue
@@ -3,15 +3,15 @@
 		:class="`slider ${isOpen ? 'open' : 'closed'} ${direction}`"
 		:style="{ width: isOpen ? contentWidth : tabWidth, minWidth: minTabWidth }"
 	>
-		<div class="slider-content-container" :style="{ width: isOpen ? contentWidth : 0 }">
-			<section class="slider-content" :style="sidePanelContentStyle">
+		<div class="container" :style="[contentStyle, { width: isOpen ? contentWidth : '0%' }]">
+			<section class="content">
 				<slot name="content" />
 			</section>
 			<footer>
 				<slot name="footerButtons" />
 			</footer>
 		</div>
-		<section class="slider-tab" :style="sidePanelTabStyle">
+		<section class="tab" :style="tabStyle">
 			<slot name="tab"></slot>
 		</section>
 	</aside>
@@ -54,9 +54,8 @@ const directionMap = {
 	}
 };
 
-const sidePanelContentStyle = computed(() => (thisSlider?.slots.footerButtons ? 'height: calc(100% - 5rem);' : ''));
-
-const sidePanelTabStyle = computed(() => `width: ${props.tabWidth}; ${directionMap[props.direction].tab()}`);
+const contentStyle = computed(() => (thisSlider?.slots.footerButtons ? 'height: calc(100% - 5rem);' : ''));
+const tabStyle = computed(() => `width: ${props.tabWidth}; ${directionMap[props.direction].tab()}`);
 </script>
 
 <style scoped>
@@ -64,8 +63,8 @@ aside {
 	position: relative;
 }
 .slider,
-.slider-content,
-.slider-tab,
+.content,
+.tab,
 footer {
 	transition: all 0.2s ease-out;
 }
@@ -75,36 +74,32 @@ footer {
 	z-index: 0;
 }
 
-.slider-content-container {
+.container {
 	position: absolute;
 	height: 100%;
 	transition: width 0.2s ease-out;
 }
 
-.slider-tab {
+.tab {
 	position: relative;
 	height: 100%;
 	background-color: var(--surface-section);
 	z-index: 1;
 }
 
-.slider.open .slider-tab,
-.slider.closed .slider-content,
+.slider.open .tab,
+.slider.closed .content,
 .slider.closed footer {
 	visibility: hidden;
 	opacity: 0;
 }
 
-.slider-content {
+.content {
 	background-color: var(--surface-section);
 	position: relative;
 	width: 100%;
 	height: 100%;
 	overflow-y: auto;
-}
-
-footer:empty {
-	display: none;
 }
 
 footer {
@@ -118,5 +113,9 @@ footer {
 	display: flex;
 	align-items: center;
 	justify-content: space-evenly;
+
+	&:empty {
+		display: none;
+	}
 }
 </style>

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -171,12 +171,14 @@
 				content-width="100%"
 			>
 				<template #content>
-					<tera-drilldown-preview :is-loading="isModelLoading">
+					<!--The isOutputOpen condition enables the model diagram within tera-model to render properly
+						since we need some sort of width available-->
+					<tera-drilldown-preview v-if="isOutputOpen" :is-loading="isModelLoading">
 						<tera-model
 							v-if="selectedModel"
 							is-workflow
 							is-save-for-reuse
-							:assetId="selectedModel.id"
+							:asset-id="selectedModel.id"
 							@on-save="onModelSaveEvent"
 						/>
 						<tera-operator-placeholder v-else :node="node" class="h-100">


### PR DESCRIPTION
# Description

* If the tera-model-diagram is within a collapsed slider it renders itself without having a width to work with
* Now with the `v-if` I added it will mount once the slider is opened
* Fix is [here](https://github.com/DARPA-ASKEM/terarium/pull/6027/files#diff-2f796b404e2219b0045f6ee5141b6caa46be4372ebd0720307afca92e0b412f2) the rest is just some css clean up related the slider components


https://github.com/user-attachments/assets/53905006-f265-48b0-897b-47f9d447632e


