### PR TITLE
Fix Vite test on main

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
 		'no-plusplus': 'off',
 		'no-use-before-define': 'off',
 		'@typescript-eslint/no-use-before-define': 'off',
+		'@typescript-eslint/no-unused-vars': ['warn', { 'argsIgnorePattern': '^_' }],
 		'prefer-destructuring': 'off',
 		'vuejs-accessibility/click-events-have-key-events': 'off',
 		'vuejs-accessibility/label-has-for': 'off',

--- a/packages/client/hmi-client/tests/setup.ts
+++ b/packages/client/hmi-client/tests/setup.ts
@@ -1,0 +1,16 @@
+class MockWorker {
+	onmessage: ((event: MessageEvent) => void) | null = null;
+
+	onerror: ((event: ErrorEvent) => void) | null = null;
+
+	postMessage(_: unknown): void {
+		// Simulate worker behavior if needed
+	}
+
+	terminate(): void {
+		// Simulate worker termination if needed
+	}
+}
+
+// Assign the mock to global.Worker
+(global as any).Worker = MockWorker;

--- a/packages/client/hmi-client/vite.config.ts
+++ b/packages/client/hmi-client/vite.config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
 				}
 			}
 		}),
-		// By default SVGs are imported as URL in order to easily reference them in img tags
+		// By default, SVGs are imported as URL in order to easily reference them in img tags
 		// In order to import SVGs as components you must add '?component' as a suffix of an SVG's path
 		svgLoader({ defaultImport: 'url' })
 	],
@@ -97,6 +97,7 @@ export default defineConfig({
 		outputFile: {
 			junit: './tests/unit/reports/junit-report.xml'
 		},
-		environment: 'jsdom'
+		environment: 'jsdom', // Ensures a browser-like environment
+		setupFiles: './tests/setup.ts' // Points to a test setup file
 	}
 });


### PR DESCRIPTION
# Description

* Add a `/tests/setup.ts` script to `vite.config.ts`.
* Add a mock `Worker` for Vite test run in node.js.
* Add a TS lint rule to allow variable with an underscore to be unused. _i.e. `_message` can be unused in the function_