### PR TITLE
correction to calibration watcher.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -1090,7 +1090,7 @@ onMounted(async () => {
 });
 
 watch(
-	() => knobs.value,
+	() => ({ ...knobs.value }),
 	(newValue, oldValue) => {
 		if (_.isEqual(newValue, oldValue)) return;
 		const state = _.cloneDeep(props.node.state);


### PR DESCRIPTION
# Description
When using new and old values for your watchers if this is not for a string or number you should watch a copy of the object instead.
More details can be found in this helpful thread: 
https://stackoverflow.com/questions/62729380/vue-watch-outputs-same-oldvalue-and-newvalue

# Testing:
Update the endTime knob, refresh page, see that your change was actually saved.