### PR TITLE
[SUBTASK]: 2. Modify pantera auth to use rebac and replace auth

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/annotations/HasProjectAccess.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/annotations/HasProjectAccess.java
@@ -33,7 +33,7 @@ import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HasProjectAccess {
-	String value() default "#id";
+	String value() default "#projectId";
 
 	Schema.Permission level() default Schema.Permission.READ;
 //TODO: Migrate this from Pantera or make decision to use our existing Schema.Permission. Update comment if needed. -dvince

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/AssetController.java
@@ -21,7 +21,6 @@ import software.uncharted.terarium.hmiserver.models.dataservice.project.ProjectA
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
-import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
 @RequestMapping("/assets")
 @RestController

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ChartAnnotationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ChartAnnotationController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.ClientEvent;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ChartAnnotation;
@@ -29,11 +30,8 @@ import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Contributor;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.ClientEventService;
-import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.ChartAnnotationService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectPermissionsService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.utils.rebac.ReBACService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 import software.uncharted.terarium.hmiserver.utils.rebac.askem.RebacProject;
@@ -46,12 +44,6 @@ import software.uncharted.terarium.hmiserver.utils.rebac.askem.RebacProject;
 public class ChartAnnotationController {
 
 	final ChartAnnotationService chartAnnotationService;
-
-	final ProjectAssetService projectAssetService;
-
-	final ProjectService projectService;
-
-	final CurrentUserService currentUserService;
 
 	final ReBACService reBACService;
 
@@ -67,6 +59,7 @@ public class ChartAnnotationController {
 	@PostMapping("/search")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets a list of chart annotations by provided node ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -89,19 +82,14 @@ public class ChartAnnotationController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestBody final SearchRequestBody body
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final List<ChartAnnotation> chartAnnotations = chartAnnotationService.getAnnotationsByNodeId(body.nodeId);
-
 		return ResponseEntity.ok(chartAnnotations);
 	}
 
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new annotation")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -123,11 +111,6 @@ public class ChartAnnotationController {
 		@RequestBody final ChartAnnotation item,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final ChartAnnotation chartAnnotation;
 		try {
 			chartAnnotation = chartAnnotationService.createAsset(item, projectId);
@@ -165,6 +148,7 @@ public class ChartAnnotationController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Delete a chart annotation by ID")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -188,11 +172,6 @@ public class ChartAnnotationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			chartAnnotationService.deleteAsset(id, projectId);
 		} catch (final Exception e) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.configuration.Config;
 import software.uncharted.terarium.hmiserver.controller.services.DownloadService;
 import software.uncharted.terarium.hmiserver.models.dataservice.PresignedURL;
@@ -51,7 +52,6 @@ import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
-import software.uncharted.terarium.hmiserver.utils.Messages;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
 @RequestMapping("/document-asset")
@@ -62,7 +62,6 @@ public class DocumentController {
 
 	final Config config;
 	final CurrentUserService currentUserService;
-	final Messages messages;
 	final JsDelivrProxy gitHubProxy;
 	private final ProjectService projectService;
 	final DocumentAssetService documentAssetService;
@@ -70,6 +69,7 @@ public class DocumentController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new document")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -87,11 +87,6 @@ public class DocumentController {
 		@RequestBody final DocumentAsset documentAsset,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final DocumentAsset document = documentAssetService.createAsset(documentAsset, projectId);
 			return ResponseEntity.status(HttpStatus.CREATED).body(document);
@@ -105,6 +100,7 @@ public class DocumentController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a document")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -124,11 +120,6 @@ public class DocumentController {
 		@RequestBody final DocumentAsset document,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// if the document asset does not have an id, set it to the id in the path
 		if (document.getId() == null) {
 			document.setId(id);
@@ -147,6 +138,7 @@ public class DocumentController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets document by ID")
+	@HasProjectAccess(level = Schema.Permission.READ)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -169,20 +161,9 @@ public class DocumentController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanReadOrNone(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Optional<DocumentAsset> document = documentAssetService.getAsset(id);
 		if (document.isEmpty()) {
 			return ResponseEntity.notFound().build();
-		}
-		// GETs not associated to a projectId cannot read private or temporary assets
-		if (
-			permission.equals(Schema.Permission.NONE) && (!document.get().getPublicAsset() || document.get().getTemporary())
-		) {
-			throw new ResponseStatusException(HttpStatus.FORBIDDEN, messages.get("rebac.unauthorized-read"));
 		}
 
 		// Test if the document as any assets
@@ -282,6 +263,7 @@ public class DocumentController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Deletes a document")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -301,11 +283,6 @@ public class DocumentController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			documentAssetService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("Document", id));
@@ -324,17 +301,13 @@ public class DocumentController {
 	 * @param fileEntity The entity containing the file to upload
 	 * @return A response containing the status of the upload
 	 */
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	private ResponseEntity<Void> uploadDocumentHelper(
 		final UUID documentId,
 		final String fileName,
 		final HttpEntity fileEntity,
-		@RequestParam(name = "project-id", required = false) final UUID projectId
+		final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			// upload file to S3
 			final Integer status = documentAssetService.uploadFile(documentId, fileName, fileEntity);
@@ -415,6 +388,7 @@ public class DocumentController {
 	@PutMapping(value = "/{id}/upload-document", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Secured(Roles.USER)
 	@Operation(summary = "Uploads a document")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -452,6 +426,7 @@ public class DocumentController {
 	@PutMapping("/{documentId}/upload-document-from-github")
 	@Secured(Roles.USER)
 	@Operation(summary = "Uploads a document from github")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/InterventionController.java
@@ -23,13 +23,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.simulationservice.interventions.InterventionPolicy;
 import software.uncharted.terarium.hmiserver.security.Roles;
-import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.InterventionService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
 @RequestMapping("/interventions")
@@ -40,15 +38,10 @@ public class InterventionController {
 
 	final InterventionService interventionService;
 
-	final ProjectAssetService projectAssetService;
-
-	final ProjectService projectService;
-
-	final CurrentUserService currentUserService;
-
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets intervention by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -71,11 +64,6 @@ public class InterventionController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Optional<InterventionPolicy> intervention = interventionService.getAsset(id);
 		return intervention.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
 	}
@@ -83,6 +71,7 @@ public class InterventionController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new intervention")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -105,13 +94,8 @@ public class InterventionController {
 		@RequestParam(name = "skip-check", required = false, defaultValue = "false") final boolean skipCheck,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
-			if (skipCheck != true) {
+			if (!skipCheck) {
 				item.validateInterventionPolicy();
 			}
 		} catch (final Exception e) {
@@ -132,6 +116,7 @@ public class InterventionController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a intervention")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -155,10 +140,6 @@ public class InterventionController {
 		@RequestBody final InterventionPolicy intervention,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
 		try {
 			intervention.setId(id);
 			final Optional<InterventionPolicy> updated = interventionService.updateAsset(intervention, projectId);
@@ -177,6 +158,7 @@ public class InterventionController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Delete a intervention by ID")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -200,11 +182,6 @@ public class InterventionController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			interventionService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("Intervention", id));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationController.java
@@ -33,18 +33,16 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.ProjectExport;
 import software.uncharted.terarium.hmiserver.security.Roles;
-import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService.ModelConfigurationUpdate;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.utils.Messages;
-import software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission;
 
 @RequestMapping("/model-configurations")
 @RestController
@@ -54,9 +52,7 @@ public class ModelConfigurationController {
 
 	final ModelConfigurationService modelConfigurationService;
 	final ModelService modelService;
-	final CurrentUserService currentUserService;
 	final Messages messages;
-	final ProjectService projectService;
 
 	/**
 	 * Gets a specific model configuration by id
@@ -68,6 +64,7 @@ public class ModelConfigurationController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets a specific model configuration by id")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -96,7 +93,6 @@ public class ModelConfigurationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
 		try {
 			final Optional<ModelConfiguration> modelConfiguration = modelConfigurationService.getAsset(id);
 			if (modelConfiguration.isEmpty()) {
@@ -116,6 +112,7 @@ public class ModelConfigurationController {
 	@PostMapping(value = "/import-archive", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Secured(Roles.USER)
 	@Operation(summary = "Imports both a model and its configuration in a single go")
+	@HasProjectAccess(level = software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -142,8 +139,6 @@ public class ModelConfigurationController {
 		if (input.getContentType() == null || !input.getContentType().equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
 			return ResponseEntity.badRequest().build();
 		}
-
-		final Permission permission = projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
 
 		try {
 			final ObjectMapper objectMapper = new ObjectMapper();
@@ -184,6 +179,7 @@ public class ModelConfigurationController {
 	@GetMapping("/download-archive/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Downloads both a model and its configuration in a single go in a zipped archive")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -216,8 +212,7 @@ public class ModelConfigurationController {
 	public ResponseEntity<byte[]> downloadModelConfigurationWithModel(
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
-	) throws IOException {
-		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
+	) {
 		final Optional<ModelConfiguration> modelConfiguration;
 		final Optional<Model> model;
 
@@ -291,6 +286,7 @@ public class ModelConfigurationController {
 	@GetMapping("/{id}/original-model")
 	@Secured(Roles.USER)
 	@Operation(summary = "Get the original model of which the configuration was created for")
+	@HasProjectAccess(level = software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -309,9 +305,6 @@ public class ModelConfigurationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission permission =
-			projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
-
 		try {
 			final Optional<Model> model = modelService.getModelFromModelConfigurationId(id);
 			if (model.isEmpty()) {
@@ -335,6 +328,7 @@ public class ModelConfigurationController {
 	@GetMapping("/{id}/model")
 	@Secured(Roles.USER)
 	@Operation(summary = "Get a model instance as specified by the configuration")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -363,7 +357,6 @@ public class ModelConfigurationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
 		try {
 			final Optional<ModelConfiguration> modelConfiguration = modelConfigurationService.getAsset(id);
 			if (modelConfiguration.isEmpty()) {
@@ -390,6 +383,7 @@ public class ModelConfigurationController {
 	@PostMapping("/as-configured-model/")
 	@Secured(Roles.USER)
 	@Operation(summary = "Creates a new model configuration based on a configured model")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -410,8 +404,6 @@ public class ModelConfigurationController {
 		@RequestParam(name = "description", required = false) final String description,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Permission permission = projectService.checkPermissionCanRead(currentUserService.get().getId(), projectId);
-
 		final ModelConfigurationUpdate options = new ModelConfigurationUpdate();
 		options.setName(name);
 		options.setDescription(description);
@@ -444,6 +436,7 @@ public class ModelConfigurationController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new model configuration")
+	@HasProjectAccess(level = software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -462,9 +455,6 @@ public class ModelConfigurationController {
 		@RequestBody final ModelConfiguration modelConfiguration,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission permission =
-			projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
-
 		try {
 			if (modelConfiguration.getId() == null) {
 				modelConfiguration.setId(UUID.randomUUID());
@@ -493,6 +483,7 @@ public class ModelConfigurationController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new model configuration")
+	@HasProjectAccess(level = software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -517,8 +508,6 @@ public class ModelConfigurationController {
 		@RequestBody final ModelConfiguration config,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission permission =
-			projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
 		try {
 			config.setId(id);
 			final Optional<ModelConfiguration> updated = modelConfigurationService.updateAsset(config, projectId);
@@ -542,6 +531,7 @@ public class ModelConfigurationController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Deletes a model configuration")
+	@HasProjectAccess(level = software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -556,9 +546,6 @@ public class ModelConfigurationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final software.uncharted.terarium.hmiserver.utils.rebac.Schema.Permission permission =
-			projectService.checkPermissionCanWrite(currentUserService.get().getId(), projectId);
-
 		try {
 			modelConfigurationService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("ModelConfiguration", id));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
@@ -47,7 +48,6 @@ import software.uncharted.terarium.hmiserver.models.simulationservice.interventi
 import software.uncharted.terarium.hmiserver.repository.data.InterventionRepository;
 import software.uncharted.terarium.hmiserver.repository.data.ModelConfigRepository;
 import software.uncharted.terarium.hmiserver.security.Roles;
-import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService;
 import software.uncharted.terarium.hmiserver.service.data.ModelConfigurationService.ModelConfigurationUpdate;
@@ -55,7 +55,6 @@ import software.uncharted.terarium.hmiserver.service.data.ModelService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.data.ProvenanceSearchService;
-import software.uncharted.terarium.hmiserver.utils.Messages;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
 @RequestMapping("/models")
@@ -64,10 +63,8 @@ import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 @RequiredArgsConstructor
 public class ModelController {
 
-	final CurrentUserService currentUserService;
 	final DocumentAssetService documentAssetService;
 	final InterventionRepository interventionRepository;
-	final Messages messages;
 	final ModelConfigRepository modelConfigRepository;
 	final ModelConfigurationService modelConfigurationService;
 	final ModelService modelService;
@@ -79,6 +76,7 @@ public class ModelController {
 	@GetMapping("/{id}/descriptions")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets a model description by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -101,11 +99,6 @@ public class ModelController {
 		@PathVariable("id") final UUID id,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<ModelDescription> model = modelService.getDescription(id);
 			return model.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
@@ -119,6 +112,7 @@ public class ModelController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets a model by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -140,20 +134,11 @@ public class ModelController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanReadOrNone(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			// Fetch the model from the data-service
 			final Optional<Model> model = modelService.getAsset(id);
 			if (model.isEmpty()) {
 				return ResponseEntity.noContent().build();
-			}
-			// GETs not associated to a projectId cannot read private or temporary assets
-			if (permission.equals(Schema.Permission.NONE) && (!model.get().getPublicAsset() || model.get().getTemporary())) {
-				throw new ResponseStatusException(HttpStatus.FORBIDDEN, messages.get("rebac.unauthorized-read"));
 			}
 
 			// Find the Document Assets linked via provenance to the model
@@ -221,6 +206,7 @@ public class ModelController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a model")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -240,11 +226,6 @@ public class ModelController {
 		@RequestBody final Model model,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<Model> originalModel = modelService.getAsset(id);
 			if (originalModel.isEmpty()) {
@@ -272,6 +253,7 @@ public class ModelController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Deletes an model")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -291,11 +273,6 @@ public class ModelController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			modelService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("Model", id));
@@ -309,6 +286,7 @@ public class ModelController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new model")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -327,11 +305,6 @@ public class ModelController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestParam(name = "model-configuration-id", required = false) final UUID modelConfigId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			// Set the model name from the AMR header name.
 			// TerariumAsset have a name field, but it's not used for the model name outside
@@ -381,6 +354,7 @@ public class ModelController {
 	@PostMapping("/new-from-old")
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new model from an old model")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -399,11 +373,6 @@ public class ModelController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestParam(name = "model-configuration-id", required = false) final UUID modelConfigId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			req.newModel.retainMetadataFields(req.oldModel);
 
@@ -447,6 +416,7 @@ public class ModelController {
 	@GetMapping("/{id}/model-configurations")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets all model configurations for a model")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -489,6 +459,7 @@ public class ModelController {
 	@GetMapping("/{id}/intervention-policies")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets all intervention policies for a model")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -58,7 +58,6 @@ public class NotebookSessionController {
 	@GetMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets all sessions")
-	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionController.java
@@ -24,12 +24,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.notebooksession.NotebookSession;
 import software.uncharted.terarium.hmiserver.models.dataservice.project.Project;
 import software.uncharted.terarium.hmiserver.security.Roles;
-import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.data.NotebookSessionService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ProjectService;
@@ -47,7 +47,6 @@ public class NotebookSessionController {
 	private final Messages messages;
 	private final ProjectService projectService;
 	private final ProjectAssetService projectAssetService;
-	private final CurrentUserService currentUserService;
 
 	/**
 	 * Retrieve the list of NotebookSessions
@@ -59,6 +58,7 @@ public class NotebookSessionController {
 	@GetMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets all sessions")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -99,6 +99,7 @@ public class NotebookSessionController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new session")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -116,11 +117,6 @@ public class NotebookSessionController {
 		@RequestBody final NotebookSession session,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			sessionService.createAsset(session, projectId);
 
@@ -136,7 +132,7 @@ public class NotebookSessionController {
 	}
 
 	/**
-	 * Retrieve an session
+	 * Retrieve a session
 	 *
 	 * @param id session id
 	 * @return NotebookSession
@@ -144,6 +140,7 @@ public class NotebookSessionController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets session by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -166,11 +163,6 @@ public class NotebookSessionController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<NotebookSession> session = sessionService.getAsset(id);
 			return session.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
@@ -191,6 +183,7 @@ public class NotebookSessionController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a session")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -210,11 +203,6 @@ public class NotebookSessionController {
 		@RequestBody final NotebookSession session,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			session.setId(id);
 			final Optional<NotebookSession> updated = sessionService.updateAsset(session, projectId);
@@ -229,6 +217,7 @@ public class NotebookSessionController {
 	@PostMapping("/{id}/clone")
 	@Secured(Roles.USER)
 	@Operation(summary = "Clone a session")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -246,10 +235,6 @@ public class NotebookSessionController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
 		final NotebookSession session = sessionService
 			.getAsset(id)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, messages.get("notebook-session.not-found")));
@@ -281,6 +266,7 @@ public class NotebookSessionController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Deletes an session")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -300,11 +286,6 @@ public class NotebookSessionController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			sessionService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("NotebookSession", id));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.configuration.Config;
 import software.uncharted.terarium.hmiserver.models.TerariumAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
@@ -84,6 +85,7 @@ public class SimulationController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new simulation")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -101,11 +103,6 @@ public class SimulationController {
 		@RequestBody final Simulation simulation,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Simulation sim = simulationService.createAsset(simulation, projectId);
 
@@ -120,6 +117,7 @@ public class SimulationController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Get a simulation by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -146,11 +144,6 @@ public class SimulationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<Simulation> simulation = simulationService.getAsset(id);
 
@@ -203,6 +196,7 @@ public class SimulationController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a simulation by ID")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -222,11 +216,6 @@ public class SimulationController {
 		@RequestBody final Simulation simulation,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			simulation.setId(id);
 			final Optional<Simulation> updated = simulationService.updateAsset(simulation, projectId);
@@ -241,6 +230,7 @@ public class SimulationController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Delete a simulation by ID")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -255,11 +245,6 @@ public class SimulationController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			simulationService.deleteAsset(id, projectId);
 			return "Simulation deleted";
@@ -323,6 +308,7 @@ public class SimulationController {
 	@PostMapping("/{id}/create-result-as-dataset/{project-id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new dataset from a simulation result, then add it to a project as a Dataset")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -349,11 +335,6 @@ public class SimulationController {
 		@RequestParam(value = "model-configuration-id", required = false) final UUID modelConfigurationId,
 		@RequestParam(value = "intervention-policy-id", required = false) final UUID interventionPolicyId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<Simulation> sim = simulationService.getAsset(id);
 			if (sim.isEmpty()) {
@@ -380,6 +361,7 @@ public class SimulationController {
 	@PostMapping("/{id}/create-assets-from-simulation")
 	@Secured(Roles.USER)
 	@Operation(summary = "Create assets from a simulation result, then add them to a project")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -403,11 +385,6 @@ public class SimulationController {
 		@RequestBody final Map<String, Object> body,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			final Optional<Project> project = projectService.getProject(projectId);
 			if (!project.isPresent()) {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SummaryController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/SummaryController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.ResponseDeleted;
 import software.uncharted.terarium.hmiserver.models.dataservice.Summary;
 import software.uncharted.terarium.hmiserver.security.Roles;
@@ -52,6 +53,7 @@ public class SummaryController {
 	@PostMapping("/search")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets a map of summaries by list of IDs")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -74,11 +76,6 @@ public class SummaryController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestBody final List<UUID> ids
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final List<Summary> summaries = summaryService.getSummaries(ids);
 
 		if (summaries.isEmpty()) {
@@ -96,6 +93,7 @@ public class SummaryController {
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Gets summary by ID")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -118,11 +116,6 @@ public class SummaryController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Optional<Summary> summary = summaryService.getAsset(id);
 		return summary.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.noContent().build());
 	}
@@ -130,6 +123,7 @@ public class SummaryController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Create a new summary")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -147,10 +141,6 @@ public class SummaryController {
 		@RequestBody final Summary item,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
 		try {
 			return ResponseEntity.status(HttpStatus.CREATED).body(summaryService.createAsset(item, projectId));
 		} catch (final IOException e) {
@@ -163,6 +153,7 @@ public class SummaryController {
 	@PutMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Update a summary")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -182,10 +173,6 @@ public class SummaryController {
 		@RequestBody final Summary summary,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
 		try {
 			summary.setId(id);
 			final Optional<Summary> updated = summaryService.updateAsset(summary, projectId);
@@ -204,6 +191,7 @@ public class SummaryController {
 	@DeleteMapping("/{id}")
 	@Secured(Roles.USER)
 	@Operation(summary = "Delete a summary by ID")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -223,11 +211,6 @@ public class SummaryController {
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		try {
 			summaryService.deleteAsset(id, projectId);
 			return ResponseEntity.ok(new ResponseDeleted("Summary", id));

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/funman/FunmanController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/funman/FunmanController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.ProgressState;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.Simulation;
 import software.uncharted.terarium.hmiserver.models.dataservice.simulation.SimulationType;
@@ -31,7 +32,6 @@ import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.data.SimulationService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskMode;
@@ -48,7 +48,6 @@ public class FunmanController {
 	private final ObjectMapper objectMapper;
 	private final TaskService taskService;
 	private final CurrentUserService currentUserService;
-	private final ProjectService projectService;
 
 	private final ValidateModelConfigHandler validateModelConfigHandler;
 	private final SimulationService simulationService;
@@ -62,6 +61,7 @@ public class FunmanController {
 	@PostMapping
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a model configuration validation task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -82,11 +82,6 @@ public class FunmanController {
 		@RequestParam(name = "new-model-config-name", required = true) final String newModelConfigName,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final TaskRequest taskRequest = new TaskRequest();
 		taskRequest.setTimeoutMinutes(45);
 		taskRequest.setType(TaskType.FUNMAN);

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/gollm/GoLLMController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.dataservice.ChartAnnotation.ChartAnnotationType;
 import software.uncharted.terarium.hmiserver.models.dataservice.dataset.Dataset;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
@@ -47,11 +47,9 @@ import software.uncharted.terarium.hmiserver.models.task.TaskRequest.TaskType;
 import software.uncharted.terarium.hmiserver.models.task.TaskResponse;
 import software.uncharted.terarium.hmiserver.security.Roles;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
-import software.uncharted.terarium.hmiserver.service.data.DKGService;
 import software.uncharted.terarium.hmiserver.service.data.DatasetService;
 import software.uncharted.terarium.hmiserver.service.data.DocumentAssetService;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.tasks.ChartAnnotationResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.CompareModelsResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.ConfigureModelFromDatasetResponseHandler;
@@ -80,9 +78,7 @@ public class GoLLMController {
 	private final DocumentAssetService documentAssetService;
 	private final DatasetService datasetService;
 	private final ModelService modelService;
-	private final ProjectService projectService;
 	private final CurrentUserService currentUserService;
-	private final DKGService dkgService;
 
 	private final CompareModelsResponseHandler compareModelsResponseHandler;
 	private final ConfigureModelFromDatasetResponseHandler configureModelFromDatasetResponseHandler;
@@ -116,6 +112,7 @@ public class GoLLMController {
 	@PostMapping("/model-card")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Model Card` task")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -141,11 +138,6 @@ public class GoLLMController {
 		@RequestParam(name = "mode", required = false, defaultValue = "ASYNC") final TaskMode mode,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the model
 		final Optional<Model> model = modelService.getAsset(modelId);
 		if (model.isEmpty()) {
@@ -208,6 +200,7 @@ public class GoLLMController {
 	@GetMapping("/configure-model")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Configure Model` task")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -234,11 +227,6 @@ public class GoLLMController {
 		@RequestParam(name = "node-id", required = false) final UUID nodeId,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the document
 		final Optional<DocumentAsset> document = documentAssetService.getAsset(documentId);
 		if (document.isEmpty()) {
@@ -326,6 +314,7 @@ public class GoLLMController {
 	@PostMapping("/configure-from-dataset")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Config from Dataset` task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -354,11 +343,6 @@ public class GoLLMController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestBody(required = false) final ConfigFromDatasetBody body
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the model
 		final Optional<Model> model = modelService.getAsset(modelId);
 		if (model.isEmpty()) {
@@ -452,6 +436,7 @@ public class GoLLMController {
 	@GetMapping("/interventions-from-document")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM interventions-from-document` task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -478,11 +463,6 @@ public class GoLLMController {
 		@RequestParam(name = "node-id", required = false) final UUID nodeId,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the document
 		final Optional<DocumentAsset> document = documentAssetService.getAsset(documentId);
 		if (document.isEmpty()) {
@@ -563,6 +543,7 @@ public class GoLLMController {
 	@GetMapping("/interventions-from-dataset")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM interventions-from-dataset` task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -589,11 +570,6 @@ public class GoLLMController {
 		@RequestParam(name = "node-id", required = false) final UUID nodeId,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the dataset
 		final List<String> dataArray = new ArrayList<>();
 
@@ -680,6 +656,7 @@ public class GoLLMController {
 	@GetMapping("/compare-models")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Compare Models` task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -706,11 +683,6 @@ public class GoLLMController {
 		@RequestParam(name = "node-id", required = false) final UUID nodeId,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final List<String> amrs = new ArrayList<>();
 		for (final UUID modelId : modelIds) {
 			// Grab the model
@@ -861,6 +833,7 @@ public class GoLLMController {
 	@GetMapping("/enrich-model-metadata")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch multiple GoLLM tasks to enrich model metadata")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -886,11 +859,6 @@ public class GoLLMController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestParam(name = "overwrite", required = false, defaultValue = "true") final boolean overwrite
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the document
 		DocumentAsset document = null;
 		if (documentId != null) {
@@ -949,6 +917,7 @@ public class GoLLMController {
 	@GetMapping("/enrich-dataset")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Enrich Dataset` task")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -974,11 +943,6 @@ public class GoLLMController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestParam(name = "overwrite", required = false, defaultValue = "true") final boolean overwrite
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Grab the document
 		DocumentAsset document = null;
 		if (documentId != null) {
@@ -1043,6 +1007,7 @@ public class GoLLMController {
 	@PostMapping("/equations-from-image")
 	@Secured(Roles.USER)
 	@Operation(summary = "Dispatch a `GoLLM Equations from image` task")
+	@HasProjectAccess
 	@ApiResponses(
 		value = {
 			@ApiResponse(
@@ -1062,11 +1027,6 @@ public class GoLLMController {
 		@RequestParam(name = "mode", required = false, defaultValue = "ASYNC") final TaskMode mode,
 		@RequestBody final EquationsFromImageBody image
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// validate that the string is a base64 encoding
 		byte[] decodedImage;
 		try {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
@@ -39,7 +40,6 @@ import software.uncharted.terarium.hmiserver.service.ClientEventService;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.ExtractionService;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
-import software.uncharted.terarium.hmiserver.service.data.ProjectService;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationGroupInstance;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationService;
 import software.uncharted.terarium.hmiserver.service.tasks.EquationsCleanupResponseHandler;
@@ -64,7 +64,6 @@ public class KnowledgeController {
 	private final ExtractionService extractionService;
 	private final TaskService taskService;
 
-	private final ProjectService projectService;
 	private final CurrentUserService currentUserService;
 	private final ClientEventService clientEventService;
 	private final NotificationService notificationService;
@@ -141,15 +140,11 @@ public class KnowledgeController {
 	 */
 	@PostMapping("/equations-to-model")
 	@Secured(Roles.USER)
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	public ResponseEntity<UUID> equationsToModel(
 		@RequestBody final JsonNode req,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		// Parse the request
 		UUID documentId = JsonUtil.parseUuidFromRequest(req, "documentId");
 		UUID modelId = JsonUtil.parseUuidFromRequest(req, "modelId");
@@ -285,6 +280,7 @@ public class KnowledgeController {
 	@PostMapping("/pdf-extractions")
 	@Secured(Roles.USER)
 	@Operation(summary = "Extracts information from the first PDF associated with the given document id")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@ApiResponses(
 		value = {
 			@ApiResponse(responseCode = "202", description = "Extraction started on PDF", content = @Content),
@@ -296,11 +292,6 @@ public class KnowledgeController {
 		@RequestParam(name = "project-id", required = false) final UUID projectId,
 		@RequestParam(name = "mode", required = false, defaultValue = "ASYNC") final TaskMode mode
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Future<DocumentAsset> f = extractionService.extractPDFAndApplyToDocument(documentId, projectId);
 		if (mode == TaskMode.SYNC) {
 			try {

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/simulationservice/SimulationRequestController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.controller.SnakeCaseController;
 import software.uncharted.terarium.hmiserver.models.dataservice.AssetType;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.configurations.ModelConfiguration;
@@ -72,14 +73,11 @@ public class SimulationRequestController implements SnakeCaseController {
 
 	@GetMapping("/{id}")
 	@Secured(Roles.USER)
+	@HasProjectAccess
 	public ResponseEntity<Simulation> getSimulation(
 		@PathVariable("id") final UUID id,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanRead(
-			currentUserService.get().getId(),
-			projectId
-		);
 		try {
 			final Optional<Simulation> sim = simulationService.getAsset(id);
 			if (sim.isEmpty()) {
@@ -95,15 +93,11 @@ public class SimulationRequestController implements SnakeCaseController {
 
 	@PostMapping("ciemss/forecast")
 	@Secured(Roles.USER)
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	public ResponseEntity<Simulation> makeForecastRunCiemss(
 		@RequestBody final SimulationRequestBody<SimulationRequest> request,
 		@RequestParam(name = "project-id", required = false) final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Optional<ModelConfiguration> modelConfiguration = modelConfigService.getAsset(
 			request.payload.getModelConfigId()
 		);
@@ -144,15 +138,12 @@ public class SimulationRequestController implements SnakeCaseController {
 	}
 
 	@PostMapping("ciemss/calibrate")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@Secured(Roles.USER)
 	public ResponseEntity<JobResponse> makeCalibrateJobCiemss(
 		@RequestBody final SimulationRequestBody<CalibrationRequestCiemss> request,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
 		final Optional<ModelConfiguration> modelConfiguration = modelConfigService.getAsset(
 			request.payload.getModelConfigId()
 		);
@@ -182,16 +173,12 @@ public class SimulationRequestController implements SnakeCaseController {
 	}
 
 	@PostMapping("ciemss/optimize")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@Secured(Roles.USER)
 	public ResponseEntity<JobResponse> makeOptimizeJobCiemss(
 		@RequestBody final SimulationRequestBody<OptimizeRequestCiemss> request,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final Optional<ModelConfiguration> modelConfiguration = modelConfigService.getAsset(
 			request.payload.getModelConfigId()
 		);
@@ -221,16 +208,12 @@ public class SimulationRequestController implements SnakeCaseController {
 	}
 
 	@PostMapping("ciemss/ensemble-simulate")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@Secured(Roles.USER)
 	public ResponseEntity<JobResponse> makeEnsembleSimulateCiemssJob(
 		@RequestBody final SimulationRequestBody<EnsembleSimulationCiemssRequest> request,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final JobResponse res = simulationCiemssServiceProxy
 			.makeEnsembleSimulateCiemssJob(convertObjectToSnakeCaseJsonNode(request.payload))
 			.getBody();
@@ -253,16 +236,12 @@ public class SimulationRequestController implements SnakeCaseController {
 	}
 
 	@PostMapping("ciemss/ensemble-calibrate")
+	@HasProjectAccess(level = Schema.Permission.WRITE)
 	@Secured(Roles.USER)
 	public ResponseEntity<JobResponse> makeEnsembleCalibrateCiemssJob(
 		@RequestBody final SimulationRequestBody<EnsembleCalibrationCiemssRequest> request,
 		@RequestParam("project-id") final UUID projectId
 	) {
-		final Schema.Permission permission = projectService.checkPermissionCanWrite(
-			currentUserService.get().getId(),
-			projectId
-		);
-
 		final JobResponse res = simulationCiemssServiceProxy
 			.makeEnsembleCalibrateCiemssJob(convertObjectToSnakeCaseJsonNode(request.payload))
 			.getBody();

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/TerariumApplicationTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/TerariumApplicationTests.java
@@ -30,7 +30,4 @@ public class TerariumApplicationTests {
 	public void beforeEach() {
 		mockMvc = MockMvcBuilders.webAppContextSetup(this.context).apply(springSecurity()).build();
 	}
-
-	/** To allow calls to Asset and Project Controllers a projectId is required */
-	public UUID PROJECT_ID = UUID.randomUUID();
 }

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/aspects/HasProjectAccessAspectClassTestService.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/aspects/HasProjectAccessAspectClassTestService.java
@@ -8,11 +8,11 @@ import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 @HasProjectAccess
 public class HasProjectAccessAspectClassTestService {
 
-	public void defaultParameterName(String id) {}
+	public void defaultParameterName(String projectId) {}
 
-	@HasProjectAccess("#projectId")
-	public void methodOverride(String projectId) {}
+	@HasProjectAccess("#id")
+	public void methodOverride(String id) {}
 
 	@HasProjectAccess(level = Schema.Permission.WRITE)
-	public void ownerLevel(String id) {}
+	public void ownerLevel(String projectId) {}
 }

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/aspects/HasProjectAccessAspectMethodTestService.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/aspects/HasProjectAccessAspectMethodTestService.java
@@ -9,25 +9,25 @@ import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 public class HasProjectAccessAspectMethodTestService {
 
 	@HasProjectAccess
-	public void defaultParameterName(String id) {}
+	public void defaultParameterName(String projectId) {}
 
-	@HasProjectAccess("#projectId")
-	public void customParameterName(String projectId) {}
+	@HasProjectAccess("#id")
+	public void customParameterName(String id) {}
 
 	@HasProjectAccess(level = Schema.Permission.WRITE)
-	public void ownerLevel(String id) {}
+	public void ownerLevel(String projectId) {}
 
-	@HasProjectAccess(level = Schema.Permission.WRITE, value = "#projectId")
-	public void ownerLevelWithCustomParameterName(String projectId) {}
+	@HasProjectAccess(level = Schema.Permission.WRITE, value = "#id")
+	public void ownerLevelWithCustomParameterName(String id) {}
 
 	@HasProjectAccess
-	public void incorrectSpel(String projectId) {}
+	public void incorrectSpel(String id) {}
 
-	@HasProjectAccess("#projectId")
-	public void incorrectSpel2(String id) {}
+	@HasProjectAccess("#id")
+	public void incorrectSpel2(String projectId) {}
 
 	@HasProjectAccess("jladjklsdjkl")
-	public void incorrectSpel3(String id) {}
+	public void incorrectSpel3(String projectId) {}
 
 	@HasProjectAccess("#p.getId()")
 	public void objectSpel(Project p) {}

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ArtifactControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ArtifactControllerTests.java
@@ -60,7 +60,7 @@ public class ArtifactControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/artifacts")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(artifact))
@@ -79,7 +79,7 @@ public class ArtifactControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/artifacts/" + artifact.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -96,7 +96,7 @@ public class ArtifactControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/artifacts/" + artifact.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetControllerTests.java
@@ -73,7 +73,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.post("/datasets")
 					.with(csrf())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(dataset))
 			)
@@ -91,7 +91,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/datasets/" + dataset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -108,7 +108,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/datasets/" + dataset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -140,7 +140,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 				MockMvcRequestBuilders.multipart("/datasets/" + dataset.getId() + "/upload-csv")
 					.file(file)
 					.queryParam("filename", "filename.csv")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
 					.with(request -> {
@@ -166,7 +166,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.put("/datasets/" + dataset.getId() + "/upload-csv-from-github")
 					.with(csrf())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.param("repo-owner-and-name", "unchartedsoftware/torflow")
 					.param("path", "README.md")
 					.param("filename", "torflow-readme.md")
@@ -199,7 +199,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 				MockMvcRequestBuilders.multipart("/datasets/" + dataset.getId() + "/upload-csv")
 					.file(file)
 					.queryParam("filename", "filename.csv")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
 					.with(request -> {
@@ -247,7 +247,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 				MockMvcRequestBuilders.multipart("/datasets/" + dataset.getId() + "/upload-file")
 					.file(file)
 					.queryParam("filename", "filename.txt")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
 					.with(request -> {
@@ -282,7 +282,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 				MockMvcRequestBuilders.multipart("/datasets/" + dataset.getId() + "/upload-csv")
 					.file(file)
 					.queryParam("filename", "filename.csv")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
 					.with(request -> {
@@ -364,7 +364,7 @@ public class DatasetControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.get("/datasets/" + dataset.getId() + "/download-url")
 					.queryParam("filename", "filename.txt")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk())

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentControllerTests.java
@@ -63,7 +63,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/document-asset")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(documentAsset))
@@ -82,7 +82,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/document-asset/" + documentAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -99,7 +99,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/document-asset/" + documentAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -128,7 +128,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.multipart("/document-asset/" + documentAsset.getId() + "/upload-document")
 					.file(file)
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.queryParam("filename", "filename.txt")
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
@@ -151,7 +151,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/document-asset/" + documentAsset.getId() + "/upload-document-from-github")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.param("repo-owner-and-name", "unchartedsoftware/torflow")
 					.param("path", "README.md")
@@ -184,7 +184,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.multipart("/document-asset/" + documentAsset.getId() + "/upload-document")
 					.file(file)
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.queryParam("filename", "filename.txt")
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
@@ -232,7 +232,7 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.multipart("/document-asset/" + documentAsset.getId() + "/upload-document")
 					.file(file)
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.queryParam("filename", "filename.txt")
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
@@ -268,7 +268,11 @@ public class DocumentControllerTests extends TerariumApplicationTests {
 		final DocumentAsset createdDocumentAsset = documentAssetService.createAsset(documentAsset, project.getId());
 
 		mockMvc
-			.perform(MockMvcRequestBuilders.get("/document-asset/" + createdDocumentAsset.getId()).with(csrf()))
+			.perform(
+				MockMvcRequestBuilders.get("/document-asset/" + createdDocumentAsset.getId())
+					.with(csrf())
+					.param("project-id", project.getId().toString())
+			)
 			.andExpect(status().isOk());
 	}
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelConfigurationControllerTests.java
@@ -64,7 +64,7 @@ public class ModelConfigurationControllerTests extends TerariumApplicationTests 
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/model-configurations/" + modelConfiguration.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -81,7 +81,7 @@ public class ModelConfigurationControllerTests extends TerariumApplicationTests 
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/model-configurations")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(modelConfiguration))
@@ -103,7 +103,7 @@ public class ModelConfigurationControllerTests extends TerariumApplicationTests 
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/model-configurations/" + modelConfiguration.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(modelConfiguration))
@@ -122,7 +122,7 @@ public class ModelConfigurationControllerTests extends TerariumApplicationTests 
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/model-configurations/" + modelConfiguration.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ModelControllerTests.java
@@ -66,7 +66,7 @@ public class ModelControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/models")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(model))
@@ -92,7 +92,9 @@ public class ModelControllerTests extends TerariumApplicationTests {
 
 		mockMvc
 			.perform(
-				MockMvcRequestBuilders.get("/models/" + model.getId()).param("project-id", PROJECT_ID.toString()).with(csrf())
+				MockMvcRequestBuilders.get("/models/" + model.getId())
+					.param("project-id", project.getId().toString())
+					.with(csrf())
 			)
 			.andExpect(status().isOk());
 	}
@@ -116,7 +118,7 @@ public class ModelControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/models/" + model.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(model))
@@ -143,7 +145,7 @@ public class ModelControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/models/" + model.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -170,7 +172,7 @@ public class ModelControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/models/" + model.getId() + "/descriptions")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/NotebookSessionControllerTests.java
@@ -77,7 +77,7 @@ public class NotebookSessionControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/sessions/" + notebookSession.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -99,7 +99,10 @@ public class NotebookSessionControllerTests extends TerariumApplicationTests {
 			project.getId()
 		);
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/sessions").with(csrf())).andExpect(status().isOk()).andReturn();
+		mockMvc
+			.perform(MockMvcRequestBuilders.get("/sessions").param("project-id", project.getId().toString()).with(csrf()))
+			.andExpect(status().isOk())
+			.andReturn();
 	}
 
 	@Test
@@ -113,7 +116,7 @@ public class NotebookSessionControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/sessions/" + notebookSession.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/ProjectControllerTests.java
@@ -130,7 +130,7 @@ public class ProjectControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.get("/document-asset/" + documentAsset.getId())
 					.param("types", AssetType.DOCUMENT.name())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk())

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/SimulationControllerTests.java
@@ -60,7 +60,7 @@ public class SimulationControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/simulations")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(simulationAsset))
@@ -79,7 +79,7 @@ public class SimulationControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/simulations/" + simulationAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -97,7 +97,7 @@ public class SimulationControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/simulations/" + simulationAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/TDSCodeControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/TDSCodeControllerTests.java
@@ -65,7 +65,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/code-asset")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(codeAsset))
@@ -84,7 +84,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/code-asset/" + codeAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -117,7 +117,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/code-asset/" + codeAsset.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -150,7 +150,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.multipart("/code-asset/" + codeAsset.getId() + "/upload-code")
 					.file(file)
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.queryParam("filename", "filename.txt")
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)
@@ -173,7 +173,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/code-asset/" + codeAsset.getId() + "/upload-code-from-github")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.param("repo-owner-and-name", "unchartedsoftware/torflow")
 					.param("path", "README.md")
@@ -194,7 +194,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/code-asset/" + codeAsset.getId() + "/upload-code-from-github-repo")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.param("repo-owner-and-name", "unchartedsoftware/torflow")
 					.param("repo-name", "torflow.zip")
@@ -226,7 +226,7 @@ public class TDSCodeControllerTests extends TerariumApplicationTests {
 			.perform(
 				MockMvcRequestBuilders.multipart("/code-asset/" + codeAsset.getId() + "/upload-code")
 					.file(file)
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.queryParam("filename", "filename.txt")
 					.with(csrf())
 					.contentType(MediaType.MULTIPART_FORM_DATA)

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/dataservice/WorkflowControllerTests.java
@@ -60,7 +60,7 @@ public class WorkflowControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.post("/workflows")
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(workflow))
@@ -79,7 +79,7 @@ public class WorkflowControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.get("/workflows/" + workflow.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());
@@ -96,7 +96,7 @@ public class WorkflowControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.put("/workflows/" + workflow.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 					.contentType("application/json")
 					.content(objectMapper.writeValueAsString(workflow))
@@ -115,7 +115,7 @@ public class WorkflowControllerTests extends TerariumApplicationTests {
 		mockMvc
 			.perform(
 				MockMvcRequestBuilders.delete("/workflows/" + workflow.getId())
-					.param("project-id", PROJECT_ID.toString())
+					.param("project-id", project.getId().toString())
 					.with(csrf())
 			)
 			.andExpect(status().isOk());


### PR DESCRIPTION
# Description

* Changing all of the explicit calls to our rebac service to instead go through the new annotation.
* `ProjectController` is going to be done seperately as its a bit more involved in issue #6673
* Changed the default param we look for for the project id from `id` (pantera) to `projectId` (terarium standard). Updated the tests to reflect this


Resolves #6653
