### PR TITLE
Comparison charts improvments

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -274,6 +274,8 @@ defineExpose({
 </style>
 <style scoped>
 .vega-chart-container {
+	display: flex;
+	justify-content: center;
 	background: var(--surface-0);
 	margin-bottom: var(--gap-4);
 	padding-top: var(--gap-2);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -273,7 +273,8 @@
 					</AccordionTab>
 				</Accordion>
 				<div v-if="!isLoading">
-					<section class="pb-3" ref="outputPanel" v-if="modelConfig && csvAsset">
+					<section class="pb-3" v-if="modelConfig && csvAsset">
+						<div class="mx-4" ref="chartWidthDiv"></div>
 						<Accordion multiple :active-index="currentActiveIndicies" class="px-2">
 							<AccordionTab header="Parameter distributions">
 								<template v-for="setting of selectedParameterSettings" :key="setting.id">
@@ -341,50 +342,30 @@
 							</AccordionTab>
 							<!-- Section: Comparison charts -->
 							<AccordionTab v-if="selectedComparisonChartSettings.length > 0" header="Comparison charts">
-								<template v-for="setting of selectedComparisonChartSettings" :key="setting.id">
-									<div v-if="setting.smallMultiples">
-										<div
-											v-for="selectedVariable of setting.selectedVariables"
-											:key="setting.id + selectedVariable"
-											class="comparison-chart-container"
-										>
-											<div class="comparison-chart">
-												<vega-chart
-													v-if="selectedVariable"
-													expandable
-													:are-embed-actions-visible="true"
-													:visualization-spec="comparisonCharts[setting.id + selectedVariable]"
-												/>
-												<div v-else class="empty-state-chart">
-													<img
-														src="@assets/svg/operator-images/simulate-deterministic.svg"
-														alt="Select a variable"
-														draggable="false"
-														height="80px"
-													/>
-													<p class="text-center">Select a variable for comparison</p>
-												</div>
-											</div>
-										</div>
-									</div>
-									<template v-else>
+								<div
+									class="flex justify-content-center"
+									v-for="setting of selectedComparisonChartSettings"
+									:key="setting.id"
+								>
+									<div class="flex flex-row flex-wrap" v-if="setting.selectedVariables.length > 0">
 										<vega-chart
-											v-if="setting.selectedVariables && setting.selectedVariables.length"
+											v-for="(spec, index) of comparisonCharts[setting.id]"
+											:key="index"
 											expandable
 											:are-embed-actions-visible="true"
-											:visualization-spec="comparisonCharts[setting.id]"
+											:visualization-spec="spec"
 										/>
-										<div v-else class="empty-state-chart">
-											<img
-												src="@assets/svg/operator-images/simulate-deterministic.svg"
-												alt="Select variables to generate comparison chart"
-												draggable="false"
-												height="80px"
-											/>
-											<p class="text-center">Select variables to generate comparison chart</p>
-										</div>
-									</template>
-								</template>
+									</div>
+									<div v-else class="empty-state-chart">
+										<img
+											src="@assets/svg/operator-images/simulate-deterministic.svg"
+											alt="Select a variable"
+											draggable="false"
+											height="80px"
+										/>
+										<p class="text-center">Select a variable for comparison</p>
+									</div>
+								</div>
 							</AccordionTab>
 						</Accordion>
 					</section>
@@ -777,8 +758,8 @@ const runButtonMessage = computed(() =>
 const selectedOutputId = ref<string>();
 const lossChartContainer = ref(null);
 const lossChartSize = useDrilldownChartSize(lossChartContainer);
-const outputPanel = ref(null);
-const chartSize = useDrilldownChartSize(outputPanel);
+const chartWidthDiv = ref(null);
+const chartSize = useDrilldownChartSize(chartWidthDiv);
 
 const groupedInterventionOutputs = computed(() =>
 	_.groupBy(flattenInterventionData(interventionPolicy.value?.interventions ?? []), 'appliedTo')

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -272,7 +272,8 @@
 				<tera-notebook-error v-bind="node.state.optimizeErrorMessage" />
 				<tera-notebook-error v-bind="node.state.simulateErrorMessage" />
 				<template v-if="runResults[knobs.postForecastRunId] && runResults[knobs.preForecastRunId] && !showSpinner">
-					<section v-if="outputViewSelection === OutputView.Charts" ref="outputPanel">
+					<section v-if="outputViewSelection === OutputView.Charts">
+						<div class="mx-4" ref="chartWidthDiv"></div>
 						<Accordion multiple :active-index="currentActiveIndicies">
 							<AccordionTab header="Success criteria">
 								<ul>
@@ -305,50 +306,30 @@
 							</AccordionTab>
 							<!-- Section: Comparison charts -->
 							<AccordionTab v-if="selectedComparisonChartSettings.length > 0" header="Comparison charts">
-								<template v-for="setting of selectedComparisonChartSettings" :key="setting.id">
-									<div v-if="setting.smallMultiples">
-										<div
-											v-for="selectedVariable of setting.selectedVariables"
-											:key="setting.id + selectedVariable"
-											class="comparison-chart-container"
-										>
-											<div class="comparison-chart">
-												<vega-chart
-													v-if="selectedVariable"
-													expandable
-													:are-embed-actions-visible="true"
-													:visualization-spec="comparisonCharts[setting.id + selectedVariable]"
-												/>
-												<div v-else class="empty-state-chart">
-													<img
-														src="@assets/svg/operator-images/simulate-deterministic.svg"
-														alt="Select a variable"
-														draggable="false"
-														height="80px"
-													/>
-													<p class="text-center">Select a variable for comparison</p>
-												</div>
-											</div>
-										</div>
-									</div>
-									<template v-else>
+								<div
+									class="flex justify-content-center"
+									v-for="setting of selectedComparisonChartSettings"
+									:key="setting.id"
+								>
+									<div class="flex flex-row flex-wrap" v-if="setting.selectedVariables.length > 0">
 										<vega-chart
-											v-if="setting.selectedVariables && setting.selectedVariables.length"
+											v-for="(spec, index) of comparisonCharts[setting.id]"
+											:key="index"
 											expandable
 											:are-embed-actions-visible="true"
-											:visualization-spec="comparisonCharts[setting.id]"
+											:visualization-spec="spec"
 										/>
-										<div v-else class="empty-state-chart">
-											<img
-												src="@assets/svg/operator-images/simulate-deterministic.svg"
-												alt="Select variables to generate comparison chart"
-												draggable="false"
-												height="80px"
-											/>
-											<p class="text-center">Select variables to generate comparison chart</p>
-										</div>
-									</template>
-								</template>
+									</div>
+									<div v-else class="empty-state-chart">
+										<img
+											src="@assets/svg/operator-images/simulate-deterministic.svg"
+											alt="Select a variable"
+											draggable="false"
+											height="80px"
+										/>
+										<p class="text-center">Select a variable for comparison</p>
+									</div>
+								</div>
 							</AccordionTab>
 						</Accordion>
 					</section>
@@ -596,8 +577,8 @@ const successDisplayChartsCheckbox = ref(true);
 const showSaveDataDialog = ref<boolean>(false);
 const showSaveInterventionPolicy = ref<boolean>(false);
 
-const outputPanel = ref(null);
-const chartSize = useDrilldownChartSize(outputPanel);
+const chartWidthDiv = ref(null);
+const chartSize = useDrilldownChartSize(chartWidthDiv);
 const cancelRunId = computed(() => props.node.state.inProgressPostForecastId || props.node.state.inProgressOptimizeId);
 
 const activePolicyGroups = computed(() =>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -162,8 +162,8 @@
 				<tera-notebook-error v-bind="node.state.errorMessage" />
 				<template v-if="runResults[selectedRunId]">
 					<div v-if="view === OutputView.Charts">
-						<div class="mx-3" ref="chartWidthDiv"></div>
-						<Accordion multiple :active-index="currentActiveIndicies">
+						<div class="mx-4" ref="chartWidthDiv"></div>
+						<Accordion multiple :active-index="currentActiveIndicies" class="px-2">
 							<!-- Section: Interventions over time -->
 							<AccordionTab v-if="selectedInterventionSettings.length > 0" header="Interventions over time">
 								<template v-for="setting in selectedInterventionSettings" :key="setting.id">

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -161,8 +161,9 @@
 				</div>
 				<tera-notebook-error v-bind="node.state.errorMessage" />
 				<template v-if="runResults[selectedRunId]">
-					<div v-if="view === OutputView.Charts" ref="outputPanel">
-						<Accordion multiple :active-index="currentActiveIndicies" class="px-2">
+					<div v-if="view === OutputView.Charts">
+						<div class="mx-3" ref="chartWidthDiv"></div>
+						<Accordion multiple :active-index="currentActiveIndicies">
 							<!-- Section: Interventions over time -->
 							<AccordionTab v-if="selectedInterventionSettings.length > 0" header="Interventions over time">
 								<template v-for="setting in selectedInterventionSettings" :key="setting.id">
@@ -185,50 +186,30 @@
 							</AccordionTab>
 							<!-- Section: Comparison charts -->
 							<AccordionTab v-if="selectedComparisonChartSettings.length > 0" header="Comparison charts">
-								<template v-for="setting of selectedComparisonChartSettings" :key="setting.id">
-									<div v-if="setting.smallMultiples">
-										<div
-											v-for="selectedVariable of setting.selectedVariables"
-											:key="setting.id + selectedVariable"
-											class="comparison-chart-container"
-										>
-											<div class="comparison-chart">
-												<vega-chart
-													v-if="selectedVariable"
-													expandable
-													:are-embed-actions-visible="true"
-													:visualization-spec="comparisonCharts[setting.id + selectedVariable]"
-												/>
-												<div v-else class="empty-state-chart">
-													<img
-														src="@assets/svg/operator-images/simulate-deterministic.svg"
-														alt="Select a variable"
-														draggable="false"
-														height="80px"
-													/>
-													<p class="text-center">Select a variable for comparison</p>
-												</div>
-											</div>
-										</div>
-									</div>
-									<template v-else>
+								<div
+									class="flex justify-content-center"
+									v-for="setting of selectedComparisonChartSettings"
+									:key="setting.id"
+								>
+									<div class="flex flex-row flex-wrap" v-if="setting.selectedVariables.length > 0">
 										<vega-chart
-											v-if="setting.selectedVariables && setting.selectedVariables.length"
+											v-for="(spec, index) of comparisonCharts[setting.id]"
+											:key="index"
 											expandable
 											:are-embed-actions-visible="true"
-											:visualization-spec="comparisonCharts[setting.id]"
+											:visualization-spec="spec"
 										/>
-										<div v-else class="empty-state-chart">
-											<img
-												src="@assets/svg/operator-images/simulate-deterministic.svg"
-												alt="Select variables to generate comparison chart"
-												draggable="false"
-												height="80px"
-											/>
-											<p class="text-center">Select variables to generate comparison chart</p>
-										</div>
-									</template>
-								</template>
+									</div>
+									<div v-else class="empty-state-chart">
+										<img
+											src="@assets/svg/operator-images/simulate-deterministic.svg"
+											alt="Select a variable"
+											draggable="false"
+											height="80px"
+										/>
+										<p class="text-center">Select a variable for comparison</p>
+									</div>
+								</div>
 							</AccordionTab>
 							<!-- Section: Sensitivity -->
 							<AccordionTab v-if="selectedSensitivityChartSettings.length > 0" header="Sensitivity analysis">
@@ -608,8 +589,8 @@ const selectedRunId = computed(() => props.node.outputs.find((o) => o.id === sel
 const cancelRunIds = computed(() =>
 	[props.node.state.inProgressForecastId, props.node.state.inProgressBaseForecastId].filter((id) => Boolean(id))
 );
-const outputPanel = ref(null);
-const chartSize = useDrilldownChartSize(outputPanel);
+const chartWidthDiv = ref(null);
+const chartSize = useDrilldownChartSize(chartWidthDiv);
 
 const showSaveDataset = ref(false);
 
@@ -958,6 +939,7 @@ onUnmounted(() => kernelManager.shutdown());
 .empty-state-chart {
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	gap: var(--gap-4);
 	justify-content: center;
 	align-items: center;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -186,7 +186,7 @@ const { useInterventionCharts, useVariableCharts, useComparisonCharts } = useCha
 );
 const interventionCharts = useInterventionCharts(selectedInterventionSettings, true);
 const variableCharts = useVariableCharts(selectedVariableSettings, null);
-const comparisonCharts = useComparisonCharts(selectedComparisonChartSettings);
+const comparisonCharts = useComparisonCharts(selectedComparisonChartSettings, true);
 const isChartsEmpty = computed(
 	() => _.isEmpty(interventionCharts.value) && _.isEmpty(variableCharts.value) && _.isEmpty(comparisonCharts.value)
 );

--- a/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
@@ -13,7 +13,7 @@
 			:key="chartSettingKey || setting"
 			:expandable="expandable"
 			:are-embed-actions-visible="areEmbedActionsVisible"
-			:visualization-spec="preparedCharts[index][chartSettingKey || setting['id']]"
+			:visualization-spec="getChartSpec(preparedCharts[index][chartSettingKey || setting['id']])"
 			:interactive="false"
 		/>
 	</div>
@@ -23,14 +23,14 @@
 		:key="'c' + index"
 		:expandable="expandable"
 		:are-embed-actions-visible="areEmbedActionsVisible"
-		:visualization-spec="preparedCharts[chartSettingKey || setting['id']]"
+		:visualization-spec="getChartSpec(preparedCharts[chartSettingKey || setting['id']])"
 		:interactive="false"
 	/>
 	<vega-chart
 		v-else-if="!visibleChartSettings"
 		v-for="(chartSpec, index) of preparedCharts"
 		:key="chartSpec.id + index"
-		:visualization-spec="chartSpec"
+		:visualization-spec="getChartSpec(chartSpec)"
 		:interactive="false"
 	/>
 	<tera-operator-placeholder v-else-if="placeholder" :node="node">
@@ -58,6 +58,8 @@ const props = defineProps<{
 	expandable?: boolean;
 	areEmbedActionsVisible?: boolean;
 }>();
+
+const getChartSpec = (spec: any[] | any) => (_.isArray(spec) ? spec[0] : spec);
 
 const visibleChartSettings = computed(() => {
 	if (props.chartSettings) {

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -521,7 +521,7 @@ export function useCharts(
 	}
 
 	// Create comparison charts based on chart settings
-	const useComparisonCharts = (chartSettings: ComputedRef<ChartSettingComparison[]>) => {
+	const useComparisonCharts = (chartSettings: ComputedRef<ChartSettingComparison[]>, isNodeChart = false) => {
 		const comparisonCharts = computed(() => {
 			const charts: Record<string, VisualizationSpec[]> = {};
 			if (!isChartReadyToBuild.value) return charts;
@@ -530,7 +530,7 @@ export function useCharts(
 			chartSettings.value.forEach((setting) => {
 				const selectedVars = setting.selectedVariables;
 				const annotations = getChartAnnotationsByChartId(setting.id);
-				if (setting.smallMultiples && setting.selectedVariables.length > 1) {
+				if (setting.smallMultiples && setting.selectedVariables.length > 1 && !isNodeChart) {
 					const sharedYExtent = setting.shareYAxis
 						? calculateYExtent(
 								resultSummary,
@@ -543,8 +543,6 @@ export function useCharts(
 					let width = chartSize.value.width;
 					if (selectedVars.length > 1) width = chartSize.value.width / 2;
 					if (selectedVars.length > 4) width = chartSize.value.width / 3;
-					console.log('full width', chartSize.value.width);
-					console.log('individual width', width);
 					const height = selectedVars.length <= 1 ? chartSize.value.height : chartSize.value.height / 2;
 					charts[setting.id] = selectedVars.map((_selectedVar, index) => {
 						const { options, sampleLayerVariables, statLayerVariables } = createComparisonChartOptions(setting, index);

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -517,13 +517,13 @@ export function useCharts(
 			),
 			annotations
 		);
-		return chart;
+		return chart as VisualizationSpec;
 	}
 
 	// Create comparison charts based on chart settings
 	const useComparisonCharts = (chartSettings: ComputedRef<ChartSettingComparison[]>) => {
 		const comparisonCharts = computed(() => {
-			const charts: Record<string, VisualizationSpec> = {};
+			const charts: Record<string, VisualizationSpec[]> = {};
 			if (!isChartReadyToBuild.value) return charts;
 			const { result, resultSummary } = chartData.value as ChartData;
 
@@ -538,13 +538,20 @@ export function useCharts(
 								Boolean(setting.showBeforeAfter)
 							)
 						: undefined;
+
 					// create multiples
-					selectedVars.forEach((selectedVar, index) => {
+					let width = chartSize.value.width;
+					if (selectedVars.length > 1) width = Math.floor(chartSize.value.width / 2);
+					if (selectedVars.length > 4) width = Math.floor(chartSize.value.width / 3);
+					console.log('full width', chartSize.value.width);
+					console.log('individual width', width);
+					const height = selectedVars.length <= 1 ? chartSize.value.height : chartSize.value.height / 2;
+					charts[setting.id] = selectedVars.map((_selectedVar, index) => {
 						const { options, sampleLayerVariables, statLayerVariables } = createComparisonChartOptions(setting, index);
-						options.width /= 2.1;
-						options.height /= 2.1;
+						options.width = width;
+						options.height = height;
 						options.yExtent = sharedYExtent;
-						charts[setting.id + selectedVar] = createComparisonChart(
+						return createComparisonChart(
 							result,
 							resultSummary,
 							statLayerVariables,
@@ -563,7 +570,7 @@ export function useCharts(
 						options,
 						annotations
 					);
-					charts[setting.id] = chart;
+					charts[setting.id] = [chart];
 				}
 			});
 			return charts;

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -541,8 +541,8 @@ export function useCharts(
 
 					// create multiples
 					let width = chartSize.value.width;
-					if (selectedVars.length > 1) width = Math.floor(chartSize.value.width / 2);
-					if (selectedVars.length > 4) width = Math.floor(chartSize.value.width / 3);
+					if (selectedVars.length > 1) width = chartSize.value.width / 2;
+					if (selectedVars.length > 4) width = chartSize.value.width / 3;
 					console.log('full width', chartSize.value.width);
 					console.log('individual width', width);
 					const height = selectedVars.length <= 1 ? chartSize.value.height : chartSize.value.height / 2;


### PR DESCRIPTION
# Description

1. Fixed small multiples layout

**Before**

<img width="1457" alt="Screenshot 2025-01-17 at 2 54 59 PM" src="https://github.com/user-attachments/assets/a1223d51-d90d-433d-ac98-48fdbddb0c34" />

**After**
![Screenshot 2025-01-17 at 2 28 18 PM](https://github.com/user-attachments/assets/49f6679a-163a-4048-87fc-d977115ff2a8)

<img width="1456" alt="Screenshot 2025-01-17 at 2 32 33 PM" src="https://github.com/user-attachments/assets/cbe6be6f-b186-4e19-a335-2a003c447d59" />

2. Make sure comparison small multipes charts appear as single chart on the simulate node
<img width="313" alt="Screenshot 2025-01-17 at 2 52 21 PM" src="https://github.com/user-attachments/assets/e749b826-c2ee-4890-ab3e-0a738e69965a" />

3. Minor styling and layout updates


Resolves #(issue)
