### PR TITLE
port branch workflow logic to api server

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -216,7 +216,7 @@ import { MenuItem } from 'primevue/menuitem';
 import * as EventService from '@/services/event';
 import { useProjects } from '@/composables/project';
 // import useAuthStore from '@/stores/auth';
-import { cloneNoteBookSession } from '@/services/notebook-session';
+// import { cloneNoteBookSession } from '@/services/notebook-session';
 import * as SimulateCiemssOp from '@/components/workflow/ops/simulate-ciemss/mod';
 import * as StratifyMiraOp from '@/components/workflow/ops/stratify-mira/mod';
 import * as DatasetOp from '@/components/workflow/ops/dataset/mod';
@@ -477,6 +477,7 @@ const duplicateBranch = async (nodeId: string) => {
 
 // We need to clone data-transform sessions, unlike other operators that are
 // append-only, data-transform updates so we need to create distinct copies.
+/*
 const cloneNoteBookSessions = async () => {
 	const sessionIdSet = new Set<string>();
 
@@ -499,6 +500,7 @@ const cloneNoteBookSessions = async () => {
 		}
 	}
 };
+*/
 
 const addOperatorToWorkflow: Function =
 	(operator: OperatorImport, nodeSize: OperatorNodeSize = OperatorNodeSize.medium) =>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -216,7 +216,6 @@ import { MenuItem } from 'primevue/menuitem';
 import * as EventService from '@/services/event';
 import { useProjects } from '@/composables/project';
 // import useAuthStore from '@/stores/auth';
-// import { cloneNoteBookSession } from '@/services/notebook-session';
 import * as SimulateCiemssOp from '@/components/workflow/ops/simulate-ciemss/mod';
 import * as StratifyMiraOp from '@/components/workflow/ops/stratify-mira/mod';
 import * as DatasetOp from '@/components/workflow/ops/dataset/mod';
@@ -468,39 +467,9 @@ const removeNode = async (nodeId: string) => {
 };
 
 const duplicateBranch = async (nodeId: string) => {
-	// wf.value.branchWorkflow(nodeId);
-	// cloneNoteBookSessions();
-
 	const updatedWorkflow = await workflowService.branchWorkflow(wf.value.getId(), nodeId);
 	wf.value.update(updatedWorkflow);
 };
-
-// We need to clone data-transform sessions, unlike other operators that are
-// append-only, data-transform updates so we need to create distinct copies.
-/*
-const cloneNoteBookSessions = async () => {
-	const sessionIdSet = new Set<string>();
-
-	const operationList = [DatasetTransformerOp.operation.name];
-
-	for (let i = 0; i < wf.value.getNodes().length; i++) {
-		const node = wf.value.getNodes()[i];
-		if (operationList.includes(node.operationType)) {
-			const state = node.state;
-			const sessionId = state.notebookSessionId as string;
-			if (!sessionId) continue;
-			if (!sessionIdSet.has(sessionId)) {
-				sessionIdSet.add(sessionId);
-			} else {
-				// eslint-disable-next-line
-				const session = await cloneNoteBookSession(sessionId);
-				state.notebookSessionId = session.id;
-				sessionIdSet.add(session.id);
-			}
-		}
-	}
-};
-*/
 
 const addOperatorToWorkflow: Function =
 	(operator: OperatorImport, nodeSize: OperatorNodeSize = OperatorNodeSize.medium) =>

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -468,11 +468,10 @@ const removeNode = async (nodeId: string) => {
 };
 
 const duplicateBranch = async (nodeId: string) => {
-	wf.value.branchWorkflow(nodeId);
+	// wf.value.branchWorkflow(nodeId);
+	// cloneNoteBookSessions();
 
-	cloneNoteBookSessions();
-
-	const updatedWorkflow = await workflowService.saveWorkflow(wf.value.dump(), currentProjectId.value ?? undefined);
+	const updatedWorkflow = await workflowService.branchWorkflow(wf.value.getId(), nodeId);
 	wf.value.update(updatedWorkflow);
 };
 

--- a/packages/client/hmi-client/src/services/workflow.ts
+++ b/packages/client/hmi-client/src/services/workflow.ts
@@ -963,6 +963,12 @@ export const updateStatus = async (id: string, statusMap: Map<string, OperatorSt
 	return response.data ?? null;
 };
 
+export const branchWorkflow = async (id: string, nodeId: string) => {
+	console.log(`>> workflowService.branchWorkflow ${nodeId}`);
+	const response = await API.post(`/workflows/${id}/branch-from-node/${nodeId}`);
+	return response.data ?? null;
+};
+
 /// /////////////////////////////////////////////////////////////////////////////
 // Events bus for workflow
 /// /////////////////////////////////////////////////////////////////////////////

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -805,7 +805,7 @@ public class WorkflowController {
 		}
 
 		try {
-			workflowService.branchWorkflow(workflow.get(), nodeId);
+			workflowService.branchWorkflow(workflow.get(), nodeId, projectId);
 			updated = workflowService.updateAsset(workflow.get(), projectId, permission);
 		} catch (final Exception e) {
 			log.error("Unable to update workflow", e);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowController.java
@@ -773,7 +773,7 @@ public class WorkflowController {
 
 	@PostMapping("/{id}/branch-from-node/{nodeId}")
 	@Secured(Roles.USER)
-	@Operation(summary = "Remove an edge from a workflow")
+	@Operation(summary = "Branch workflow starting from a given node")
 	@ApiResponses(
 		value = {
 			@ApiResponse(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/InputPort.java
@@ -24,6 +24,23 @@ public class InputPort implements Serializable {
 	private ArrayNode value;
 	private Boolean isOptional;
 
+	@Override
+	public InputPort clone() {
+		final InputPort clone = new InputPort();
+		clone.setId(id);
+		clone.setVersion(version);
+		clone.setType(type);
+		clone.setOriginalType(originalType);
+		clone.setStatus(status);
+		clone.setLabel(label);
+		if (value != null) {
+			clone.setValue(value.deepCopy());
+		}
+		clone.setIsOptional(isOptional);
+
+		return clone;
+	}
+
 	// FIXME: backwards compatibility, to be removed
 	private Boolean acceptMultiple;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/OutputPort.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/OutputPort.java
@@ -29,6 +29,28 @@ public class OutputPort implements Serializable {
 	private JsonNode state;
 	private Timestamp timestamp;
 
+	@Override
+	public OutputPort clone() {
+		final OutputPort clone = new OutputPort();
+		clone.setId(id);
+		clone.setVersion(version);
+		clone.setType(type);
+		clone.setOriginalType(originalType);
+		clone.setStatus(status);
+		clone.setLabel(label);
+		if (value != null) {
+			clone.setValue(value.deepCopy());
+		}
+		clone.setIsOptional(isOptional);
+		clone.setIsSelected(isSelected);
+		clone.setOperatorStatus(operatorStatus);
+		if (state != null) {
+			clone.setState(state.deepCopy());
+		}
+		clone.setTimestamp(timestamp);
+		return clone;
+	}
+
 	// FIXME: backwards compatibility, to be removed
 	private Boolean acceptMultiple;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowEdge.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowEdge.java
@@ -2,6 +2,7 @@ package software.uncharted.terarium.hmiserver.models.dataservice.workflow;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.Data;
@@ -44,6 +45,29 @@ public class WorkflowEdge extends SupportAdditionalProperties implements Seriali
 		clone.setSourcePortId(sourcePortId);
 		clone.setTarget(target);
 		clone.setTargetPortId(targetPortId);
+
+		clone.setPoints(new ArrayList<>());
+		for (final JsonNode d : points) {
+			clone.getPoints().add(d.deepCopy());
+		}
+		return clone;
+	}
+
+	// Used for branching
+	@Override
+	public WorkflowEdge clone() {
+		final WorkflowEdge clone = (WorkflowEdge) super.clone();
+		clone.setId(id);
+		clone.setWorkflowId(workflowId);
+		clone.setSource(source);
+		clone.setSourcePortId(sourcePortId);
+		clone.setTarget(target);
+		clone.setTargetPortId(targetPortId);
+
+		clone.setPoints(new ArrayList<>());
+		for (final JsonNode d : points) {
+			clone.getPoints().add(d.deepCopy());
+		}
 		return clone;
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowEdge.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowEdge.java
@@ -47,8 +47,10 @@ public class WorkflowEdge extends SupportAdditionalProperties implements Seriali
 		clone.setTargetPortId(targetPortId);
 
 		clone.setPoints(new ArrayList<>());
-		for (final JsonNode d : points) {
-			clone.getPoints().add(d.deepCopy());
+		if (points != null) {
+			for (final JsonNode d : points) {
+				clone.getPoints().add(d.deepCopy());
+			}
 		}
 		return clone;
 	}
@@ -65,8 +67,10 @@ public class WorkflowEdge extends SupportAdditionalProperties implements Seriali
 		clone.setTargetPortId(targetPortId);
 
 		clone.setPoints(new ArrayList<>());
-		for (final JsonNode d : points) {
-			clone.getPoints().add(d.deepCopy());
+		if (points != null) {
+			for (final JsonNode d : points) {
+				clone.getPoints().add(d.deepCopy());
+			}
 		}
 		return clone;
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowNode.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowNode.java
@@ -62,12 +62,16 @@ public class WorkflowNode extends SupportAdditionalProperties implements Seriali
 		clone.setWorkflowId(workflowId);
 
 		clone.setInputs(new ArrayList<>());
-		for (final InputPort port : inputs) {
-			clone.getInputs().add(port.clone());
+		if (inputs != null) {
+			for (final InputPort port : inputs) {
+				clone.getInputs().add(port.clone());
+			}
 		}
 		clone.setOutputs(new ArrayList<>());
-		for (final OutputPort port : outputs) {
-			clone.getOutputs().add(port.clone());
+		if (outputs != null) {
+			for (final OutputPort port : outputs) {
+				clone.getOutputs().add(port.clone());
+			}
 		}
 		return clone;
 	}
@@ -79,12 +83,16 @@ public class WorkflowNode extends SupportAdditionalProperties implements Seriali
 		clone.setId(id);
 		clone.setWorkflowId(workflowId);
 		clone.setInputs(new ArrayList<>());
-		for (final InputPort port : inputs) {
-			clone.getInputs().add(port.clone());
+		if (inputs != null) {
+			for (final InputPort port : inputs) {
+				clone.getInputs().add(port.clone());
+			}
 		}
 		clone.setOutputs(new ArrayList<>());
-		for (final OutputPort port : outputs) {
-			clone.getOutputs().add(port.clone());
+		if (outputs != null) {
+			for (final OutputPort port : outputs) {
+				clone.getOutputs().add(port.clone());
+			}
 		}
 		return clone;
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowNode.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/workflow/WorkflowNode.java
@@ -60,6 +60,32 @@ public class WorkflowNode extends SupportAdditionalProperties implements Seriali
 		final WorkflowNode clone = (WorkflowNode) super.clone();
 		clone.setId(UUID.randomUUID());
 		clone.setWorkflowId(workflowId);
+
+		clone.setInputs(new ArrayList<>());
+		for (final InputPort port : inputs) {
+			clone.getInputs().add(port.clone());
+		}
+		clone.setOutputs(new ArrayList<>());
+		for (final OutputPort port : outputs) {
+			clone.getOutputs().add(port.clone());
+		}
+		return clone;
+	}
+
+	// Used for branching
+	@Override
+	public WorkflowNode clone() {
+		final WorkflowNode clone = (WorkflowNode) super.clone();
+		clone.setId(id);
+		clone.setWorkflowId(workflowId);
+		clone.setInputs(new ArrayList<>());
+		for (final InputPort port : inputs) {
+			clone.getInputs().add(port.clone());
+		}
+		clone.setOutputs(new ArrayList<>());
+		for (final OutputPort port : outputs) {
+			clone.getOutputs().add(port.clone());
+		}
 		return clone;
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -907,7 +907,8 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 
 		final List<WorkflowEdge> anchorUpstreamEdges = workflow
 			.getEdges()
-			.filter(edge -> edge.isDeleted() == false && edge.getTarget().equals(anchor.getId()))
+			.stream()
+			.filter(edge -> edge.getIsDeleted() == false && edge.getTarget().equals(anchor.getId()))
 			.collect(Collectors.toList());
 
 		for (final WorkflowEdge edge : upstreamEdges) {
@@ -923,6 +924,19 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 
 		// 4. Reassign identifiers
 		final Map<UUID, UUID> registry = new HashMap<UUID, UUID>();
+		for (final WorkflowNode node : copyNodes) {
+			registry.put(node.getId(), UUID.randomUUID());
+
+			for (final InputPort input : node.getInputs()) {
+				registry.put(input.getId(), UUID.randomUUID());
+			}
+			for (final OutputPort output : node.getOutputs()) {
+				registry.put(output.getId(), UUID.randomUUID());
+			}
+		}
+		for (final WorkflowEdge edge : copyEdges) {
+			registry.put(edge.getId(), UUID.randomUUID());
+		}
 	}
 
 	public void addOrUpdateAnnotation(final Workflow workflow, final WorkflowAnnotation annotation) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -904,6 +904,25 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 			.stream()
 			.filter(edge -> edge.getIsDeleted() == false && targetIds.contains(edge.getId()))
 			.collect(Collectors.toList());
+
+		final List<WorkflowEdge> anchorUpstreamEdges = workflow
+			.getEdges()
+			.filter(edge -> edge.isDeleted() == false && edge.getTarget().equals(anchor.getId()))
+			.collect(Collectors.toList());
+
+		for (final WorkflowEdge edge : upstreamEdges) {
+			final WorkflowEdge foundEdge = copyEdges
+				.stream()
+				.filter(copyEdge -> copyEdge.getId().equals(edge.getId()))
+				.findFirst()
+				.orElse(null);
+			if (foundEdge == null) {
+				copyEdges.add(edge.clone(workflowId, edge.getSource(), edge.getTarget()));
+			}
+		}
+
+		// 4. Reassign identifiers
+		final Map<UUID, UUID> registry = new HashMap<UUID, UUID>();
 	}
 
 	public void addOrUpdateAnnotation(final Workflow workflow, final WorkflowAnnotation annotation) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -882,7 +882,9 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 			final WorkflowNode node = getOperator(workflow, id);
 
 			if (node != null) {
-				copyNodes.add(node.clone(workflowId));
+				WorkflowNode nodeClone = node.clone(workflowId);
+				nodeClone.setId(node.getId());
+				copyNodes.add(nodeClone);
 			} else {
 				continue;
 			}
@@ -899,17 +901,30 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 				if (processed.contains(newId) == false) {
 					stack.add(newId);
 				}
-				copyEdges.add(edge.clone(workflowId, edge.getSource(), edge.getTarget()));
+				WorkflowEdge edgeClone = edge.clone(workflowId, edge.getSource(), edge.getTarget());
+				edgeClone.setId(edge.getId());
+				copyEdges.add(edgeClone);
 			}
 		}
 
 		// 3. Collect the upstream edges
 		final List<UUID> targetIds = copyNodes.stream().map(node -> node.getId()).collect(Collectors.toList());
+
+		System.out.println("");
+		System.out.println("targetIds " + targetIds);
+		System.out.println("edges" + workflow.getEdges());
+		System.out.println("");
+
 		final List<WorkflowEdge> upstreamEdges = workflow
 			.getEdges()
 			.stream()
-			.filter(edge -> edge.getIsDeleted() == false && targetIds.contains(edge.getId()))
+			.filter(edge -> edge.getIsDeleted() == false && targetIds.contains(edge.getTarget()))
 			.collect(Collectors.toList());
+
+		System.out.println("");
+		System.out.println("upstram edges");
+		System.out.println(upstreamEdges);
+		System.out.println("");
 
 		final List<WorkflowEdge> anchorUpstreamEdges = workflow
 			.getEdges()
@@ -924,7 +939,9 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 				.findFirst()
 				.orElse(null);
 			if (foundEdge == null) {
-				copyEdges.add(edge.clone(workflowId, edge.getSource(), edge.getTarget()));
+				WorkflowEdge edgeClone = edge.clone(workflowId, edge.getSource(), edge.getTarget());
+				edgeClone.setId(edge.getId());
+				copyEdges.add(edgeClone);
 			}
 		}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/WorkflowService.java
@@ -882,8 +882,7 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 			final WorkflowNode node = getOperator(workflow, id);
 
 			if (node != null) {
-				WorkflowNode nodeClone = node.clone(workflowId);
-				nodeClone.setId(node.getId());
+				WorkflowNode nodeClone = node.clone();
 				copyNodes.add(nodeClone);
 			} else {
 				continue;
@@ -901,8 +900,7 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 				if (processed.contains(newId) == false) {
 					stack.add(newId);
 				}
-				WorkflowEdge edgeClone = edge.clone(workflowId, edge.getSource(), edge.getTarget());
-				edgeClone.setId(edge.getId());
+				WorkflowEdge edgeClone = edge.clone();
 				copyEdges.add(edgeClone);
 			}
 		}
@@ -910,21 +908,11 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 		// 3. Collect the upstream edges
 		final List<UUID> targetIds = copyNodes.stream().map(node -> node.getId()).collect(Collectors.toList());
 
-		System.out.println("");
-		System.out.println("targetIds " + targetIds);
-		System.out.println("edges" + workflow.getEdges());
-		System.out.println("");
-
 		final List<WorkflowEdge> upstreamEdges = workflow
 			.getEdges()
 			.stream()
 			.filter(edge -> edge.getIsDeleted() == false && targetIds.contains(edge.getTarget()))
 			.collect(Collectors.toList());
-
-		System.out.println("");
-		System.out.println("upstram edges");
-		System.out.println(upstreamEdges);
-		System.out.println("");
 
 		final List<WorkflowEdge> anchorUpstreamEdges = workflow
 			.getEdges()
@@ -939,8 +927,7 @@ public class WorkflowService extends TerariumAssetService<Workflow, WorkflowRepo
 				.findFirst()
 				.orElse(null);
 			if (foundEdge == null) {
-				WorkflowEdge edgeClone = edge.clone(workflowId, edge.getSource(), edge.getTarget());
-				edgeClone.setId(edge.getId());
+				WorkflowEdge edgeClone = edge.clone();
 				copyEdges.add(edgeClone);
 			}
 		}


### PR DESCRIPTION
### Summary
This PR ports the branching logic from server/workflow.ts => WorkflowService.java. This should completely move the user-initiated workflow CRUD operations to the API layer and have a more consistent update pattern.


### Testing
Create some sample workflow (eg model => stratify => model-config => simulate), the "duplicate" operation on a given node should branch the node itself and everything down stream of it, plus the first-order uptream edges.