### PR TITLE
Get all project bit faster.

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectController.java
@@ -186,6 +186,9 @@ public class ProjectController {
 			return ResponseEntity.noContent().build();
 		}
 
+		// Empty all the non-necessary information to speed up getting all the projects
+		projects.forEach(project -> project.setOverviewContent(null));
+
 		projects.forEach(project -> {
 			final RebacProject rebacProject = new RebacProject(project.getId(), reBACService);
 


### PR DESCRIPTION
When fetching ALL the projects, we do not need the `overviewContent` at all.
The overview is fetched when it need to be displayed.