### PR TITLE
fix model from equations text state saving

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -167,6 +167,7 @@
 									<Textarea
 										v-if="selectedItem === equation.name"
 										v-model="equation.asset.text"
+										@blur="onUpdateEquation($event, equation)"
 										autoResize
 										rows="1"
 										placeholder="Add an expression with LaTeX"
@@ -220,6 +221,7 @@
 									<Textarea
 										v-if="selectedItem === equation.name"
 										v-model="equation.asset.text"
+										@blur="onUpdateEquation($event, equation)"
 										autoResize
 										rows="1"
 										placeholder="Add an expression with LaTeX"
@@ -480,6 +482,13 @@ function onCheckBoxChange(equation) {
 	const state = cloneDeep(props.node.state);
 	const index = state.equations.findIndex((e) => e.name === equation.name);
 	state.equations[index].includeInProcess = equation.includeInProcess;
+	emit('update-state', state);
+}
+
+function onUpdateEquation(event, equation) {
+	const state = cloneDeep(props.node.state);
+	const index = state.equations.findIndex((e) => e.name === equation.name);
+	state.equations[index].asset.text = event.target.value;
 	emit('update-state', state);
 }
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -167,7 +167,6 @@
 									<Textarea
 										v-if="selectedItem === equation.name"
 										v-model="equation.asset.text"
-										@blur="onUpdateEquation($event, equation)"
 										autoResize
 										rows="1"
 										placeholder="Add an expression with LaTeX"
@@ -221,7 +220,6 @@
 									<Textarea
 										v-if="selectedItem === equation.name"
 										v-model="equation.asset.text"
-										@blur="onUpdateEquation($event, equation)"
 										autoResize
 										rows="1"
 										placeholder="Add an expression with LaTeX"
@@ -479,17 +477,8 @@ const onSelection = (id: string) => {
 };
 
 function onCheckBoxChange(equation) {
-	const state = cloneDeep(props.node.state);
-	const index = state.equations.findIndex((e) => e.name === equation.name);
-	state.equations[index].includeInProcess = equation.includeInProcess;
-	emit('update-state', state);
-}
-
-function onUpdateEquation(event, equation) {
-	const state = cloneDeep(props.node.state);
-	const index = state.equations.findIndex((e) => e.name === equation.name);
-	state.equations[index].asset.text = event.target.value;
-	emit('update-state', state);
+	const index = clonedState.value.equations.findIndex((e) => e.name === equation.name);
+	clonedState.value.equations[index].includeInProcess = equation.includeInProcess;
 }
 
 async function onRun(extractionService: 'mira' | 'skema' = 'skema') {


### PR DESCRIPTION
# Description

* Fixes an issue in the model from equations node where the state was not being saved while editing equations

Testing:
Open a model from equations drilldown and edit equations that you want.  Uncheck/check whether you want to include the equations or not.  You should see that the edited equations should keep their edit value rather than reverted to its original state
