### PR TITLE
better route naming convention

### DIFF
--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -886,7 +886,7 @@ export const newOperator = (
 
 export const selectOutput = async (id: string, nodeId: string, outputId: string, projectId?: string) => {
 	console.log('>> workflowService.selectOutput');
-	const response = await API.post(`/workflows/${id}/select-output/${nodeId}/${outputId}`, {
+	const response = await API.post(`/workflows/${id}/node/${nodeId}/select-output/${outputId}`, {
 		params: { 'project-id': projectId }
 	});
 	return response.data ?? null;
@@ -894,13 +894,13 @@ export const selectOutput = async (id: string, nodeId: string, outputId: string,
 
 export const appendOutput = async (id: string, nodeId: string, output: WorkflowOutput<any>, nodeState: any) => {
 	console.log('>> workflowService.appendOutput');
-	const response = await API.post(`/workflows/${id}/append-output/${nodeId}`, { output, nodeState });
+	const response = await API.post(`/workflows/${id}/node/${nodeId}/output`, { output, nodeState });
 	return response.data ?? null;
 };
 
 export const appendInput = async (id: string, nodeId: string, input: WorkflowPort) => {
 	console.log('>> workflowService.appendInput');
-	const response = await API.post(`/workflows/${id}/append-input/${nodeId}`, input);
+	const response = await API.post(`/workflows/${id}/node/${nodeId}/input`, input);
 	return response.data ?? null;
 };
 
@@ -916,6 +916,9 @@ export const addEdge = async (id: string, edge: WorkflowEdge) => {
 	return response.data ?? null;
 };
 
+/// /////////////////////////////////////////////////////////////////////////////
+// Bulk API actions
+/// /////////////////////////////////////////////////////////////////////////////
 export const removeNodes = async (id: string, nodeIds: string[]) => {
 	console.log('>> workflowService.removeNode', nodeIds);
 	const response = await API.post(`/workflows/${id}/remove-nodes`, nodeIds);

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -886,7 +886,7 @@ export const newOperator = (
 
 export const selectOutput = async (id: string, nodeId: string, outputId: string, projectId?: string) => {
 	console.log('>> workflowService.selectOutput');
-	const response = await API.post(`/workflows/${id}/node/${nodeId}/select-output/${outputId}`, {
+	const response = await API.post(`/workflows/${id}/node/${nodeId}/selected-output/${outputId}`, {
 		params: { 'project-id': projectId }
 	});
 	return response.data ?? null;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -280,7 +280,7 @@ public class WorkflowController {
 		return ResponseEntity.ok(new ResponseDeleted("Workflow", id));
 	}
 
-	@PostMapping("/{id}/node/{nodeId}/select-output/{outputId}")
+	@PostMapping("/{id}/node/{nodeId}/selected-output/{outputId}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Select an operator output to use")
 	@ApiResponses(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -280,7 +280,7 @@ public class WorkflowController {
 		return ResponseEntity.ok(new ResponseDeleted("Workflow", id));
 	}
 
-	@PostMapping("/{id}/select-output/{nodeId}/{outputId}")
+	@PostMapping("/{id}/node/{nodeId}/select-output/{outputId}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Select an operator output to use")
 	@ApiResponses(
@@ -423,7 +423,7 @@ public class WorkflowController {
 		private JsonNode nodeState;
 	}
 
-	@PostMapping("/{id}/append-input/{nodeId}")
+	@PostMapping("/{id}/node/{nodeId}/input")
 	@Secured(Roles.USER)
 	@Operation(summary = "Append an input port to an operator node")
 	@ApiResponses(
@@ -469,7 +469,7 @@ public class WorkflowController {
 		return updated.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
 	}
 
-	@PostMapping("/{id}/append-output/{nodeId}")
+	@PostMapping("/{id}/node/{nodeId}/output")
 	@Secured(Roles.USER)
 	@Operation(summary = "Append an output to an operator node")
 	@ApiResponses(


### PR DESCRIPTION
### Summary
More consistent and resource oriented REST API route names. Try to adhere to:

```
/resource/:resource-id/sub-resource/:sub-resource-id/sub-sub-resource ... 
```


### Testing
No real function changes, workflow should behave the same as before.