### PR TITLE
Fixed Model-parts bug where the description was displayed twice

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -85,9 +85,9 @@
 			:throw-on-error="false"
 		/>
 		<span v-if="!isTimePart" class="description" :class="{ 'mt-1': showDescription }">
-			<template v-if="!featureConfig.isPreview">{{ descriptionText }}</template>
+			<template v-if="featureConfig.isPreview">{{ descriptionText }}</template>
 			<tera-input-text
-				v-if="showDescription"
+				v-else-if="showDescription"
 				placeholder="Add a description"
 				v-model="descriptionText"
 				@change="$emit('update-item', { key: 'description', value: descriptionText })"


### PR DESCRIPTION
# BEFORE
There's something wrong with the logic on the description field of tera-model-parts. It is displaying the description text twice. It's weird.
![model part before](https://github.com/user-attachments/assets/4bf12c6b-d2e6-430f-8dfb-be6049deb3e3)

# AFTER
The v-if on the description field was incorrect. It was displaying when when NOT the preview mode was true. That's wrong. In preview mode we want to show the text version. In not-preview mode we only want to show the input text field. 
![model part after](https://github.com/user-attachments/assets/dd0ebd6e-c454-466a-8427-87521930ef85)

