### PR TITLE
fix compare dataset charts from template

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
@@ -17,7 +17,6 @@ import {
 import { ChartSetting, ChartSettingType } from '@/types/common';
 import { updateChartSettingsBySelectedVariables } from '@/services/chart-settings';
 import { InterventionPolicy } from '@/types/Types';
-import { getMeanCompareDatasetVariables } from '../scenario-template-utils';
 
 export class DecisionMakingScenario extends BaseScenario {
 	public static templateId = 'decision-making';
@@ -178,7 +177,7 @@ export class DecisionMakingScenario extends BaseScenario {
 		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
 			compareDatasetChartSettings,
 			ChartSettingType.VARIABLE,
-			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+			this.simulateSpec.ids
 		);
 
 		// 2. Add base simulation (no interventions) and connect it to the compare datasets node

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
@@ -15,7 +15,6 @@ import { DistributionType } from '@/services/distribution';
 import { calculateUncertaintyRange } from '@/utils/math';
 import { blankIntervention, createInterventionPolicy, getInterventionPolicyById } from '@/services/intervention-policy';
 import { useProjects } from '@/composables/project';
-import { getMeanCompareDatasetVariables } from '../scenario-template-utils';
 
 export interface HorizonScanningParameter {
 	id: string;
@@ -220,7 +219,7 @@ export class HorizonScanningScenario extends BaseScenario {
 		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
 			compareDatasetChartSettings,
 			ChartSettingType.VARIABLE,
-			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+			this.simulateSpec.ids
 		);
 
 		wf.updateNode(compareDatasetNode, {

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/scenario-template-utils.ts
@@ -1,6 +1,5 @@
 import { DistributionType } from '@/services/distribution';
-import { getInitials, getObservables } from '@/services/model-configurations';
-import { ModelConfiguration, ParameterSemantic } from '@/types/Types';
+import { ParameterSemantic } from '@/types/Types';
 import { calculateUncertaintyRange } from '@/utils/math';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -34,18 +33,6 @@ export const switchToUniformDistribution = (parameter: ParameterSemantic) => {
 		parameter.distribution.parameters = { minimum, maximum };
 	}
 };
-
-const getCompareDatasetVariablePrefixes = (selectedMetrics: string[], modelConfiguration: ModelConfiguration) =>
-	selectedMetrics.map((metric) => {
-		const state = getInitials(modelConfiguration).some((i) => i.target === metric);
-		if (state) return `${metric}_state`;
-		const observable = getObservables(modelConfiguration).some((o) => o.referenceId === metric);
-		if (observable) return `${metric}_observable_state`;
-		return metric;
-	});
-
-export const getMeanCompareDatasetVariables = (selectedMetrics: string[], modelConfiguration: ModelConfiguration) =>
-	getCompareDatasetVariablePrefixes(selectedMetrics, modelConfiguration).map((metric) => `${metric}_mean`);
 
 export function usePolicyModel(props, interventionDropdowns, policyModalContext, isPolicyModalVisible) {
 	const onOpenPolicyModel = (index: number) => {

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
@@ -17,7 +17,7 @@ import { updateChartSettingsBySelectedVariables } from '@/services/chart-setting
 import { AssetType, InterventionPolicy, ParameterSemantic } from '@/types/Types';
 import { blankIntervention, createInterventionPolicy, getInterventionPolicyById } from '@/services/intervention-policy';
 import { useProjects } from '@/composables/project';
-import { getMeanCompareDatasetVariables, switchToUniformDistribution } from '../scenario-template-utils';
+import { switchToUniformDistribution } from '../scenario-template-utils';
 
 /*
  * Value of information scenario
@@ -206,7 +206,7 @@ export class ValueOfInformationScenario extends BaseScenario {
 		compareDatasetChartSettings = updateChartSettingsBySelectedVariables(
 			compareDatasetChartSettings,
 			ChartSettingType.VARIABLE,
-			getMeanCompareDatasetVariables(this.simulateSpec.ids, modelConfig)
+			this.simulateSpec.ids
 		);
 
 		wf.updateNode(compareDatasetNode, {


### PR DESCRIPTION
# Description

* A recent change to the chart selection in compare dataset caused the template default selection to break since we were selecting different variables, this is now fixed with this changed
* removed now unused functions
