### PR TITLE
Remove filter to show charts in nodes

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
@@ -69,7 +69,6 @@ const visibleChartSettings = computed(() => {
 			return (
 				(props.chartSettings as ChartSetting[][])
 					// TODO: find source of empty arrays instead of this hack
-					.filter((settingArray) => settingArray.length)
 					.map((settingsArray) => settingsArray.filter((setting) => !setting?.hideInNode))
 			);
 		}

--- a/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/tera-node-preview.vue
@@ -79,4 +79,3 @@ const visibleChartSettings = computed(() => {
 	return null;
 });
 </script>
-s


### PR DESCRIPTION
# Description
- This will show charts again in nodes if it is removed
- This is helpful for demos but we have more things afoot to look into
- Matt has an issue somewhere to look into this further in the meantime we can merge this to get our charts back at the cost of thumbnails (which his initial issue was looking into)
#6266

