### PR TITLE
checkbox for startify parameter factor

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/stratify-mira-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/stratify-mira-operation.ts
@@ -15,6 +15,8 @@ export interface StratifyGroup {
 	structure: null | any[];
 
 	useStructure: boolean;
+
+	useFactoredParameter: boolean;
 }
 
 export interface StratifyCode {
@@ -52,7 +54,9 @@ export const blankStratifyGroup: StratifyGroup = {
 	useStructure: true,
 
 	// Always true for now - Feb 2024
-	directed: true
+	directed: true,
+
+	useFactoredParameter: true
 };
 
 export const StratifyMiraOperation: Operation = {

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -42,6 +42,11 @@
 				<Checkbox @change="emit('update-self', updatedConfig)" v-model="cartesianProduct" binary />
 				<label>Allow existing interactions to involve multiple strata</label>
 			</div>
+
+			<div class="flex align-items-center gap-2">
+				<Checkbox @change="emit('update-self', updatedConfig)" v-model="useFactoredParameter" binary />
+				<label>Stratify parameter via multiplication factors</label>
+			</div>
 		</div>
 	</div>
 </template>
@@ -68,6 +73,7 @@ const cartesianProduct = ref<boolean>(props.config.cartesianProduct);
 const directed = ref<boolean>(props.config.directed); // Currently not used, assume to be true
 const structure = ref<any>(props.config.structure); // Proxied by "useStructure"
 const useStructure = ref<any>(props.config.useStructure);
+const useFactoredParameter = ref<boolean>(props.config.useFactoredParameter || false);
 
 const updatedConfig = computed<StratifyGroup>(() => ({
 	borderColour: props.config.borderColour,
@@ -77,7 +83,8 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	cartesianProduct: cartesianProduct.value,
 	directed: directed.value,
 	structure: structure.value,
-	useStructure: useStructure.value
+	useStructure: useStructure.value,
+	useFactoredParameter: useFactoredParameter.value
 }));
 
 watch(

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -216,7 +216,8 @@ const stratifyModel = () => {
 		concepts_to_stratify: conceptsToStratify,
 		params_to_stratify: parametersToStratify,
 		cartesian_control: strataOption.cartesianProduct,
-		structure: strataOption.useStructure ? null : []
+		structure: strataOption.useStructure ? null : [],
+		add_param_factor: strataOption.useFactoredParameter || false
 	};
 	kernelManager.sendMessage('reset_mira_request', {}).register('reset_mira_response', () => {
 		kernelManager


### PR DESCRIPTION
### Summary
Adding a checkbox for controlling whether stratify operation should use factored parameters, eg whether it should be `beta_aa, beta_bb`, or `beta * fbeta_aa, beta * fbeta_bb`

<img width="435" alt="image" src="https://github.com/user-attachments/assets/02326898-9a6e-4398-a5b6-d1ed6fb6889d" />

By default this is set to "true"


### Testing
Start with an SIR-model, link it to two different stratify-operators
- For one, stratify on S and beta with "Stratify parameter via multiplication factors = True"
- For the other, stratify on S and beta with "Stratify parameter via multiplication factors = False"

Check the output model's parameter section.

The first should look like:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/0eb8217f-a9e8-4ebd-87fd-d69c16724055" />


The second should look like:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/7d5c268b-867c-46df-9bab-cfcb45deb566" />

