### PR TITLE
fix double placeholder in simulate node

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -1,20 +1,16 @@
 <template>
 	<main>
-		<section v-if="!isChartsEmpty && selectedRunId && runResults[selectedRunId]">
+		<section>
 			<tera-node-preview
 				:node="node"
 				:is-loading="!!inProgressForecastRun"
 				:prepared-charts="[interventionCharts, variableCharts, comparisonCharts]"
 				:chart-settings="[selectedInterventionSettings, selectedVariableSettings, selectedComparisonChartSettings]"
 				:are-embed-actions-visible="true"
+				:placeholder="placeholderText"
 			/>
 		</section>
-
-		<div v-else-if="isChartsEmpty" class="empty-chart">
-			<tera-operator-placeholder :node="node">No variables selected</tera-operator-placeholder>
-		</div>
 		<Button v-if="areInputsFilled" label="Open" @click="emit('open-drilldown')" severity="secondary" outlined />
-		<tera-operator-placeholder v-else :node="node"> Connect a model configuration </tera-operator-placeholder>
 	</main>
 </template>
 
@@ -37,7 +33,6 @@ import {
 } from '@/services/models/simulation-service';
 import { createLLMSummary } from '@/services/summary-service';
 
-import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import { nodeOutputLabel } from '@/components/workflow/util';
 
 import { ModelConfiguration, type InterventionPolicy, type Model } from '@/types/Types';
@@ -190,6 +185,15 @@ const comparisonCharts = useComparisonCharts(selectedComparisonChartSettings);
 const isChartsEmpty = computed(
 	() => _.isEmpty(interventionCharts.value) && _.isEmpty(variableCharts.value) && _.isEmpty(comparisonCharts.value)
 );
+const placeholderText = computed(() => {
+	if (!areInputsFilled.value) {
+		return 'Connect a model configuration';
+	}
+	if (isChartsEmpty.value) {
+		return 'No variables selected';
+	}
+	return undefined;
+});
 
 const poller = new Poller();
 const pollResult = async (runId: string) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
@@ -3,6 +3,9 @@
 		<div v-if="processing">{{ processing }}</div>
 		<div v-else>Processing...</div>
 	</tera-progress-spinner>
+	<tera-operator-placeholder v-else-if="placeholder" :node="node">
+		{{ placeholder }}
+	</tera-operator-placeholder>
 	<div
 		v-else-if="visibleChartSettings && _.isArray(visibleChartSettings[0])"
 		v-for="(settingsArray, index) of visibleChartSettings"
@@ -33,9 +36,6 @@
 		:visualization-spec="chartSpec"
 		:interactive="false"
 	/>
-	<tera-operator-placeholder v-else-if="placeholder" :node="node">
-		{{ placeholder }}
-	</tera-operator-placeholder>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
# Description

* Fixes the double placeholder on the simulate node.
* Placeholder text updates if not model is connected and if no charts are available.


Before: 
![image (1)](https://github.com/user-attachments/assets/35407bfe-21c4-4724-ba75-896adb3ad01e)


After:
<img width="400" alt="Screenshot 2025-01-17 at 5 25 23 PM" src="https://github.com/user-attachments/assets/c601d038-c0b4-41d3-8174-5730dbb569c6" />
<img width="399" alt="Screenshot 2025-01-17 at 5 25 13 PM" src="https://github.com/user-attachments/assets/df61e4e0-a5e2-4d12-8e80-7dad9c93f960" />




Resolves #(issue)
