### PR TITLE
base config in ranking

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
@@ -238,19 +238,25 @@ export function generateRankingCharts(
 				({ id }) => id === metadata.simulationAttributes?.interventionPolicyId
 			);
 
-			if (!policy?.name || !modelConfiguration?.name) {
+			const policyName = policy?.name ?? 'no policy';
+
+			if (!modelConfiguration?.name) {
 				return;
 			}
 
-			if (!interventionNameColorMap[policy.name]) {
-				interventionNameColorMap[policy.name] = CATEGORICAL_SCHEME[colorIndex];
-				interventionNameScoresMap[policy.name] = [];
-				colorIndex++;
+			if (!interventionNameColorMap[policyName]) {
+				interventionNameScoresMap[policyName] = [];
+				if (!policy?.name) {
+					interventionNameColorMap[policyName] = 'black';
+				} else {
+					interventionNameColorMap[policyName] = CATEGORICAL_SCHEME[colorIndex];
+					colorIndex++;
+				}
 			}
 
 			rankingCriteriaValues.push({
 				score: pointOfComparison[`${variableKey}:${index}`] ?? 0,
-				policyName: policy.name,
+				policyName,
 				configName: modelConfiguration.name
 			});
 		});


### PR DESCRIPTION
# Description

* show base config in ranking

![image](https://github.com/user-attachments/assets/c60d6501-577d-46a7-bd88-f80d710b8eb2)