### PR TITLE
fix dataset multiple menu items

### DIFF
--- a/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
+++ b/packages/client/hmi-client/src/components/dataset/tera-dataset.vue
@@ -195,9 +195,11 @@ const fetchDataset = async () => {
 		image.value = await getClimateDatasetPreview(dataset.value.esgfId);
 	}
 
+	// Remove download options from previous dataset
+	optionsMenuItems.value = optionsMenuItems.value.filter((item) => item.label !== 'Download');
 	// Add download options to the ellipsis menu
 	if (dataset.value?.fileNames) {
-		optionsMenuItems.value.push({
+		optionsMenuItems.value.unshift({
 			label: 'Download',
 			icon: 'pi pi-download',
 			items: dataset.value.fileNames.map((fileName) => ({


### PR DESCRIPTION
# Description

* Switching between datasets would add another "Download" option to the ellipses menu.  
* The fix now clears all down options before another one is pushed in
