### PR TITLE
add back in unused field for backwards compatibility

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
@@ -20,4 +20,7 @@ public class InputPort implements Serializable {
 	private String label;
 	private ArrayNode value;
 	private Boolean isOptional;
+
+	// FIXME: backwards compatibility, to be removed
+	private Boolean acceptMultiple;
 }


### PR DESCRIPTION
### Summary
Add back removed "accepMultiple" field to satisfy old workflows still in the system