### PR TITLE
do not generate equations if num states + num observables > 100

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
@@ -9,17 +9,22 @@
 		@update-model-from-equation="updateModelFromEquations"
 	>
 		<template #math-editor>
-			<tera-math-editor
-				v-for="(eq, index) in equations"
-				:key="index"
-				:index="index"
-				:is-editable="isEditable"
-				:is-editing-eq="isEditing"
-				:latex-equation="eq"
-				@equation-updated="setNewEquation"
-				@delete="deleteEquation"
-				ref="equationsRef"
-			/>
+			<div v-if="exceedEquationsThreshold == false">
+				<tera-math-editor
+					v-for="(eq, index) in equations"
+					:key="index"
+					:index="index"
+					:is-editable="isEditable"
+					:is-editing-eq="isEditing"
+					:latex-equation="eq"
+					@equation-updated="setNewEquation"
+					@delete="deleteEquation"
+					ref="equationsRef"
+				/>
+			</div>
+			<div v-else>
+				<p>Number of equations exceed LaTex generator threshold.</p>
+			</div>
 		</template>
 	</tera-equation-container>
 </template>
@@ -47,6 +52,7 @@ const equations = ref<string[]>([]);
 const originalEquations = ref<string[]>([]);
 const isEditing = ref(false);
 const isUpdating = ref<boolean>(false);
+const exceedEquationsThreshold = ref(false);
 
 const setNewEquation = (index: number, latexEq: string) => {
 	equations.value[index] = latexEq;
@@ -89,6 +95,19 @@ watch(
 	() => props.model.semantics,
 	async (newSemantics, oldSemantics) => {
 		if (isEqual(newSemantics, oldSemantics)) return;
+
+		// If there are too many states, don't bother generating the equations - Jan 2025
+		let eqLength = 0;
+		eqLength += props.model.model.states.length;
+		if (props.model.semantics?.ode.observables) {
+			eqLength += props.model.semantics.ode.observables.length;
+		}
+		if (eqLength > 250) {
+			exceedEquationsThreshold.value = true;
+			return;
+		}
+		exceedEquationsThreshold.value = false;
+
 		const latexFormula = await getModelEquation(props.model);
 		if (latexFormula) {
 			updateLatexFormula(cleanLatexEquations(latexFormula.split(' \\\\')));

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
@@ -47,6 +47,8 @@ const props = defineProps<{
 
 const emit = defineEmits(['model-updated']);
 
+const MAX_EQUATION_THRESHOLD = 100;
+
 const equationsRef = ref<any[]>([]);
 const equations = ref<string[]>([]);
 const originalEquations = ref<string[]>([]);
@@ -102,7 +104,7 @@ watch(
 		if (props.model.semantics?.ode.observables) {
 			eqLength += props.model.semantics.ode.observables.length;
 		}
-		if (eqLength > 250) {
+		if (eqLength > MAX_EQUATION_THRESHOLD) {
 			exceedEquationsThreshold.value = true;
 			return;
 		}


### PR DESCRIPTION
### Summary
In discussion with jaehwan, pascale and tom on perf and stabilization, we decided to not run genreate_model_latex task if there are too many expressions that need to be parsed in sympy, which is the bottleneck. We proxy this idea by restricting the number of equations (number of states + number of observables). 

The 250 is just a somewhat reasonable max that a modeller might go through.

<img width="596" alt="image" src="https://github.com/user-attachments/assets/4ea9ad02-f276-4d17-a132-d73b58cdaed9" />


### Testing
If you don't have a large model handy, lower the 250 threshold to 2.