### PR TITLE
fix: 6772 - In 'Configure model', 'Save' button gets disabled unexpectedly when a focused expression input box loose the focus.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/model-config-operation.ts
@@ -103,7 +103,13 @@ export const isModelConfigsEqual = (
 	return true;
 };
 
-// check if model config values are equal
+/** Compares the 'critical' values from two ModelConfiguration objects.
+ *  Critical values are any that will affect downstream operations / nodes.
+ *  @param originalConfig - The original model configuration to compare
+ *  @param newConfig 			- The new model configuration to compare against
+ *  @returns boolean 			- True if all critical values are equal or
+ * 													false if not (or if either config is empty).
+ */
 export const isModelConfigValuesEqual = (
 	originalConfig: ModelConfiguration | null,
 	newConfig: ModelConfiguration | null
@@ -129,11 +135,7 @@ export const isModelConfigValuesEqual = (
 	// compare initial values are the same
 	const initialValuesDifferent = originalInitialList.some((originalItem) => {
 		const newItem = initialMap.get(originalItem.target);
-		return (
-			newItem &&
-			(!isEqual(originalItem.expression, newItem.expression) ||
-				!isEqual(originalItem.expressionMathml, newItem.expressionMathml))
-		);
+		return newItem && !isEqual(originalItem.expression, newItem.expression);
 	});
 
 	if (initialValuesDifferent) return false;
@@ -149,11 +151,7 @@ export const isModelConfigValuesEqual = (
 	// compare observable values are the same
 	const observableValuesDifferent = originalObservableList.some((originalItem) => {
 		const newItem = observableMap.get(originalItem.referenceId);
-		return (
-			newItem &&
-			(!isEqual(originalItem.expression, newItem.expression) ||
-				!isEqual(originalItem.expressionMathml, newItem.expressionMathml))
-		);
+		return newItem && !isEqual(originalItem.expression, newItem.expression);
 	});
 
 	if (observableValuesDifferent) return false;


### PR DESCRIPTION
When the user is editing the configuration, the initial value of the mathml expression has a value of  

`<ci>I0</ci>` 

(at least in the example cited in the bug).  Then, when the user tabs away from the initial expression input, we make a call to `pythonInstance.parseExpression` to get a more detailed mathml, resulting in: 

`<ci><mml:msub><mml:mi>I</mml:mi><mml:mi>0</mml:mi></mml:msub></ci>`.  

This causes the disabling of the save button because the `isModelConfigValuesEqual` fn flags this as being a difference in the 'critical' values of the configuration.  However, the mathml expression should not affect the behaviour of downstream operators.  So, omit the mathml expressions from the comparison of 'critical' model configuration values.

Resolves #6772
