### PR TITLE
[FEAT]: Copy model interventions and configs with model #5739

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -866,7 +866,7 @@ public class ProjectController {
 			if (owningProjectId != null) {
 				// if the asset is already under another project, we need to clone it and its
 				// dependencies
-				assets = cloneService.cloneAndPersistAsset(owningProjectId, assetId);
+				assets = cloneService.cloneAndPersistAsset(owningProjectId, assetId, assetType);
 			} else {
 				// TODO: we should probably check asset dependencies and make sure they are part
 				// of the project, and if not clone them
@@ -885,7 +885,7 @@ public class ProjectController {
 		for (final TerariumAsset asset : assets) {
 			final Optional<ProjectAsset> projectAsset = projectAssetService.createProjectAsset(
 				project.get(),
-				assetType,
+				TerariumAssetServices.getAssetType(asset),
 				asset,
 				permission
 			);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServices.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import software.uncharted.terarium.hmiserver.models.TerariumAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.Artifact;
@@ -15,6 +16,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.document.Documen
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
+import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.workflow.Workflow;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
@@ -23,6 +25,7 @@ import software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TerariumAssetServices {
 
 	private final ArtifactService artifactService;
@@ -107,5 +110,44 @@ public class TerariumAssetServices {
 			case PROJECT -> projectService.getProject(assetId).orElse(null);
 			default -> null;
 		};
+	}
+
+	public static AssetType getAssetType(final TerariumAsset asset) {
+		if (asset instanceof Artifact) {
+			return AssetType.ARTIFACT;
+		}
+		if (asset instanceof Code) {
+			return AssetType.CODE;
+		}
+		if (asset instanceof Dataset) {
+			return AssetType.DATASET;
+		}
+		if (asset instanceof DocumentAsset) {
+			return AssetType.DOCUMENT;
+		}
+		if (asset instanceof InterventionPolicy) {
+			return AssetType.INTERVENTION_POLICY;
+		}
+		if (asset instanceof Model) {
+			return AssetType.MODEL;
+		}
+		if (asset instanceof ModelConfiguration) {
+			return AssetType.MODEL_CONFIGURATION;
+		}
+		if (asset instanceof NotebookSession) {
+			return AssetType.NOTEBOOK_SESSION;
+		}
+		if (asset instanceof Simulation) {
+			return AssetType.SIMULATION;
+		}
+		if (asset instanceof Workflow) {
+			return AssetType.WORKFLOW;
+		}
+		if (asset instanceof Project) {
+			return AssetType.PROJECT;
+		}
+
+		log.warn("Unknown asset type: {}", asset.getClass().getName());
+		return null;
 	}
 }

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
@@ -159,7 +159,11 @@ public class TerariumAssetCloneServiceTests extends TerariumApplicationTests {
 
 		projectAssetService.createProjectAsset(project, AssetType.WORKFLOW, workflow, ASSUME_WRITE_PERMISSION);
 
-		final List<TerariumAsset> cloned = cloneService.cloneAndPersistAsset(project.getId(), workflow.getId());
+		final List<TerariumAsset> cloned = cloneService.cloneAndPersistAsset(
+			project.getId(),
+			workflow.getId(),
+			AssetType.WORKFLOW
+		);
 
 		Assertions.assertEquals(1 + NUM_DOCUMENTS, cloned.size());
 		Assertions.assertEquals(1, cloned.stream().filter(a -> a instanceof Workflow).count());


### PR DESCRIPTION
# Description

Manually checking for a model to be copied, then check for intervention policies or configurations associated with that model to clone. The manual check has to be done because currently we walk the json of the `model` in a one-direction way, but models don't contain references to their configs/interventions... thats the other way around. This was a quicker fix for a deadline. Better fix would be to have models include references outward and then this problem goes away.

Resolves #5739
