### PR TITLE
Stop refreshing MMT on Model metadata updates

### DIFF
--- a/packages/client/hmi-client/src/components/model/tera-model.vue
+++ b/packages/client/hmi-client/src/components/model/tera-model.vue
@@ -177,16 +177,7 @@ async function refreshMMT() {
 }
 
 function updateTemporaryModel(newModel: Model) {
-	let doMmtUpdate = false;
-	// Only update the MMT when the semantics of the model changes
-	if (
-		!isEqual(temporaryModel.value?.model, newModel.model) ||
-		!isEqual(temporaryModel.value?.semantics, newModel.semantics)
-	) {
-		doMmtUpdate = true;
-	}
 	temporaryModel.value = cloneDeep(newModel);
-	if (doMmtUpdate) refreshMMT();
 }
 
 function onUpdateModelPart(property: 'state' | 'parameter' | 'observable' | 'transition' | 'time', event: any) {


### PR DESCRIPTION
Fix #6680 

The change simplifies the function by removing the conditional logic that checked for semantic changes to update the MMT before updating the model.