### PR TITLE
Integrate MIRA support of branching ratios in equation-to-model feature

### DIFF
--- a/packages/gollm/common/prompts/latex_style_guide.py
+++ b/packages/gollm/common/prompts/latex_style_guide.py
@@ -28,10 +28,12 @@ LATEX_STYLE_GUIDE = """
     b) replace "x ÷ y" with "\\frac{{x}}{{y}}"
     c) replace "x / y" with "\\frac{{x}}{{y}}"
 14) Rewrite expressions with negative exponents as explicit fractions
-    a) for example, replace "N^{{-1}}" with "\\frac{{1}}{{N}}"
+    a) replace "N^{{-1}}" with "\\frac{{1}}{{N}}"
 15) Do not use square brackets "[ ]", curly braces "{ }", and angle brackets "< >" when grouping expressions
-16) Always expand expressions surrounded by parentheses using the order of mathematical operations
+16) Expand expressions surrounded by parentheses using the order of mathematical operations
     a) for example, replace "x(t) (\\alpha y(t) + \\beta z(t))" with "\\alpha * x(t) * y(t) + \\beta * x(t) * z(t)"
     b) for example, replace "-(\\alpha + \\beta + \\gamma) x(t)" with "- \\alpha * x(t) - \\beta * x(t) - \\gamma * x(t)"
     c) for example, replace "(x(t) + y(t)) (z(t) + w(t))" with "x(t) * z(t) + x(t) * w(t) + y(t) * z(t) + y(t) * w(t)"
+17) Do not expand expressions of the form "(1 - a) * S(t)" where "a" is some constant parameter
+    a) for example, preserve "(1 - \\alpha) \\gamma I(t)" as "(1 - \\alpha) * \\gamma * I(t)"
 """

--- a/packages/gollm/common/prompts/latex_style_guide.py
+++ b/packages/gollm/common/prompts/latex_style_guide.py
@@ -21,10 +21,13 @@ LATEX_STYLE_GUIDE = """
     e) for example, replace "\\varsigma" with "\\sigma"
     f) for example, replace "\\varphi" with "\\phi"
 12) If equations are separated by punctuation (like comma, period, semicolon), do not include the punctuation in the LaTeX code.
-13) Rewrite expressions with negative exponents as explicit fractions
+13) Rewrite divisions to use "\\frac{{ }}{{ }}"
+    a) for example, replace "x ÷ y" with "\\frac{{x}}{{y}}"
+    b) for example, replace "x / y" with "\\frac{{x}}{{y}}"
+14) Rewrite expressions with negative exponents as explicit fractions
     a) for example, replace "N^{{-1}}" with "\\frac{{1}}{{N}}"
-14) Do not use square brackets "[ ]", curly braces "{ }", and angle brackets "< >" when grouping expressions
-15) Always expand expressions surrounded by parentheses using the order of mathematical operations
+15) Do not use square brackets "[ ]", curly braces "{ }", and angle brackets "< >" when grouping expressions
+16) Always expand expressions surrounded by parentheses using the order of mathematical operations
     a) for example, replace "x(t) (\\alpha y(t) + \\beta z(t))" with "\\alpha * x(t) * y(t) + \\beta * x(t) * z(t)"
     b) for example, replace "-(\\alpha + \\beta + \\gamma) x(t)" with "- \\alpha * x(t) - \\beta * x(t) - \\gamma * x(t)"
     c) for example, replace "(x(t) + y(t)) (z(t) + w(t))" with "x(t) * z(t) + x(t) * w(t) + y(t) * z(t) + y(t) * w(t)"

--- a/packages/gollm/common/prompts/latex_style_guide.py
+++ b/packages/gollm/common/prompts/latex_style_guide.py
@@ -10,7 +10,8 @@ LATEX_STYLE_GUIDE = """
     a) replace "b S(t) I(t)" with "b * S(t) * I(t)"
     b) replace "b \\ast S(t) \ast I(t)" with "b * S(t)"
     c) replace "b \\star S(t)" with "b * S(t)"
-    d) replace "(a b)S(t) with "a * b * S(t)"
+    d) replace "b \times S(t)" with "b * S(t)"
+    e) replace "(a b)S(t) with "a * b * S(t)"
 7) Avoid capital sigma and pi notations for summation and product
 8) Avoid non-ASCII characters when possible
 9) Avoid using homoglyphs
@@ -34,6 +35,16 @@ LATEX_STYLE_GUIDE = """
     a) for example, replace "x(t) (\\alpha y(t) + \\beta z(t))" with "\\alpha * x(t) * y(t) + \\beta * x(t) * z(t)"
     b) for example, replace "-(\\alpha + \\beta + \\gamma) x(t)" with "- \\alpha * x(t) - \\beta * x(t) - \\gamma * x(t)"
     c) for example, replace "(x(t) + y(t)) (z(t) + w(t))" with "x(t) * z(t) + x(t) * w(t) + y(t) * z(t) + y(t) * w(t)"
-17) Do not expand expressions of the form "(1 - a) * S(t)" where "a" is some constant parameter
-    a) for example, preserve "(1 - \\alpha) \\gamma I(t)" as "(1 - \\alpha) * \\gamma * I(t)"
+17) Do not expand expressions of the form "(1 - a * b)" where "a" and "b" are some constant parameters
+    a) these expressions represent branching ratios
+    b) for example, preserve "(1 - \\alpha) \\gamma I(t)" as "(1 - \\alpha) * \\gamma * I(t)"
+    c) for example, preserve "(1 - \\gamma_1 - \\gamma_2) I(t)" as "(1 - \\gamma_1 - \\gamma_2) * I(t)"
+18) Write named mathematical functions and operators using their corresponding LaTeX code
+    a) replace "sin(\\omega t)" with "\\sin{{(\\omega * t)}}"
+    b) replace "cos", "tan", "csc", "sec", "cot, sinh, cosh, tanh, csch, sech, coth" with "\\cos", "\\tan", "\\csc", "\\cot", "\\csc", "\\sinh", "\\cosh", "\\tanh", "\\csch", "\\coth", "\\csc" similarly
+    c) replace "ln(a x + b)" or "log(a x + b)" with "\\log {{(a * x + b)}}"
+    d) replace "log_2 (a x + b)" with "\\log_2 {{(a * x + b)}}"
+    e) replace "exp(-a t)", "e^(-a t)", or "\\mathrm{e}^(-a t)" with "\\exp{{(-a * t)}}"
+    f) replace "max(x(t))", "min(x(t))" with "\\max{{(x(t))}}", "\\min{{(x(t))}}"
+    g) for other named functions like "CustomFunc(a * x)", write "\operatorname{{CustomFunc}}{{(a * x)}}"
 """

--- a/packages/gollm/common/prompts/latex_style_guide.py
+++ b/packages/gollm/common/prompts/latex_style_guide.py
@@ -7,23 +7,26 @@ LATEX_STYLE_GUIDE = """
 4) Rewrite superscripts and LaTeX superscripts "^" that denote indices to subscripts using LaTeX "_"
 5) Replace any unicode subscripts with LaTeX subscripts using "_". Ensure that all characters used in the subscript are surrounded by a pair of curly brackets "{{...}}"
 6) Use " * " to denote multiplication
-    a) for example, replace "b S(t) I(t)" with "b * S(t) * I(t)"
-    b) for example, replace "(a b)I(t) with "a * b * I(t)"
+    a) replace "b S(t) I(t)" with "b * S(t) * I(t)"
+    b) replace "b \\ast S(t) \ast I(t)" with "b * S(t)"
+    c) replace "b \\star S(t)" with "b * S(t)"
+    d) replace "(a b)S(t) with "a * b * S(t)"
 7) Avoid capital sigma and pi notations for summation and product
 8) Avoid non-ASCII characters when possible
 9) Avoid using homoglyphs
 10) Avoid words or multi-character names for variables and names. Use camel case to express multi-word or multi-character names
 11) Replace any variant form of Greek letters to their main form when representing a variable or parameter 
-    a) for example, replace "\\varepsilon" with "\\epsilon"
-    b) for example, replace "\\vartheta" with "\\theta"
-    c) for example, replace "\\varpi" with "\\pi"
-    d) for example, replace "\\varrho" with "\\rho"
-    e) for example, replace "\\varsigma" with "\\sigma"
-    f) for example, replace "\\varphi" with "\\phi"
+    a) replace "\\varepsilon" with "\\epsilon"
+    b) replace "\\vartheta" with "\\theta"
+    c) replace "\\varpi" with "\\pi"
+    d) replace "\\varrho" with "\\rho"
+    e) replace "\\varsigma" with "\\sigma"
+    f) replace "\\varphi" with "\\phi"
 12) If equations are separated by punctuation (like comma, period, semicolon), do not include the punctuation in the LaTeX code.
 13) Rewrite divisions to use "\\frac{{ }}{{ }}"
-    a) for example, replace "x ÷ y" with "\\frac{{x}}{{y}}"
-    b) for example, replace "x / y" with "\\frac{{x}}{{y}}"
+    a) replace "x \div y" with "\\frac{{x}}{{y}}"
+    b) replace "x ÷ y" with "\\frac{{x}}{{y}}"
+    c) replace "x / y" with "\\frac{{x}}{{y}}"
 14) Rewrite expressions with negative exponents as explicit fractions
     a) for example, replace "N^{{-1}}" with "\\frac{{1}}{{N}}"
 15) Do not use square brackets "[ ]", curly braces "{ }", and angle brackets "< >" when grouping expressions

--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -1,5 +1,5 @@
 LATEX_TO_SYMPY_PROMPT="""
-You are a helpful assistant who is an expert in writing mathematical expressions in LaTeX code and the Python package SymPy:
+You are a helpful assistant who is an expert in writing mathematical expressions in LaTeX code and using the Python package SymPy:
     a) follow SymPy's best practice
     b) avoid the pitfalls in SymPy documentation
     c) focus on quality over quantity and write Python 3 code that runs without error

--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -3,33 +3,38 @@ You are a helpful assistant who is an expert in writing mathematical expressions
 
 Here is an example input LaTeX
 [
-    "\\frac{{d S(t)}}{{d t}} = -beta * S(t) * I(t) * \\frac{{1}}{{N}} + b - m * S(t)",
+    "\\frac{{d S(t)}}{{d t}} = -\\beta * S(t) * I(t) * \\frac{{1}}{{N}} + b - \\mu * S(t)",
     "\\frac{{d I(t)}}{{d t}} = \\beta * S(t) * I(t) * \\frac{{1}}{{N}} - \\gamma * I(t)",
-    "\\frac{{d R(t)}}{{d t}} = \\gamma * I(t) + \\lambda",
-    "N = S(t) + I(t) + R(t)"
+    "\\frac{{d R(t)}}{{d t}} = (1 - \\lambda) * \\gamma * I(t)",
+    "\\frac{{d D(t)}}{{d t}} = \\lambda * \\gamma * I(t)"
+    "N = S(t) + I(t) + R(t) + D(t)"
 ]
 
 
 You should return this output in SymPy:
 ```
 import sympy
+from sympy import _clash
 
 # Define time variable
 t = sympy.symbols("t")
 
-# Define variables with time derivative to be time-dependent functions
-S, I, R = sympy.symbols("S I R", cls=sympy.Function)
-
 # Define all parameters with explicit time dependence
-beta, mu, gamma, lambd, N = sympy.symbols("beta mu gamma lambd N")
+beta, N, b, mu, gamma, lambda_, N = sympy.symbols("beta N b mu gamma lambda")
 
-# Define the equations without time-derivative on the left hand side
-N = S(t) + I(t) + R(t)
+# For all equations with time derivative on the left hand side,
+# declare the left hand side quantity as SymPy functions
+S, I, R, D = sympy.symbols("S I R D", cls = sympy.Function)
+
+# For all equations without time derivative on the left hand side, 
+# declare the quantity on the left hand side and assign the right hand side expression to it
+N = S(t) + I(t) + R(t) + D(t)
 
 equation_output = [
-    sympy.Eq(S(t).diff(t), (-beta * S(t) * I(t) / N + mu).expand()),
-    sympy.Eq(I(t).diff(t), (beta * S(t) * I(t) / N - gamma * I(t)).expand()),
-    sympy.Eq(R(t).diff(t), (gamma * I(t) + lambd).expand())
+    sympy.Eq(S(t).diff(t), -beta * S(t) * I(t) / N + b - mu * S(t))),
+    sympy.Eq(I(t).diff(t), beta * S(t) * I(t) / N - gamma * I(t)),
+    sympy.Eq(R(t).diff(t), (1 - lambda_) * gamma * I(t)),
+    sympy.Eq(D(t).diff(t), lambda_ * gamma * I(t))
 ]
 ```
 

--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -1,5 +1,9 @@
 LATEX_TO_SYMPY_PROMPT="""
-You are a helpful assistant who is an expert in writing mathematical expressions in LaTeX code and the Python package SymPy.
+You are a helpful assistant who is an expert in writing mathematical expressions in LaTeX code and the Python package SymPy:
+    a) follow SymPy's best practice
+    b) avoid the pitfalls in SymPy documentation
+    c) focus on quality over quantity and write Python 3 code that runs without error
+    d) when translating named functions in LaTeX to SymPy, use SymPy's built-in functions such as `sympy.sin`, `sympy.exp`, `sympy.Abs`, `sympy.log` if they exist
 
 Here is an example input LaTeX
 [


### PR DESCRIPTION
# Description

- [x] Update latex-to-sympy instructions to remove `.expand()` (prevents loss of `(1 - p)` factors)
- [x] Update LaTeX style guide to retain all factors of the form `(1 - p)` but expand all others such as `b * S(t) * (I(t) + A(t) + H(t))`
- [x] Update style guide to handle named functions like `sin, cos, exp, log`
- [x] Add guardrails to the latex-to-sympy instructions

Resolves #6601 
