### PR TITLE
change order of sensitivity charts

### DIFF
--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -1128,7 +1128,7 @@ export function createSimulateSensitivityScatter(samplingLayer: SensitivityChart
 			mark: { type: 'point', filled: true },
 			encoding: {
 				x: {
-					field: { repeat: 'row' },
+					field: { repeat: 'column' },
 					type: 'quantitative',
 					axis: {
 						gridColor: '#EEE'
@@ -1139,7 +1139,7 @@ export function createSimulateSensitivityScatter(samplingLayer: SensitivityChart
 					}
 				},
 				y: {
-					field: { repeat: 'column' },
+					field: { repeat: 'row' },
 					type: 'quantitative',
 					axis: {
 						gridColor: '#EEE',


### PR DESCRIPTION
# Description

* As per request the ordering of the sensitivty charts has changed to be like this format:

|  | `lambda` | `alpha` | ... | `j` |
| -------- | ------- | --- | --- | --- |
| `lambda`  | (`x = lambda, y = lambda`) | (`x = alpha, y = lambda`) | ... | (`x = j, y = lambda`) | 
| `alpha` | (`x = lambda, y = alpha`)     | (`x = alpha, y = alpha`) | ... | (`x = j, y = alpha`) | 
| ...  | ...  | ... | ... | (`x = j, y = ...`) | 
| `i` | (`x = lambda, y = i`) | (`x = alpha, y = i`) | (`x = ..., y = i`) | (`x = j, y = i`) | 
