### PR TITLE
fix dupe model creation on intervention policy creation

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/decision-making/decision-making-scenario.ts
@@ -16,7 +16,8 @@ import {
 } from '@/services/intervention-policy';
 import { ChartSetting, ChartSettingType, CiemssPresetTypes } from '@/types/common';
 import { updateChartSettingsBySelectedVariables } from '@/services/chart-settings';
-import { InterventionPolicy } from '@/types/Types';
+import { AssetType, InterventionPolicy } from '@/types/Types';
+import { useProjects } from '@/composables/project';
 import { createDefaultForecastSettings, runSimulations } from '../scenario-template-utils';
 
 export class DecisionMakingScenario extends BaseScenario {
@@ -266,6 +267,12 @@ export class DecisionMakingScenario extends BaseScenario {
 						interventions: [blankIntervention]
 					},
 					true
+				);
+
+				await useProjects().addAsset(
+					AssetType.InterventionPolicy,
+					interventionPolicy!.id,
+					useProjects().activeProject.value?.id
 				);
 			}
 

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
@@ -388,6 +388,12 @@ export class HorizonScanningScenario extends BaseScenario {
 						},
 						true
 					);
+
+					await useProjects().addAsset(
+						AssetType.InterventionPolicy,
+						interventionPolicy!.id,
+						useProjects().activeProject.value?.id
+					);
 				}
 
 				// Add to list of intervention policies

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
@@ -386,6 +386,12 @@ export class ValueOfInformationScenario extends BaseScenario {
 						},
 						true
 					);
+
+					await useProjects().addAsset(
+						AssetType.InterventionPolicy,
+						interventionPolicy!.id,
+						useProjects().activeProject.value?.id
+					);
 				}
 
 				fetchedInterventionPolicies.push(interventionPolicy!);

--- a/packages/client/hmi-client/src/services/save-asset.ts
+++ b/packages/client/hmi-client/src/services/save-asset.ts
@@ -58,10 +58,7 @@ export async function saveAs(
 		return;
 	}
 
-	// this is already done in the backend for intervention policies
-	if (assetType !== AssetType.InterventionPolicy) {
-		await useProjects().addAsset(assetType, response.id, projectId);
-	}
+	await useProjects().addAsset(assetType, response.id, projectId);
 
 	// After saving notify the user and do any necessary actions
 	logger.info(`${response.name} saved successfully in project ${useProjects().activeProject.value?.name}.`);

--- a/packages/client/hmi-client/src/services/save-asset.ts
+++ b/packages/client/hmi-client/src/services/save-asset.ts
@@ -57,7 +57,11 @@ export async function saveAs(
 		logger.error(`Asset can't be saved since target project doesn't exist.`);
 		return;
 	}
-	await useProjects().addAsset(assetType, response.id, projectId);
+
+	// this is already done in the backend for intervention policies
+	if (assetType !== AssetType.InterventionPolicy) {
+		await useProjects().addAsset(assetType, response.id, projectId);
+	}
 
 	// After saving notify the user and do any necessary actions
 	logger.info(`${response.name} saved successfully in project ${useProjects().activeProject.value?.name}.`);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
@@ -123,10 +123,6 @@ public class InterventionController {
 		}
 		try {
 			final InterventionPolicy policy = interventionService.createAsset(item, projectId, permission);
-			final Optional<Project> project = projectService.getProject(projectId);
-			if (project.isPresent()) {
-				projectAssetService.createProjectAsset(project.get(), AssetType.INTERVENTION_POLICY, policy, permission);
-			}
 			return ResponseEntity.status(HttpStatus.CREATED).body(policy);
 		} catch (final IOException e) {
 			final String error = "Unable to create intervention";


### PR DESCRIPTION
# Description

* Fixes an issue where a new model would be added to the resources page when an intervention policy was created
* This seems to be a caveat of the cloning process.  Looking at the backend if we add an asset to the project when it already exists it will clone it and it's dependent assets hence why the model was cloned.  Since we are already adding the intervention policy in the backend when it is created we do not need to add it in the front end and this cloning is prevented

***EDIT***
* After a chat with Dan, going to keep things consistent here and I've removed the adding of the asset to the project in the backend.  I will be adding that functionality to the templates themselves for consistencies sake
