### PR TITLE
supporting week-interval for model and simulations

### DIFF
--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -29,9 +29,9 @@
 						option-value="value"
 						:options="[
 							{ label: 'Days', value: CalendarDateType.DATE },
+							{ label: 'Weeks', value: CalendarDateType.WEEK },
 							{ label: 'Months', value: CalendarDateType.MONTH },
-							{ label: 'Years', value: CalendarDateType.YEAR },
-							{ label: 'Weeks', value: CalendarDateType.WEEK }
+							{ label: 'Years', value: CalendarDateType.YEAR }
 						]"
 					/>
 					<tera-input-text

--- a/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
+++ b/packages/client/hmi-client/src/components/model/model-parts/tera-model-part-entry.vue
@@ -30,7 +30,8 @@
 						:options="[
 							{ label: 'Days', value: CalendarDateType.DATE },
 							{ label: 'Months', value: CalendarDateType.MONTH },
-							{ label: 'Years', value: CalendarDateType.YEAR }
+							{ label: 'Years', value: CalendarDateType.YEAR },
+							{ label: 'Weeks', value: CalendarDateType.WEEK }
 						]"
 					/>
 					<tera-input-text

--- a/packages/client/hmi-client/src/components/widgets/tera-timestep-calendar.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-timestep-calendar.vue
@@ -11,7 +11,7 @@
 			:model-value="date"
 			showIcon
 			iconDisplay="input"
-			:view="calendarSettings?.view"
+			:view="calendarView"
 			:date-format="calendarSettings?.format"
 			:disabled="disabled"
 			@date-select="onDateSelect($event)"
@@ -43,6 +43,13 @@ const date = computed(() => {
 		props.modelValue,
 		props.calendarSettings?.view ?? CalendarDateType.DATE
 	);
+});
+
+const calendarView = computed(() => {
+	if (props.calendarSettings?.view === CalendarDateType.WEEK) {
+		return CalendarDateType.DATE;
+	}
+	return props.calendarSettings?.view;
 });
 
 const onDateSelect = (newDate: Date) => {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -116,7 +116,7 @@
 							:model-value="
 								knobs.transientModelConfig.temporalContext ? new Date(knobs.transientModelConfig.temporalContext) : null
 							"
-							:view="calendarSettings?.view"
+							:view="calendarView"
 							:date-format="calendarSettings?.format"
 							showIcon
 							iconDisplay="input"
@@ -280,7 +280,7 @@ import { useProjects } from '@/composables/project';
 import TeraPdfPanel from '@/components/widgets/tera-pdf-panel.vue';
 import Calendar from 'primevue/calendar';
 import { CalendarSettings } from '@/utils/date';
-import { DrilldownTabs } from '@/types/common';
+import { CalendarDateType, DrilldownTabs } from '@/types/common';
 import { formatListWithConjunction } from '@/utils/text';
 import { DistributionType } from '@/services/distribution';
 import {
@@ -556,6 +556,12 @@ const mmtParams = ref<MiraTemplateParams>({});
 const configuredMmt = ref(makeConfiguredMMT(mmt.value, knobs.value.transientModelConfig));
 
 const calendarSettings = ref<CalendarSettings | null>(null);
+const calendarView = computed(() => {
+	if (calendarSettings.value?.view === CalendarDateType.WEEK) {
+		return CalendarDateType.DATE;
+	}
+	return calendarSettings.value?.view;
+});
 
 const downloadZippedModelAndConfig = async (configuration: ModelConfiguration = knobs.value.transientModelConfig) => {
 	const archive = await getArchive(configuration);

--- a/packages/client/hmi-client/src/services/charts.ts
+++ b/packages/client/hmi-client/src/services/charts.ts
@@ -150,6 +150,8 @@ function formatDateLabelFn(date: Date, datum: string, type: CalendarDateType): s
 			return `timeFormat(datetime(${date.getFullYear()} + ${datum}, ${date.getMonth()}, ${date.getDate()}), '%Y')`;
 		case CalendarDateType.MONTH:
 			return `timeFormat(datetime(${date.getFullYear()} + floor(${datum} / 12), ${date.getMonth()} + (${datum} % 12) , ${date.getDate()}), '%b %Y')`;
+		case CalendarDateType.WEEK:
+			return `timeFormat(datetime(${date.getFullYear()}, ${date.getMonth()}, ${date.getDate()} + 7 * ${datum}), '%b %d, %Y')`;
 		case CalendarDateType.DATE:
 		default:
 			return `timeFormat(datetime(${date.getFullYear()}, ${date.getMonth()}, ${date.getDate()} + ${datum}), '%b %d, %Y')`;

--- a/packages/client/hmi-client/src/services/model.ts
+++ b/packages/client/hmi-client/src/services/model.ts
@@ -321,7 +321,7 @@ export function getTimeUnits(model: Model): CalendarDateType {
 export function getCalendarSettingsFromModel(model: Model): { view: CalendarDateType; format: string } {
 	const units = model?.semantics?.ode?.time?.units?.expression;
 	const view = units;
-	let format;
+	let format = '';
 
 	switch (units) {
 		case CalendarDateType.MONTH:
@@ -331,6 +331,7 @@ export function getCalendarSettingsFromModel(model: Model): { view: CalendarDate
 			format = 'yy';
 			break;
 		case CalendarDateType.DATE:
+		case CalendarDateType.WEEK:
 		default:
 			format = 'MM dd, yy';
 			break;

--- a/packages/client/hmi-client/src/types/common.ts
+++ b/packages/client/hmi-client/src/types/common.ts
@@ -274,5 +274,6 @@ export const programmingLanguageOptions = (): { name: string; value: string; dis
 export enum CalendarDateType {
 	DATE = 'date',
 	MONTH = 'month',
-	YEAR = 'year'
+	YEAR = 'year',
+	WEEK = 'week'
 }

--- a/packages/client/hmi-client/src/utils/date.ts
+++ b/packages/client/hmi-client/src/utils/date.ts
@@ -88,6 +88,8 @@ export function getTimestepFromDateRange(startDate: Date, endDate: Date, stepTyp
 			return (endDate.getFullYear() - startDate.getFullYear()) * 12 + (endDate.getMonth() - startDate.getMonth());
 		case 'year':
 			return endDate.getFullYear() - startDate.getFullYear();
+		case 'week':
+			return Math.floor(diffInMilliseconds / (1000 * 60 * 60 * 24 * 7));
 		case 'date':
 		default:
 			return Math.floor(diffInMilliseconds / (1000 * 60 * 60 * 24));
@@ -103,6 +105,9 @@ export function getEndDateFromTimestep(startDate: Date, timestep: number, stepTy
 			break;
 		case 'year':
 			endDate.setFullYear(endDate.getFullYear() + timestep);
+			break;
+		case 'week':
+			endDate.setDate(endDate.getDate() + 7 * timestep);
 			break;
 		case 'date':
 		default:
@@ -127,6 +132,7 @@ export function getTimePointString(
 	const dateOptions: Intl.DateTimeFormatOptions = {
 		year: 'numeric',
 		...(view === CalendarDateType.DATE && { month: 'long', day: 'numeric' }),
+		...(view === CalendarDateType.WEEK && { month: 'long', day: 'numeric' }),
 		...(view === CalendarDateType.MONTH && { month: 'long' })
 	};
 


### PR DESCRIPTION
### Summary
Support "week" intervals for model and simulations. 


https://github.com/user-attachments/assets/def735fb-ea63-496d-b723-8bb1f766f153



### Note 
Our notion for the "start of the week" is whatever date the modeller chose in the model-configuration operator. If the modeller goes backward (using the calendar to set timestep), we assume they will select the same weekday as they had originally selected on the model-configuration operator.



### Testing
- Save a model with timeunit = week
- Create a config and pick a starting date/day
- Run a simulation, verify that the intervals for setting "end time" and the chart's data points are multiples of seven days