### PR TITLE
fix warnings in drag and drop validation

### DIFF
--- a/packages/client/hmi-client/src/components/extracting/tera-drag-n-drop-importer.vue
+++ b/packages/client/hmi-client/src/components/extracting/tera-drag-n-drop-importer.vue
@@ -74,12 +74,20 @@ const props = defineProps({
 	acceptTypes: {
 		type: Array<AcceptedTypes>,
 		required: true,
-		validator: (value: Array<string>) => Object.values(AcceptedTypes).every((v) => value.includes(v))
+		validator: (value: Array<string>) =>
+			value.every((v) => {
+				const typeString = <string[]>Object.values(AcceptedTypes);
+				return typeString.includes(v);
+			})
 	},
 	acceptExtensions: {
 		type: Array<AcceptedExtensions>,
 		required: true,
-		validator: (value: Array<string>) => Object.values(AcceptedExtensions).every((v) => value.includes(v))
+		validator: (value: Array<string>) =>
+			value.every((v) => {
+				const extensionStrings = <string[]>Object.values(AcceptedExtensions);
+				return extensionStrings.includes(v);
+			})
 	},
 	// custom import action can be passed in as prop
 	importAction: {


### PR DESCRIPTION
# Description

* There used to be warnings when uploading documents because the validation was comparing arrays in the wrong direction.
* This PR fixes that

Before:
<img width="783" alt="Screenshot 2025-03-04 at 4 09 47 PM" src="https://github.com/user-attachments/assets/f05caf28-d8fa-4a20-9abf-00fa9223921f" />
