### PR TITLE
fix for copying project name

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -57,6 +57,7 @@ import { RoutePath, useCurrentRoute } from '@/router/index';
 import { RouteName } from '@/router/routes';
 import { useProjects } from '@/composables/project';
 import { useProjectMenu } from '@/composables/project-menu';
+import { isEmtpy } from 'lodash';
 
 const router = useRouter();
 const currentRoute = useCurrentRoute();

--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -96,6 +96,9 @@ watch(
 	async () => {
 		if (isCopyDialogVisible.value) {
 			project.value = await useProjects().activeProject.value;
+			if (project.value === null) {
+				project.value = menuProject.value;
+			}
 			const name = project.value.name ?? null;
 			projectName.value = name ? `Copy of ${name}` : 'Enter new project name';
 		}

--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -57,7 +57,7 @@ import { RoutePath, useCurrentRoute } from '@/router/index';
 import { RouteName } from '@/router/routes';
 import { useProjects } from '@/composables/project';
 import { useProjectMenu } from '@/composables/project-menu';
-import { isEmtpy } from 'lodash';
+import { isEmpty } from 'lodash';
 
 const router = useRouter();
 const currentRoute = useCurrentRoute();

--- a/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-common-modal-dialogs.vue
@@ -95,12 +95,8 @@ watch(
 	() => isCopyDialogVisible.value,
 	async () => {
 		if (isCopyDialogVisible.value) {
-			project.value = await useProjects().activeProject.value;
-			if (project.value === null) {
-				project.value = menuProject.value;
-			}
-			const name = project.value.name ?? null;
-			projectName.value = name ? `Copy of ${name}` : 'Enter new project name';
+			const name = await useProjects().getActiveProjectName();
+			projectName.value = isEmpty(name) ? 'Enter new project name' : `Copy of ${name}`;
 		}
 	}
 );


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/a36c00a2-5902-4fca-b32f-0a738fe3d380)

Issue: 
- When copying a project on the home, the default input isn't correct


Testing:
- try copying a project on the home page
- default name should look like 
  - `Copy of <Name>`

Resolves #(issue)
