### PR TITLE
fix compare dataset initialization

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-utils.ts
@@ -345,7 +345,13 @@ export async function initialize(
 	const datasetInputs = inputs.filter(
 		(input) => input.type === 'datasetId' && input.status === WorkflowPortStatus.CONNECTED
 	);
-	const datasetPromises = datasetInputs.map((input) => getDataset(input.value![0]));
+
+	const datasetPromises = datasetInputs.map((input) => {
+		const datasetId = input.value?.[0];
+		if (!datasetId) return Promise.resolve(null);
+		return getDataset(datasetId);
+	});
+
 	isFetchingDatasets.value = true;
 	await Promise.all(datasetPromises).then((ds) => {
 		ds.forEach((dataset) => {


### PR DESCRIPTION
# Description

* Fixes an issue where compare dataset assumes that the input always has a value.  Cases like from scenario templates or just simply connecting an empty sim node to a compare dataset operator results in a console error
```
compare-datasets-utils.ts:348 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at compare-datasets-utils.ts:348:72
    at Array.map (<anonymous>)
    at initialize (compare-datasets-utils.ts:348:40)
    at tera-compare-datasets-node.vue:68:2
```

