### PR TITLE
ensure timestamp column name is present when we run calibrate, clean …

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -947,6 +947,8 @@ const runCalibrate = async () => {
 		state.currentProgress = 0;
 		state.inProgressForecastId = '';
 		state.inProgressPreForecastId = '';
+		state.timestampColName = knobs.value.timestampColName;
+
 		initDefaultChartSettings(state);
 		emit('update-state', state);
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -207,9 +207,7 @@ const pollResult = async (runId: string) => {
 				value: simulation.status,
 				traceback: simulation.statusMessage
 			};
-			emit('update-state', state);
 		}
-		throw Error('Failed Runs');
 	}
 	emit('update-state', state);
 	return pollerResults;


### PR DESCRIPTION
### Summary
This is an additional fix on top of https://github.com/DARPA-ASKEM/terarium/pull/6172 to have the ground-truth data setup correctly. The problem seems to be that, if you never change the timestamp mapping, this `timestampColName` is not set correctly


### Testing
In calibrate, do not touch the timestamp mapping, but set up other variable mappings.
Run calibrate, when it is finished the variable chart should have the ground truth data correctly displayed and not all bunched together.
