### PR TITLE
6197 task do not re extract configurations from existing inputs which were already extracted just extract new inputs

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -464,7 +464,7 @@ const extractConfigurationsFromInputs = async () => {
 		.filter((id) => id);
 
 	const newDocumentIds = difference(documentIds.value, configExtractionDocumentIds);
-	if (newDocumentIds) {
+	if (newDocumentIds.length) {
 		const promiseList = [] as Promise<TaskResponse | null>[];
 		newDocumentIds.forEach((documentId) => {
 			promiseList.push(
@@ -480,7 +480,7 @@ const extractConfigurationsFromInputs = async () => {
 	}
 
 	const newDatasetIds = difference(datasetIds.value, configExtractionDocumentIds);
-	if (newDatasetIds) {
+	if (newDatasetIds.length) {
 		const matrixStr = generateModelDatasetConfigurationContext(mmt.value, mmtParams.value);
 		const promiseList = [] as Promise<TaskResponse | null>[];
 		newDatasetIds.forEach((datasetId) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -459,12 +459,13 @@ const extractConfigurationsFromInputs = async () => {
 		return;
 	}
 
+	// We only want to run extractions on documents and datasets that have not previously been run
 	const configExtractionDocumentIds = modelConfigurations.value
 		.map((config) => config.extractionDocumentId)
-		.filter((id) => id);
+		.filter(Boolean);
 
 	const newDocumentIds = difference(documentIds.value, configExtractionDocumentIds);
-	if (newDocumentIds.length) {
+	if (!isEmpty(newDocumentIds)) {
 		const promiseList = [] as Promise<TaskResponse | null>[];
 		newDocumentIds.forEach((documentId) => {
 			promiseList.push(
@@ -480,7 +481,7 @@ const extractConfigurationsFromInputs = async () => {
 	}
 
 	const newDatasetIds = difference(datasetIds.value, configExtractionDocumentIds);
-	if (newDatasetIds.length) {
+	if (!isEmpty(newDatasetIds)) {
 		const matrixStr = generateModelDatasetConfigurationContext(mmt.value, mmtParams.value);
 		const promiseList = [] as Promise<TaskResponse | null>[];
 		newDatasetIds.forEach((datasetId) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -225,7 +225,7 @@
 <script setup lang="ts">
 import '@/ace-config';
 import { ComponentPublicInstance, computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
-import { cloneDeep, debounce, isEmpty, orderBy, omit } from 'lodash';
+import { cloneDeep, debounce, difference, isEmpty, orderBy, omit } from 'lodash';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import Button from 'primevue/button';
@@ -459,11 +459,16 @@ const extractConfigurationsFromInputs = async () => {
 		return;
 	}
 
-	if (documentIds.value) {
+	const configExtractionDocumentIds = modelConfigurations.value
+		.map((config) => config.extractionDocumentId)
+		.filter((id) => id);
+
+	const newDocumentIds = difference(documentIds.value, configExtractionDocumentIds);
+	if (newDocumentIds) {
 		const promiseList = [] as Promise<TaskResponse | null>[];
-		documentIds.value.forEach((documentId) => {
+		newDocumentIds.forEach((documentId) => {
 			promiseList.push(
-				configureModelFromDocument(documentId, model.value?.id as string, props.node.workflowId, props.node.id)
+				configureModelFromDocument(`${documentId}`, model.value?.id as string, props.node.workflowId, props.node.id)
 			);
 		});
 		const responsesRaw = await Promise.all(promiseList);
@@ -474,12 +479,19 @@ const extractConfigurationsFromInputs = async () => {
 		});
 	}
 
-	if (datasetIds.value) {
+	const newDatasetIds = difference(datasetIds.value, configExtractionDocumentIds);
+	if (newDatasetIds) {
 		const matrixStr = generateModelDatasetConfigurationContext(mmt.value, mmtParams.value);
 		const promiseList = [] as Promise<TaskResponse | null>[];
-		datasetIds.value.forEach((datasetId) => {
+		newDatasetIds.forEach((datasetId) => {
 			promiseList.push(
-				configureModelFromDataset(model.value?.id as string, datasetId, matrixStr, props.node.workflowId, props.node.id)
+				configureModelFromDataset(
+					model.value?.id as string,
+					`${datasetId}`,
+					matrixStr,
+					props.node.workflowId,
+					props.node.id
+				)
 			);
 		});
 		const responsesRaw = await Promise.all(promiseList);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDatasetResponseHandler.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDatasetResponseHandler.java
@@ -81,6 +81,10 @@ public class ConfigureModelFromDatasetResponseHandler extends TaskResponseHandle
 					configuration.setModelId(props.modelId);
 				}
 
+				if (configuration.getExtractionDocumentId() != props.datasetId) {
+					configuration.setExtractionDocumentId(props.datasetId);
+				}
+
 				// Fetch the dataset name
 				final Optional<Dataset> dataset = datasetService.getAsset(
 					props.datasetId,

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDocumentResponseHandler.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDocumentResponseHandler.java
@@ -73,8 +73,12 @@ public class ConfigureModelFromDocumentResponseHandler extends TaskResponseHandl
 			for (final JsonNode condition : configurations.response.get("conditions")) {
 				final ModelConfiguration configuration = objectMapper.treeToValue(condition, ModelConfiguration.class);
 
-				if (configuration.getModelId() != props.modelId) {
-					configuration.setModelId(props.modelId);
+				if (configuration.getModelId() != props.documentId) {
+					configuration.setModelId(props.documentId);
+				}
+
+				if (configuration.getExtractionDocumentId() != props.documentId) {
+					configuration.setExtractionDocumentId(props.documentId);
 				}
 
 				// Fetch the document name

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDocumentResponseHandler.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ConfigureModelFromDocumentResponseHandler.java
@@ -73,8 +73,8 @@ public class ConfigureModelFromDocumentResponseHandler extends TaskResponseHandl
 			for (final JsonNode condition : configurations.response.get("conditions")) {
 				final ModelConfiguration configuration = objectMapper.treeToValue(condition, ModelConfiguration.class);
 
-				if (configuration.getModelId() != props.documentId) {
-					configuration.setModelId(props.documentId);
+				if (configuration.getModelId() != props.modelId) {
+					configuration.setModelId(props.modelId);
 				}
 
 				if (configuration.getExtractionDocumentId() != props.documentId) {


### PR DESCRIPTION
# Description

* Saves extraction document id to the model configuration. 
* Model config drilldown checks for existing extraction document ids before requesting more extractions.

Resolves #6197
