### PR TITLE
fix issue with indexing across pages

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/intervention-policy/tera-intervention-policy-drilldown.vue
@@ -78,19 +78,20 @@
 							firstRow,
 							firstRow + MAX_NUMBER_OF_ROWS
 						)"
-						:key="index"
-						@click="selectInterventionPolicy(intervention, index)"
+						:key="firstRow + index"
+						@click="selectInterventionPolicy(intervention, firstRow + index)"
 					>
 						<tera-intervention-card
 							class="intervention"
 							:class="{
-								selected: selectedIntervention?.name === intervention?.name && selectedIntervention?.index === index
+								selected:
+									selectedIntervention?.name === intervention?.name && selectedIntervention?.index === firstRow + index
 							}"
 							:intervention="intervention"
 							:parameterOptions="parameterOptions"
 							:stateOptions="stateOptions"
-							@update="onUpdateInterventionCard($event, index)"
-							@delete="onDeleteIntervention(index)"
+							@update="onUpdateInterventionCard($event, firstRow + index)"
+							@delete="onDeleteIntervention(firstRow + index)"
 						/>
 					</li>
 				</ul>


### PR DESCRIPTION
Closes https://github.com/DARPA-ASKEM/terarium/issues/6621

### Summary
Fix intervention indexing due to pagination wrap-around


### Testing
In intervention-policy operator, add 9 or more interventions , eg:
- time=1, beta=1
- time=2, beta=2
- time=3, beta=3
- ...
- time=10, beta=10

Check that editing the 9th or 10th intervention does not affect the first page. Check that intervention can be saved.