### PR TITLE
fix compare models not connecting from output menu selection

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -496,12 +496,6 @@ async function onMenuSelection(operatorType: string, menuNode: WorkflowNode<any>
 			}
 		});
 
-		// Will not connect nodes if there is anything besides 1 match
-		if (inputPorts.length !== 1) {
-			console.warn(`Ambiguous matching types [${newNode.inputs}] to [${port}]`);
-			return;
-		}
-
 		const edgePayload: WorkflowEdge = {
 			id: uuidv4(),
 			workflowId: wf.value.getId(),


### PR DESCRIPTION
# Description

* When there exists more than one potential match for input ports it now just connects to the first available

Resolves #6012 
