### PR TITLE
fix 'disabled not used' linter github issue

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/funman/tera-funman-drilldown.vue
@@ -606,7 +606,7 @@ const request = computed<FunmanPostQueriesRequest | null>(() => {
 		model: configuredInputModel,
 		request: {
 			constraints,
-			parameters: knobs.value.requestParameters.map(({ disabled, ...rest }) => rest), // Remove the disabled property from the request (it's only used for UI)
+			parameters: knobs.value.requestParameters.map(({ disabled: _disabled, ...rest }) => rest), // Remove the disabled property from the request (it's only used for UI)
 			structure_parameters: [
 				{
 					name: 'schedules',


### PR DESCRIPTION
# Description

* We get some warning in every PR about this disabled property.  Setting an underscore here so this no longer happens

![Screenshot 2025-02-12 at 10 18 59 AM](https://github.com/user-attachments/assets/44f0f928-f87f-4125-8066-feca7afbb348)
