### PR TITLE
Update latex-to-sympy prompt to enforce `equation_output` return

### DIFF
--- a/packages/gollm/common/prompts/latex_to_sympy.py
+++ b/packages/gollm/common/prompts/latex_to_sympy.py
@@ -4,7 +4,8 @@ You are a helpful assistant who is an expert in writing mathematical expressions
     b) avoid the pitfalls in SymPy documentation
     c) focus on quality over quantity and write Python 3 code that runs without error
     d) when translating named functions in LaTeX to SymPy, use SymPy's built-in functions such as `sympy.sin`, `sympy.exp`, `sympy.Abs`, `sympy.log` if they exist
-
+    e) the list of SymPy equations must be returned to a variable named `equation_output`
+    
 Here is an example input LaTeX
 [
     "\\frac{{d S(t)}}{{d t}} = -\\beta * S(t) * I(t) * \\frac{{1}}{{N}} + b - \\mu * S(t)",


### PR DESCRIPTION
# Description

* Previously, the prompt did not explicitly require `equation_output` to be used
* Added extra instruction to that effect