### PR TITLE
set time point to end time in sensitivity analysis template

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-node-ciemss.vue
@@ -111,6 +111,7 @@ const processResult = async (runId: string) => {
 		});
 	}
 
+	// FIXME: This emit might be getting overridden by the one in the poller
 	emit('update-state', state);
 	const start = _.first(summaryData);
 	const end = _.last(summaryData);

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/sensitivity-analysis/sensitivity-analysis-scenario.ts
@@ -194,7 +194,7 @@ export class SensitivityAnalysisScenario extends BaseScenario {
 		simulateChartSettings = updateSensitivityChartSettingOption(simulateChartSettings as ChartSettingSensitivity[], {
 			selectedVariables: this.simulateSpec.ids,
 			selectedInputVariables: this.parameters.map((parameter) => parameter!.referenceId),
-			timepoint: 0
+			timepoint: this.simulateSpec.endTime
 		});
 
 		wf.updateNode(simulateNode, {


### PR DESCRIPTION
# Description

* Now that we have the simulation settings in the scenario template, we can set it as the end time point indicated by the template
