### PR TITLE
Workflow sync fix part 3

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -299,7 +299,7 @@ const saveNodeStateHandler = debounce(async () => {
 	const updatedWorkflow = await workflowService.updateState(wf.value.getId(), nodeStateMap);
 	nodeStateMap.clear();
 	wf.value.update(updatedWorkflow, false);
-}, 300);
+}, 250);
 
 const saveWorkflowHandler = () => {
 	saveWorkflowDebounced();
@@ -337,13 +337,17 @@ async function appendOutput(
 		operatorStatus: OperatorStatus.SUCCESS
 	};
 
-	const updatedWorkflow = await workflowService.appendOutput(wf.value.getId(), node.id, outputPort, node.state);
+	const updatedWorkflow = await workflowService.appendOutput(wf.value.getId(), node.id, outputPort, null);
 	wf.value.update(updatedWorkflow, false);
 }
 
 function updateWorkflowNodeState(node: WorkflowNode<any> | null, state: any) {
 	if (!node) return;
-	nodeStateMap.set(node.id, state);
+	if (nodeStateMap.has(node.id)) {
+		nodeStateMap.set(node.id, Object.assign(nodeStateMap.get(node.id), state));
+	} else {
+		nodeStateMap.set(node.id, state);
+	}
 	saveNodeStateHandler();
 }
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -633,7 +633,6 @@ public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow,
 
 		// If nodeState is provided, also set the state
 		if (nodeState != null && nodeState.isNull() == false) {
-			System.out.println("setting state!!!");
 			operator.setState(nodeState);
 		}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -632,7 +632,8 @@ public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow,
 		}
 
 		// If nodeState is provided, also set the state
-		if (nodeState != null) {
+		if (nodeState != null && nodeState.isNull() == false) {
+			System.out.println("setting state!!!");
 			operator.setState(nodeState);
 		}
 
@@ -645,6 +646,7 @@ public class WorkflowService extends TerariumAssetServiceWithoutSearch<Workflow,
 		operator.setOutputs(
 			operator.getOutputs().stream().filter(output -> output.getValue() != null).collect(Collectors.toList())
 		);
+
 		selectOutput(workflow, nodeId, port.getId());
 	}
 


### PR DESCRIPTION
### Summary
This PR address a couple of sync issues

1. In part-1 https://github.com/DARPA-ASKEM/terarium/pull/5979 we changed appendOutput to also include a state, mostly this was because the state changes were done in part-2 https://github.com/DARPA-ASKEM/terarium/pull/6019 and it acted as a kind of polyfill. Basically in part-2 I forgot to remove it. Here we take this out but left adding a state as an option as it is probably a better way to handle new outputs and we can migrate slowly.

2. We introduced a bug with ☝️ in workflowservice.java checking nulls where we need to check for json-nulls on top of it.

3. To actually address the problem @Tom-Szendrey  found. There are scenarios where update-state event are emitted back-to-back-to-back programmatically. In order to ensure state variable dependencies are sane, we need to update the local copy immediately rather than debouncing the update to the DB.




