### PR TITLE
model sanity check: check for closed system

### DIFF
--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -354,6 +354,12 @@ export function checkPetrinetAMR(amr: Model) {
 		if (rateSet.has(rate?.target as string)) {
 			results.push({ type: 'error', content: `rate (${rate?.target}) has duplicate` });
 		}
+
+		// Check if the system is closed (constant population)
+		if (transition.input.length !== transition.output.length) {
+			results.push({ type: 'warn', content: `${transition.id} does not conserve input/output` });
+		}
+
 		transitionSet.add(transition.id);
 		rateSet.add(rate?.target as string);
 	});


### PR DESCRIPTION
### Summary
Add a check to see if the system is closed (preserves constant population). This is not an error but something to be called out for, as it can lead to overflow/underflow in simulations. 

This is potentially part of the suite of checks to be deployed into the operators.

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/23d33d18-dc6f-40f1-af74-d2548b8ec2c4" />



### Testing
Can test with this model 
[no-mass.json](https://github.com/user-attachments/files/18907661/no-mass.json)

and pasting the content into http://localhost:8080/amr-petri-test

