### PR TITLE
transition table: add controllers, remove concepts

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -7,9 +7,10 @@
 				<tera-input-text v-else placeholder="Add a name" v-model="nameText" />
 			</span>
 			<span class="unit" :class="{ time: isTimePart }">
-				<template v-if="input || output">
-					<span><label>Input:</label> {{ input }}</span>
-					<span><label>Output:</label> {{ output }}</span>
+				<template v-if="subject || outcome">
+					<span><label>Subject:</label> {{ subject }}</span>
+					<span><label>Outcome:</label> {{ outcome }}</span>
+					<span v-if="controllers"><label>Controllers:</label> {{ controllers }}</span>
 				</template>
 				<!--amr_to_mmt doesn't like unit expressions with spaces, removing them here before they are saved to the amr-->
 				<template v-else-if="showUnit">
@@ -79,12 +80,12 @@ const props = defineProps<{
 	description?: string;
 	name?: string;
 	unitExpression?: string;
-	templateId?: string;
 	id?: string;
 	grounding?: any;
 	expression?: string;
-	input?: any;
-	output?: any;
+	subject?: string;
+	outcome?: string;
+	controllers?: string;
 	featureConfig: FeatureConfig;
 	partType: PartType;
 }>();

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -45,7 +45,7 @@
 					:label="showDescription ? 'Hide description' : descriptionText ? 'Show description' : 'Add description'"
 					@click="showDescription = !showDescription"
 				/>
-				<aside class="concept">
+				<aside class="concept" v-if="!isTransitionPart">
 					<tera-concept v-model="grounding" :is-preview="featureConfig.isPreview" />
 				</aside>
 			</template>
@@ -128,6 +128,7 @@ const showUnit = computed(
 );
 
 const isTimePart = props.partType === PartType.TIME;
+const isTransitionPart = props.partType === PartType.TRANSITION;
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -8,9 +8,9 @@
 			</span>
 			<span class="unit" :class="{ time: isTimePart }">
 				<template v-if="subject || outcome">
-					<span><label>Subject:</label> {{ subject }}</span>
-					<span><label>Outcome:</label> {{ outcome }}</span>
-					<span v-if="controllers"><label>Controllers:</label> {{ controllers }}</span>
+					<span><label>Subject:</label> {{ subject !== '' ? subject : 'n/a' }}</span>
+					<span><label>&nbsp;Outcome:</label> {{ outcome !== '' ? outcome : 'n/a' }}</span>
+					<span v-if="controllers"><label>&nbsp;Controllers:</label> {{ controllers }}</span>
 				</template>
 				<!--amr_to_mmt doesn't like unit expressions with spaces, removing them here before they are saved to the amr-->
 				<template v-else-if="showUnit">

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
@@ -123,9 +123,9 @@
 								:name="child.name"
 								:id="child.id"
 								:grounding="child.grounding"
-								:templateId="child.templateId"
-								:input="child.input"
-								:output="child.output"
+								:subject="child.subject"
+								:outcome="child.outcome"
+								:controllers="child.controllers"
 								:unitExpression="child.unitExpression"
 								:expression="child.expression"
 								:feature-config="featureConfig"
@@ -152,9 +152,9 @@
 				:name="base.name"
 				:id="base.id"
 				:grounding="base.grounding"
-				:templateId="base.templateId"
-				:input="base.input"
-				:output="base.output"
+				:subject="base.subject"
+				:outcome="base.outcome"
+				:controllers="base.controllers"
 				:unitExpression="base.unitExpression"
 				:expression="base.expression"
 				:feature-config="featureConfig"
@@ -177,7 +177,7 @@
 <script setup lang="ts">
 import { isEmpty } from 'lodash';
 import { ref, computed } from 'vue';
-import type { ModelPartItem } from '@/types/Model';
+import type { ModelPartItem, ModelPartItemTree } from '@/types/Model';
 import type { DKG } from '@/types/Types';
 import { searchCuriesEntities } from '@/services/concept';
 import TeraModelPartEntry from '@/components/model/model-parts/tera-model-part-entry.vue';
@@ -189,7 +189,7 @@ import Paginator from 'primevue/paginator';
 import { PartType } from '@/model-representation/service';
 
 const props = defineProps<{
-	items: any[];
+	items: ModelPartItemTree[];
 	featureConfig: FeatureConfig;
 	collapsedItems?: Map<string, string[]>;
 	showMatrix?: boolean;
@@ -220,8 +220,7 @@ const filteredItems = computed(() => {
 	return props.items
 		.map(({ base, children, isParent }) => {
 			const filteredChildren = children.filter((child) => child.id.toLowerCase().includes(filterText));
-			const baseMatches =
-				base.id.toLowerCase().includes(filterText) || base.templateId?.toLowerCase().includes(filterText);
+			const baseMatches = base.id.toLowerCase().includes(filterText);
 			const childrenMatch = filteredChildren.length > 0;
 			if (baseMatches || childrenMatch) {
 				return { base, children: filteredChildren, isParent };

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
@@ -30,7 +30,7 @@
 							/>
 						</template>
 						<Button v-if="showMatrix" label="Open matrix" text size="small" @click="$emit('open-matrix', base.id)" />
-						<template v-if="!featureConfig.isPreview">
+						<template v-if="!featureConfig.isPreview && partType !== PartType.TRANSITION">
 							<Button
 								:disabled="getEditingState(index).isEditingChildrenConcepts"
 								@click="getEditingState(index).isEditingChildrenConcepts = true"

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -174,8 +174,8 @@ const createTransitionParts = () => {
 	const extract = (t: MiraTemplate): ModelPartItem => ({
 		id: t.name,
 		name: t.name,
-		subject: t.subject.name,
-		outcome: t.outcome.name,
+		subject: t.subject ? t.subject.name : '',
+		outcome: t.outcome ? t.outcome.name : '',
 		controllers: getControllerNames(t).join(', '),
 		expression: t.rate_law
 	});

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -119,6 +119,7 @@ import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import { createPartsList, createObservablesList, createTimeList, PartType } from '@/model-representation/service';
 import TeraStratifiedMatrixModal from '@/components/model/petrinet/model-configurations/tera-stratified-matrix-modal.vue';
 import { ModelPartItem, ModelPartItemTree, StratifiedMatrix } from '@/types/Model';
+import { getControllerNames } from '@/model-representation/mira/mira-util';
 
 const props = defineProps<{
 	model: Model;
@@ -170,22 +171,12 @@ const transitions = computed<Transition[]>(() =>
 );
 
 const createTransitionParts = () => {
-	const getControlellers = (t: MiraTemplate) => {
-		if (t.controllers) {
-			return t.controllers.map((d) => d.name).join(', ');
-		}
-		if (t.controller) {
-			return t.controller.name;
-		}
-		return '';
-	};
-
 	const extract = (t: MiraTemplate): ModelPartItem => ({
 		id: t.name,
 		name: t.name,
 		subject: t.subject.name,
 		outcome: t.outcome.name,
-		controllers: getControlellers(t),
+		controllers: getControllerNames(t).join(', '),
 		expression: t.rate_law
 	});
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -118,7 +118,7 @@ import type { FeatureConfig } from '@/types/common';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import { createPartsList, createObservablesList, createTimeList, PartType } from '@/model-representation/service';
 import TeraStratifiedMatrixModal from '@/components/model/petrinet/model-configurations/tera-stratified-matrix-modal.vue';
-import { ModelPartItem, StratifiedMatrix } from '@/types/Model';
+import { ModelPartItem, ModelPartItemTree, StratifiedMatrix } from '@/types/Model';
 
 const props = defineProps<{
 	model: Model;
@@ -126,12 +126,6 @@ const props = defineProps<{
 	mmtParams: MiraTemplateParams;
 	featureConfig: FeatureConfig;
 }>();
-
-interface ModelPartItemTree {
-	base: ModelPartItem;
-	children: ModelPartItem[];
-	isParent: boolean;
-}
 
 const emit = defineEmits(['update-state', 'update-parameter', 'update-observable', 'update-transition', 'update-time']);
 
@@ -176,11 +170,22 @@ const transitions = computed<Transition[]>(() =>
 );
 
 const createTransitionParts = () => {
+	const getControlellers = (t: MiraTemplate) => {
+		if (t.controllers) {
+			return t.controllers.map((d) => d.name).join(', ');
+		}
+		if (t.controller) {
+			return t.controller.name;
+		}
+		return '';
+	};
+
 	const extract = (t: MiraTemplate): ModelPartItem => ({
 		id: t.name,
 		name: t.name,
-		input: t.subject.name,
-		output: t.outcome.name,
+		subject: t.subject.name,
+		outcome: t.outcome.name,
+		controllers: getControlellers(t),
 		expression: t.rate_law
 	});
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -107,7 +107,7 @@
 
 <script setup lang="ts">
 import type { Model, Transition, State } from '@/types/Types';
-import { isEmpty, isPlainObject } from 'lodash';
+import { isEmpty } from 'lodash';
 import Accordion from 'primevue/accordion';
 import AccordionTab from 'primevue/accordiontab';
 import { computed, ref, watch } from 'vue';
@@ -127,6 +127,12 @@ const props = defineProps<{
 	featureConfig: FeatureConfig;
 }>();
 
+interface ModelPartItemTree {
+	base: ModelPartItem;
+	children: ModelPartItem[];
+	isParent: boolean;
+}
+
 const emit = defineEmits(['update-state', 'update-parameter', 'update-observable', 'update-transition', 'update-time']);
 
 // Keep track of active indexes using ref
@@ -142,11 +148,7 @@ const time = computed(() => (props.model?.semantics?.ode?.time ? [props.model?.s
 
 const collapsedInitials = collapseInitials(props.mmt);
 const states = computed<State[]>(() => props.model?.model?.states ?? []);
-let stateList: {
-	base: ModelPartItem;
-	children: ModelPartItem[];
-	isParent: boolean;
-}[] = createPartsList(collapsedInitials, props.model, PartType.STATE);
+let stateList: ModelPartItemTree[] = createPartsList(collapsedInitials, props.model, PartType.STATE);
 
 watch(
 	() => props.model?.model?.states,
@@ -156,11 +158,7 @@ watch(
 );
 
 const collapsedParameters = collapseParameters(props.mmt, props.mmtParams);
-let parameterList: {
-	base: ModelPartItem;
-	children: ModelPartItem[];
-	isParent: boolean;
-}[] = createPartsList(collapsedParameters, props.model, PartType.PARAMETER);
+let parameterList: ModelPartItemTree[] = createPartsList(collapsedParameters, props.model, PartType.PARAMETER);
 
 watch(
 	() => props.model.semantics?.ode?.parameters,
@@ -205,20 +203,12 @@ const createTransitionParts = () => {
 	});
 };
 
-const transitionsList: {
-	base: ModelPartItem;
-	children: ModelPartItem[];
-	isParent: boolean;
-}[] = createTransitionParts();
+const transitionsList: ModelPartItemTree[] = createTransitionParts();
 
 const parameterMatrixModalId = ref('');
 const transitionMatrixModalId = ref('');
 const observablesList = computed(() => createObservablesList(observables.value));
-const timeList: {
-	base: ModelPartItem;
-	children: ModelPartItem[];
-	isParent: boolean;
-}[] = createTimeList(time.value);
+const timeList: ModelPartItemTree[] = createTimeList(time.value);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
+++ b/packages/client/hmi-client/src/model-representation/mira/mira-util.ts
@@ -1,5 +1,15 @@
 import { MiraTemplate, MiraMatrix, TemplateSummary, MiraMatrixEntry } from './mira-common';
 
+export const getControllerNames = (t: MiraTemplate) => {
+	if (t.controllers) {
+		return t.controllers.map((d) => d.name);
+	}
+	if (t.controller) {
+		return [t.controller.name];
+	}
+	return [];
+};
+
 export const removeModifiers = (v: string, context: { [key: string]: string }, scrubbingKeys: string[]) => {
 	let result = v;
 	scrubbingKeys.forEach((key) => {
@@ -18,12 +28,9 @@ export const extractConceptNames = (templates: MiraTemplate[], key: string) => {
 	}
 	if (key === 'controllers') {
 		templates.forEach((template) => {
-			if (template.controller) {
-				names.push(template.controller.name);
-			}
-			if (template.controllers && template.controllers.length > 0) {
-				const list = template.controllers.map((d) => d.name).sort();
-				names.push(list.join('-'));
+			const controllerNames = getControllerNames(template).sort();
+			if (controllerNames.length > 0) {
+				names.push(controllerNames.join('-'));
 			}
 		});
 	}

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -371,7 +371,6 @@ export enum PartType {
 
 // FIXME: should refactor so typing is explicit and clear
 // Note "model" is both an AMR model, or it can be a list of transition templates
-// FIXME: Nelson recommended we show subject/outcome/controllers instead of input/output
 export function createPartsList(parts, model, partType) {
 	return Array.from(parts.keys()).map((id) => {
 		const childTargets = parts.get(id) ?? [];

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -405,21 +405,12 @@ export function createPartsList(parts, model, partType) {
 				};
 				if (partType === PartType.STATE || partType === PartType.PARAMETER) {
 					returnObj.unitExpression = t.units?.expression;
-				} else if (partType === PartType.TRANSITION) {
-					returnObj.expression = t.expression;
-					returnObj.input = t.input.join(', ');
-					returnObj.output = t.output.join(', ');
 				}
 				return returnObj;
 			})
 			.filter(Boolean) as ModelPartItem[];
 
-		const basePart: any = types.find((t) => {
-			if (partType === PartType.TRANSITION) {
-				return t.id === childTargets[0];
-			}
-			return t.id === id;
-		});
+		const basePart: any = types.find((t) => t.id === id);
 		const base: ModelPartItem =
 			isParent || !basePart
 				? { id: `${id}` }
@@ -430,15 +421,6 @@ export function createPartsList(parts, model, partType) {
 						grounding: basePart.grounding,
 						unitExpression: basePart.units?.expression
 					};
-		if (partType === PartType.TRANSITION) {
-			base.templateId = `${id}`;
-			if (basePart) {
-				base.expression = basePart.expression;
-				base.input = basePart.input.join(', ');
-				base.output = basePart.output.join(', ');
-			}
-		}
-
 		return { base, children, isParent };
 	});
 }

--- a/packages/client/hmi-client/src/types/Model.ts
+++ b/packages/client/hmi-client/src/types/Model.ts
@@ -10,11 +10,18 @@ export type ModelPartItem = {
 	unitExpression?: string;
 	expression?: string;
 	expression_mathml?: string;
+
 	// Transition/rate
-	templateId?: string;
-	input?: string;
-	output?: string;
+	subject?: string;
+	outcome?: string;
+	controllers?: string;
 };
+
+export interface ModelPartItemTree {
+	base: ModelPartItem;
+	children: ModelPartItem[];
+	isParent: boolean;
+}
 
 export enum StratifiedMatrix {
 	Initials = 'initials',


### PR DESCRIPTION
Closes: https://github.com/DARPA-ASKEM/terarium/issues/6445

### Summary
- Remove concept search/entries as transition concepts do not exist
- Split **input/output** => **subject/output/controllers** per Nelson request
- Start to split apart "createPartsList(...)", this function seemingly treats state/transition/parameter as if they are the same object, which they are not. It makes it difficult to modify/tweak things. 
- Minor clean up in tera-model-part-entry for unused props

### Testing
Where models are displayed:
- Input/Output becomes Subject/Outcome/Controllers in transition table
- No more concepts in the transition table

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/fa0a783f-670c-4dbf-8089-a98f9b4b5d27" />
