### PR TITLE
Use different debouncer for each field so they do not override each other

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -91,29 +91,35 @@ const props = defineProps<{
 
 const emit = defineEmits(['update-item']);
 
-const debouncer = debounce((key: string, value: string = '') => {
-	emit('update-item', { key, value });
-}, 300);
+const makeDebouncer = (key: string) =>
+	debounce((value: string) => {
+		emit('update-item', { key, value });
+	}, 300);
+
+const unitExpressionDebouncer = makeDebouncer('unitExpression');
+const nameDebouncer = makeDebouncer('name');
+const groundingDebouncer = makeDebouncer('grounding');
+const descriptionDebouncer = makeDebouncer('description');
 
 const nameText = computed({
 	get: () => props.name,
-	set: (newName) => debouncer('name', newName)
+	set: (newName) => nameDebouncer(newName as string)
 });
 const unitExpression = computed({
 	get: () => props.unitExpression,
-	set: (newUnitExpression) => debouncer('unitExpression', newUnitExpression)
+	set: (newUnitExpression) => unitExpressionDebouncer(newUnitExpression as string)
 });
 const descriptionText = computed({
 	get: () => props.description,
 	set: (newDescription) => {
-		debouncer('description', newDescription);
+		descriptionDebouncer(newDescription as string);
 		showDescription.value = !!newDescription;
 	}
 });
 const showDescription = ref<boolean>(!!descriptionText.value);
 const grounding = computed({
 	get: () => props.grounding,
-	set: (newGrounding) => debouncer('grounding', newGrounding)
+	set: (newGrounding) => groundingDebouncer(newGrounding as string)
 });
 
 // If we are in preview mode and there is no content, show nothing


### PR DESCRIPTION
Closes: https://github.com/DARPA-ASKEM/terarium/issues/6409

### Summary
Have separate debouncers for each field so the queued up emit-events from field-A are not overwritten by event from fieldB.


### Testing
In model page, try to change variable's description, unit, name, ... etc. Should all work as expected and not lose previous edits.