### PR TITLE
Added 'Normalize' option in the output settings of Simulate operator

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
@@ -76,6 +76,14 @@
 							/>
 						</div>
 						<Divider />
+						<h5>Normalize</h5>
+						<tera-checkbox
+							label="Normalize data by total strata population"
+							:disabled="false"
+							:model-value="normalizeData"
+							@update:model-value="toggleNormalizeData($event)"
+						/>
+						<Divider />
 					</section>
 				</div>
 			</div>
@@ -122,16 +130,22 @@ const toggleHideInNode = (hideInNode: boolean) => {
 
 // Settings for comparison method
 const comparisonSettings = computed(() => props.activeSettings as ChartSettingComparison | null);
+// Small multiples
 const smallMultiplesRadioValue = computed(() =>
 	comparisonSettings.value?.smallMultiples ? 'small-multiples' : 'all-charts'
 );
 const onSmallMultiplesRadioButtonChange = (value: 'all-charts' | 'small-multiples') => {
 	emit('update-settings', { smallMultiples: value === 'small-multiples' });
 };
+// Share Y axis
 const isShareYAxis = computed(() => Boolean(comparisonSettings.value?.shareYAxis));
-const showBeforeAfter = computed(() => Boolean(comparisonSettings.value?.showBeforeAfter));
 const toggleShareYAxis = (value: boolean) => emit('update-settings', { shareYAxis: value });
+// Show before and after
+const showBeforeAfter = computed(() => Boolean(comparisonSettings.value?.showBeforeAfter));
 const toggleShowBeforeAfter = (value: boolean) => emit('update-settings', { showBeforeAfter: value });
+// Normalize
+const normalizeData = computed(() => Boolean(comparisonSettings.value?.normalize));
+const toggleNormalizeData = (value: boolean) => emit('update-settings', { normalize: value });
 // ==============================
 
 // Primary color

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -221,6 +221,30 @@ export const getTypesFromModelParts = (model: Model) => {
 	return typeMapping;
 };
 
+/**
+ * For a given state variable, return the state modifiers
+ */
+export const getModelStateModifiers = (id: string, model: Model) => {
+	const states = model.model.states;
+	const modifiers: Record<string, string> = (states as any[]).find((s) => s.id === id)?.grounding?.modifiers || {};
+	return modifiers;
+};
+
+/**
+ * For a given state variable, return the state modifiers object entries in a array of string formatted in the form of key:value, e.g. ['key:value']. The array is sorted.
+ */
+export const getStateVariableStrata = (id: string, model: Model) => {
+	const modifiers = getModelStateModifiers(id, model);
+	const entries = Object.entries(modifiers)
+		.map(([key, value]) => `${key}:${value}`)
+		.sort();
+	// Filter out entries with value that are not included in the name.
+	// For example, we see something like "modifiers": { "diagnosis": "ncit:C15220", "Age": "old" }, for id, `I_old`. We only care about strata, 'old' in this case.
+	// TODO: This is not ideal and have potential issues in some edge cases. We need to find a better way to identify the strata for each state variable.
+	const filtered = entries.filter((entry) => id.includes(entry.split(':')[1]));
+	return filtered;
+};
+
 export function isInitial(obj: Initial | ModelParameter | null): obj is Initial {
 	return obj !== null && 'target' in obj && 'expression' in obj && 'expression_mathml' in obj;
 }

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -233,7 +233,7 @@ export const getModelStateModifiers = (id: string, model: Model) => {
 /**
  * For a given state variable, return the state modifiers object entries in a array of string formatted in the form of key:value, e.g. ['key:value']. The array is sorted.
  */
-export const getStateVariableStrata = (id: string, model: Model) => {
+export const getStateVariableStrataEntries = (id: string, model: Model) => {
 	const modifiers = getModelStateModifiers(id, model);
 	const entries = Object.entries(modifiers)
 		.map(([key, value]) => `${key}:${value}`)

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -212,6 +212,8 @@ export interface ChartSettingComparison extends ChartSettingBase {
 	shareYAxis?: boolean;
 	/** If true, also plot the pre-calibration or base simulation (without the intervention) data */
 	showBeforeAfter?: boolean;
+	/** Normalize data by total strata population. Only supported for stratified models */
+	normalize?: boolean;
 }
 
 export interface ChartSettingEnsembleVariableOptions {

--- a/packages/client/hmi-client/src/utils/math.ts
+++ b/packages/client/hmi-client/src/utils/math.ts
@@ -283,3 +283,54 @@ export function calculateUncertaintyRange(value: number, percentage: number): { 
 		max
 	};
 }
+
+/**
+ * Sums the corresponding elements of multiple arrays of numbers.
+ *
+ * @param arrays - An array of arrays of numbers.
+ * @returns A new array where each element is the sum of the corresponding elements of the input arrays.
+ * @throws Will throw an error if the input arrays are not of the same length.
+ */
+export function sumArrays(...arrays: number[][]): number[] {
+	if (arrays.length === 0) {
+		throw new Error('At least one array is required');
+	}
+
+	const length = arrays[0].length;
+	if (!arrays.every((array) => array.length === length)) {
+		throw new Error('All arrays must be of the same length');
+	}
+
+	const result = new Array(length).fill(0);
+	// eslint-disable-next-line
+	for (const array of arrays) {
+		for (let i = 0; i < length; i++) {
+			result[i] += array[i];
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Divides the corresponding elements of two arrays of numbers.
+ *
+ * @param array1 - The first array of numbers.
+ * @param array2 - The second array of numbers.
+ * @returns A new array where each element is the result of dividing the corresponding elements of `array1` by `array2`.
+ * @throws Will throw an error if the input arrays are not of the same length or if division by zero occurs.
+ */
+export function divideArrays(array1: number[], array2: number[]): number[] {
+	if (array1.length !== array2.length) {
+		throw new Error('Arrays must be of the same length');
+	}
+
+	const result = new Array(array1.length);
+	for (let i = 0; i < array1.length; i++) {
+		if (array2[i] === 0) {
+			throw new Error('Division by zero');
+		}
+		result[i] = array1[i] / array2[i];
+	}
+	return result;
+}


### PR DESCRIPTION
# Description

In comparison chart setting, added an option to show the chart with normalized stratified model data

https://github.com/orgs/DARPA-ASKEM/projects/3/views/8?pane=issue&itemId=94761557&issue=DARPA-ASKEM%7Cterarium%7C6173

Displaying the equations used to calculate the normalized charts (non-editable in this pass) is not yet implemented with this PR. 


<img width="1040" alt="Screenshot 2025-01-28 at 8 19 50 PM" src="https://github.com/user-attachments/assets/36f5aea6-c574-467d-b102-f86df96ecf18" />
<img width="1034" alt="Screenshot 2025-01-28 at 8 20 11 PM" src="https://github.com/user-attachments/assets/57f92650-e06a-42a5-9d1b-58e017be176e" />




Resolves #(issue)
