### PR TITLE
chips dont cover close button in drilldown

### DIFF
--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown-header.vue
@@ -53,6 +53,12 @@ header > * {
 	justify-content: space-between;
 }
 
+.title-row {
+	display: flex;
+	align-items: center;
+	gap: var(--gap-3);
+}
+
 .title-row > h4 > i {
 	color: var(--text-color-secondary);
 	margin-left: 1rem;

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -39,7 +39,7 @@
 			>
 				{{ title ?? node.displayName }}
 				<template #top-header-actions>
-					<aside class="flex gap-1 ml-3 mr-auto">
+					<aside class="chips">
 						<Chip
 							v-for="(input, index) in node.inputs.filter((input) => input.value)"
 							:key="index"
@@ -53,7 +53,6 @@
 					<template v-if="!hideDropdown && outputOptions && selectedOutputId">
 						<section v-if="isDraft">There are unsaved changes</section>
 						<tera-output-dropdown
-							class="mx-2"
 							:class="{ draft: isDraft }"
 							:options="outputOptions"
 							:output="selectedOutputId"
@@ -326,6 +325,14 @@ onUnmounted(() => window.removeEventListener('keydown', handleKeyNavigation));
 	& > label {
 		color: var(--text-color-subdued);
 	}
+}
+
+.chips {
+	display: flex;
+	gap: var(--gap-1);
+	margin-right: auto;
+	overflow-x: auto;
+	scrollbar-width: thin;
 }
 
 footer {

--- a/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-output-dropdown.vue
@@ -63,7 +63,6 @@ const getCreateTimeById = (id: string) => {
 .p-dropdown {
 	/*FIXME: We may want to truncate the text with ellipsis or something (up to designers) */
 	max-width: 25rem;
-	align-self: end;
 }
 
 .output-dropdown:deep(.p-inputtext) {


### PR DESCRIPTION
# Description

* Added a thin scroll for the chips

 
<img width="1241" alt="Screenshot 2025-01-24 at 3 01 07 PM" src="https://github.com/user-attachments/assets/994e6912-65f8-400e-8b73-cea61d2b95bb" />
