### PR TITLE
Update latex_to_sympy.py to forcibly expand all the parentheses in the SymPy expressions

### DIFF
--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -13,7 +13,7 @@ t = sympy.symbols("t")
 S, I = sympy.symbols("S I", cls = sympy.Function)
 # Define constant parameters
 beta, b, m = sympy.symbols("beta b m")
-equation_output = [sympy.Eq(S(t).diff(t), -beta * S(t) * I(t) + b - m * S(t))]
+equation_output = [sympy.Eq(S(t).diff(t), (-beta * S(t) * I(t) + b - m * S(t)).expand())]
 ```
 
 Now, do the same for this LaTeX input:


### PR DESCRIPTION
# Description

* Follow-up to the tweaks to the equation style guide instructions
* In case the agent fails to do proper algebra (expanding/distributing parenthesis expressions), ask SymPy to do it
