### PR TITLE
Rest workflow zoom

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
@@ -107,7 +107,7 @@ function setZoom(tx: number, ty: number, k: number) {
 	const svg = d3.select(backgroundLayerRef.value as SVGGElement); // Parent SVG
 	svg
 		.transition()
-		.duration(2500)
+		.duration(1500)
 		.call(zoom.transform as any, d3.zoomIdentity.translate(tx, ty).scale(k));
 }
 

--- a/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
@@ -46,6 +46,7 @@ let yAxis: d3.Axis<d3.NumberValue>;
 let gX: d3.Selection<SVGGElement, any, null, any>;
 let gY: d3.Selection<SVGGElement, any, null, any>;
 let currentTransform: d3.ZoomTransform;
+let zoom: d3.ZoomBehavior<Element, unknown>;
 
 const width = ref(0);
 const height = ref(0);
@@ -92,6 +93,28 @@ function handleZoomEnd() {
 	}
 }
 
+function setZoom(tx: number, ty: number, k: number) {
+	// const svgContainer = d3.select(svgRef.value as SVGGElement); // Pan/zoom area
+	// const svg = d3.select(backgroundLayerRef.value as SVGGElement); // Parent SVG
+	// const transform = d3.zoomIdentity.translate(e.x, e.y).scale(e.k);
+	// svg.call(zoom.transform as any, transform);
+
+	// const svgContainer = d3.select(svgRef.value as SVGGElement); // Pan/zoom area
+	// handleZoom(e, svgContainer);
+	// handleZoomEnd();
+	// zoom.transform(svgContainer as any, e);
+
+	const svg = d3.select(backgroundLayerRef.value as SVGGElement); // Parent SVG
+	svg
+		.transition()
+		.duration(2500)
+		.call(zoom.transform as any, d3.zoomIdentity.translate(tx, ty).scale(k));
+}
+
+defineExpose({
+	setZoom
+});
+
 function updateDimensions() {
 	// Update dimensions
 	width.value = canvasRef.value?.clientWidth ?? window.innerWidth;
@@ -132,7 +155,7 @@ onMounted(() => {
 	const svgContainer = d3.select(svgRef.value as SVGGElement); // Pan/zoom area
 
 	// Zoom config is applied and event handler
-	const zoom = d3
+	zoom = d3
 		.zoom()
 		.filter((evt: any) => {
 			const classStr = d3.select(evt.target).attr('class') || '';

--- a/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-infinite-canvas.vue
@@ -94,16 +94,6 @@ function handleZoomEnd() {
 }
 
 function setZoom(tx: number, ty: number, k: number) {
-	// const svgContainer = d3.select(svgRef.value as SVGGElement); // Pan/zoom area
-	// const svg = d3.select(backgroundLayerRef.value as SVGGElement); // Parent SVG
-	// const transform = d3.zoomIdentity.translate(e.x, e.y).scale(e.k);
-	// svg.call(zoom.transform as any, transform);
-
-	// const svgContainer = d3.select(svgRef.value as SVGGElement); // Pan/zoom area
-	// handleZoom(e, svgContainer);
-	// handleZoomEnd();
-	// zoom.transform(svgContainer as any, e);
-
 	const svg = d3.select(backgroundLayerRef.value as SVGGElement); // Parent SVG
 	svg
 		.transition()

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -829,7 +829,6 @@ function relinkEdges(node: WorkflowNode<any> | null) {
 }
 
 function resetZoom() {
-	console.log('resetting zoom!!!');
 	let scaleFactor = 1;
 	let translateX = 1;
 	let translateY = 1;
@@ -843,15 +842,12 @@ function resetZoom() {
 	const yMin = yExtent[0] - 20;
 	const yMax = yExtent[1] + 300;
 
-	console.log('extends', xMin, yMin, xMax, yMax);
-
+	// Find fitted scale
 	const workflowCenterX = 0.5 * (xMax - xMin);
 	const workflowCenterY = 0.5 * (yMax - yMin);
 
 	const canvasW = (canvasRef.value.$el as HTMLElement).clientWidth;
 	const canvasH = (canvasRef.value.$el as HTMLElement).clientHeight;
-
-	console.log('canvas', canvasW, canvasH);
 
 	scaleFactor = Math.min(canvasW / (xMax - xMin), canvasH / (yMax - yMin));
 
@@ -859,22 +855,9 @@ function resetZoom() {
 	translateX = canvasW / 2 - scaleFactor * workflowCenterX;
 	translateY = canvasH / 2 - scaleFactor * workflowCenterY;
 
-	// const transform = {
-	// 	x: translateX,
-	// 	y: translateY,
-	// 	k: scaleFactor
-	// };
-
-	const transform = d3.zoomIdentity.translate(translateX, translateY).scale(scaleFactor);
-
-	console.log('transform is', transform);
-	// return;
-
 	// Call exposed function to set zoom
 	canvasRef.value.setZoom(translateX, translateY, scaleFactor);
 }
-
-window.resetZoom = resetZoom;
 
 let prevX = 0;
 let prevY = 0;

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -819,6 +819,54 @@ function relinkEdges(node: WorkflowNode<any> | null) {
 	}
 }
 
+function resetZoom() {
+	console.log('resetting zoom!!!');
+	let scaleFactor = 1;
+	let translateX = 1;
+	let translateY = 1;
+
+	// Approximate the bounding box of the workflow
+	const xExtent = d3.extent(wf.value.getNodes().map((n) => n.x)) as [number, number];
+	const yExtent = d3.extent(wf.value.getNodes().map((n) => n.y)) as [number, number];
+
+	const xMin = xExtent[0] - 20;
+	const xMax = xExtent[1] + 200;
+	const yMin = yExtent[0] - 20;
+	const yMax = yExtent[1] + 300;
+
+	console.log('extends', xMin, yMin, xMax, yMax);
+
+	const workflowCenterX = 0.5 * (xMax - xMin);
+	const workflowCenterY = 0.5 * (yMax - yMin);
+
+	const canvasW = (canvasRef.value.$el as HTMLElement).clientWidth;
+	const canvasH = (canvasRef.value.$el as HTMLElement).clientHeight;
+
+	console.log('canvas', canvasW, canvasH);
+
+	scaleFactor = Math.min(canvasW / (xMax - xMin), canvasH / (yMax - yMin));
+
+	// Calculate the translation to center the graph
+	translateX = canvasW / 2 - scaleFactor * workflowCenterX;
+	translateY = canvasH / 2 - scaleFactor * workflowCenterY;
+
+	// const transform = {
+	// 	x: translateX,
+	// 	y: translateY,
+	// 	k: scaleFactor
+	// };
+
+	const transform = d3.zoomIdentity.translate(translateX, translateY).scale(scaleFactor);
+
+	console.log('transform is', transform);
+	// return;
+
+	// Call exposed function to set zoom
+	canvasRef.value.setZoom(translateX, translateY, scaleFactor);
+}
+
+window.resetZoom = resetZoom;
+
 let prevX = 0;
 let prevY = 0;
 

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -20,6 +20,15 @@
 				<div class="button-group">
 					<Button
 						id="add-component-btn"
+						icon="pi pi-expand"
+						label="Reset Zoom"
+						@click="resetZoom"
+						size="small"
+						class="white-space-nowrap"
+					/>
+
+					<Button
+						id="add-component-btn"
 						icon="pi pi-plus"
 						label="Add component"
 						@click="showAddComponentMenu"


### PR DESCRIPTION
### Summary
Pascale was asking for a reset workflow canvas feature.

This is a somewhat working reset zoom for the workflow. We need to "exposed" a setZoom function in tera-infinite-canvas in order to make this happen.

Note the math is not precise, because we don't have easy access to the actual dimensions of the nodes which varies, only their XY-coords, so the restoration fitting is not exact, but probably good enough.


https://github.com/user-attachments/assets/f00d12ca-db9f-4ff9-bf4c-8cf16a01a2b8

