### PR TITLE
fix: #6691 cannot actually change the unit of time in the model page 

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -214,7 +214,7 @@ const transitionsList: ModelPartItemTree[] = createTransitionParts();
 const parameterMatrixModalId = ref('');
 const transitionMatrixModalId = ref('');
 const observablesList = computed(() => createObservablesList(observables.value));
-const timeList: ModelPartItemTree[] = createTimeList(time.value);
+const timeList = computed<ModelPartItemTree[]>(() => createTimeList(time.value));
 </script>
 
 <style scoped>


### PR DESCRIPTION
After selecting a time interval from the Time drop down on the model page, the drop down input does not display the updated value the user selected.

![image](https://github.com/user-attachments/assets/b5cd87b4-625b-4238-9bfb-325d3eb142d4)

Fixed by making the related properties passed to the `tera-model-part` and `tera-model-part-entry` components  computed and hence reactive.

Resolves #6691 
