### PR TITLE
fix rendering edges that are created through quick-menu

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -484,7 +484,7 @@ async function onMenuSelection(operatorType: string, menuNode: WorkflowNode<any>
 		const updatedWorkflow = await workflowService.addEdge(wf.value.getId(), edgePayload);
 		wf.value.update(updatedWorkflow, false);
 
-		// Force edges to re-evaulate
+		// Force edges to re-evaluate
 		relinkEdges(null);
 	}
 }

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -483,6 +483,9 @@ async function onMenuSelection(operatorType: string, menuNode: WorkflowNode<any>
 
 		const updatedWorkflow = await workflowService.addEdge(wf.value.getId(), edgePayload);
 		wf.value.update(updatedWorkflow, false);
+
+		// Force edges to re-evaulate
+		relinkEdges(null);
 	}
 }
 


### PR DESCRIPTION
### Summary
Force edges to re-evaluate when adding connecting operators through the quick-menu.  This is a new problem due to splitting apart the updates APIs, and some certain actions no longer trigger edge evaluations because things are done piece-wise.


### Testing
Add a model to workflow
- Connect to model-config
- From the quick-menu in model-config (the "+" button), create a connection to calibrate and calibrante-ensemble

Both the calibrate/calibrate-ensemble node and connecting edge should be shown.

![Uploading image.png…]()
