### PR TITLE
fix: model page entry key should be id instead of index

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
@@ -2,7 +2,7 @@
 	<ul v-bind="$attrs">
 		<li
 			v-for="({ base, children, isParent }, index) in filteredItems.slice(firstRow, firstRow + MAX_NUMBER_OF_ROWS)"
-			:key="index"
+			:key="base.id"
 			class="model-part"
 		>
 			<template v-if="isParent && !isEmpty(editingState)">


### PR DESCRIPTION
# Description

* Editing entries were based on list index instead of id
* Now the same list index of a different page can be uniquely edited

Before: 


https://github.com/user-attachments/assets/ba904583-274a-4384-b834-0819fd2b56ca



After:

https://github.com/user-attachments/assets/a43c3275-a54e-4a60-b22b-db4a792b9de4


