### PR TITLE
add a base simulation for each config in scenario templates

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/horizon-scanning/horizon-scanning-scenario.ts
@@ -279,7 +279,8 @@ export class HorizonScanningScenario extends BaseScenario {
 		);
 
 		// add input ports for each simulation to the dataset transformer, this will be a matrix of intervention x parameter low and high
-		for (let i = 0; i < this.interventionSpecs.length * 2 ** this.parameters.length; i++) {
+		const filledInterventionSpecs = this.interventionSpecs.filter((spec) => !!spec.id);
+		for (let i = 0; i < (filledInterventionSpecs.length + 1) * 2 ** this.parameters.length; i++) {
 			workflowService.appendInputPort(compareDatasetNode, {
 				type: 'datasetId|simulationId',
 				label: 'Dataset or Simulation'
@@ -458,7 +459,7 @@ export class HorizonScanningScenario extends BaseScenario {
 				{ x: 0, y: 0 }
 			]);
 
-			interventionNodes.forEach((interventionNode, index) => {
+			interventionNodes.forEach((interventionNode) => {
 				const interventionPolicy = fetchedInterventionPolicies.find(
 					(policy) => policy.id === interventionNode.outputs[0].value?.[0]
 				);
@@ -471,66 +472,52 @@ export class HorizonScanningScenario extends BaseScenario {
 						Object.keys(_.groupBy(flattenInterventionData(interventionPolicy?.interventions ?? []), 'appliedTo'))
 					);
 				}
-				// If this is the first intervention node, connect it to the model config node and the already created simulate node
-				if (index === 0) {
-					wf.addEdge(interventionNode.id, interventionNode.outputs[0].id, simulateNode.id, simulateNode.inputs[1].id, [
+				const additionalSimNode = wf.addNode(
+					SimulateCiemssOp,
+					{ x: 0, y: 0 },
+					{
+						size: OperatorNodeSize.medium
+					}
+				);
+
+				wf.updateNode(additionalSimNode, {
+					state: {
+						chartSettings: chartSettingsClone,
+						...this.getDefaultForecastSettings()
+					}
+				});
+
+				wf.addEdge(
+					modelConfigNode.id,
+					modelConfigNode.outputs[0].id,
+					additionalSimNode.id,
+					additionalSimNode.inputs[0].id,
+					[
 						{ x: 0, y: 0 },
 						{ x: 0, y: 0 }
-					]);
-					wf.updateNode(simulateNode, {
-						state: {
-							...simulateNode.state,
-							chartSettings: chartSettingsClone
-						}
-					});
-				} else {
-					const additionalSimNode = wf.addNode(
-						SimulateCiemssOp,
+					]
+				);
+				wf.addEdge(
+					interventionNode.id,
+					interventionNode.outputs[0].id,
+					additionalSimNode.id,
+					additionalSimNode.inputs[1].id,
+					[
 						{ x: 0, y: 0 },
-						{
-							size: OperatorNodeSize.medium
-						}
-					);
-
-					wf.updateNode(additionalSimNode, {
-						state: {
-							chartSettings: chartSettingsClone,
-							...this.getDefaultForecastSettings()
-						}
-					});
-
-					wf.addEdge(
-						modelConfigNode.id,
-						modelConfigNode.outputs[0].id,
-						additionalSimNode.id,
-						additionalSimNode.inputs[0].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					wf.addEdge(
-						interventionNode.id,
-						interventionNode.outputs[0].id,
-						additionalSimNode.id,
-						additionalSimNode.inputs[1].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					wf.addEdge(
-						additionalSimNode.id,
-						additionalSimNode.outputs[0].id,
-						compareDatasetNode.id,
-						compareDatasetNode.inputs[compareDatasetIndex].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					compareDatasetIndex++;
-				}
+						{ x: 0, y: 0 }
+					]
+				);
+				wf.addEdge(
+					additionalSimNode.id,
+					additionalSimNode.outputs[0].id,
+					compareDatasetNode.id,
+					compareDatasetNode.inputs[compareDatasetIndex].id,
+					[
+						{ x: 0, y: 0 },
+						{ x: 0, y: 0 }
+					]
+				);
+				compareDatasetIndex++;
 			});
 
 			wf.addEdge(
@@ -567,7 +554,7 @@ export class HorizonScanningScenario extends BaseScenario {
 
 		// Build the XY axis
 		interventionNodes.forEach((interventionNode, idx) => {
-			interventionNode.x = modelNode.x + nodeGapHorizontal * (idx + 2);
+			interventionNode.x = modelNode.x + nodeGapHorizontal * (idx + 3);
 			interventionNode.y = modelNode.y - 50;
 		});
 
@@ -599,7 +586,7 @@ export class HorizonScanningScenario extends BaseScenario {
 
 		// Data comparison
 		if (interventionNodes.length > 0) {
-			compareDatasetNode.x = modelNode.x + (2 + interventionNodes.length) * nodeGapHorizontal;
+			compareDatasetNode.x = modelNode.x + (3 + interventionNodes.length) * nodeGapHorizontal;
 		} else {
 			compareDatasetNode.x = modelNode.x + 3 * nodeGapHorizontal;
 		}

--- a/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
+++ b/packages/client/hmi-client/src/components/workflow/scenario-templates/value-of-information/value-of-information-scenario.ts
@@ -267,16 +267,8 @@ export class ValueOfInformationScenario extends BaseScenario {
 			]
 		);
 
-		// add input ports for each simulation to the dataset transformer, this will be a matrix of intervention x parameter
-		for (let i = 0; i < this.interventionSpecs.length - 1; i++) {
-			workflowService.appendInputPort(compareDatasetNode, {
-				type: 'datasetId|simulationId',
-				label: 'Dataset or Simulation'
-			});
-		}
-
 		// add input ports for each simulation to the dataset transformer, this will be a matrix of intervention x parameter low and high
-		for (let i = 0; i < this.interventionSpecs.length * 2 ** this.parameters.length; i++) {
+		for (let i = 0; i < (this.interventionSpecs.length + 1) * 2 ** this.parameters.length; i++) {
 			workflowService.appendInputPort(compareDatasetNode, {
 				type: 'datasetId|simulationId',
 				label: 'Dataset or Simulation'
@@ -455,7 +447,7 @@ export class ValueOfInformationScenario extends BaseScenario {
 				{ x: 0, y: 0 }
 			]);
 
-			interventionNodes.forEach((interventionNode, index) => {
+			interventionNodes.forEach((interventionNode) => {
 				const interventionPolicy = fetchedInterventionPolicies.find(
 					(policy) => policy.id === interventionNode.outputs[0].value?.[0]
 				);
@@ -468,66 +460,52 @@ export class ValueOfInformationScenario extends BaseScenario {
 						Object.keys(_.groupBy(flattenInterventionData(interventionPolicy?.interventions ?? []), 'appliedTo'))
 					);
 				}
-				// If this is the first intervention node, connect it to the model config node and the already created simulate node
-				if (index === 0) {
-					wf.addEdge(interventionNode.id, interventionNode.outputs[0].id, simulateNode.id, simulateNode.inputs[1].id, [
+				const additionalSimNode = wf.addNode(
+					SimulateCiemssOp,
+					{ x: 0, y: 0 },
+					{
+						size: OperatorNodeSize.medium
+					}
+				);
+
+				wf.updateNode(additionalSimNode, {
+					state: {
+						chartSettings: chartSettingsClone,
+						...this.getDefaultForecastSettings()
+					}
+				});
+
+				wf.addEdge(
+					modelConfigNode.id,
+					modelConfigNode.outputs[0].id,
+					additionalSimNode.id,
+					additionalSimNode.inputs[0].id,
+					[
 						{ x: 0, y: 0 },
 						{ x: 0, y: 0 }
-					]);
-					wf.updateNode(simulateNode, {
-						state: {
-							...simulateNode.state,
-							chartSettings: chartSettingsClone
-						}
-					});
-				} else {
-					const additionalSimNode = wf.addNode(
-						SimulateCiemssOp,
+					]
+				);
+				wf.addEdge(
+					interventionNode.id,
+					interventionNode.outputs[0].id,
+					additionalSimNode.id,
+					additionalSimNode.inputs[1].id,
+					[
 						{ x: 0, y: 0 },
-						{
-							size: OperatorNodeSize.medium
-						}
-					);
-
-					wf.updateNode(additionalSimNode, {
-						state: {
-							chartSettings: chartSettingsClone,
-							...this.getDefaultForecastSettings()
-						}
-					});
-
-					wf.addEdge(
-						modelConfigNode.id,
-						modelConfigNode.outputs[0].id,
-						additionalSimNode.id,
-						additionalSimNode.inputs[0].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					wf.addEdge(
-						interventionNode.id,
-						interventionNode.outputs[0].id,
-						additionalSimNode.id,
-						additionalSimNode.inputs[1].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					wf.addEdge(
-						additionalSimNode.id,
-						additionalSimNode.outputs[0].id,
-						compareDatasetNode.id,
-						compareDatasetNode.inputs[compareDatasetIndex].id,
-						[
-							{ x: 0, y: 0 },
-							{ x: 0, y: 0 }
-						]
-					);
-					compareDatasetIndex++;
-				}
+						{ x: 0, y: 0 }
+					]
+				);
+				wf.addEdge(
+					additionalSimNode.id,
+					additionalSimNode.outputs[0].id,
+					compareDatasetNode.id,
+					compareDatasetNode.inputs[compareDatasetIndex].id,
+					[
+						{ x: 0, y: 0 },
+						{ x: 0, y: 0 }
+					]
+				);
+				compareDatasetIndex++;
 			});
 
 			wf.addEdge(
@@ -564,7 +542,7 @@ export class ValueOfInformationScenario extends BaseScenario {
 
 		// Build the XY axis
 		interventionNodes.forEach((interventionNode, idx) => {
-			interventionNode.x = modelNode.x + nodeGapHorizontal * (idx + 2);
+			interventionNode.x = modelNode.x + nodeGapHorizontal * (idx + 3);
 			interventionNode.y = modelNode.y - 50;
 		});
 
@@ -595,7 +573,7 @@ export class ValueOfInformationScenario extends BaseScenario {
 		});
 
 		// Data comparison
-		compareDatasetNode.x = modelNode.x + (2 + interventionNodes.length) * nodeGapHorizontal;
+		compareDatasetNode.x = modelNode.x + (3 + interventionNodes.length) * nodeGapHorizontal;
 
 		compareDatasetNode.y = 500;
 


### PR DESCRIPTION
# Description

* Add a base simulation node for each generated  model configuration in the horizon scanning and value of information templates

Now looks like this 😄 
<img width="1072" alt="Screenshot 2025-01-29 at 12 57 49 PM" src="https://github.com/user-attachments/assets/057cd363-38e3-4679-9d90-b302b85adc14" />

Testing: 
* Create a horizon scanning and/or a value of information workflow
* see that there are base simulation nodes (no interventions) for each generated configuration