### PR TITLE
Remove ES indexing of assets

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServiceWithSearch.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServiceWithSearch.java
@@ -239,6 +239,7 @@ public abstract class TerariumAssetServiceWithSearch<
 			return Optional.empty();
 		}
 
+		/** TODO - Asset search needs to be removed properly	
 		if (!updated.get().getTemporary() && updated.get().getPublicAsset()) {
 			elasticService.index(getAssetAlias(), updated.get().getId().toString(), updated);
 		}
@@ -246,7 +247,8 @@ public abstract class TerariumAssetServiceWithSearch<
 		if (updated.get().getTemporary() || !updated.get().getPublicAsset()) {
 			elasticService.delete(getAssetAlias(), updated.get().getId().toString());
 		}
-
+		*/
+		
 		return updated;
 	}
 


### PR DESCRIPTION
This pull request includes a change to the `updateAsset` method in the `TerariumAssetServiceWithSearch` class. The change involves commenting out a block of code related to asset search indexing and deletion.

* [`packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetServiceWithSearch.java`](diffhunk://#diff-e4d400331539438f5e64748557689224735645ee38ca0e07c70cc4b849ba8429R242-R250): Commented out the code that indexes and deletes assets in the `elasticService` based on their `temporary` and `publicAsset` status.