### PR TITLE
Calibrate Mapping Options: Filter dataset columns on filename.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -1045,7 +1045,6 @@ const getConfiguredModelConfig = async () => {
 
 onMounted(async () => {
 	initialize();
-	console.log(datasetColumns);
 });
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -617,7 +617,9 @@ const modelParameters = ref<ModelParameter[]>([]);
 const isOutputSettingsPanelOpen = ref(false);
 
 const dataset = shallowRef<Dataset | null>(null);
-const datasetColumns = computed(() => dataset.value?.columns);
+const datasetColumns = computed(() =>
+	dataset.value?.columns?.filter((col) => col.fileName === currentDatasetFileName.value)
+);
 const csvAsset = shallowRef<CsvAsset | undefined>(undefined);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 
@@ -1043,6 +1045,7 @@ const getConfiguredModelConfig = async () => {
 
 onMounted(async () => {
 	initialize();
+	console.log(datasetColumns);
 });
 
 watch(


### PR DESCRIPTION
# Description
This is related to this morning's PR about updating dataset columns. We should filter based off of our current dataset now so we are not showing risk.json's dataset columns as options for the user

Pre change:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/941bb3ad-d135-4b9e-9c8c-8a8c50a6fd58" />

Post change: 
<img width="470" alt="image" src="https://github.com/user-attachments/assets/2884c55d-8c9f-47ed-b767-12e7931cf76e" />

