### PR TITLE
Jamie adjust situational awareness template

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/blank-canvas/blank-canvas-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/blank-canvas/blank-canvas-scenario.ts
@@ -4,7 +4,7 @@ import * as workflowService from '@/services/workflow';
 export class BlankCanvasScenario extends BaseScenario {
 	public static templateId = 'blank-canvas';
 
-	public static templateName = 'Blank Canvas';
+	public static templateName = 'Blank canvas';
 
 	constructor() {
 		super();

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
@@ -21,7 +21,7 @@ import { InterventionPolicy } from '@/types/Types';
 export class DecisionMakingScenario extends BaseScenario {
 	public static templateId = 'decision-making';
 
-	public static templateName = 'Decision Making';
+	public static templateName = 'Decision making';
 
 	modelSpec: { id: string };
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/tera-decision-making-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/tera-decision-making-template.vue
@@ -34,7 +34,9 @@
 			</Dropdown>
 
 			<template v-for="(intervention, i) in scenario.interventionSpecs" :key="intervention">
-				<label>Select intervention policy {{ i + 1 }}</label>
+				<label :class="{ 'disabled-label': isEmpty(modelConfigurations) || isFetchingModelInformation }"
+					>Select intervention policy {{ i + 1 }}</label
+				>
 				<div class="flex">
 					<Dropdown
 						ref="interventionDropdowns"
@@ -45,7 +47,7 @@
 						option-label="name"
 						option-value="id"
 						@update:model-value="scenario.setInterventionSpec($event, i)"
-						:disabled="isFetchingModelInformation"
+						:disabled="isEmpty(modelConfigurations) || isFetchingModelInformation"
 						:loading="isFetchingModelInformation"
 						filter
 					>
@@ -68,6 +70,7 @@
 						size="small"
 						@click="scenario.removeInterventionSpec(i)"
 						class="mb-3"
+						:disabled="isEmpty(modelConfigurations) || isFetchingModelInformation"
 					/>
 				</div>
 			</template>
@@ -79,6 +82,7 @@
 					label="Add a new intervention"
 					size="small"
 					@click="scenario.addInterventionSpec()"
+					:disabled="isEmpty(modelConfigurations) || isFetchingModelInformation"
 				/>
 			</div>
 		</template>

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/tera-horizon-scanning-template.vue
@@ -81,7 +81,7 @@
 				/>
 			</div>
 
-			<label>Planned intervention policy (optional)</label>
+			<label :class="{ 'disabled-label': !selectedModelConfiguration }">Planned intervention policy (optional)</label>
 			<div v-for="(intervention, i) in scenario.interventionSpecs" :key="i" class="flex">
 				<Dropdown
 					ref="interventionDropdowns"
@@ -93,7 +93,7 @@
 					placeholder="Select an intervention policy (optional)"
 					@update:model-value="scenario.setInterventionSpec($event, i)"
 					:key="i"
-					:disabled="isFetchingModelInformation"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 					:loading="isFetchingModelInformation"
 					filter
 				>
@@ -116,6 +116,7 @@
 					text
 					icon="pi pi-trash"
 					@click="scenario.deleteInterventionSpec(i)"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 				/>
 			</div>
 			<div>
@@ -126,6 +127,7 @@
 					icon="pi pi-plus"
 					label="Add more interventions"
 					@click="scenario.addInterventionSpec()"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 				/>
 			</div>
 		</template>

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
@@ -19,7 +19,7 @@ import { switchToUniformDistribution } from '../scenario-template-utils';
 export class SensitivityAnalysisScenario extends BaseScenario {
 	public static templateId = 'sensitivity-analysis';
 
-	public static templateName = 'Sensitivity Analysis';
+	public static templateName = 'Sensitivity analysis';
 
 	modelSpec: { id: string };
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/situational-awareness/situational-awareness-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/situational-awareness/situational-awareness-scenario.ts
@@ -13,7 +13,7 @@ import { updateChartSettingsBySelectedVariables } from '@/services/chart-setting
 export class SituationalAwarenessScenario extends BaseScenario {
 	public static templateId = 'situational-awareness';
 
-	public static templateName = 'Situational Awareness';
+	public static templateName = 'Situational awareness';
 
 	modelSpec: { id: string };
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/situational-awareness/tera-situational-awareness-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/situational-awareness/tera-situational-awareness-template.vue
@@ -12,17 +12,6 @@
 				class="mb-3"
 			/>
 
-			<label>Select a dataset</label>
-			<Dropdown
-				:model-value="scenario.datasetSpec.id"
-				:options="datasets"
-				option-label="assetName"
-				option-value="assetId"
-				placeholder="Select a dataset"
-				@update:model-value="scenario.setDatasetSpec($event)"
-				class="mb-3"
-			/>
-
 			<!-- TODO: adding intervention policies -->
 			<!-- <label>Select an intervention policy (historical)</label>
 			<Dropdown
@@ -56,6 +45,7 @@
 				@update:model-value="scenario.setModelConfigSpec($event)"
 				:disabled="isEmpty(sortedConfigurations) || isFetchingModelInformation"
 				:loading="isFetchingModelInformation"
+				class="mb-3"
 			>
 				<template #option="slotProps">
 					<p>
@@ -63,6 +53,16 @@
 					</p>
 				</template>
 			</Dropdown>
+
+			<label>Select a dataset</label>
+			<Dropdown
+				:model-value="scenario.datasetSpec.id"
+				:options="datasets"
+				option-label="assetName"
+				option-value="assetId"
+				placeholder="Select a dataset"
+				@update:model-value="scenario.setDatasetSpec($event)"
+			/>
 		</template>
 
 		<template #outputs>

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/tera-value-of-information-template.vue
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/tera-value-of-information-template.vue
@@ -82,7 +82,7 @@
 				/>
 			</div>
 
-			<label>Planned intervention policy (optional)</label>
+			<label :class="{ 'disabled-label': !selectedModelConfiguration }">Planned intervention policy (optional)</label>
 			<div v-for="(intervention, i) in scenario.interventionSpecs" :key="i" class="flex">
 				<Dropdown
 					ref="interventionDropdowns"
@@ -94,7 +94,7 @@
 					placeholder="Select an intervention policy"
 					@update:model-value="scenario.setInterventionSpec($event, i)"
 					:key="i"
-					:disabled="isFetchingModelInformation"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 					:loading="isFetchingModelInformation"
 					filter
 				>
@@ -117,6 +117,7 @@
 					text
 					icon="pi pi-trash"
 					@click="scenario.deleteInterventionSpec(i)"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 				/>
 			</div>
 			<div>
@@ -127,6 +128,7 @@
 					icon="pi pi-plus"
 					label="Add more interventions"
 					@click="scenario.addInterventionSpec()"
+					:disabled="!selectedModelConfiguration || isFetchingModelInformation"
 				/>
 			</div>
 		</template>

--- a/packages/client/hmi-client/src/components/workflow/tera-create-workflow-modal.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-create-workflow-modal.vue
@@ -3,10 +3,17 @@
 		<template #default>
 			<div class="grid" style="height: 70vh">
 				<aside class="flex flex-column col-3">
-					<label class="p-text-secondary pb-2">Select a template</label>
-					<div v-for="[id, { name }] in scenarioMap" :key="id" class="flex align-items-center py-1 template-option">
-						<RadioButton :inputId="id" :value="id" v-model="selectedTemplateId" />
-						<label class="pl-2" :for="id">{{ name }}</label>
+					<label class="p-text-secondary pb-3">Select a template</label>
+					<div class="template-list">
+						<div
+							v-for="[id, { name }] in scenarioMap"
+							:key="id"
+							class="template-option"
+							:class="{ 'template-option--selected': selectedTemplateId === id }"
+							@click="selectedTemplateId = id"
+						>
+							{{ name }}
+						</div>
 					</div>
 				</aside>
 				<main class="col-9 flex flex-column">
@@ -38,7 +45,6 @@ import TeraModal from '@/components/widgets/tera-modal.vue';
 import Button from 'primevue/button';
 import { markRaw, nextTick, onMounted, ref } from 'vue';
 import type { Component } from 'vue';
-import RadioButton from 'primevue/radiobutton';
 import { BaseScenario } from '@/components/workflow/scenario-templates/base-scenario';
 import { createWorkflow } from '@/services/workflow';
 import { AssetType } from '@/types/Types';
@@ -170,7 +176,28 @@ onMounted(() => {
 const getScenario = () => scenarioMap.value.get(selectedTemplateId.value) as ScenarioItem;
 </script>
 <style scoped>
-.template-option:first-of-type {
-	margin-bottom: var(--gap-5);
+.template-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-right: 3rem;
+}
+
+.template-option {
+	padding: var(--gap-4) var(--gap-4);
+	border-radius: 4px;
+	background-color: var(--surface-50);
+	cursor: pointer;
+	border-left: 4px solid var(--surface-300);
+	transition: all 0.2s ease;
+}
+
+.template-option:hover {
+	background-color: var(--surface-hover);
+}
+
+.template-option--selected {
+	background-color: var(--surface-highlight);
+	border-left-color: var(--primary-color);
 }
 </style>


### PR DESCRIPTION
BEFORE
Some templates had a bit of a confusing workflow due to the order of the form fields. For instance, Situational awareness had the dataset field above the configuration field. 

Also, some templates had a field for selecting interventions, but it wasn't disabled before a model is selected.

Also, the radio button list wasn't beautiful.
![image](https://github.com/user-attachments/assets/76d59b82-97a4-46f9-840c-8baeb9f59120)

Also, there were a bunch of titles that weren't sentence case

AFTER
![image](https://github.com/user-attachments/assets/43472008-59b1-4766-9d62-4e7cb4754acd)
