### PR TITLE
modify-run-task-sync-behaviour

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -45,6 +45,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.modelparts.Model
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.DKGService;
@@ -187,6 +188,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -300,6 +305,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -432,6 +441,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -543,6 +556,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -660,6 +677,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -756,6 +777,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -829,6 +854,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input: {}", e.getMessage());
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -929,6 +958,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -1017,6 +1050,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -1115,6 +1152,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));
@@ -1197,6 +1238,10 @@ public class GoLLMController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTask(mode, req);
+			if (mode == TaskMode.SYNC && resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input: {}", e.getMessage());
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.gollm.json-processing"));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -34,6 +34,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.ClientEventService;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
@@ -96,6 +97,10 @@ public class KnowledgeController {
 
 		try {
 			cleanupResp = taskService.runTask(TaskMode.SYNC, cleanupReq);
+			if (cleanupResp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", cleanupResp.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, cleanupResp.getStderr());
+			}
 			// Get the equations from the cleanup response
 			if (cleanupResp != null && cleanupResp.getOutput() != null) {
 				try {
@@ -186,6 +191,10 @@ public class KnowledgeController {
 		TaskResponse cleanupResp = null;
 		try {
 			cleanupResp = taskService.runTask(TaskMode.SYNC, cleanupReq);
+			if (cleanupResp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task failed", cleanupResp.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, cleanupResp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.warn("Unable to clean-up equations due to a JsonProcessingException. Reverting to original equations.", e);
 		} catch (final TimeoutException e) {
@@ -222,12 +231,21 @@ public class KnowledgeController {
 			latexToSympyRequest = createLatexToSympyTask(equationsReq);
 			latexToSympyResponse = taskService.runTaskSync(latexToSympyRequest);
 
+			if (latexToSympyResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", latexToSympyResponse.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, latexToSympyResponse.getStderr());
+			}
+
 			// 2. hand off
 			final String code = extractCodeFromLatexToSympy(latexToSympyResponse);
 
 			// 3. sympy code string to amr json
 			sympyToAMRRequest = createSympyToAMRTask(code);
 			sympyToAMRResponse = taskService.runTaskSync(sympyToAMRRequest);
+			if (sympyToAMRResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", sympyToAMRResponse.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, sympyToAMRResponse.getStderr());
+			}
 
 			final JsonNode taskResponseJSON = mapper.readValue(sympyToAMRResponse.getOutput(), JsonNode.class);
 			final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
@@ -344,8 +362,15 @@ public class KnowledgeController {
 
 		try {
 			sympyToAMRRequest = createSympyToAMRTask(code.getCode());
-			sympyToAMRResponse = taskService.runTaskSyncDebug(sympyToAMRRequest);
+			sympyToAMRResponse = taskService.runTaskSync(sympyToAMRRequest);
 			response = mapper.readValue(sympyToAMRResponse.getOutput(), JsonNode.class);
+
+			if (sympyToAMRResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", sympyToAMRResponse.getStderr());
+				ObjectNode objectNode = mapper.createObjectNode();
+				objectNode.put("error", sympyToAMRResponse.getStderr());
+				return ResponseEntity.ok().body(objectNode);
+			}
 			return ResponseEntity.ok().body(response);
 		} catch (final TimeoutException e) {
 			log.warn("Timeout while waiting for task response", e);
@@ -358,9 +383,7 @@ public class KnowledgeController {
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.execution-failure"));
 		} catch (final Exception e) {
 			log.error("Unexpected error", e);
-			ObjectNode objectNode = mapper.createObjectNode();
-			objectNode.put("error", sympyToAMRResponse.getStderr());
-			return ResponseEntity.ok().body(objectNode);
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, messages.get("generic.io-error.read"));
 		}
 	}
 
@@ -399,6 +422,10 @@ public class KnowledgeController {
 			JsonNode temp = mapper.readValue(latex, JsonNode.class);
 			latexToSympyRequest = createLatexToSympyTask(temp);
 			latexToSympyResponse = taskService.runTaskSync(latexToSympyRequest);
+			if (latexToSympyResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", latexToSympyResponse.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, latexToSympyResponse.getStderr());
+			}
 			code = extractCodeFromLatexToSympy(latexToSympyResponse);
 		} catch (final TimeoutException e) {
 			log.warn("Timeout while waiting for task response", e);
@@ -429,6 +456,10 @@ public class KnowledgeController {
 		try {
 			sympyToAMRRequest = createSympyToAMRTask(code);
 			sympyToAMRResponse = taskService.runTaskSync(sympyToAMRRequest);
+			if (sympyToAMRResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", sympyToAMRResponse.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, sympyToAMRResponse.getStderr());
+			}
 			response = mapper.readValue(sympyToAMRResponse.getOutput(), JsonNode.class);
 			return ResponseEntity.ok().body(response);
 		} catch (final TimeoutException e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/mira/MiraController.java
@@ -38,6 +38,7 @@ import software.uncharted.terarium.hmiserver.models.mira.EntitySimilarityResult;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.proxies.mira.MIRAProxy;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
@@ -189,6 +190,10 @@ public class MiraController {
 		final TaskResponse taskResponse;
 		try {
 			taskResponse = taskService.runTaskSync(taskRequest);
+			if (taskResponse.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", taskResponse.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, taskResponse.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.json-processing"));
@@ -248,6 +253,10 @@ public class MiraController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.json-processing"));
@@ -308,6 +317,10 @@ public class MiraController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.json-processing"));
@@ -349,10 +362,13 @@ public class MiraController {
 			@ApiResponse(responseCode = "500", description = "There was an issue dispatching the request", content = @Content)
 		}
 	)
-	public ResponseEntity<Model> convertAndCreateModel(@RequestBody final ModelConversionRequest conversionRequest) {
+	public ResponseEntity<Model> convertAndCreateModel(
+		@RequestBody final ModelConversionRequest conversionRequest,
+		@RequestParam(name = "project-id", required = false) final UUID projectId
+	) {
 		final Schema.Permission permission = projectService.checkPermissionCanRead(
 			currentUserService.get().getId(),
-			conversionRequest.getProjectId()
+			projectId
 		);
 
 		final Optional<Artifact> artifact = artifactService.getAsset(conversionRequest.artifactId, permission);
@@ -382,7 +398,7 @@ public class MiraController {
 		}
 
 		final ConversionAdditionalProperties additionalProperties = new ConversionAdditionalProperties();
-		additionalProperties.setProjectId(conversionRequest.projectId);
+		additionalProperties.setProjectId(projectId);
 		additionalProperties.setFileName(filename);
 
 		final TaskRequest req = new TaskRequest();
@@ -412,6 +428,10 @@ public class MiraController {
 		final TaskResponse resp;
 		try {
 			resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				log.error("Task Failed", resp.getStderr());
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, resp.getStderr());
+			}
 		} catch (final JsonProcessingException e) {
 			log.error("Unable to serialize input", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.json-processing"));
@@ -434,7 +454,7 @@ public class MiraController {
 				model,
 				new ModelConfigurationUpdate()
 			);
-			modelConfigurationService.createAsset(modelConfiguration, conversionRequest.projectId, permission);
+			modelConfigurationService.createAsset(modelConfiguration, projectId, permission);
 		} catch (final IOException e) {
 			log.error("Unable to deserialize output", e);
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("generic.io-error.read"));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/ExtractionService.java
@@ -43,6 +43,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Progr
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationGroupInstance;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationService;
@@ -476,6 +477,9 @@ public class ExtractionService {
 
 		return executor.submit(() -> {
 			final TaskResponse resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				throw new RuntimeException("Equation extraction failed" + resp.getStderr());
+			}
 
 			final byte[] outputBytes = resp.getOutput();
 			final ExtractEquationsResponseHandler.ResponseOutput output = objectMapper.readValue(
@@ -531,6 +535,9 @@ public class ExtractionService {
 
 		return executor.submit(() -> {
 			final TaskResponse resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				throw new RuntimeException("Text extraction failed" + resp.getStderr());
+			}
 
 			final byte[] outputBytes = resp.getOutput();
 			final ExtractTextResponseHandler.ResponseOutput output = objectMapper.readValue(
@@ -571,6 +578,9 @@ public class ExtractionService {
 
 		return executor.submit(() -> {
 			final TaskResponse resp = taskService.runTaskSync(req);
+			if (resp.getStatus() != TaskStatus.SUCCESS) {
+				throw new RuntimeException("Table extraction failed" + resp.getStderr());
+			}
 
 			final byte[] outputBytes = resp.getOutput();
 			final ExtractTablesResponseHandler.ResponseOutput output = objectMapper.readValue(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/gollm/DatasetStatistics.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/gollm/DatasetStatistics.java
@@ -23,6 +23,7 @@ import software.uncharted.terarium.hmiserver.models.dataservice.dataset.DatasetC
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
 import software.uncharted.terarium.hmiserver.utils.Messages;
 
@@ -88,6 +89,9 @@ public class DatasetStatistics {
 
 		// Get the response from the Gollm service
 		final TaskResponse taskResponse = taskService.runTaskSync(taskRequest);
+		if (taskResponse.getStatus() != TaskStatus.SUCCESS) {
+			throw new RuntimeException("Task failed: " + taskResponse.getStderr());
+		}
 		final byte[] outputBytes = taskResponse.getOutput();
 		final JsonNode output = objectMapper.readTree(outputBytes);
 		final DatasetStatisticsResponse response = objectMapper.convertValue(output, DatasetStatisticsResponse.class);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/gollm/EmbeddingService.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/service/gollm/EmbeddingService.java
@@ -21,6 +21,7 @@ import software.uncharted.terarium.hmiserver.models.TerariumAssetEmbeddings.Embe
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
+import software.uncharted.terarium.hmiserver.models.task.TaskStatus;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
 
@@ -75,6 +76,9 @@ public class EmbeddingService {
 		}
 
 		final TaskResponse resp = taskService.runTaskSync(req);
+		if (resp.getStatus() != TaskStatus.SUCCESS) {
+			throw new RuntimeException("Task failed: " + resp.getStderr());
+		}
 
 		final byte[] outputBytes = resp.getOutput();
 		final JsonNode output = objectMapper.readTree(outputBytes);
@@ -122,6 +126,9 @@ public class EmbeddingService {
 		}
 
 		final TaskResponse resp = taskService.runTaskSync(req);
+		if (resp.getStatus() != TaskStatus.SUCCESS) {
+			throw new RuntimeException("Task failed: " + resp.getStderr());
+		}
 
 		final byte[] outputBytes = resp.getOutput();
 		final JsonNode output = objectMapper.readTree(outputBytes);


### PR DESCRIPTION
# Description

* Modifying the behaviour of the runTaskSync function such that we now have to explicitly handle the task failures and how we want to handle them rather than generically throwing a RuntimeException.  This can either mean bubbling up the error to the front end or simply just logging the error in the backend.
