### PR TITLE
Operator initialization tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/dataset/tera-dataset-node.vue
@@ -38,7 +38,7 @@ const props = defineProps<{
 	node: WorkflowNode<DatasetOperationState>;
 }>();
 
-const emit = defineEmits(['append-output', 'update-state', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'open-drilldown']);
 
 const datasets = computed(() => useProjects().getActiveProjectAssets(AssetType.Dataset));
 const dataset = ref<Dataset | null>(null);
@@ -50,15 +50,17 @@ async function getDatasetById(id: string) {
 		// Once a dataset is selected the output is assigned here,
 		const outputs = props.node.outputs;
 		if (canPropagateResource(outputs)) {
-			emit('update-state', {
-				datasetId: dataset.value.id
-			});
-
-			emit('append-output', {
-				type: 'datasetId',
-				label: dataset.value.name,
-				value: [dataset.value.id]
-			});
+			emit(
+				'append-output',
+				{
+					type: 'datasetId',
+					label: dataset.value.name,
+					value: [dataset.value.id]
+				},
+				{
+					datasetId: dataset.value.id
+				}
+			);
 		}
 	}
 }

--- a/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-node.vue
@@ -54,7 +54,7 @@ const props = defineProps<{
 	node: WorkflowNode<ModelOperationState>;
 }>();
 
-const emit = defineEmits(['update-state', 'append-output', 'open-drilldown']);
+const emit = defineEmits(['append-output', 'open-drilldown']);
 const models = computed(() => useProjects().getActiveProjectAssets(AssetType.Model));
 
 enum ModelNodeView {
@@ -74,12 +74,16 @@ async function getModelById(modelId: string) {
 		if (canPropagateResource(outputs)) {
 			const state = _.cloneDeep(props.node.state);
 			state.modelId = model.value?.id;
-			emit('update-state', state);
-			emit('append-output', {
-				type: 'modelId',
-				label: model.value.header.name,
-				value: [model.value.id]
-			});
+
+			emit(
+				'append-output',
+				{
+					type: 'modelId',
+					label: model.value.header.name,
+					value: [model.value.id]
+				},
+				state
+			);
 		}
 	}
 }


### PR DESCRIPTION
### Summary
Small tweaks to model and dataset operators, so nodes are initialized with a single append-output instead append-output + update-state events.


### Testing
Model and dataset operators should work as normal