### PR TITLE
Jamie add filter to dropdown in intervention cards

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -60,7 +60,7 @@
 							option-label="label"
 							option-value="value"
 							placeholder="Select"
-							filter
+							:filter="semanticOptions(intervention.dynamicInterventions[0].type).length > 5"
 							autoFilterFocus
 						/>
 					</section>
@@ -86,7 +86,7 @@
 								option-label="label"
 								option-value="value"
 								placeholder="Select"
-								filter
+								:filter="semanticOptions(intervention.staticInterventions[0].type).length > 5"
 								autoFilterFocus
 							/>
 						</section>
@@ -120,7 +120,7 @@
 										option-label="label"
 										option-value="value"
 										placeholder="Select"
-										filter
+										:filter="semanticOptions(i.type).length > 5"
 										autoFilterFocus
 									/>
 								</section>
@@ -161,7 +161,7 @@
 						option-label="label"
 						option-value="value"
 						placeholder="Select a trigger"
-						filter
+						:filter="stateOptions.length > 5"
 						autoFilterFocus
 					/>
 					crosses the threshold

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -155,6 +155,7 @@
 					/>
 					when
 					<Dropdown
+						class="applied-to-menu"
 						:model-value="intervention.dynamicInterventions[0].parameter"
 						@change="onTargetParameterChange"
 						:options="stateOptions"
@@ -423,4 +424,6 @@ ul {
 .nudge-left {
 	margin-left: -0.5rem;
 }
+
+/* smaller dropdown to match other inputs in this card */
 </style>

--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-card.vue
@@ -60,6 +60,8 @@
 							option-label="label"
 							option-value="value"
 							placeholder="Select"
+							filter
+							autoFilterFocus
 						/>
 					</section>
 				</template>
@@ -84,6 +86,8 @@
 								option-label="label"
 								option-value="value"
 								placeholder="Select"
+								filter
+								autoFilterFocus
 							/>
 						</section>
 						to
@@ -116,6 +120,8 @@
 										option-label="label"
 										option-value="value"
 										placeholder="Select"
+										filter
+										autoFilterFocus
 									/>
 								</section>
 								to
@@ -155,6 +161,8 @@
 						option-label="label"
 						option-value="value"
 						placeholder="Select a trigger"
+						filter
+						autoFilterFocus
 					/>
 					crosses the threshold
 					<tera-input-number


### PR DESCRIPTION
## BEFORE
It can be hard to find the parameter you want in the intervention card dropdowns if there are a lot of them.

Pascale sent me this today:
![image](https://github.com/user-attachments/assets/1ba9fae3-a402-4581-97ca-914463403658)

## AFTER
I added filter and autoFilterFocus to the dropdowns.
![added filter to parameter dropdown](https://github.com/user-attachments/assets/4af03419-b660-4d9e-87bc-93969f7e17d7)

I also added a conditional to the filter so we only show it if there are more than five items in the menu. It felt weird to show a filter on a menu with few items.
![image](https://github.com/user-attachments/assets/e8fca62b-e21c-4c95-af4e-ead2043e3891)
![image](https://github.com/user-attachments/assets/719b47a2-fec6-41b2-9948-9bbfb4becd76)
