### PR TITLE
horizon scanning tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -136,7 +136,14 @@ Provide a summary in 100 words or less.
 
 	const summaryResponse = await createLLMSummary(prompt);
 
-	const datasetName = nodeOutputLabel(props.node, interventionPolicy.value?.name ?? 'no intervention');
+	// generate label like "Configuration (intervention)"
+	const nodeLabel = (): string => {
+		const configName = modelConfiguration.value?.name;
+		const interventionName = interventionPolicy.value?.name ?? 'no intervention';
+		return configName ? `${configName} (${interventionName})` : '';
+	};
+
+	const datasetName = nodeOutputLabel(props.node, nodeLabel());
 	const projectId = useProjects().activeProject.value?.id ?? '';
 	const datasetResult = await createDatasetFromSimulationResult(
 		projectId,

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
@@ -290,8 +290,8 @@ export class HorizonScanningScenario extends BaseScenario {
 
 		// Generate Cartesian product of parameter extrema
 		const parameterExtrema = this.parameters.map((parameter) => [
-			{ id: parameter!.id, type: 'Low', value: parameter!.low },
-			{ id: parameter!.id, type: 'High', value: parameter!.high }
+			{ id: parameter!.id, label: 'Low', value: parameter!.low },
+			{ id: parameter!.id, label: 'High', value: parameter!.high }
 		]);
 
 		const cartesianConfigs = cartesianProduct(parameterExtrema);
@@ -307,7 +307,7 @@ export class HorizonScanningScenario extends BaseScenario {
 				}
 			});
 
-			clonedModelConfig.name = config.map((param) => `${param.id}${param.type}`).join('_');
+			clonedModelConfig.name = config.map((param) => `${param.id}${param.label}`).join('_');
 			clonedModelConfig.description = `This is a configuration created from "${modelConfig.name}" with extreme values for the parameters: ${config.map((param) => `${param.id}: ${param.value}`).join(', ')} using the horizon scanning scenario template.`;
 
 			const newModelConfig = await createModelConfiguration(clonedModelConfig);


### PR DESCRIPTION
# Description

* Some name changes for the horizon scanning created model configurations
* Added a baseline configuration for the horizon scanning template (selected config w/o interventions)
* Simulation results name now like `Configuration (intervention)` so that this can be carried into downstream nodes
