### PR TITLE
Stratify model with model config

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -28,6 +28,7 @@ export interface StratifyOperationStateMira extends BaseState {
 	strataGroup: StratifyGroup;
 	strataCodeHistory: StratifyCode[];
 	hasCodeBeenRun: boolean;
+	baseModelId: string;
 }
 
 export const blankStratifyGroup: StratifyGroup = {
@@ -68,7 +69,8 @@ export const StratifyMiraOperation: Operation = {
 		const init: StratifyOperationStateMira = {
 			strataGroup: blankStratifyGroup,
 			strataCodeHistory: [],
-			hasCodeBeenRun: false
+			hasCodeBeenRun: false,
+			baseModelId: ''
 		};
 		return init;
 	}

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -105,7 +105,6 @@ import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue'
 import TeraStratificationGroupForm from '@/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue';
 import { KernelSessionManager } from '@/services/jupyter';
 import { createModelFromOld, getModel } from '@/services/model';
-// import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
 import type { Model } from '@/types/Types';
 import { AMRSchemaNames } from '@/types/common';
 import { OperatorStatus, WorkflowNode } from '@/types/workflow';
@@ -326,18 +325,6 @@ const getStatesAndParameters = (amrModel: Model) => {
 };
 
 const inputChangeHandler = async () => {
-	/*
-	const input = props.node.inputs[0];
-	if (!input) return;
-
-	let modelId: string | null = null;
-	if (input.type === 'modelId') {
-		modelId = input.value?.[0];
-	} else if (input.type === 'modelConfigId') {
-		modelId = await getModelIdFromModelConfigurationId(input.value?.[0]);
-	}
-	if (!modelId) return;
-	*/
 	const modelId = props.node.state.baseModelId;
 	if (!modelId) return;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -105,7 +105,7 @@ import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue'
 import TeraStratificationGroupForm from '@/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue';
 import { KernelSessionManager } from '@/services/jupyter';
 import { createModelFromOld, getModel } from '@/services/model';
-import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
+// import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
 import type { Model } from '@/types/Types';
 import { AMRSchemaNames } from '@/types/common';
 import { OperatorStatus, WorkflowNode } from '@/types/workflow';
@@ -326,6 +326,7 @@ const getStatesAndParameters = (amrModel: Model) => {
 };
 
 const inputChangeHandler = async () => {
+	/*
 	const input = props.node.inputs[0];
 	if (!input) return;
 
@@ -335,6 +336,9 @@ const inputChangeHandler = async () => {
 	} else if (input.type === 'modelConfigId') {
 		modelId = await getModelIdFromModelConfigurationId(input.value?.[0]);
 	}
+	if (!modelId) return;
+	*/
+	const modelId = props.node.state.baseModelId;
 	if (!modelId) return;
 
 	amr.value = await getModel(modelId);
@@ -465,7 +469,7 @@ watch(
 
 // Set model, modelNodeOptions
 watch(
-	() => props.node.inputs[0],
+	() => props.node.state.baseModelId,
 	async () => {
 		await inputChangeHandler();
 	},

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -34,11 +34,12 @@ watch(
 	async () => {
 		const input = props.node.inputs[0];
 		// Create a default if we dont have an output yet:
-		if (input && !props.node.outputs[0].value) {
+		// if (input && !props.node.outputs[0].value) {
+		if (input && input.value) {
 			let baseModelId = '';
 
 			if (input.type === 'modelId') {
-				baseModelId = input.value?.[0];
+				baseModelId = input.value[0];
 			} else if (input.type === 'modelConfigId') {
 				const modelConfigId = input.value?.[0];
 
@@ -48,7 +49,7 @@ watch(
 				// Mark the model as orginating from the config
 				model.temporary = true;
 				model.name += `(${modelConfiguration.name})`;
-				model.header.name = model.name;
+				model.header.name = model.name as string;
 
 				const res = await createModel(model);
 				if (res) {

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -15,9 +15,9 @@ import { WorkflowNode } from '@/types/workflow';
 import TeraOperatorPlaceholder from '@/components/operator/tera-operator-placeholder.vue';
 import TeraModelDiagram from '@/components/model/petrinet/tera-model-diagram.vue';
 import Button from 'primevue/button';
-import { getModel } from '@/services/model';
+import { getModel, createModel } from '@/services/model';
+import { getModelConfigurationById, getAsConfiguredModel } from '@/services/model-configurations';
 import { Model } from '@/types/Types';
-import { getModelIdFromModelConfigurationId } from '@/services/model-configurations';
 import { StratifyOperationStateMira, StratifyMiraOperation } from './stratify-mira-operation';
 
 const emit = defineEmits(['open-drilldown', 'append-output']);
@@ -27,31 +27,55 @@ const props = defineProps<{
 	node: WorkflowNode<StratifyOperationStateMira>;
 }>();
 
+// /models/from-model-configuration/:config-id
+
 watch(
 	() => props.node.inputs,
 	async () => {
 		const input = props.node.inputs[0];
 		// Create a default if we dont have an output yet:
 		if (input && !props.node.outputs[0].value) {
-			let modelId: string | null = null;
-			if (input.type === 'modelId') {
-				modelId = input.value?.[0];
-			} else if (input.type === 'modelConfigId') {
-				modelId = await getModelIdFromModelConfigurationId(input.value?.[0]);
-			}
-			if (!modelId) return;
+			let baseModelId = '';
 
-			const model = await getModel(modelId);
-			const modelName = model?.name;
-			emit('append-output', {
-				type: StratifyMiraOperation.outputs[0].type,
-				label: modelName ?? 'Default Model',
-				value: modelId,
-				state: {
-					strataGroup: cloneDeep(props.node.state.strataGroup),
-					strataCodeHistory: cloneDeep(props.node.state.strataCodeHistory)
+			if (input.type === 'modelId') {
+				baseModelId = input.value?.[0];
+			} else if (input.type === 'modelConfigId') {
+				const modelConfigId = input.value?.[0];
+
+				const modelConfiguration = await getModelConfigurationById(modelConfigId);
+				const model = (await getAsConfiguredModel(modelConfigId)) as Model;
+
+				// Mark the model as orginating from the config
+				model.temporary = true;
+				model.name += `(${modelConfiguration.name})`;
+				model.header.name = model.name;
+
+				const res = await createModel(model);
+				if (res) {
+					baseModelId = res.id as string;
 				}
-			});
+			}
+			if (!baseModelId) return;
+
+			const model = await getModel(baseModelId);
+			const modelName = model?.name;
+
+			const state = cloneDeep(props.node.state);
+			state.baseModelId = baseModelId;
+
+			emit(
+				'append-output',
+				{
+					type: StratifyMiraOperation.outputs[0].type,
+					label: modelName ?? 'Default Model',
+					value: baseModelId,
+					state: {
+						strataGroup: cloneDeep(props.node.state.strataGroup),
+						strataCodeHistory: cloneDeep(props.node.state.strataCodeHistory)
+					}
+				},
+				state
+			);
 		}
 	},
 	{ deep: true }

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -17,8 +17,8 @@ import TeraModelDiagram from '@/components/model/petrinet/tera-model-diagram.vue
 import Button from 'primevue/button';
 import { getModel, createModel } from '@/services/model';
 import { getModelConfigurationById, getAsConfiguredModel } from '@/services/model-configurations';
-import { Model, AssetType } from '@/types/Types';
-import { useProjects } from '@/composables/project';
+import { Model } from '@/types/Types';
+// import { useProjects } from '@/composables/project';
 import { StratifyOperationStateMira, StratifyMiraOperation } from './stratify-mira-operation';
 
 const emit = defineEmits(['open-drilldown', 'append-output']);
@@ -56,7 +56,7 @@ watch(
 				if (res) {
 					baseModelId = res.id as string;
 				}
-				await useProjects().addAsset(AssetType.Model, baseModelId, useProjects().activeProject.value?.id);
+				// await useProjects().addAsset(AssetType.Model, baseModelId, useProjects().activeProject.value?.id);
 			}
 			if (!baseModelId) return;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -17,7 +17,8 @@ import TeraModelDiagram from '@/components/model/petrinet/tera-model-diagram.vue
 import Button from 'primevue/button';
 import { getModel, createModel } from '@/services/model';
 import { getModelConfigurationById, getAsConfiguredModel } from '@/services/model-configurations';
-import { Model } from '@/types/Types';
+import { Model, AssetType } from '@/types/Types';
+import { useProjects } from '@/composables/project';
 import { StratifyOperationStateMira, StratifyMiraOperation } from './stratify-mira-operation';
 
 const emit = defineEmits(['open-drilldown', 'append-output']);
@@ -55,6 +56,7 @@ watch(
 				if (res) {
 					baseModelId = res.id as string;
 				}
+				await useProjects().addAsset(AssetType.Model, baseModelId, useProjects().activeProject.value?.id);
 			}
 			if (!baseModelId) return;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -48,7 +48,7 @@ watch(
 
 				// Mark the model as orginating from the config
 				model.temporary = true;
-				model.name += `(${modelConfiguration.name})`;
+				model.name += ` (${modelConfiguration.name})`;
 				model.header.name = model.name as string;
 
 				const res = await createModel(model);


### PR DESCRIPTION
### Summary
Allow stratification via a model-configuration to carry forward the values of the config, as oppose to the values of the original model.


### Testing
Start with an SIR model
- Create from it a new model-configuration with a different starting S0 value, say 123456
- Feed this model-config into stratify operator, and run a stratification that includes the S-state by say 3-groups
- Feed the stratify output into another model-config operator, verify that the S0 is 123456 and not the S0 value from the origin model