### PR TITLE
clean up redundant prop collapsed-items

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part.vue
@@ -191,7 +191,6 @@ import { PartType } from '@/model-representation/service';
 const props = defineProps<{
 	items: ModelPartItemTree[];
 	featureConfig: FeatureConfig;
-	collapsedItems?: Map<string, string[]>;
 	showMatrix?: boolean;
 	partType: PartType;
 	filter?: string;
@@ -258,9 +257,10 @@ function getEditingState(filteredIndex: number) {
 }
 
 function updateAllChildren(base: string, key: string, value: string) {
-	if (isEmpty(value) || !props.collapsedItems) return;
-	const ids = props.collapsedItems.get(base);
-	ids?.forEach((id) => emit('update-item', { id, key, value }));
+	if (isEmpty(value)) return;
+
+	const ids = props.items.find((d) => d.base.id === base)!.children.map((d) => d.id);
+	ids.forEach((id) => emit('update-item', { id, key, value }));
 }
 </script>
 

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -9,7 +9,6 @@
 				v-if="!isEmpty(mmt.initials)"
 				:part-type="PartType.STATE"
 				:items="stateList"
-				:collapsed-items="collapsedInitials"
 				:feature-config="featureConfig"
 				:filter="statesFilter"
 				@update-item="emit('update-state', $event)"
@@ -29,7 +28,6 @@
 				v-if="!isEmpty(mmt.parameters)"
 				:part-type="PartType.PARAMETER"
 				:items="parameterList"
-				:collapsed-items="collapsedParameters"
 				:feature-config="featureConfig"
 				show-matrix
 				:filter="parametersFilter"


### PR DESCRIPTION
### Summary
Simplify props for tera-model-part component, we are seemingly passing in redundant data structures

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/fa574e74-a4d2-4237-97a9-ae8faf6afc0e"/>


### Testing
Find a stratified model, the operations `add xyz to all children` should work, eg update all state units for a stratified state V.