### PR TITLE
Display project in add to project menu in alphabetical order

### DIFF
--- a/packages/client/hmi-client/src/composables/project.ts
+++ b/packages/client/hmi-client/src/composables/project.ts
@@ -64,7 +64,17 @@ export function useProjects() {
 			const interval = setInterval(() => {
 				if (areProjectsLoaded) {
 					clearInterval(interval);
-					resolve(allProjects.value?.filter((project) => project.id !== activeProjectId.value) ?? []);
+					const projects: Project[] = (allProjects.value ?? [])
+						.filter((project) => project.id !== activeProjectId.value)
+						.sort((a, b) => {
+							// sort by name
+							const nameA = (a?.name ?? '').toUpperCase();
+							const nameB = (b?.name ?? '').toUpperCase();
+							if (nameA < nameB) return -1;
+							if (nameA > nameB) return 1;
+							return 0; // names must be equal
+						});
+					resolve(projects);
 				}
 			}, TIMEOUT_MS);
 		});


### PR DESCRIPTION
This pull request includes a change to the `useProjects` function in the `packages/client/hmi-client/src/composables/project.ts` file to improve the sorting of projects. The most important change is the addition of a sorting mechanism to order the projects by name.

fix #6070 