### PR TITLE
hook up append-input event in workflow to server workflow update

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -72,7 +72,7 @@
 							:is="registry.getNode(node.operationType)"
 							:node="node"
 							@append-output="(port: any, newState: any) => appendOutput(node, port, newState)"
-							@append-input-port="(event: any) => workflowService.appendInputPort(node, event)"
+							@append-input-port="(event: any) => appendInput(node, event)"
 							@update-state="(event: any) => updateWorkflowNodeState(node, event)"
 							@open-drilldown="addOperatorToRoute(node.id)"
 						/>
@@ -304,6 +304,27 @@ const saveNodeStateHandler = debounce(async () => {
 const saveWorkflowHandler = () => {
 	saveWorkflowDebounced();
 };
+
+async function appendInput(
+	node: WorkflowNode<any>,
+	port: {
+		label: string;
+		type: string;
+		isOptional?: boolean;
+	}
+) {
+	const inputPort: WorkflowPort = {
+		id: uuidv4(),
+		type: port.type,
+		label: port.label,
+		isOptional: port.isOptional || false,
+		value: null,
+		status: WorkflowPortStatus.NOT_CONNECTED
+	};
+
+	const updatedWorkflow = await workflowService.appendInput(wf.value.getId(), node.id, inputPort);
+	wf.value.update(updatedWorkflow, false);
+}
 
 /**
  * The operator creates a new output, this will mark the

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -898,6 +898,12 @@ export const appendOutput = async (id: string, nodeId: string, output: WorkflowO
 	return response.data ?? null;
 };
 
+export const appendInput = async (id: string, nodeId: string, input: WorkflowPort) => {
+	console.log('>> workflowService.appendInput');
+	const response = await API.post(`/workflows/${id}/append-input/${nodeId}`, input);
+	return response.data ?? null;
+};
+
 export const addNode = async (id: string, node: WorkflowNode<any>) => {
 	console.log('>> workflowService.addNode');
 	const response = await API.post(`/workflows/${id}/node`, node);
@@ -1160,6 +1166,7 @@ export function setLocalStorageTransform(id: string, canvasTransform: { x: numbe
 	localStorage.setItem('terariumWorkflowTransforms', JSON.stringify(workflowTransformations));
 }
 
+// FIXME: move this into WorkflowWrapper, confusing with appendInput which is an API call
 export function appendInputPort(node: WorkflowNode<any>, port: { type: string; label?: string }) {
 	node.inputs.push({
 		id: uuidv4(),


### PR DESCRIPTION
Closes https://github.com/DARPA-ASKEM/terarium/issues/6031

### Summary
`append-input` event wasn't wired up correctly. It only changes the client's version of the workflow, so the server's version does not have any of the newly created ports. This PR should address that.

Note: Things are a bit messy currently, as there is the workflow-wrapper, that functionally overlaps with the server logic. While the workflow-wrapper is more or less deprecated with respect to terarium-workflow.vue, it is used in the scenariot-templates. I marked a couple of areas where we should start tidying up things but these are out of scope here.