### PR TITLE
Correction to dynamic intervention wording

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-dynamic-intervention-policy-group.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-dynamic-intervention-policy-group.vue
@@ -12,7 +12,7 @@
 		<p>
 			Set the {{ dynamicInterventions[0].type }}&nbsp; <strong>{{ dynamicInterventions[0].appliedTo }}</strong> to
 			<strong>{{ dynamicInterventions[0].value }}</strong> when it crosses the threshold value
-			<strong>{{ dynamicInterventions[0].threshold }}</strong> person.
+			<strong>{{ dynamicInterventions[0].threshold }}</strong>
 		</p>
 	</div>
 </template>

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-dynamic-intervention-policy-group.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-dynamic-intervention-policy-group.vue
@@ -11,8 +11,8 @@
 		</div>
 		<p>
 			Set the {{ dynamicInterventions[0].type }}&nbsp; <strong>{{ dynamicInterventions[0].appliedTo }}</strong> to
-			<strong>{{ dynamicInterventions[0].threshold }}</strong> days when it crosses the threshold value
-			<strong>{{ dynamicInterventions[0].value }}</strong> person.
+			<strong>{{ dynamicInterventions[0].value }}</strong> when it crosses the threshold value
+			<strong>{{ dynamicInterventions[0].threshold }}</strong> person.
 		</p>
 	</div>
 </template>


### PR DESCRIPTION
# Description
- Do not assume units as theyre not guaranteed and we are not reading them from anywhere
- Correct ordering for threshold vs value.

# Pictures
Provided the following: 
<img width="533" alt="image" src="https://github.com/user-attachments/assets/9c4d84b0-4607-4e0e-b498-153d2df72829" />

**From:** 
<img width="572" alt="image" src="https://github.com/user-attachments/assets/43adbf8e-9a83-48b8-8a0b-fa637355d278" />

**To:**
<img width="581" alt="image" src="https://github.com/user-attachments/assets/a1395ca4-df1a-4e67-8a0f-94c883a3e44e" />

