### PR TITLE
remove custom formatter in vegalite

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/VegaChart.vue
+++ b/packages/client/hmi-client/src/components/widgets/VegaChart.vue
@@ -42,6 +42,7 @@ import { expressionFunctions } from '@/services/charts';
 
 // This config is default for all charts, but can be overridden by individual chart spec
 const defaultChartConfig: Partial<Config> = {
+	/* commented out Feb 2025, this is disrupting Vegalite export
 	customFormatTypes: true,
 	numberFormatType: 'chartNumberFormatter',
 	numberFormat: 'chartNumberFormatter',
@@ -49,6 +50,7 @@ const defaultChartConfig: Partial<Config> = {
 		numberFormat: 'tooltipFormatter',
 		numberFormatType: 'tooltipFormatter'
 	},
+	*/
 	axis: {
 		labelFontSize: 12
 	}


### PR DESCRIPTION
### Summary
It seems like we are not really using the custom formatters specified in the vegalite global config, and they disrupt the chart-export because the custom code fragments are not exported. I have comment this out for now.


### Testing
You should be able to click on the hamburger-option (...) and select "open in vega editor", and you should be able to export and interact with the chart outside of Terarium. You may need to refresh once or twice, I think the volume of data we usually have in simulate makes the editor a bit chunky, but it should show up without errors.


<img width="919" alt="image" src="https://github.com/user-attachments/assets/4b49bc75-4ad1-4cd2-96c9-c6c62270f755" />
