### PR TITLE
Update to equation style guide to solve SIDARTHE issue

### DIFF
--- a/packages/gollm/common/prompts/latex_style_guide.py
+++ b/packages/gollm/common/prompts/latex_style_guide.py
@@ -7,14 +7,13 @@ LATEX_STYLE_GUIDE = """
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{{...}}"
 6) Do not use square brackets "[ ]", curly braces "{ }", and angle brackets "< >" when grouping algebraic expressions; use parentheses "( )" when necessary
-7) Expand time-dependent algebraic expressions grouped by parentheses according to distributivity property of multiplication (for example, "S(t) * (a * I(t) + b * D(t) + c * A(t))" -> "a * S(t) * I(t) + b * S(t) * D(t) + c * A(t) * S(t)")
-8) Do not expand constant algebraic expressions grouped by parentheses; for example, "a * b * (1 - c)" should not be expanded since "a", "b", "c" are constants
-9) Avoid capital sigma and pi notations for summation and product
-10) Avoid non-ASCII characters when possible
-11) Avoid using homoglyphs
-12) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
-13) Use " * " to denote multiplication; for example, "b S(t) I(t)" -> "b * S(t) * I(t)"
-14) Replace any variant form of Greek letters to their main form when representing a variable or parameter; "\\varepsilon" -> "\\epsilon", "\\vartheta" -> "\\theta", "\\varpi" -> "\\pi", "\\varrho" -> "\\rho",  "\\varsigma" -> "\\sigma", "\\varphi" -> "\\phi"
-15) If equations are separated by punctuation (like comma, period, semicolon), do not include the punctuation in the LaTeX code.
-16) Rewrite expressions with negative exponents as explicit fractions; for example, "N^{{-1}}" should be rewritten as "\\frac{{1}}{{N}}"
+7) Expand algebraic expressions grouped by parentheses according to distributivity property of multiplication; example 1: "S(t) * (a * I(t) + b * D(t) + c * A(t))" -> "a * S(t) * I(t) + b * S(t) * D(t) + c * A(t) * S(t)"; example 2: "(a + b) * R(t)" -> "a * R(t) + b * R(t)"
+8) Avoid capital sigma and pi notations for summation and product
+9) Avoid non-ASCII characters when possible
+10) Avoid using homoglyphs
+11) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
+12) Use " * " to denote multiplication; for example, "b S(t) I(t)" -> "b * S(t) * I(t)"
+13) Replace any variant form of Greek letters to their main form when representing a variable or parameter; "\\varepsilon" -> "\\epsilon", "\\vartheta" -> "\\theta", "\\varpi" -> "\\pi", "\\varrho" -> "\\rho",  "\\varsigma" -> "\\sigma", "\\varphi" -> "\\phi"
+14) If equations are separated by punctuation (like comma, period, semicolon), do not include the punctuation in the LaTeX code.
+15) Rewrite expressions with negative exponents as explicit fractions; for example, "N^{{-1}}" should be rewritten as "\\frac{{1}}{{N}}"
 """


### PR DESCRIPTION
# Description

* The SIDARTHE model continued to be extracted incorrectly
* The issue lies with incomplete parenthesis term expansion
* Terms like `(a + b) * R(t)` were not expanded to `a * R(t) + b * R(t)` due to conflicting instruction
* The conflicting instruction has been removed and more examples provided on correct behaviour
* Eventually, we will hit the problem of terms like `a * (b + 1) * R(t)` that should not be expanded...
