### PR TITLE
Calibrate minor updates

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -868,7 +868,9 @@ const updateLossChartSpec = (data: string | Record<string, any>[], size: { width
 };
 
 const initDefaultChartSettings = (state: CalibrationOperationStateCiemss) => {
-	const defaultSelectedParam = modelParameters.value.filter((p) => !!p.distribution).map((p) => p.id);
+	// TODO: Determine the most interesting parameters to show to the user.
+	// https://github.com/DARPA-ASKEM/terarium/issues/6284
+	const defaultSelectedParam = [];
 	const mappedModelVariables = mapping.value
 		.filter((c) => ['state', 'observable'].includes(modelPartTypesMap.value[c.modelVariable]))
 		.map((c) => c.modelVariable);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-node-ciemss.vue
@@ -8,7 +8,7 @@
 				:is-loading="!!inProgressCalibrationId"
 				:prepared-charts="[variableCharts, interventionCharts]"
 				:chart-settings="[selectedVariableSettings, selectedInterventionSettings]"
-				:progress="node.state.currentProgress + '%'"
+				:processing="node.state.currentProgress + '%'"
 			/>
 		</template>
 		<vega-chart v-else-if="lossChartSpec" :are-embed-actions-visible="false" :visualization-spec="lossChartSpec" />


### PR DESCRIPTION
# Description
- Correct prop name for node-preview. This will remove a warning we are seeing.
- Remove default parameter selection as this is causing many charts to be produced that the user likely wont care about and will need to remove - slowly.

