### PR TITLE
exclude non rate-expression variables from stratification

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -290,6 +290,9 @@ const getStatesAndParameters = (amrModel: Model) => {
 	const model = amrModel.model;
 	const semantics = amrModel.semantics;
 
+	const rates = semantics!.ode.rates || [];
+	const rateExpressions = rates.map((r) => r.expression);
+
 	if ((modelFramework === AMRSchemaNames.PETRINET || modelFramework === AMRSchemaNames.STOCKFLOW) && semantics?.ode) {
 		const { initials, parameters, observables } = semantics.ode;
 
@@ -297,7 +300,15 @@ const getStatesAndParameters = (amrModel: Model) => {
 			modelStates.push(i.target);
 		});
 		parameters?.forEach((p) => {
-			modelParameters.push(p.id);
+			// Parameters should be used within transition expressions for them to be "stratifiable"
+			// FIXME: This would be more accurate if we parse and check rate expressions' free variables
+			// instead of just the rate expression string
+			for (let i = 0; i < rateExpressions.length; i++) {
+				if (rateExpressions[i]?.includes(p.id)) {
+					modelParameters.push(p.id);
+					break;
+				}
+			}
 		});
 		observables?.forEach((o) => {
 			modelStates.push(o.id);

--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -22,42 +22,42 @@ def main():
         # =========================================
         # Generate LaTeX code string from MMT model
         # =========================================
-        
+
         odeterms = {var: 0 for var in model.get_concepts_name_map().keys()}
-    
+
         for template in model.templates:
             if hasattr(template, "subject"):
-                var = t.subject.name
+                var = template.subject.name
                 odeterms[var] -= template.rate_law.args[0]
-    
+
             if hasattr(template, "outcome"):
                 var = template.outcome.name
                 odeterms[var] += template.rate_law.args[0]
-    
+
         # Time
         if model.time and model.time.name:
             time = model.time.name
         else:
             time = "t"
         t = sympy.Symbol(time)
-    
+
         # Construct Sympy equations
         odesys = []
         for var, terms in odeterms.items():
             lhs = sympy.diff(sympy.Function(var)(t), t)
-      
+
             # Write (time-dependent) symbols with "(t)"
             rhs = terms
             if hasattr(terms, 'atoms'):
                 for atom in terms.atoms(sympy.Symbol):
                     if str(atom) in odeterms.keys():
                         rhs = rhs.subs(atom, sympy.Function(str(atom))(t))
-    
+
             odesys.append(sympy.latex(sympy.Eq(lhs, rhs)))
-            
+
         # Observables
         if len(model.observables) > 0:
-    
+
             # Write (time-dependent) symbols with "(t)"
             obs_eqs = []
             for obs in model.observables.values():
@@ -69,14 +69,14 @@ def main():
                         if str(atom) in odeterms.keys():
                             rhs = rhs.subs(atom, sympy.Function(str(atom))(t))
                 obs_eqs.append(sympy.latex(sympy.Eq(lhs, rhs)))
-    
+
             # Add observables
             odesys += obs_eqs
-    
+
         # Reformat:
         odesys = "\\begin{align} \n    " + " \\\\ \n    ".join([eq for eq in odesys]) + "\n\\end{align}"
         # =========================================
-        
+
         taskrunner.write_output_dict_with_timeout({"response": odesys})
         print("Generate LaTeX succeeded")
 


### PR DESCRIPTION
### Summary
Exclude parameters that do not participate in rate expressions from the stratify option dropdown, since they'd be basically a no-op if we send them for stratification anyway.


### Testing
- Upload gauldie-sir.json as a model
- Create a workflow with it and stratify-operation
- In the variables dropdown, S0, I0 and R0 will NOT be available as they designated as the initials and not rate-expressions.

<img width="572" alt="image" src="https://github.com/user-attachments/assets/0e00efb0-46da-4eac-b948-f68e03181e3c" />


[gauldie-sir.json](https://github.com/user-attachments/files/18482615/gauldie-sir.json)
