### PR TITLE
Sort model equations alphabetically and wrap equations with more than 5 terms

### DIFF
--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -23,7 +23,7 @@ def main():
         # Generate LaTeX code string from MMT model
         # =========================================
 
-        odeterms = {var: 0 for var in model.get_concepts_name_map().keys()}
+        odeterms = {var: 0 for var in sorted(model.get_concepts_name_map().keys())}
 
         for template in model.templates:
             if hasattr(template, "subject"):

--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -23,16 +23,19 @@ def main():
         # Generate LaTeX code string from MMT model
         # =========================================
 
-        odeterms = {var: 0 for var in sorted(model.get_concepts_name_map().keys())}
+        odeterms = {var: [] for var in sorted(model.get_concepts_name_map().keys())}
 
         for template in model.templates:
             if hasattr(template, "subject"):
                 var = template.subject.name
-                odeterms[var] -= template.rate_law.args[0]
+                odeterms[var].append(-template.rate_law.args[0])
 
             if hasattr(template, "outcome"):
                 var = template.outcome.name
-                odeterms[var] += template.rate_law.args[0]
+                odeterms[var].append(template.rate_law.args[0])
+
+        # Sort the terms such that all negative ones come first
+        odeterms = {var: sorted(terms, key = lambda term: str(term)) for var, terms in odeterms.items()}
 
         # Time
         if model.time and model.time.name:


### PR DESCRIPTION
# Description

* Users requested the model equations to be sorted alphabetically such that they are easier to review and compare with literature
* Ditto for the observables
* Wrapped around equations that are too long
* SymPy does not allow me to maintain a given order of terms in a multiplication or addition (so not alphabetical term order within each equation)

![Screenshot 2025-02-10 at 11 42 39 PM](https://github.com/user-attachments/assets/ce978a98-1869-42ea-96e9-02b12cba4e02)
