### PR TITLE
Fetch simulation result from `getRunResultCSV` to leverage cached results

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
@@ -1,6 +1,11 @@
 import { Dataset } from '@/types/Types';
 import { renameFnGenerator } from '@/components/workflow/ops/calibrate-ciemss/calibrate-utils';
-import { DataArray, parsePyCiemssMap, processAndSortSamplesByTimepoint } from '@/services/models/simulation-service';
+import {
+	DataArray,
+	getRunResultCSV,
+	parsePyCiemssMap,
+	processAndSortSamplesByTimepoint
+} from '@/services/models/simulation-service';
 import { DATASET_VAR_NAME_PREFIX, getDatasetResultCSV, mergeResults } from '@/services/dataset';
 import { ChartData } from '@/composables/useCharts';
 import { PlotValue } from './compare-datasets-operation';
@@ -31,7 +36,7 @@ export async function fetchDatasetResults(datasetList: Dataset[]) {
 		await Promise.all(
 			datasetList.map((dataset, datasetIndex) => {
 				if (!isSimulationData(dataset)) return Promise.resolve([]);
-				return getDatasetResultCSV(dataset, 'result.csv', renameFnGenerator(`${datasetIndex}`));
+				return getRunResultCSV(dataset.metadata.simulationId, 'result.csv', renameFnGenerator(`${datasetIndex}`));
 			})
 		)
 	).filter((result) => result.length > 0);
@@ -40,7 +45,11 @@ export async function fetchDatasetResults(datasetList: Dataset[]) {
 		await Promise.all(
 			datasetList.map((dataset, datasetIndex) => {
 				if (!isSimulationData(dataset)) return Promise.resolve([]);
-				return getDatasetResultCSV(dataset, 'result_summary.csv', renameFnGenerator(`${datasetIndex}`));
+				return getRunResultCSV(
+					dataset.metadata.simulationId,
+					'result_summary.csv',
+					renameFnGenerator(`${datasetIndex}`)
+				);
 			})
 		)
 	).filter((result) => result.length > 0);


### PR DESCRIPTION
# Description

For simulation data result in compare datasets operator, using `getRunResultCSV` allows to use already cached results from the simulation operators which are inputs to this node. 

Resolves #(issue)
