### PR TITLE
Fix incorrect example in GoLLM prompt for LaTeX-to-SymPy

### DIFF
--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -18,7 +18,7 @@ Here is an example input LaTeX
 You should return this output in SymPy:
 ```
 import sympy
-from sympy import _clash
+from sympy.abc import _clash
 
 # Define time variable
 t = sympy.symbols("t")


### PR DESCRIPTION
Should be `from sympy.abc import _clash` instead of `from sympy import _clash`