### PR TITLE
[BUG]: Uploading a .PDF instead of a .pdf fail

### DIFF
--- a/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
+++ b/packages/client/hmi-client/src/components/documents/tera-document-asset.vue
@@ -33,7 +33,7 @@ watch(
 			document.value = await getDocumentAsset(assetId);
 			const filename = document.value?.fileNames?.[0];
 
-			const isPdf = filename?.endsWith('.pdf');
+			const isPdf = filename?.toLowerCase().endsWith('.pdf');
 			if (document.value?.id && filename) {
 				if (isPdf) {
 					pdfLink.value = (await downloadDocumentAsset(props.assetId, filename)) ?? null;

--- a/packages/client/hmi-client/src/components/extracting/tera-drag-n-drop-importer.vue
+++ b/packages/client/hmi-client/src/components/extracting/tera-drag-n-drop-importer.vue
@@ -103,7 +103,7 @@ const addFiles = (addedFiles: File[] | undefined) => {
 			const addedFile = addedFiles[i];
 			if (
 				props.acceptTypes.includes(addedFile.type as AcceptedTypes) ||
-				props.acceptExtensions.includes(addedFile.name.split('.').pop() as AcceptedExtensions)
+				props.acceptExtensions.includes(addedFile.name.split('.').pop()?.toLowerCase() as AcceptedExtensions)
 			) {
 				// only add files that weren't added before
 				const index = importFiles.value.findIndex((item) => item.name === addedFile.name);

--- a/packages/client/hmi-client/src/components/project/tera-upload-resources-modal.vue
+++ b/packages/client/hmi-client/src/components/project/tera-upload-resources-modal.vue
@@ -128,7 +128,7 @@ onMounted(() => {
 
 async function processFiles(files: File[], description: string) {
 	return files.map(async (file) => {
-		switch (file.name.split('.').pop()) {
+		switch (file.name.split('.').pop()?.toLowerCase()) {
 			case AcceptedExtensions.CSV:
 			case AcceptedExtensions.NC:
 				return processDataset(file, description);


### PR DESCRIPTION
# Description

There were a few instances where extensions on the front end weren't `toLowerCase()`ed. Arguably we shouldn't be using hardcoded ".pdf" everywhere and instead should use the `AcceptedTypes.PDF` type but thats another time...

Resolves #6356
