### PR TITLE
tweak update-state pattern

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -122,7 +122,6 @@
 										rows="1"
 										placeholder="Add an expression with LaTeX"
 										class="w-full"
-										@update:model-value="emit('update-state', clonedState)"
 									/>
 								</tera-asset-block>
 							</li>
@@ -168,7 +167,6 @@
 										rows="1"
 										placeholder="Add an expression with LaTeX"
 										class="w-full"
-										@update:model-value="emit('update-state', clonedState)"
 									/>
 								</tera-asset-block>
 							</li>
@@ -411,6 +409,9 @@ function arrayBufferToBase64(buffer) {
 }
 
 onBeforeUnmount(async () => {
+	// flush changes
+	emit('update-state', clonedState.value);
+
 	window.removeEventListener('paste', handlePasteEvent);
 });
 


### PR DESCRIPTION
### Summary
Change from updating-state at every keystroke to an update flush when the drilldown component is unmounted. Unconstrained calls to update-state can cause issues since they are now API bound and possible to get out of sync if there are streams of updates.


