### PR TITLE
[BUG]: Can't copy a project anymore #6143

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/TerariumAssetCloneService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/TerariumAssetCloneService.java
@@ -83,8 +83,12 @@ public class TerariumAssetCloneService {
 			final List<InterventionPolicy> interventionPolicies =
 				interventionRepository.findByModelIdAndDeletedOnIsNullAndTemporaryFalse(assetId, PageRequest.of(0, 100));
 
-			assetsToClone.addAll(modelConfigurations.stream().map(ModelConfiguration::getId).toList());
-			assetsToClone.addAll(interventionPolicies.stream().map(InterventionPolicy::getId).toList());
+			assetsToClone.addAll(
+				modelConfigurations.stream().map(ModelConfiguration::getId).filter(projectAssetsById::containsKey).toList()
+			);
+			assetsToClone.addAll(
+				interventionPolicies.stream().map(InterventionPolicy::getId).filter(projectAssetsById::containsKey).toList()
+			);
 		}
 
 		final Map<UUID, AssetDependencyMap> assetDependencies = new HashMap<>();


### PR DESCRIPTION
# Description
Some legacy assets can exist in multiple projects. This weird edge case resulted in a scenario where a model can exist in project A yet have configs laying around in project B, C, D, etc. This filtering fixes this edge case

Resolves #6143 
