### PR TITLE
chart tweaks

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -48,6 +48,9 @@ const defaultChartConfig: Partial<Config> = {
 	tooltipFormat: {
 		numberFormat: 'tooltipFormatter',
 		numberFormatType: 'tooltipFormatter'
+	},
+	axis: {
+		labelFontSize: 12
 	}
 };
 

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -11,6 +11,7 @@ import { flattenInterventionData } from './intervention-policy';
 import type { FunmanBox, FunmanConstraintsResponse } from './models/funman-service';
 
 const VEGALITE_SCHEMA = 'https://vega.github.io/schema/vega-lite/v5.json';
+const GLOBAL_FONT = 'Figtree';
 
 const NUMBER_FORMAT = '.3~s';
 export const expressionFunctions = {
@@ -135,7 +136,6 @@ export function createErrorChart(dataset: Record<string, any>[], options: ErrorC
 	const axisColor = '#EEE';
 	const labelColor = '#667085';
 	const labelFontWeight = 'normal';
-	const globalFont = 'Figtree';
 
 	const areaChartColor = options.color ?? '#1B8073';
 	const dotColor = options.color ?? '#1B8073';
@@ -180,7 +180,7 @@ export function createErrorChart(dataset: Record<string, any>[], options: ErrorC
 
 	const config = {
 		facet: { spacing: 2 },
-		font: globalFont,
+		font: GLOBAL_FONT,
 		mark: { opacity: 1 },
 		view: { stroke: 'transparent' },
 		axis: {
@@ -324,7 +324,6 @@ export function createHistogramChart(dataset: Record<string, any>[], options: Hi
 	const axisColor = '#EEE';
 	const labelColor = '#667085';
 	const labelFontWeight = 'normal';
-	const globalFont = 'Figtree';
 	const titleObj = options.title
 		? {
 				text: options.title,
@@ -376,7 +375,7 @@ export function createHistogramChart(dataset: Record<string, any>[], options: Hi
 		},
 		layer: [],
 		config: {
-			font: globalFont
+			font: GLOBAL_FONT
 		}
 	};
 
@@ -508,7 +507,6 @@ export function createForecastChart(
 	const axisColor = '#EEE';
 	const labelColor = '#667085';
 	const labelFontWeight = 'normal';
-	const globalFont = 'Figtree';
 	const titleObj = options.title
 		? {
 				text: options.title,
@@ -597,7 +595,7 @@ export function createForecastChart(
 			type: options.autosize || AUTOSIZE.FIT_X
 		},
 		config: {
-			font: globalFont,
+			font: GLOBAL_FONT,
 			legend: {
 				layout: {
 					anchor: 'start'
@@ -1129,7 +1127,6 @@ export function createQuantilesForecastChart(
 	const axisColor = '#EEE';
 	const labelColor = '#667085';
 	const labelFontWeight = 'normal';
-	const globalFont = 'Figtree';
 	const titleObj = options.title
 		? {
 				text: options.title,
@@ -1221,7 +1218,7 @@ export function createQuantilesForecastChart(
 			type: options.autosize || AUTOSIZE.FIT_X
 		},
 		config: {
-			font: globalFont,
+			font: GLOBAL_FONT,
 			legend: {
 				layout: {
 					direction: legendProperties.direction,
@@ -1376,12 +1373,10 @@ export function createSimulateSensitivityScatter(
 /* -------------------------------------------------------------------------- */
 
 export function createSensitivityRankingChart(data: { parameter: string; score: number }[], options: BaseChartOptions) {
-	const globalFont = 'Figtree';
-
 	const spec: any = {
 		$schema: VEGALITE_SCHEMA,
 		config: {
-			font: globalFont,
+			font: GLOBAL_FONT,
 			bar: {
 				discreteBandSize: 8 // Fixed bar width
 			}
@@ -1749,7 +1744,6 @@ export function createFunmanStateChart(
 	if (isEmpty(trajectories)) return null;
 
 	const threshold = 1e25;
-	const globalFont = 'Figtree';
 
 	const stateIdConstraints = constraints.filter((c) => c.variables.includes(stateId));
 	// Find min/max values to set an appropriate viewing range for y-axis
@@ -1791,7 +1785,7 @@ export function createFunmanStateChart(
 	return {
 		$schema: VEGALITE_SCHEMA,
 		id: stateId,
-		config: { font: globalFont },
+		config: { font: GLOBAL_FONT },
 		width: 600,
 		height: 300,
 		title: {
@@ -1907,11 +1901,10 @@ export function createFunmanParameterCharts(
 		});
 	});
 
-	const globalFont = 'Figtree';
 	return {
 		$schema: VEGALITE_SCHEMA,
 		config: {
-			font: globalFont,
+			font: GLOBAL_FONT,
 			tick: { thickness: 2 }
 		},
 		width: 600,
@@ -2073,12 +2066,10 @@ export function createRankingInterventionsChart(
 	title: string | null = null,
 	variableName: string | null = null
 ) {
-	const globalFont = 'Figtree';
-
 	return {
 		$schema: VEGALITE_SCHEMA,
 		config: {
-			font: globalFont,
+			font: GLOBAL_FONT,
 			bar: {
 				discreteBandSize: 20 // Fixed bar width
 			},

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -1472,7 +1472,8 @@ export function createForecastChartAnnotation(axis: 'x' | 'y', datum: number, la
 					dx: 16,
 					dy: -16,
 					angle: isVertical ? 90 : 0,
-					baseline: 'top'
+					baseline: 'top',
+					fontSize: 12
 				},
 				encoding: {
 					text: { value: label }


### PR DESCRIPTION
### Summary
Clean up and small tweaks based on feedback 
- True global font instead of redeclaration all over the place
- Font size tweak

Before:

<img width="882" alt="image" src="https://github.com/user-attachments/assets/cf03599f-13f1-4363-aa04-83a122074976" />


After:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/17262a22-53a1-4cca-8a34-457042019f27" />
