### PR TITLE
Fix issue that quantile baseline not showing up with normalize

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/simulate-utils.ts
@@ -39,6 +39,7 @@ export function usePreparedChartInputs(
 		const reverseMap: Record<string, string> = {};
 		Object.keys(pyciemssMap.value).forEach((key) => {
 			reverseMap[pyciemssMap.value[key]] = key;
+			reverseMap[`${pyciemssMap.value[key]}:pre`] = `${key} (baseline)`;
 			reverseMap[`${pyciemssMap.value[key]}_mean`] = key;
 			reverseMap[`${pyciemssMap.value[key]}_mean:pre`] = `${key} (baseline)`;
 		});

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -176,7 +176,7 @@ const normalizeStratifiedModelChartData = (setting: ChartSettingComparison, data
 						if (includeBeforeData) {
 							newEntry[`${variable}:pre`] = !group
 								? row[variable]
-								: calculatePercentages(row[variable], denominatorValues);
+								: calculatePercentages(row[`${variable}:pre`], denominatorValues);
 						}
 					});
 			});
@@ -559,6 +559,7 @@ export function useCharts(
 			// loaded before rendering the charts, but beware to not break rendering in the case
 			// when there are no interventions
 
+			// TODO: create the color map outside of this function and pass `interventionNameColorMap` as parameter
 			const { interventionNameColorMap } = getInterventionColorAndScoreMaps(
 				datasets,
 				modelConfigurations,
@@ -1292,6 +1293,7 @@ export function useCharts(
 	};
 }
 
+// TODO: Move this out of this file. Maybe to compare-datasets-utils.ts
 export function getInterventionColorAndScoreMaps(
 	datasets: Ref<Dataset[]>,
 	modelConfigurations: Ref<ModelConfiguration[]>,


### PR DESCRIPTION
# Description

- Fix issue that quantile baseline not showing up with normalize option
- Fix the baseline label missing the variable name

**Before**
![Screenshot 2025-01-31 at 5 56 04 PM](https://github.com/user-attachments/assets/a48c91bd-f1ff-41de-ab36-1882e07ca6d0)
**After**
![Screenshot 2025-01-31 at 5 53 28 PM](https://github.com/user-attachments/assets/4772c1ce-2f48-4664-a5ee-3be01589151f)



Resolves #(issue)
