### PR TITLE
restore coloring when all inputs share an intervention, including none

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-drilldown.vue
@@ -580,6 +580,7 @@ const baselineDatasetIndex = computed(() =>
 const variableCharts = useCompareDatasetCharts(
 	selectedVariableSettings,
 	selectedPlotType,
+	baselineDatasetIndex,
 	datasets,
 	modelConfigurations,
 	interventionPolicies

--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/tera-compare-datasets-node.vue
@@ -85,6 +85,7 @@ onMounted(() => {
 const comparisonCharts = useCompareDatasetCharts(
 	selectedVariableSettings,
 	selectedPlotType,
+	baselineDatasetIndex,
 	datasets,
 	modelConfigurations,
 	interventionPolicies

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -537,6 +537,7 @@ export function useCharts(
 	const useCompareDatasetCharts = (
 		chartSettings: ComputedRef<ChartSetting[]>,
 		selectedPlotType: ComputedRef<PlotValue>,
+		baselineIndex: ComputedRef<number>,
 		datasets: Ref<Dataset[]>,
 		modelConfigurations: Ref<ModelConfiguration[]>,
 		interventionPolicies: Ref<InterventionPolicy[]>
@@ -572,6 +573,7 @@ export function useCharts(
 				});
 			} else {
 				variableColorMap = cloneDeep(CATEGORICAL_SCHEME);
+				variableColorMap.splice(baselineIndex.value, 0, 'black');
 			}
 
 			chartSettings.value.forEach((settings) => {


### PR DESCRIPTION
# Description

* When no interventions are present in the inputs to compare datasets, use the old coloring scheme in the charts.

<img width="992" alt="Screenshot 2025-02-06 at 10 07 51 AM" src="https://github.com/user-attachments/assets/564cb2fc-acdc-4288-9443-f15d67d20214" />
