### PR TITLE
Updated weight chart extent

### DIFF
--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -794,6 +794,7 @@ export function useCharts(
 					xAxisTitle: `Weights`,
 					yAxisTitle: 'Count',
 					maxBins,
+					extent: [0, 1], // Weights are between 0 and 1
 					variables: [
 						{ field: beforeFieldName, label: labelBefore, width: barWidth, color: BASE_GREY },
 						{ field: fieldName, label: labelAfter, width: barWidth / 2, color: colors[index % colors.length] }

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -83,6 +83,7 @@ export interface HistogramChartOptions extends BaseChartOptions {
 	maxBins?: number;
 	variables: { field: string; label?: string; width: number; color: string }[];
 	legendProperties?: Record<string, any>;
+	extent?: [number, number];
 }
 
 export interface ErrorChartOptions extends Omit<BaseChartOptions, 'height' | 'yAxisTitle' | 'legend'> {
@@ -362,12 +363,14 @@ export function createHistogramChart(dataset: Record<string, any>[], options: Hi
 
 	spec.data = { values: data };
 
-	// Create an extent from the min max of the data across all variables, this is used to set the bin extent and let multiple histograms from different layers to share the same bin extent
-	const extent = [Infinity, -Infinity];
-	data.forEach((d) => {
-		extent[0] = Math.min(extent[0], Math.min(...Object.values(d)));
-		extent[1] = Math.max(extent[1], Math.max(...Object.values(d)));
-	});
+	const extent = options.extent ?? [Infinity, -Infinity];
+	if (!options.extent) {
+		// Create an extent from the min max of the data across all variables, this is used to set the bin extent and let multiple histograms from different layers to share the same bin extent
+		data.forEach((d) => {
+			extent[0] = Math.min(extent[0], Math.min(...Object.values(d)));
+			extent[1] = Math.max(extent[1], Math.max(...Object.values(d)));
+		});
+	}
 
 	const createLayers = (opts) => {
 		const colorScale = {


### PR DESCRIPTION
# Description

The weight plots share the same x axis 0-1

**Before**
![Screenshot 2025-01-14 at 5 20 19 PM](https://github.com/user-attachments/assets/35e6bf52-c63f-45af-ab3a-b26f07237325)

**After**
![Screenshot 2025-01-14 at 5 17 13 PM](https://github.com/user-attachments/assets/c49201bd-5b2d-42d6-80bd-73eeaf88cf09)

Resolves #5897 
