### PR TITLE
Calibrate ensemble chart to allow variables not mapped

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -102,8 +102,7 @@ export function getChartEnsembleMapping(
 
 	// For every State Variable that has not been mapped in the ensembleMapping
 	// We will fill in here so the user can still see these if they want
-	const allStates = Object.keys(stateToModelConfigMap);
-	allStates.forEach((state) => {
+	Object.keys(stateToModelConfigMap).forEach((state) => {
 		const modelConfigurationsMap = {};
 		stateToModelConfigMap[state].forEach((id) => {
 			modelConfigurationsMap[id] = state;

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -88,7 +88,7 @@ export function formatCalibrateModelConfigurations(
 
 export function getChartEnsembleMapping(
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>,
-	variableChartOptionsObject: { [key: string]: string[] },
+	stateToModelConfigMap: { [key: string]: string[] },
 	hasTimestampCol = true
 ) {
 	const wfOutputState = getActiveOutput(node)?.state;
@@ -102,10 +102,10 @@ export function getChartEnsembleMapping(
 
 	// For every State Variable that has not been mapped in the ensembleMapping
 	// We will fill in here so the user can still see these if they want
-	const allStates = Object.keys(variableChartOptionsObject);
+	const allStates = Object.keys(stateToModelConfigMap);
 	allStates.forEach((state) => {
 		const modelConfigurationsMap = {};
-		variableChartOptionsObject[state].forEach((id) => {
+		stateToModelConfigMap[state].forEach((id) => {
 			modelConfigurationsMap[id] = state;
 		});
 		mapping.push({
@@ -241,8 +241,8 @@ export function getEnsembleErrorData(
 // 		D: ["uuid-1"]
 // }
 
-export async function setVariableChartOptionsObject(modelConfigurationIds: string[]) {
-	const variableChartOptionsObject: { [key: string]: string[] } = {};
+export async function setStateToModelConfigMap(modelConfigurationIds: string[]) {
+	const stateToModelConfigMap: { [key: string]: string[] } = {};
 	const models: any[] = [];
 	// Model configuration input
 	await Promise.all(
@@ -256,11 +256,11 @@ export async function setVariableChartOptionsObject(modelConfigurationIds: strin
 		const modelConfigId = model.configId as string;
 		model.model.states.forEach((state) => {
 			const key = state.id;
-			if (!variableChartOptionsObject[key]) {
-				variableChartOptionsObject[key] = [];
+			if (!stateToModelConfigMap[key]) {
+				stateToModelConfigMap[key] = [];
 			}
-			variableChartOptionsObject[key].push(modelConfigId);
+			stateToModelConfigMap[key].push(modelConfigId);
 		});
 	});
-	return variableChartOptionsObject;
+	return stateToModelConfigMap;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -88,7 +88,7 @@ export function formatCalibrateModelConfigurations(
 
 export function getChartEnsembleMapping(
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>,
-	variableChartOptionsObject: any,
+	variableChartOptionsObject: { [key: string]: string[] },
 	hasTimestampCol = true
 ) {
 	const wfOutputState = getActiveOutput(node)?.state;
@@ -104,17 +104,15 @@ export function getChartEnsembleMapping(
 	// We will fill in here so the user can still see these if they want
 	const allStates = Object.keys(variableChartOptionsObject);
 	allStates.forEach((state) => {
-		if (!mapping.find((map) => map.newName === state)) {
-			const modelConfigurationsMap = {};
-			variableChartOptionsObject[state].forEach((id) => {
-				modelConfigurationsMap[id] = state;
-			});
-			mapping.push({
-				newName: state,
-				datasetMapping: '',
-				modelConfigurationMappings: modelConfigurationsMap
-			});
-		}
+		const modelConfigurationsMap = {};
+		variableChartOptionsObject[state].forEach((id) => {
+			modelConfigurationsMap[id] = state;
+		});
+		mapping.push({
+			newName: state,
+			datasetMapping: '',
+			modelConfigurationMappings: modelConfigurationsMap
+		});
 	});
 	return mapping;
 }
@@ -244,7 +242,7 @@ export function getEnsembleErrorData(
 // }
 
 export async function setVariableChartOptionsObject(modelConfigurationIds: string[]) {
-	const variableChartOptionsObject = {};
+	const variableChartOptionsObject: { [key: string]: string[] } = {};
 	const models: any[] = [];
 	// Model configuration input
 	await Promise.all(

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -86,7 +86,7 @@ export function formatCalibrateModelConfigurations(
 	return [...Object.values(ensembleModelConfigMap)];
 }
 
-export function getSelectedOutputEnsembleMapping(
+export function getChartEnsembleMapping(
 	node: WorkflowNode<CalibrateEnsembleCiemssOperationState>,
 	variableChartOptionsObject: any,
 	hasTimestampCol = true

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/calibrate-ensemble-util.ts
@@ -103,15 +103,17 @@ export function getChartEnsembleMapping(
 	// For every State Variable that has not been mapped in the ensembleMapping
 	// We will fill in here so the user can still see these if they want
 	Object.keys(stateToModelConfigMap).forEach((state) => {
-		const modelConfigurationsMap = {};
-		stateToModelConfigMap[state].forEach((id) => {
-			modelConfigurationsMap[id] = state;
-		});
-		mapping.push({
-			newName: state,
-			datasetMapping: '',
-			modelConfigurationMappings: modelConfigurationsMap
-		});
+		if (!mapping.find((map) => map.newName === state)) {
+			const modelConfigurationsMap = {};
+			stateToModelConfigMap[state].forEach((id) => {
+				modelConfigurationsMap[id] = state;
+			});
+			mapping.push({
+				newName: state,
+				datasetMapping: '',
+				modelConfigurationMappings: modelConfigurationsMap
+			});
+		}
 	});
 	return mapping;
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -473,7 +473,7 @@ const modelConfigIds = computed(() =>
 );
 const listModelLabels = ref<string[]>([]);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
-const variableChartOptionsObject = ref({});
+const variableChartOptionsObject = ref<{ [key: string]: string[] }>({});
 
 const tableHeaders = computed(() => {
 	const headers = ['Ensemble model'];

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -396,7 +396,7 @@ import {
 	getEnsembleErrorData,
 	EnsembleErrorData,
 	fetchModelConfigurations,
-	setVariableChartOptionsObject
+	setStateToModelConfigMap
 } from './calibrate-ensemble-util';
 
 const props = defineProps<{
@@ -473,7 +473,7 @@ const modelConfigIds = computed(() =>
 );
 const listModelLabels = ref<string[]>([]);
 const allModelConfigurations = ref<ModelConfiguration[]>([]);
-const variableChartOptionsObject = ref<{ [key: string]: string[] }>({});
+const stateToModelConfigMap = ref<{ [key: string]: string[] }>({});
 
 const tableHeaders = computed(() => {
 	const headers = ['Ensemble model'];
@@ -626,7 +626,7 @@ const runEnsemble = async () => {
 };
 
 onMounted(async () => {
-	variableChartOptionsObject.value = await setVariableChartOptionsObject(modelConfigIds.value as string[]);
+	stateToModelConfigMap.value = await setStateToModelConfigMap(modelConfigIds.value as string[]);
 	const configs = await fetchModelConfigurations(props.node.inputs);
 	if (!configs) return;
 	allModelConfigurations.value = configs.allModelConfigurations;
@@ -671,7 +671,7 @@ const outputData = ref<{
 } | null>(null);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 const chartSize = useDrilldownChartSize(chartWidthDiv);
-const selectedOutputMapping = computed(() => getChartEnsembleMapping(props.node, variableChartOptionsObject.value));
+const selectedOutputMapping = computed(() => getChartEnsembleMapping(props.node, stateToModelConfigMap.value));
 const {
 	activeChartSettings,
 	chartSettings,
@@ -710,7 +710,7 @@ const errorData = computed<EnsembleErrorData>(() =>
 );
 
 const ensembleVariables = computed(() =>
-	getChartEnsembleMapping(props.node, variableChartOptionsObject.value, false).map((d) => d.newName)
+	getChartEnsembleMapping(props.node, stateToModelConfigMap.value, false).map((d) => d.newName)
 );
 // console.log(ensembleVariables);
 // console.log(selectedOutputMapping);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -712,9 +712,6 @@ const errorData = computed<EnsembleErrorData>(() =>
 const ensembleVariables = computed(() =>
 	getChartEnsembleMapping(props.node, stateToModelConfigMap.value, false).map((d) => d.newName)
 );
-// console.log(ensembleVariables);
-// console.log(selectedOutputMapping);
-// console.log(selectedEnsembleVariableSettings);
 const ensembleVariableCharts = useEnsembleVariableCharts(selectedEnsembleVariableSettings, groundTruthData);
 const weightsDistributionCharts = useWeightsDistributionCharts();
 const { errorCharts, onExpandErrorChart } = useEnsembleErrorCharts(selectedErrorVariableSettings, errorData);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -390,7 +390,7 @@ import {
 	updateLossChartSpec,
 	getLossValuesFromSimulation,
 	formatCalibrateModelConfigurations,
-	getSelectedOutputEnsembleMapping,
+	getChartEnsembleMapping,
 	fetchOutputData,
 	buildChartData,
 	getEnsembleErrorData,
@@ -671,9 +671,7 @@ const outputData = ref<{
 } | null>(null);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
 const chartSize = useDrilldownChartSize(chartWidthDiv);
-const selectedOutputMapping = computed(() =>
-	getSelectedOutputEnsembleMapping(props.node, variableChartOptionsObject.value)
-);
+const selectedOutputMapping = computed(() => getChartEnsembleMapping(props.node, variableChartOptionsObject.value));
 const {
 	activeChartSettings,
 	chartSettings,
@@ -712,7 +710,7 @@ const errorData = computed<EnsembleErrorData>(() =>
 );
 
 const ensembleVariables = computed(() =>
-	getSelectedOutputEnsembleMapping(props.node, variableChartOptionsObject.value, false).map((d) => d.newName)
+	getChartEnsembleMapping(props.node, variableChartOptionsObject.value, false).map((d) => d.newName)
 );
 // console.log(ensembleVariables);
 // console.log(selectedOutputMapping);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -456,7 +456,11 @@ const isRunInProgress = computed(() => Boolean(inProgressCalibrationId.value || 
 
 const datasetId = computed(() => props.node.inputs[0].value?.[0] as string | undefined);
 const currentDatasetFileName = ref<string>();
-const datasetColumnNames = computed(() => dataset.value?.columns?.map((col) => col.name) ?? ([] as string[]));
+const datasetColumnNames = computed(
+	() =>
+		dataset.value?.columns?.filter((col) => col.fileName === currentDatasetFileName.value).map((col) => col.name) ??
+		([] as string[])
+);
 // Loss Chart:
 const lossChartRef = ref<InstanceType<typeof VegaChart>>();
 const lossChartSpec = ref();

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -59,7 +59,7 @@ import {
 	updateLossChartSpec,
 	getLossValuesFromSimulation,
 	formatCalibrateModelConfigurations,
-	getSelectedOutputEnsembleMapping,
+	getChartEnsembleMapping,
 	buildChartData,
 	fetchModelConfigurations,
 	fetchOutputData
@@ -93,7 +93,7 @@ const outputData = ref<{
 	resultGroupByTimepoint: GroupedDataArray;
 } | null>(null);
 const groundTruthData = computed<DataArray>(() => parseCsvAsset(csvAsset.value as CsvAsset));
-const selectedOutputMapping = computed(() => getSelectedOutputEnsembleMapping(props.node));
+const selectedOutputMapping = computed(() => getChartEnsembleMapping(props.node, {}));
 const { selectedEnsembleVariableSettings } = useChartSettings(props, emit);
 const { useEnsembleVariableCharts } = useCharts(
 	props.node.id,

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -803,7 +803,7 @@ onMounted(async () => {
 	const modelConfigurationId = props.node.inputs[0].value?.[0];
 	if (!modelConfigurationId) return;
 	const modelConfiguration = await getModelConfigurationById(modelConfigurationId);
-	configuredInputModel = await getAsConfiguredModel(modelConfiguration);
+	configuredInputModel = await getAsConfiguredModel(modelConfiguration.id as string);
 
 	setModelOptions();
 

--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -803,7 +803,7 @@ onMounted(async () => {
 	const modelConfigurationId = props.node.inputs[0].value?.[0];
 	if (!modelConfigurationId) return;
 	const modelConfiguration = await getModelConfigurationById(modelConfigurationId);
-	configuredInputModel = await getAsConfiguredModel(modelConfiguration.id as string);
+	configuredInputModel = await getAsConfiguredModel(modelConfigurationId);
 
 	setModelOptions();
 

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -193,6 +193,7 @@ export function useCharts(
 		multiVariable = false,
 		showBaseLines = false
 	) => {
+		setting.hideInNode = true;
 		const ensembleVarName = setting.selectedVariables[0];
 		const options: ForecastChartOptions = {
 			title: getModelConfigName(<ModelConfiguration[]>modelConfig?.value ?? [], modelConfigId) || ensembleVarName,

--- a/packages/client/hmi-client/src/services/model-configurations.ts
+++ b/packages/client/hmi-client/src/services/model-configurations.ts
@@ -46,8 +46,8 @@ export const deleteModelConfiguration = async (id: string) => {
 	return response?.data ?? null;
 };
 
-export const getAsConfiguredModel = async (modelConfiguration: ModelConfiguration): Promise<Model> => {
-	const response = await API.get<Model>(`model-configurations/as-configured-model/${modelConfiguration.id}`);
+export const getAsConfiguredModel = async (modelConfigurationId: string): Promise<Model> => {
+	const response = await API.get<Model>(`model-configurations/as-configured-model/${modelConfigurationId}`);
 	return response?.data ?? null;
 };
 


### PR DESCRIPTION
# Description
- _unrelated_ datasetColumn options should be restricted to current file 
- Update getAsConfiguredModel to be a more user friendly interface
- Add mapping to `getSelectedOutputEnsembleMapping` to also include not selected mapping
- Rename `getSelectedOutputEnsembleMapping` to be more accurate
- By default do not show ensemble charts in drilldown.

Looking into:
- Remove _other_ chart all together?
- Ground truth not being shown in small multiples

# Video:
https://github.com/user-attachments/assets/95e8f02a-e049-4334-aa49-8310261b8152


