### PR TITLE
Latex - Remove wrap on longer lines

### DIFF
--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -60,7 +60,7 @@ def main():
                             term = term.subs(atom, sympy.Function(str(atom))(t))
                     terms[i] = term
 
- 
+
         # Construct equations
         num_terms = 5 # Max number of terms per line in LaTeX align
         odesys = []
@@ -69,7 +69,7 @@ def main():
 
             lhs = sympy.diff(sympy.Function(var)(t), t)
             rhs = sum(terms)
-            exprs += sympy.latex(lhs) + " ={}& "
+            exprs += sympy.latex(lhs) + " ={} "
 
             # Few equation terms = no wrapping needed
             if len(terms) < num_terms:
@@ -83,7 +83,7 @@ def main():
 
             if i < (len(odeterms) - 1):
                 exprs += " \\\\ \n"
-            
+
             odesys = [exprs]
 
 
@@ -104,7 +104,7 @@ def main():
             for i, (obs, expr) in enumerate(observables.items()):
                 lhs = sympy.Function(obs)(t)
                 rhs = expr
-                exprs = "     " + sympy.latex(lhs) + " ={}& " + sympy.latex(rhs)
+                exprs = "     " + sympy.latex(lhs) + " ={} " + sympy.latex(rhs)
                 if i == 0:
                     exprs = " \\\\ \n" + exprs
                 if i < (len(observables) - 1):

--- a/packages/mira/tasks/generate_model_latex.py
+++ b/packages/mira/tasks/generate_model_latex.py
@@ -62,7 +62,6 @@ def main():
 
 
         # Construct equations
-        num_terms = 5 # Max number of terms per line in LaTeX align
         odesys = []
         exprs = ""
         for i, (var, terms) in enumerate(odeterms.items()):
@@ -72,14 +71,7 @@ def main():
             exprs += sympy.latex(lhs) + " ={} "
 
             # Few equation terms = no wrapping needed
-            if len(terms) < num_terms:
-                exprs += sympy.latex(rhs)
-
-            # otherwise, wrap around
-            else:
-                rhs = [sympy.latex(sum(terms[j:(j + num_terms)])) for j in range(0, len(terms), num_terms)]
-                rhs = [line if (j == 0) | (line[0] == '-') else "+ " + line for j, line in enumerate(rhs)] # Add '+ ' to all lines past the first if not start with '- '
-                exprs += " \\\\ \n    &".join(rhs)
+            exprs += sympy.latex(rhs)
 
             if i < (len(odeterms) - 1):
                 exprs += " \\\\ \n"


### PR DESCRIPTION
# Description
When latex equations are more than 5 characters we were wrapping them to the next line.
This would be clear and helpful if we were to be rendering the entire latex at once but as we are sending individual equations via our model drilldown this is not the case. 


# Before 
<img width="723" alt="image" src="https://github.com/user-attachments/assets/ca77c2eb-9db0-4dc9-b7b3-e81ef1d21fcd" />


# After
<img width="827" alt="image" src="https://github.com/user-attachments/assets/29af6a88-f75e-4acd-bb1c-ca91cbe106d5" />
