### PR TITLE
stratify use input temporal context in output

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
@@ -275,7 +275,8 @@ function updateCodeState(code: string = codeText.value, hasCodeRun: boolean = tr
 
 const createOutput = async (modelToSave: Model) => {
 	// If it's the original model, use that otherwise create a new one
-	const modelData = isReadyToCreateDefaultOutput.value ? modelToSave : await createModel(modelToSave);
+	const modelConfigId = props.node.inputs.find((d) => d.type === 'modelConfigId')?.value?.[0];
+	const modelData = isReadyToCreateDefaultOutput.value ? modelToSave : await createModel(modelToSave, modelConfigId);
 	if (!modelData) return;
 
 	const modelLabel = isReadyToCreateDefaultOutput.value

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -111,7 +111,7 @@ import { OperatorStatus, WorkflowNode } from '@/types/workflow';
 import { logger } from '@/utils/logger';
 import Button from 'primevue/button';
 import { v4 as uuidv4 } from 'uuid';
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
 import { VAceEditorInstance } from 'vue3-ace-editor/types';
 import { blankStratifyGroup, StratifyGroup, StratifyOperationStateMira } from './stratify-mira-operation';

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -111,7 +111,7 @@ import { OperatorStatus, WorkflowNode } from '@/types/workflow';
 import { logger } from '@/utils/logger';
 import Button from 'primevue/button';
 import { v4 as uuidv4 } from 'uuid';
-import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
 import { VAceEditorInstance } from 'vue3-ace-editor/types';
 import { blankStratifyGroup, StratifyGroup, StratifyOperationStateMira } from './stratify-mira-operation';
@@ -248,7 +248,8 @@ const handleModelPreview = async (data: any) => {
 	amrResponse.header.name = newName;
 
 	// Create output
-	const modelData = await createModelFromOld(amr.value, amrResponse);
+	const modelConfigId = props.node.inputs.find((i) => i.type === 'modelConfigId')?.value?.[0];
+	const modelData = await createModelFromOld(amr.value, amrResponse, modelConfigId);
 	if (!modelData) return;
 	outputAmr.value = modelData;
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-node.vue
@@ -52,7 +52,7 @@ watch(
 				model.name += ` (${modelConfiguration.name})`;
 				model.header.name = model.name as string;
 
-				const res = await createModel(model);
+				const res = await createModel(model, modelConfiguration.id);
 				if (res) {
 					baseModelId = res.id as string;
 				}

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -10,17 +10,25 @@ import { fileToJson } from '@/utils/file';
 import { Ref } from 'vue';
 import { DateOptions } from './charts';
 
-export async function createModel(model: Model): Promise<Model | null> {
+export async function createModel(
+	model: Model,
+	modelConfigurationId?: ModelConfiguration['id']
+): Promise<Model | null> {
 	delete model.id;
-	const response = await API.post(`/models`, model);
+	const response = await API.post(`/models`, { model, modelConfigurationId });
 	return response?.data ?? null;
 }
 
-export async function createModelFromOld(oldModel: Model, newModel: Model): Promise<Model | null> {
+export async function createModelFromOld(
+	oldModel: Model,
+	newModel: Model,
+	modelConfigurationId?: ModelConfiguration['id']
+): Promise<Model | null> {
 	delete newModel.id;
 	const response = await API.post(`/models/new-from-old`, {
 		newModel,
-		oldModel
+		oldModel,
+		modelConfigurationId
 	});
 	return response?.data ?? null;
 }

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -8,6 +8,7 @@ import { Artifact, EventType } from '@/types/Types';
 import { AMRSchemaNames, CalendarDateType } from '@/types/common';
 import { fileToJson } from '@/utils/file';
 import { Ref } from 'vue';
+import { AxiosRequestConfig } from 'axios';
 import { DateOptions } from './charts';
 
 export async function createModel(
@@ -15,7 +16,13 @@ export async function createModel(
 	modelConfigurationId?: ModelConfiguration['id']
 ): Promise<Model | null> {
 	delete model.id;
-	const response = await API.post(`/models`, { model, modelConfigurationId });
+	const params: AxiosRequestConfig['params'] = {};
+	if (modelConfigurationId) {
+		params['model-configuration-id'] = modelConfigurationId;
+	}
+	const response = await API.post(`/models`, model, {
+		params
+	});
 	return response?.data ?? null;
 }
 
@@ -25,11 +32,20 @@ export async function createModelFromOld(
 	modelConfigurationId?: ModelConfiguration['id']
 ): Promise<Model | null> {
 	delete newModel.id;
-	const response = await API.post(`/models/new-from-old`, {
-		newModel,
-		oldModel,
-		modelConfigurationId
-	});
+	const params: AxiosRequestConfig['params'] = {};
+	if (modelConfigurationId) {
+		params['model-configuration-id'] = modelConfigurationId;
+	}
+	const response = await API.post(
+		`/models/new-from-old`,
+		{
+			newModel,
+			oldModel
+		},
+		{
+			params
+		}
+	);
 	return response?.data ?? null;
 }
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
@@ -40,6 +40,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.project.ProjectE
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
+import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService.ModelConfigurationUpdate;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.utils.Messages;
@@ -374,10 +375,13 @@ public class ModelConfigurationController {
 	) {
 		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
 
+		final ModelConfigurationUpdate options = new ModelConfigurationUpdate();
+		options.setName(name);
+		options.setDescription(description);
+
 		final ModelConfiguration modelConfiguration = ModelConfigurationService.modelConfigurationFromAMR(
 			configuredModel,
-			name,
-			description
+			options
 		);
 
 		try {
@@ -419,10 +423,13 @@ public class ModelConfigurationController {
 	) {
 		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
 
+		final ModelConfigurationUpdate options = new ModelConfigurationUpdate();
+		options.setName(name);
+		options.setDescription(description);
+
 		final ModelConfiguration modelConfiguration = ModelConfigurationService.modelConfigurationFromAMR(
 			configuredModel,
-			name,
-			description
+			options
 		);
 
 		modelConfiguration.setId(id);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
@@ -411,13 +411,6 @@ public class ModelController {
 		}
 	}
 
-	@Data
-	public static class UpdateModelRequest {
-
-		Model model;
-		UUID modelConfigurationId;
-	}
-
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new model")
@@ -435,8 +428,9 @@ public class ModelController {
 		}
 	)
 	ResponseEntity<Model> createModel(
-		@RequestBody final UpdateModelRequest req,
-		@RequestParam(name = "project-id", required = false) final UUID projectId
+		@RequestBody final Model model,
+		@RequestParam(name = "project-id", required = false) final UUID projectId,
+		@RequestParam(name = "model-configuration-id", required = false) final UUID modelConfigId
 	) {
 		final Schema.Permission permission = projectService.checkPermissionCanWrite(
 			currentUserService.get().getId(),
@@ -447,11 +441,10 @@ public class ModelController {
 			// Set the model name from the AMR header name.
 			// TerariumAsset have a name field, but it's not used for the model name outside
 			// the front-end.
-			final Model model = req.model;
 
 			ModelConfiguration oldModelConfiguration = null;
-			if (req.getModelConfigurationId() != null) {
-				oldModelConfiguration = modelConfigurationService.getAsset(req.getModelConfigurationId(), permission).get();
+			if (modelConfigId != null) {
+				oldModelConfiguration = modelConfigurationService.getAsset(modelConfigId, permission).get();
 			}
 
 			final ModelConfigurationUpdate options = new ModelConfigurationUpdate();
@@ -493,7 +486,6 @@ public class ModelController {
 
 		Model oldModel;
 		Model newModel;
-		UUID modelConfigurationId;
 	}
 
 	@PostMapping("/new-from-old")
@@ -514,7 +506,8 @@ public class ModelController {
 	)
 	ResponseEntity<Model> createModelFromOld(
 		@RequestBody final CreateModelFromOldRequest req,
-		@RequestParam(name = "project-id", required = false) final UUID projectId
+		@RequestParam(name = "project-id", required = false) final UUID projectId,
+		@RequestParam(name = "model-configuration-id", required = false) final UUID modelConfigId
 	) {
 		final Schema.Permission permission = projectService.checkPermissionCanWrite(
 			currentUserService.get().getId(),
@@ -531,8 +524,8 @@ public class ModelController {
 			final Model created = modelService.createAsset(req.newModel, projectId, permission);
 
 			ModelConfiguration oldModelConfiguration = null;
-			if (req.getModelConfigurationId() != null) {
-				oldModelConfiguration = modelConfigurationService.getAsset(req.getModelConfigurationId(), permission).get();
+			if (modelConfigId != null) {
+				oldModelConfiguration = modelConfigurationService.getAsset(modelConfigId, permission).get();
 			}
 
 			final ModelConfigurationUpdate options = new ModelConfigurationUpdate();

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
@@ -45,6 +45,7 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.ArtifactService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
+import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService.ModelConfigurationUpdate;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.tasks.AMRToMMTResponseHandler;
@@ -455,8 +456,7 @@ public class MiraController {
 			// create a default configuration
 			final ModelConfiguration modelConfiguration = ModelConfigurationService.modelConfigurationFromAMR(
 				model,
-				null,
-				null
+				new ModelConfigurationUpdate()
 			);
 			modelConfigurationService.createAsset(modelConfiguration, conversionRequest.projectId, permission);
 		} catch (final IOException e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/data/ModelConfigurationService.java
@@ -3,6 +3,7 @@ package software.uncharted.terarium.hmiserver.service.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.observation.annotation.Observed;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.Data;
 import org.springframework.stereotype.Service;
 import software.uncharted.terarium.hmiserver.configuration.Config;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
@@ -92,11 +94,22 @@ public class ModelConfigurationService extends TerariumAssetService<ModelConfigu
 		return super.createAssets(assets, projectId, hasWritePermission);
 	}
 
+	@Data
+	public static class ModelConfigurationUpdate {
+
+		private String name;
+		private String description;
+		private Timestamp temporalContext;
+	}
+
 	public static ModelConfiguration modelConfigurationFromAMR(
 		final Model model,
-		final String name,
-		final String description
+		final ModelConfigurationUpdate options
 	) {
+		final String name = options.getName();
+		final String description = options.getDescription();
+		final Timestamp temporalContext = options.getTemporalContext();
+
 		final ModelConfiguration modelConfiguration = new ModelConfiguration();
 		modelConfiguration.setName(name != null ? name : "Default configuration");
 		modelConfiguration.setDescription(description != null ? description : "This is a default configuration.");
@@ -104,6 +117,7 @@ public class ModelConfigurationService extends TerariumAssetService<ModelConfigu
 		modelConfiguration.setParameterSemanticList(createParameterSemanticList(model));
 		modelConfiguration.setInitialSemanticList(createInitialSemanticList(model));
 		modelConfiguration.setObservableSemanticList(createObservableSemanticList(model));
+		modelConfiguration.setTemporalContext(temporalContext);
 		return modelConfiguration;
 	}
 

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ValidateModelConfigHandler.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/tasks/ValidateModelConfigHandler.java
@@ -19,6 +19,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Progr
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
+import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService.ModelConfigurationUpdate;
 import software.uncharted.terarium.hmiserver.service.data.SimulationService;
 
 @Component
@@ -123,10 +124,13 @@ public class ValidateModelConfigHandler extends TaskResponseHandler {
 			// Only use contracted model to create model configuration, no need to save it
 			final Model contractedModel = objectMapper.convertValue(contractedModelObject, Model.class);
 
+			final ModelConfigurationUpdate options = new ModelConfigurationUpdate();
+			options.setName(props.newModelConfigName);
+			options.setDescription(contractedModel.getDescription());
+
 			final ModelConfiguration contractedModelConfiguration = ModelConfigurationService.modelConfigurationFromAMR(
 				contractedModel,
-				props.newModelConfigName,
-				contractedModel.getDescription()
+				options
 			);
 			contractedModelConfiguration.setTemporary(true);
 			contractedModelConfiguration.setModelId(props.modelId); // Config should be linked to the original model

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
@@ -14,7 +14,6 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
 import software.uncharted.terarium.hmiserver.configuration.MockUser;
-import software.uncharted.terarium.hmiserver.controller.dataservice.ModelController.UpdateModelRequest;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelHeader;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
@@ -64,17 +63,13 @@ public class ModelControllerTests extends TerariumApplicationTests {
 					.setDescription("test-description")
 					.setSchemaName("petrinet")
 			);
-
-		UpdateModelRequest updateModelRequest = new UpdateModelRequest();
-		updateModelRequest.setModel(model);
-
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/models")
 					.param("project-id", PROJECT_ID.toString())
 					.with(csrf())
 					.contentType("application/json")
-					.content(objectMapper.writeValueAsString(updateModelRequest))
+					.content(objectMapper.writeValueAsString(model))
 			)
 			.andExpect(status().isCreated());
 	}

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
@@ -14,6 +14,7 @@ import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import software.uncharted.terarium.hmiserver.TerariumApplicationTests;
 import software.uncharted.terarium.hmiserver.configuration.MockUser;
+import software.uncharted.terarium.hmiserver.controller.dataservice.ModelController.UpdateModelRequest;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.ModelHeader;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
@@ -64,13 +65,16 @@ public class ModelControllerTests extends TerariumApplicationTests {
 					.setSchemaName("petrinet")
 			);
 
+		UpdateModelRequest updateModelRequest = new UpdateModelRequest();
+		updateModelRequest.setModel(model);
+
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/models")
 					.param("project-id", PROJECT_ID.toString())
 					.with(csrf())
 					.contentType("application/json")
-					.content(objectMapper.writeValueAsString(model))
+					.content(objectMapper.writeValueAsString(updateModelRequest))
 			)
 			.andExpect(status().isCreated());
 	}


### PR DESCRIPTION
# Description

* as per a suggestion by @mwdchang it might be better to send in an optional model config id and try to populate the temporal data in the default configuration in the backend

* A request for when we attach a model configuration node to a stratify operator we want that model configuration's temporal context to be carried over to the output's temporal context.  Since this temporal context is not apart of the AMR, we need to get the temporal context of the input model configuration and use the temporal context in the created default configuration

* Added an optional model config id to the create model and create new from old model endpoints to take metadata from and populate

