### PR TITLE
optimize how model-configuration communicates update events

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-node.vue
@@ -96,16 +96,20 @@ watch(
 		if (configs[0]?.id) {
 			const config = configs[0];
 			state.transientModelConfig = config;
-			emit('update-state', state);
+
 			// Auto append output if and only if there isnt already an output
 			if (!props.node.outputs.at(0)?.value) {
-				emit('append-output', {
-					type: ModelConfigOperation.outputs[0].type,
-					label: config.name,
-					value: config.id,
-					isSelected: false,
-					state: omit(state, ['transientModelConfig'])
-				});
+				emit(
+					'append-output',
+					{
+						type: ModelConfigOperation.outputs[0].type,
+						label: config.name,
+						value: config.id,
+						isSelected: false,
+						state: omit(state, ['transientModelConfig'])
+					},
+					state
+				);
 			}
 		}
 	},


### PR DESCRIPTION
### Summary
A more efficient way to update both output and state at the same time in model-config operator. 
This should reduce the flickering due to updates happening back-to-back

Where we used to have this sequence of events (you can see it in the dev-console)
```
append-output
update-position
update-state
update-position
```

This is now
```
append-output
update-position
```

### Testing
Connect model => model-config, the model-config operator node should be relatively stable.