### PR TITLE
Ta3 operators to include rk4 as a solver option

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/calibrate-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/calibrate-operation.ts
@@ -2,11 +2,12 @@ import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import { ChartSetting } from '@/types/common';
 import { CalibrateMap } from '@/services/calibrate-workflow';
 import calibrateSimulateCiemss from '@assets/svg/operator-images/calibrate-simulate-probabilistic.svg';
+import { CiemssMethodOptions } from '@/services/models/simulation-service';
 
 const DOCUMENTATION_URL = 'https://documentation.terarium.ai/simulation/calibrate-model/';
 
 export interface CalibrationOperationStateCiemss extends BaseState {
-	method: string;
+	method: CiemssMethodOptions;
 	timestampColName: string;
 	mapping: CalibrateMap[];
 	chartSettings: ChartSetting[] | null; // null indicates that the chart settings have not been set yet
@@ -51,7 +52,7 @@ export const CalibrationOperationCiemss: Operation = {
 
 	initState: () => {
 		const init: CalibrationOperationStateCiemss = {
-			method: 'dopri5',
+			method: CiemssMethodOptions.dopri5,
 			chartSettings: null,
 			timestampColName: '',
 			mapping: [{ modelVariable: '', datasetVariable: '' }],

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -160,14 +160,14 @@
 									<Dropdown
 										id="5"
 										v-model="knobs.method"
-										:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
+										:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.rk4, CiemssMethodOptions.euler]"
 										@update:model-value="updateState"
 									/>
 								</div>
 								<div class="label-and-input">
 									<label for="num-steps">Solver step size</label>
 									<tera-input-number
-										:disabled="knobs.method !== CiemssMethodOptions.euler"
+										:disabled="![CiemssMethodOptions.rk4, CiemssMethodOptions.euler].includes(knobs.method)"
 										:min="0"
 										v-model="knobs.stepSize"
 									/>
@@ -594,7 +594,7 @@ interface BasicKnobs {
 	endTime: number;
 	stepSize: number;
 	learningRate: number;
-	method: string;
+	method: CiemssMethodOptions;
 	timestampColName: string;
 }
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -149,13 +149,15 @@
 										<label>Solver method</label>
 										<Dropdown
 											v-model="knobs.extra.solverMethod"
-											:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
+											:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.rk4, CiemssMethodOptions.euler]"
 										/>
 									</div>
 									<div class="label-and-input">
 										<label for="num-steps">Solver step size</label>
 										<tera-input-number
-											:disabled="knobs.extra.solverMethod !== CiemssMethodOptions.euler"
+											:disabled="
+												![CiemssMethodOptions.rk4, CiemssMethodOptions.euler].includes(knobs.extra.solverMethod)
+											"
 											:min="0"
 											v-model="knobs.extra.stepSize"
 										/>

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-ciemss-operation.ts
@@ -1,6 +1,6 @@
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
 import { Intervention, InterventionSemanticType, InterventionPolicy } from '@/types/Types';
-import { getRunResult, getSimulation } from '@/services/models/simulation-service';
+import { CiemssMethodOptions, getRunResult, getSimulation } from '@/services/models/simulation-service';
 import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
 import { createInterventionPolicy, blankIntervention } from '@/services/intervention-policy';
 import optimizeModel from '@assets/svg/operator-images/optimize-model.svg';
@@ -55,7 +55,7 @@ export interface OptimizeCiemssOperationState extends BaseState {
 	endTime: number;
 	numSamples: number;
 	solverStepSize: number;
-	solverMethod: string;
+	solverMethod: CiemssMethodOptions;
 	maxiter: number;
 	maxfeval: number;
 	// Intervention policies
@@ -138,7 +138,7 @@ export const OptimizeCiemssOperation: Operation = {
 			endTime: 90,
 			numSamples: 100,
 			solverStepSize: 0.1,
-			solverMethod: 'dopri5',
+			solverMethod: CiemssMethodOptions.dopri5,
 			maxiter: 5,
 			maxfeval: 25,
 			interventionPolicyId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -147,7 +147,7 @@
 									<label><br />Solver method</label>
 									<Dropdown
 										class="p-inputtext-sm"
-										:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
+										:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.rk4, CiemssMethodOptions.euler]"
 										v-model="knobs.solverMethod"
 										placeholder="Select"
 									/>
@@ -157,7 +157,7 @@
 									<div>
 										<tera-input-number
 											v-model="knobs.solverStepSize"
-											:disabled="knobs.solverMethod !== CiemssMethodOptions.euler"
+											:disabled="![CiemssMethodOptions.rk4, CiemssMethodOptions.euler].includes(knobs.solverMethod)"
 											:min="0"
 										/>
 									</div>
@@ -545,7 +545,7 @@ interface BasicKnobs {
 	endTime: number;
 	numSamples: number;
 	solverStepSize: number;
-	solverMethod: string;
+	solverMethod: CiemssMethodOptions;
 	maxiter: number;
 	maxfeval: number;
 	preForecastRunId: string;

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-ciemss-operation.ts
@@ -1,3 +1,4 @@
+import { CiemssMethodOptions } from '@/services/models/simulation-service';
 import { ChartSetting } from '@/types/common';
 import type { TimeSpan } from '@/types/Types';
 import { Operation, WorkflowOperationTypes, BaseState } from '@/types/workflow';
@@ -13,7 +14,7 @@ export interface SimulateCiemssOperationState extends BaseState {
 	currentTimespan: TimeSpan;
 	numSamples: number;
 	solverStepSize: number;
-	method: string;
+	method: CiemssMethodOptions;
 	forecastId: string; // Completed run's Id
 	baseForecastId: string; // Simulation without intervention
 
@@ -47,7 +48,7 @@ export const SimulateCiemssOperation: Operation = {
 			currentTimespan: { start: 0, end: 100 },
 			numSamples: 100,
 			solverStepSize: 0.1,
-			method: 'dopri5',
+			method: CiemssMethodOptions.dopri5,
 			forecastId: '',
 			baseForecastId: '',
 			inProgressForecastId: '',

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -81,7 +81,7 @@
 								<Dropdown
 									id="solver-method"
 									v-model="method"
-									:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
+									:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.rk4, CiemssMethodOptions.euler]"
 									@update:model-value="updateState"
 								/>
 							</div>
@@ -89,7 +89,7 @@
 								<label for="num-samples">Solver step size</label>
 								<tera-input-number
 									v-model="solverStepSize"
-									:disabled="method !== CiemssMethodOptions.euler"
+									:disabled="![CiemssMethodOptions.rk4, CiemssMethodOptions.euler].includes(method)"
 									:min="0"
 									@update:model-value="updateState"
 								/>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -167,13 +167,13 @@
 										<label>Solver method</label>
 										<Dropdown
 											v-model="knobs.method"
-											:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.euler]"
+											:options="[CiemssMethodOptions.dopri5, CiemssMethodOptions.rk4, CiemssMethodOptions.euler]"
 										/>
 									</div>
-									<div v-if="knobs.method === CiemssMethodOptions.euler" class="label-and-input">
+									<div class="label-and-input">
 										<label>Solver step size</label>
 										<tera-input-number
-											:disabled="knobs.method !== CiemssMethodOptions.euler"
+											:disabled="![CiemssMethodOptions.rk4, CiemssMethodOptions.euler].includes(knobs.method)"
 											:min="0"
 											v-model="knobs.stepSize"
 										/>

--- a/packages/client/hmi-client/src/services/models/simulation-service.ts
+++ b/packages/client/hmi-client/src/services/models/simulation-service.ts
@@ -29,6 +29,7 @@ export type DataArray = Record<string, any>[];
 
 export enum CiemssMethodOptions {
 	dopri5 = 'dopri5',
+	rk4 = 'rk4',
 	euler = 'euler'
 }
 


### PR DESCRIPTION
# Description
- Update states to have method type to ciemss method's enum 
- Update enum to include rk4
- Ensure when rk4 or euler are selected user can write in `step_size`
