### PR TITLE
Correct timing on when we save code to state

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -209,7 +209,6 @@ const stratifyModel = () => {
 		if (modelParameters.includes(v)) parametersToStratify.push(v);
 	});
 
-	let executedCode = '';
 	const messageContent = {
 		key: strataOption.name,
 		strata: strataOption.groupLabels.split(',').map((d) => d.trim()),
@@ -222,7 +221,7 @@ const stratifyModel = () => {
 		kernelManager
 			.sendMessage('stratify_request', messageContent)
 			.register('stratify_response', (data: any) => {
-				executedCode = data.content.executed_code;
+				const executedCode = data.content.executed_code;
 				saveCodeToState(executedCode, false);
 			})
 			.register('model_preview', async (data: any) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -223,10 +223,10 @@ const stratifyModel = () => {
 			.sendMessage('stratify_request', messageContent)
 			.register('stratify_response', (data: any) => {
 				executedCode = data.content.executed_code;
+				saveCodeToState(executedCode, false);
 			})
 			.register('model_preview', async (data: any) => {
 				await handleModelPreview(data);
-				saveCodeToState(executedCode, false);
 			});
 	});
 };


### PR DESCRIPTION
# Description
Previously we were calling `update-state` (within saveCodeToState) only after our `append-output` (within handleModelPreview) 
This changes the timing such that we call `update-state` with our executed code whenever we get the response
And we call `append-output` whenever we get our preview 

# Video
https://github.com/user-attachments/assets/12d63b23-ed42-459f-9a78-4bb1df7b3a8f

