### PR TITLE
Fix two issues with Model page's LaTeX equations

### DIFF
--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -113,7 +113,7 @@ def main():
                 odesys[0] += exprs
 
         # Reformat:
-        odesys = "\\begin{align*} \n    " + odesys[0] + "\n\\end{align*}"
+        odesys = "\\begin{align} \n    " + odesys[0] + "\n\\end{align}"
         # =========================================
 
         taskrunner.write_output_dict_with_timeout({"response": odesys})

--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -25,14 +25,21 @@ def main():
 
         odeterms = {var: [] for var in sorted(model.get_concepts_name_map().keys())}
 
+        # ODE terms from template rate laws
         for template in model.templates:
             if hasattr(template, "subject"):
                 var = template.subject.name
-                odeterms[var].append(-template.rate_law.args[0])
+                if template.rate_law is not None:
+                    odeterms[var].append(-template.rate_law.args[0])
+                else:
+                    odeterms[var].append(0)
 
             if hasattr(template, "outcome"):
                 var = template.outcome.name
-                odeterms[var].append(template.rate_law.args[0])
+                if template.rate_law is not None:
+                    odeterms[var].append(template.rate_law.args[0])
+                else:
+                    odeterms[var].append(0)
 
         # Sort the terms such that all negative ones come first
         odeterms = {var: sorted(terms, key = lambda term: str(term)) for var, terms in odeterms.items()}


### PR DESCRIPTION
# Description

* Fix the "align" env rending failure, possibly due to lack of support for `align*`
* Fix error caused by `dX/dt = 0` case, https://github.com/DARPA-ASKEM/terarium/issues/6693
