### PR TITLE
6481 text-extraction fails on arm64 machines

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -73,9 +73,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Setup Node 20.10.0 LTS
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -59,8 +59,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -100,7 +100,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-equation-extraction-taskrunner.yml
+++ b/.github/workflows/publish-equation-extraction-taskrunner.yml
@@ -72,9 +72,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-equation-extraction-taskrunner.yml
+++ b/.github/workflows/publish-equation-extraction-taskrunner.yml
@@ -58,8 +58,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-funman-taskrunner.yml
+++ b/.github/workflows/publish-funman-taskrunner.yml
@@ -72,9 +72,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-funman-taskrunner.yml
+++ b/.github/workflows/publish-funman-taskrunner.yml
@@ -58,8 +58,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-gollm-taskrunner.yml
+++ b/.github/workflows/publish-gollm-taskrunner.yml
@@ -72,9 +72,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-gollm-taskrunner.yml
+++ b/.github/workflows/publish-gollm-taskrunner.yml
@@ -58,8 +58,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-mira-taskrunner.yml
+++ b/.github/workflows/publish-mira-taskrunner.yml
@@ -59,8 +59,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -103,7 +103,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-mira-taskrunner.yml
+++ b/.github/workflows/publish-mira-taskrunner.yml
@@ -73,9 +73,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -65,8 +65,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -112,7 +112,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -79,9 +79,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-table-extraction-taskrunner.yml
+++ b/.github/workflows/publish-table-extraction-taskrunner.yml
@@ -72,9 +72,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-table-extraction-taskrunner.yml
+++ b/.github/workflows/publish-table-extraction-taskrunner.yml
@@ -58,8 +58,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/.github/workflows/publish-text-extraction-taskrunner.yml
+++ b/.github/workflows/publish-text-extraction-taskrunner.yml
@@ -72,9 +72,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish-text-extraction-taskrunner.yml
+++ b/.github/workflows/publish-text-extraction-taskrunner.yml
@@ -58,8 +58,8 @@ jobs:
           push: true
           tags: ${{ needs.image-tag.outputs.tagged-image-name }}--amd64
 
-  arm64-emulation:
-    runs-on: ubuntu-24.04
+  arm64:
+    runs-on: ubuntu-24.04-arm
     needs: image-tag
     permissions:
       contents: read
@@ -102,7 +102,7 @@ jobs:
     needs:
       - image-tag
       - amd64
-      - arm64-emulation
+      - arm64
     uses: ./.github/workflows/merge-images.yml
     with:
       name: ${{ needs.image-tag.outputs.tagged-image-name }}

--- a/packages/text_extraction/Dockerfile
+++ b/packages/text_extraction/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 	rm -rf /var/lib/apt/lists/*
 
 # Install PyMuPDF
-RUN pip install --no-cache-dir PyMuPDF
+RUN pip install --no-cache-dir PyMuPDF==1.25.2
 
 #^^^^^^^^^^^^^^^^^^^^
 ######################
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 	rm -rf /var/lib/apt/lists/*
 
 # Install PyMuPDF
-RUN pip install --no-cache-dir PyMuPDF
+RUN pip install --no-cache-dir PyMuPDF==1.25.2
 
 # Copy the Spring Boot fat JAR from the builder image
 COPY --from=text_extraction_taskrunner_builder /taskrunner/build/libs/*.jar /taskrunner.jar


### PR DESCRIPTION
# Description

* remove arm64-emulation for CI builds. We now run on native arm64 runners
* Pinned pyMuPDF to version 1.25.2

Resolves #6481
