### PR TITLE
Update to "Create model from equations" - Disable default initial parameters

### DIFF
--- a/packages/mira/tasks/sympy_to_amr.py
+++ b/packages/mira/tasks/sympy_to_amr.py
@@ -81,10 +81,11 @@ def main():
             param.value = 0.0
     
         # Ensure every state variable has an initial condition parameter
-        mmt.initials = mmt.initials | {c: Initial(concept = concept, expression = safe_parse_expr(f'{c}0')) for c, concept in mmt.get_concepts_name_map().items()}
+        mmt.initials = mmt.initials | {c: Initial(concept = concept, expression = safe_parse_expr(f'0.0')) for c, concept in mmt.get_concepts_name_map().items()}
+        # mmt.initials = mmt.initials | {c: Initial(concept = concept, expression = safe_parse_expr(f'{c}0')) for c, concept in mmt.get_concepts_name_map().items()}
     
         # Set default values for the initial condition parameters
-        mmt.parameters = mmt.parameters | {f'{c}0': Parameter(name = f'{c}0', display_name = f'{c}0', description = f'Initial value of state variable "{c}"', value = 0.0) for c in mmt.get_concepts_name_map().keys()}
+        # mmt.parameters = mmt.parameters | {f'{c}0': Parameter(name = f'{c}0', display_name = f'{c}0', description = f'Initial value of state variable "{c}"', value = 0.0) for c in mmt.get_concepts_name_map().keys()}
 
         # =======================
 


### PR DESCRIPTION
# Description

* Need to reduce complexity for the config extraction agent
* Created model will not have by default an initial expression `X0` and a parameter `X0 = 0.0`
* Instead, all the initial expressions will be just `0.0` and no parameter `X0`
