### PR TITLE
only print the first 10k in byte array to prevent log from blowing up

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ClientEventService.java
@@ -7,6 +7,7 @@ import com.rabbitmq.client.Channel;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -248,10 +249,10 @@ public class ClientEventService {
 				return null;
 			} catch (final Exception e1) {
 				log.error(
-					"Error decoding message as either {} or {}. Raw message is: {}",
+					"Error decoding message as either {} or {}. Raw message is (up to 10k bytes): {}",
 					clazz.getName(),
 					JsonNode.class.getName(),
-					message.getBody()
+					Arrays.copyOfRange(message.getBody(), 0, 10000)
 				);
 				log.error("", e1);
 				return null;


### PR DESCRIPTION
### Summary
When exception happens in the fail over, we print out the bytes array stream, it is not particularly useful, especially if the content is large and it will completely overwhelm the server logging.

This PR caps to the first 10k bytes.


### Testing
You can test this by uploading or viewing a very large AMR, eg the one that is 25MB from the eval. This will blow up the jackson serialization (a different issue) but also client-event. The byte-printing should last 2-3 pages and the actual useful exception trace is printed.


```
...snipped...
88, 50, 49, 102, 77, 72, 82, 118, 78, 86, 57, 110, 77, 122, 69, 105, 88, 88, 48, 115, 73, 67, 74, 48, 77, 70, 57, 50, 88, 51, 90, 102, 98, 86, 57, 116, 88, 122, 66, 48, 98, 122, 86, 102, 77, 72, 82, 118, 78, 86, 57, 110, 77, 68, 70, 102, 90, 122, 77, 121, 73, 106, 111, 103, 101, 121, 74, 117, 89, 87, 49, 108, 73, 106, 111, 103, 73, 110, 81, 119, 88, 51, 90, 102, 100, 108, 57, 116, 88, 50, 49, 102, 77, 72, 82, 118, 78, 86, 56, 119, 100, 71, 56, 49, 88, 50, 99, 119, 77, 86, 57, 110, 77, 122, 73, 105, 76, 67, 65, 105, 99, 71, 70, 121, 89, 87, 49, 122, 73, 106, 111, 103, 87, 121, 74, 48, 97, 71, 86, 48, 89, 86, 57, 50, 88, 51, 89, 105, 76, 67, 65, 105, 101, 71, 108, 102, 77, 72, 82, 118, 78, 86, 56, 119, 100, 71, 56, 49, 73, 105, 119, 103, 73, 109, 86, 48, 89, 86, 57, 110, 77, 68, 70, 102, 90, 122, 77, 121, 73, 105, 119, 103, 73, 107, 52, 105, 76, 67, 65, 105, 89, 109] [software.uncharted.terarium.hmiserver.service.ClientEventService:252]
2025-02-13 16:03:34 [ERROR]  [software.uncharted.terarium.hmiserver.service.ClientEventService:258]
com.fasterxml.jackson.core.exc.StreamConstraintsException: String length (20054016) exceeds the maximum length (20000000)
```