### PR TITLE
removed goto for  model config and intervention

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -292,7 +292,6 @@ interface SelectedIntervention {
 
 const currentActiveIndicies = ref([0, 1]);
 const pdfPanelRef = ref();
-const pdfViewer = computed(() => pdfPanelRef.value?.pdfRef[0]);
 const selectedIntervention = ref<SelectedIntervention | null>(null);
 
 const isPdfSidebarOpen = ref(true);
@@ -451,11 +450,6 @@ const fetchInterventionPolicies = async (modelId: string) => {
 
 const selectInterventionPolicy = (intervention: Intervention, index: number) => {
 	selectedIntervention.value = { ...intervention, index };
-	if (!intervention?.extractionPage) return;
-
-	if (pdfViewer.value) {
-		pdfViewer.value.goToPage(selectedIntervention.value.extractionPage);
-	}
 };
 
 const onUpdateInterventionCard = (intervention: Intervention, index: number) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -315,7 +315,6 @@ const currentActiveIndexes = ref([0, 1, 2]);
 const observableActiveIndicies = ref([0]);
 const pdfData = ref<{ document: any; data: string; isPdf: boolean; name: string }[]>([]);
 const pdfPanelRef = ref();
-const pdfViewer = computed(() => pdfPanelRef.value?.pdfRef);
 
 const isSidebarOpen = ref(true);
 const isEditingDescription = ref(false);
@@ -692,16 +691,6 @@ const initialize = async (overwriteWithState: boolean = false) => {
 };
 
 const onSelectConfiguration = async (config: ModelConfiguration) => {
-	let tabIndex = 0;
-	if (pdfPanelRef.value && config.extractionDocumentId) {
-		tabIndex = await pdfPanelRef.value.selectPdf(config.extractionDocumentId);
-		await nextTick();
-	}
-
-	if (pdfViewer.value && config.extractionPage) {
-		pdfViewer.value[tabIndex].goToPage(config.extractionPage);
-	}
-
 	const { transientModelConfig } = knobs.value;
 	// If no changes were made switch right away
 	if (isModelConfigsEqual(originalConfig, transientModelConfig)) {


### PR DESCRIPTION
# Description

Design Change:
- Remove Pdf goto page function from Model Config & Intervention drill down.

Testing:
- Create a model config and connect a pdf document
- extract inputs
- pdf page shouldn't change when selecting different configs

- Create a intervention policy and connect a pdf document & model
- extract inputs
- pdf page shouldn't change when switching between interventions 

Resolves #(issue)
