### PR TITLE
6228 bug matrix popup from a stratified model appears cutoff

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix-preview.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix-preview.vue
@@ -25,7 +25,7 @@
 				</template>
 			</div>
 		</section>
-		<p>Click to open</p>
+		<p class="ml-auto">Click to open</p>
 	</section>
 </template>
 

--- a/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/model-configurations/tera-stratified-matrix.vue
@@ -87,7 +87,7 @@
 								/>
 								<div class="w-full" :class="{ 'hide-content': editableCellStates[cell.row][cell.col] }">
 									<div
-										class="subdue mb-1 flex align-items-center gap-1 w-full justify-content-between"
+										class="subdue text-sm mb-1 flex align-items-center gap-1 w-full justify-content-between"
 										v-if="stratifiedMatrixType !== StratifiedMatrix.Initials"
 									>
 										{{ cell?.content.id }}

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -1,5 +1,10 @@
 <template>
-	<tera-tooltip :custom-position="hoveredTransitionPosition" :show-tooltip="!isEmpty(hoveredTransitionId)">
+	<tera-tooltip
+		:custom-position="hoveredTransitionPosition"
+		:show-tooltip="!isEmpty(hoveredTransitionId)"
+		:has-arrow="false"
+		title=""
+	>
 		<tera-resizable-panel v-if="!featureConfig?.isPreview" class="diagram-container">
 			<Toolbar>
 				<template #start>
@@ -200,12 +205,11 @@ function makeGraphInteractive(renderer: PetrinetRenderer | NestedPetrinetRendere
 			if (diagramBounds && transitionMatrixBounds && tooltipHeight && tooltipWidth) {
 				const transitionMatrixX = transitionMatrixBounds.left - diagramBounds.left;
 				const transitionMatrixY = transitionMatrixBounds.top - diagramBounds.top;
-				const transitionMatrixHeight = selection.datum().height;
 				const transitionMatrixWidth = selection.datum().width;
 
 				// Shift tooltip to the top center of the transition matrix
 				const x = transitionMatrixX - (tooltipWidth + transitionMatrixWidth / 2) / 2 + transitionMatrixBounds.width / 2;
-				const y = transitionMatrixY - tooltipHeight - transitionMatrixHeight / 2;
+				const y = transitionMatrixY - tooltipHeight / 2;
 
 				hoveredTransitionPosition.value = { x, y };
 			}

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-diagram.vue
@@ -27,7 +27,7 @@
 				</template>
 			</Toolbar>
 			<figure ref="graphElement" class="graph-element"></figure>
-			<ul class="legend" v-if="!isEmpty(graphLegendLabels)">
+			<ul class="legend text-sm" v-if="!isEmpty(graphLegendLabels)">
 				<li v-for="(label, index) in graphLegendLabels" :key="index">
 					<div class="legend-circle" :style="`background: ${graphLegendColors[index]}`" />
 					{{ label }}
@@ -364,5 +364,6 @@ ul.legend {
 	display: inline-block;
 	height: 1rem;
 	width: 1rem;
+	margin-right: var(--gap-1);
 }
 </style>

--- a/packages/client/hmi-client/src/components/widgets/tera-tooltip.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-tooltip.vue
@@ -3,7 +3,7 @@
 		<slot />
 		<div
 			v-if="props.showTooltip"
-			class="tooltip-content"
+			class="tooltip-content pointer-events-none"
 			:class="[{ 'has-arrow': hasArrow }, arrowClass]"
 			:style="tooltipStyle"
 		>

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -20,13 +20,16 @@
 				class="common-input-height"
 			/>
 		</div>
-		<div class="input-row">
+		<div class="flex flex-column gap-2 mb-4 w-full">
 			<label>Enter a comma separated list of labels for each group.</label>
-			<tera-input-text
+			<Textarea
 				v-model="labels"
+				rows="1"
 				placeholder="e.g., Young, Old"
 				@focusout="emit('update-self', updatedConfig)"
-				class="common-input-height"
+				:autoResize="true"
+				class="w-full"
+				style="min-height: 2.35rem"
 			/>
 		</div>
 		<div class="input-row">
@@ -45,6 +48,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
+import Textarea from 'primevue/textarea';
 import MultiSelect from 'primevue/multiselect';
 import Checkbox from 'primevue/checkbox';
 import { StratifyGroup } from '@/components/workflow/ops/stratify-mira/stratify-mira-operation';


### PR DESCRIPTION
# Not a perfect solution but better than before

This is not a z-index issue. The problem is the tooltip is too close to the top of the section that it's in, so the top goes out of bounds. We would have to add a bunch of top padding to the section to see it, but that would be weird.
![image](https://github.com/user-attachments/assets/e6d4f705-c6c4-44f9-866d-57efbbb17878)

## My imperfect solution
Instead of positioning the tooltip above the trigger, I centered it over the trigger. This moves it down a fair amount. It may still get cut off if it's large, but this is a decent temporary solution.
![matrix hover](https://github.com/user-attachments/assets/6535ef8e-30a1-4415-b8b5-b6f7d8f19158)

A better solution would be to move the tooltip to the top level layer, like app.vue, and then trigger it there. But that feels a bit drastic just as we're about to begin the eval. 

I also made the text smaller in two places:
![image](https://github.com/user-attachments/assets/fc4bdc37-e25d-4753-b5b7-ddf8718e3f54)
![image](https://github.com/user-attachments/assets/ebfe2750-f4ad-4279-9853-44c198588eaf)

Oh, and I changed the field in the Stratify operator for naming the strata groups from a regular input to a Textarea that grows if the content is larger than one line.
![image](https://github.com/user-attachments/assets/89dfef25-9696-47a1-b804-00861cb1eb55)
![image](https://github.com/user-attachments/assets/7dbfc188-b767-4be9-9fbd-4fe6e174431f)
