### PR TITLE
rename reset_request/reset_response

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
@@ -198,7 +198,7 @@ const syncWithMiraModel = (data: any) => {
 const runCode = () => {
 	isUpdatingModel.value = true;
 	outputModel.value = null;
-	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
+	kernelManager.sendMessage('reset_mira_request', {}).register('reset_mira_response', () => {
 		const messageContent = {
 			silent: false,
 			store_history: false,
@@ -246,8 +246,8 @@ const resetModel = () => {
 	if (!outputModel.value) return;
 
 	kernelManager
-		.sendMessage('reset_request', {})
-		.register('reset_response', handleResetResponse)
+		.sendMessage('reset_mira_request', {})
+		.register('reset_mira_response', handleResetResponse)
 		.register('model_preview', syncWithMiraModel);
 };
 

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -177,8 +177,8 @@ const processLLMOutput = (data: any) => {
 const resetModel = () => {
 	if (!amr.value) return;
 	kernelManager
-		.sendMessage('reset_request', {})
-		.register('reset_response', handleResetResponse)
+		.sendMessage('reset_mira_request', {})
+		.register('reset_mira_response', handleResetResponse)
 		.register('model_preview', handleModelPreview);
 };
 
@@ -218,7 +218,7 @@ const stratifyModel = () => {
 		cartesian_control: strataOption.cartesianProduct,
 		structure: strataOption.useStructure ? null : []
 	};
-	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
+	kernelManager.sendMessage('reset_mira_request', {}).register('reset_mira_response', () => {
 		kernelManager
 			.sendMessage('stratify_request', messageContent)
 			.register('stratify_response', (data: any) => {
@@ -368,7 +368,7 @@ const runCodeStratify = () => {
 
 	let executedCode = '';
 
-	kernelManager.sendMessage('reset_request', {}).register('reset_response', () => {
+	kernelManager.sendMessage('reset_mira_request', {}).register('reset_mira_response', () => {
 		kernelManager
 			.sendMessage('execute_request', messageContent)
 			.register('execute_input', (data) => {


### PR DESCRIPTION
Requires: https://github.com/DARPA-ASKEM/askem-beaker/pull/207

### Summary
Corresponding event renaming changes for beaker PR. Rename reset_request and reset_response to avoid collision and confusion with internal kernerl-level events.


### Testing
There is a caveat that our AspectJ is not correctly configured, to test currently you need to go into "ModelController.java" and remove the `@HasProjectAccess` annotation/aspect from the `GET /{id}` route.

After this stratify operations should work in both wizard and notebook views.


