### PR TITLE
generate_model_latex typo

### DIFF
--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -22,42 +22,42 @@ def main():
         # =========================================
         # Generate LaTeX code string from MMT model
         # =========================================
-        
+
         odeterms = {var: 0 for var in model.get_concepts_name_map().keys()}
-    
+
         for template in model.templates:
             if hasattr(template, "subject"):
-                var = t.subject.name
+                var = template.subject.name
                 odeterms[var] -= template.rate_law.args[0]
-    
+
             if hasattr(template, "outcome"):
                 var = template.outcome.name
                 odeterms[var] += template.rate_law.args[0]
-    
+
         # Time
         if model.time and model.time.name:
             time = model.time.name
         else:
             time = "t"
         t = sympy.Symbol(time)
-    
+
         # Construct Sympy equations
         odesys = []
         for var, terms in odeterms.items():
             lhs = sympy.diff(sympy.Function(var)(t), t)
-      
+
             # Write (time-dependent) symbols with "(t)"
             rhs = terms
             if hasattr(terms, 'atoms'):
                 for atom in terms.atoms(sympy.Symbol):
                     if str(atom) in odeterms.keys():
                         rhs = rhs.subs(atom, sympy.Function(str(atom))(t))
-    
+
             odesys.append(sympy.latex(sympy.Eq(lhs, rhs)))
-            
+
         # Observables
         if len(model.observables) > 0:
-    
+
             # Write (time-dependent) symbols with "(t)"
             obs_eqs = []
             for obs in model.observables.values():
@@ -69,14 +69,14 @@ def main():
                         if str(atom) in odeterms.keys():
                             rhs = rhs.subs(atom, sympy.Function(str(atom))(t))
                 obs_eqs.append(sympy.latex(sympy.Eq(lhs, rhs)))
-    
+
             # Add observables
             odesys += obs_eqs
-    
+
         # Reformat:
         odesys = "\\begin{align} \n    " + " \\\\ \n    ".join([eq for eq in odesys]) + "\n\\end{align}"
         # =========================================
-        
+
         taskrunner.write_output_dict_with_timeout({"response": odesys})
         print("Generate LaTeX succeeded")
 


### PR DESCRIPTION
### Summary
Fixing

```
Error: local variable 't' referenced before assignment
Traceback (most recent call last):
  File "/mira_task/tasks/generate_model_latex.py", line 30, in main
    var = t.subject.name
UnboundLocalError: local variable 't' referenced before assignment
```