### PR TITLE
reduce initial routing threshold

### DIFF
--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -306,7 +306,7 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 
 		// FIXME: temp hack, need to optimize OrthogonalConnector
 		const nonControllerEdges = graphData.edges.filter((edge: IEdge<any>) => edge.data?.isController !== true);
-		if (nonControllerEdges.length < 100) {
+		if (nonControllerEdges.length < 50) {
 			rerouteEdges(graphData.nodes, nonControllerEdges);
 		}
 


### PR DESCRIPTION
### Summary
Lower threshold for using ortho-edge routing to make model-diagram-loading faster for medium/large sized models (ones with 50+ edges).