### PR TITLE
Fix: Add intervention to calibration forecast runs.

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
@@ -266,6 +266,11 @@ watch(
 			engine: 'ciemss'
 		};
 
+		// If we have an intervention add it to both simulation runs:
+		if (policyInterventionId.value) {
+			baseRequestPayload.policyInterventionId = policyInterventionId.value;
+		}
+
 		// Calibration has finished, now kick of two forecast jobs to do comparison
 		// - using the default configuration ()
 		// - using the calibfrated configuration


### PR DESCRIPTION
# Description
When a calibration is finished running we will run two simulations. A before and an after calibration.
Both of these should include any interventions applied to the calibration.
