### PR TITLE
6719 bug cannot select configuration in configure model op

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -53,7 +53,6 @@
 									:configuration="configuration"
 									:selected="selectedConfigId === configuration.id"
 									:empty-input-count="missingInputCount(configuration)"
-									@click="onSelectConfiguration(configuration)"
 									@delete="fetchConfigurations(model.id)"
 									@downloadArchive="downloadZippedModelAndConfig(configuration)"
 									@downloadModel="downloadModel(configuration)"

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-configuration-item.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-configuration-item.vue
@@ -1,5 +1,5 @@
 <template>
-	<main :class="{ selected: selected }">
+	<main :class="{ selected: selected }" @click="emit('use')">
 		<header>
 			<h6 class="constrain-width">{{ configuration.name }}</h6>
 			<Button text icon="pi pi-ellipsis-v" @click.stop="toggleContextMenu" />


### PR DESCRIPTION
Resolves #6719 

Adding the modal made the `@click` event lost, so added back to the right place and remove duplicate event. 
