### PR TITLE
Fix: Correct Optimize Chart Label

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-utils.ts
@@ -97,7 +97,7 @@ export function setQoIData(resultData: DataArray, config: Criterion) {
 	const amountOfRiskIndexes = Math.ceil(((100 - config.riskTolerance) / 100) * data.length);
 	if (config.isMinimized) {
 		// Get for the top X
-		const topX = data.sort((n1, n2) => n1 - n2).slice(-amountOfRiskIndexes, 99);
+		const topX = data.sort((n1, n2) => n1 - n2).slice(data.length - amountOfRiskIndexes, data.length);
 		averageRisk = sum(topX) / topX.length;
 	} else {
 		// Get bottom X

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-utils.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/optimize-utils.ts
@@ -97,11 +97,11 @@ export function setQoIData(resultData: DataArray, config: Criterion) {
 	const amountOfRiskIndexes = Math.ceil(((100 - config.riskTolerance) / 100) * data.length);
 	if (config.isMinimized) {
 		// Get for the top X
-		const topX = data.sort().slice(data.length - amountOfRiskIndexes, data.length);
+		const topX = data.sort((n1, n2) => n1 - n2).slice(-amountOfRiskIndexes, 99);
 		averageRisk = sum(topX) / topX.length;
 	} else {
 		// Get bottom X
-		const bottomX = data.sort().slice(0, amountOfRiskIndexes);
+		const bottomX = data.sort((n1, n2) => n1 - n2).slice(0, amountOfRiskIndexes);
 		averageRisk = sum(bottomX) / bottomX.length;
 	}
 


### PR DESCRIPTION
# Description
Correct the sorting used to determine the average risk so that we have the correctly our value.
Note that the sorting was using the default sort which will sort as though we are looking at strings and not in number order

# Pictures:
New:
<img width="842" alt="image" src="https://github.com/user-attachments/assets/baacb050-a925-4e65-b949-c0819dbed6dc" />

Old:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/6c5ccd58-724f-479a-a61b-29acf99c65b1" />


# Test:
Run `yarn staging` and check out my optimize node:
`/projects/43693d8d-b162-413d-b119-0610f61c9e70/workflow/e8fb32d1-f0b3-4afe-9fa9-aff8ebfe6e3d?operator=512d4ff4-a7d7-4121-acf3-8b7bcc129adf`


[new sort.txt](https://github.com/user-attachments/files/19215221/new.sort.txt)
[Old Sort.txt](https://github.com/user-attachments/files/19215222/Old.Sort.txt)


