### PR TITLE
revert using fast routing, and make edge-route post dragging more eff…

### DIFF
--- a/packages/client/graph-scaffolder/src/core/renderer.ts
+++ b/packages/client/graph-scaffolder/src/core/renderer.ts
@@ -479,7 +479,10 @@ export abstract class Renderer<V, E> extends EventEmitter {
 			renderer.isDragEnabled = false;
 
 			if (sufficientlyMoved && options.edgeReroutingFn) {
-				options.edgeReroutingFn(nodes, edges);
+				const affectedEdges = edges.filter(
+					(e) => nodeDraggingIds.includes(e.source) || nodeDraggingIds.includes(e.target)
+				);
+				options.edgeReroutingFn(nodes, affectedEdges);
 			}
 
 			updateEdgePoints();

--- a/packages/client/hmi-client/src/services/graph.ts
+++ b/packages/client/hmi-client/src/services/graph.ts
@@ -337,7 +337,8 @@ export const runDagreLayout = <V, E>(graphData: IGraph<V, E>, lr: boolean = true
 
 		// manual route controller edges
 		const controllerEdges = graphData.edges.filter((edge: IEdge<any>) => edge.data?.isController === true);
-		if (controllerEdges.length < 8) {
+		if (controllerEdges.length < 99999) {
+			// Effectively disabling fast-version, DC Feb 2025
 			rerouteEdges(graphData.nodes, controllerEdges);
 		} else {
 			rerouteEdgesFast(graphData.nodes, controllerEdges);


### PR DESCRIPTION
### Summary
- Revert to use prettier routing algorithm as per Request
- Only route affected edges after dragging interactions

Before

<img width="441" alt="image" src="https://github.com/user-attachments/assets/64d9d3ac-546b-4ad3-bfb1-78d9a18e88fa" />


After

<img width="498" alt="image" src="https://github.com/user-attachments/assets/65c4f86d-48a6-4054-8203-32cf94fd0caf" />
