### PR TITLE
Simulate - Save Solver Step Size with output

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -417,7 +417,7 @@ watch(
 						datasetId: datasetResult.id
 					}
 				],
-				state
+				state: _.omit(state, ['chartSettings'])
 			});
 		}
 	},

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -280,7 +280,7 @@ watch(
 				type: CalibrateEnsembleCiemssOperation.outputs[0].type,
 				label: nodeOutputLabel(props.node, `Calibration Result`),
 				value: datasetResult.id,
-				state
+				state: _.omit(state, ['chartSettings'])
 			});
 		}
 	},

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-node.vue
@@ -270,7 +270,7 @@ Provide a consis summary in 100 words or less.
 					}
 				],
 				isSelected: false,
-				state
+				state: _.omit(state, ['chartSettings'])
 			});
 		} else {
 			// Simulation Failed:

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -44,9 +44,7 @@
 import _ from 'lodash';
 import { computed, ref, toRef, watch } from 'vue';
 import Button from 'primevue/button';
-
 import { logger } from '@/utils/logger';
-
 import { updateChartSettingsBySelectedVariables, updateSensitivityChartSettingOption } from '@/services/chart-settings';
 import { createDatasetFromSimulationResult } from '@/services/dataset';
 import { flattenInterventionData, getInterventionPolicyById } from '@/services/intervention-policy';
@@ -180,19 +178,12 @@ Provide a summary in 100 words or less.
 		logger.error('Error creating dataset from simulation result.');
 		return;
 	}
-
+	console.log(_.omit({ ...props.node.state, summaryId: summaryResponse?.id }, ['chartSettings']));
 	emit('append-output', {
 		type: SimulateCiemssOperation.outputs[0].type,
 		label: datasetName,
 		value: [datasetResult.id],
-		state: {
-			currentTimespan: state.currentTimespan,
-			numSamples: state.numSamples,
-			method: state.method,
-			solverStepSize: state.solverStepSize,
-			summaryId: summaryResponse?.id,
-			forecastId: runId
-		},
+		state: _.omit({ ...props.node.state, summaryId: summaryResponse?.id }, ['chartSettings']),
 		isSelected: false
 	});
 };

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -180,6 +180,7 @@ Provide a summary in 100 words or less.
 		logger.error('Error creating dataset from simulation result.');
 		return;
 	}
+
 	emit('append-output', {
 		type: SimulateCiemssOperation.outputs[0].type,
 		label: datasetName,
@@ -188,6 +189,7 @@ Provide a summary in 100 words or less.
 			currentTimespan: state.currentTimespan,
 			numSamples: state.numSamples,
 			method: state.method,
+			solverStepSize: state.solverStepSize,
 			summaryId: summaryResponse?.id,
 			forecastId: runId
 		},

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -178,7 +178,7 @@ Provide a summary in 100 words or less.
 		logger.error('Error creating dataset from simulation result.');
 		return;
 	}
-	console.log(_.omit({ ...props.node.state, summaryId: summaryResponse?.id }, ['chartSettings']));
+
 	emit('append-output', {
 		type: SimulateCiemssOperation.outputs[0].type,
 		label: datasetName,

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -104,7 +104,7 @@ const processResult = async (simulationId: string) => {
 		type: SimulateEnsembleCiemssOperation.outputs[0].type,
 		label: nodeOutputLabel(props.node, `${portLabel} Result`),
 		value: [datasetResult.id],
-		state,
+		state: _.omit(state, ['chartSettings']),
 		isSelected: false
 	});
 };


### PR DESCRIPTION
# Description
- Chart settings should not be stored in output's state as per a quick conversation in the design channel.
- make sure that simulate follows the same set up as the rest of the TA3