### PR TITLE
serialization fix for inputport and outputport

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.workflow;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.Serializable;
@@ -11,9 +12,11 @@ import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InputPort implements Serializable {
 
 	private UUID id;
+	private Long version;
 	private String type;
 	private String originalType;
 	private String status;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/OutputPort.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/OutputPort.java
@@ -1,5 +1,6 @@
 package software.uncharted.terarium.hmiserver.models.dataservice.workflow;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.Serializable;
@@ -12,9 +13,11 @@ import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OutputPort implements Serializable {
 
 	private UUID id;
+	private Long version;
 	private String type;
 	private String originalType;
 	private String status;


### PR DESCRIPTION
Existing objects in DB have the "version" fields that do not deserialize