### PR TITLE
Fix issue that chart label setting input resets while user is still typing

### DIFF
--- a/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
@@ -273,6 +273,7 @@ watch(
 	(newVal, oldVal) => {
 		// If the active setting is the same, do nothing
 		if (newVal?.id === oldVal?.id) return;
+		// Init ref values with the values from the settings when the active setting changes
 		chartLabelTitle.value = chartLabelsFromSettings.value?.title ?? '';
 		chartLabelXAxis.value = chartLabelsFromSettings.value?.xAxisTitle ?? '';
 		chartLabelYAxis.value = chartLabelsFromSettings.value?.yAxisTitle ?? '';

--- a/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
@@ -281,7 +281,7 @@ watch(
 	{ immediate: true }
 );
 
-const CHART_LABEL_UPDATE_DELAY = 1000;
+const CHART_LABEL_UPDATE_DELAY = 1500;
 const updateLabelSettings = _.debounce(() => {
 	const existing = chartLabelsFromSettings.value;
 	const updated = {

--- a/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-chart-settings-panel.vue
@@ -296,18 +296,18 @@ const updateLabelSettings = _.debounce(() => {
 }, CHART_LABEL_UPDATE_DELAY);
 
 const onChartLabelInputBlur = (field: 'title' | 'xAxisTitle' | 'yAxisTitle' | 'fontSize') => {
-	const ValRef = {
+	const valRef = {
 		title: chartLabelTitle,
 		xAxisTitle: chartLabelXAxis,
 		yAxisTitle: chartLabelYAxis,
 		fontSize: chartLabelFontSize
 	}[field];
-	if (!ValRef.value) {
+	if (!valRef.value) {
 		// Replace empty input with default value on blur
 		const setting = _.clone(props.activeSettings) as ChartSetting;
 		setting[field] = undefined;
 		const defaultValue = field === 'fontSize' ? DEFAULT_FONT_SIZE : props.getChartLabels?.(setting)?.[field];
-		ValRef.value = defaultValue ?? '';
+		valRef.value = defaultValue ?? '';
 	}
 	updateLabelSettings();
 };


### PR DESCRIPTION
# Description

Fix the issue that chart label input resets to default value when it's empty while user is still typing (or on focus)

https://github.com/user-attachments/assets/a9ad3f58-9dbd-45df-a41b-39ac09a8385a

Resolves #6764 
