### PR TITLE
Add dataset_column index, resolving conflicting conditions for stats

### DIFF
--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DatasetController.java
@@ -150,7 +150,7 @@ public class DatasetController {
 			final Schema.Permission permissionCanWrite = projectService.checkPermissionCanWrite(userId, projectId);
 			if (
 				permissionCanWrite.equals(Schema.Permission.WRITE) &&
-				dataset.getColumns().stream().anyMatch(column -> column.getStats() == null)
+				dataset.getColumns().stream().allMatch(column -> column.getStats() == null)
 			) {
 				// Calculate the statistics for the columns
 				final Optional<PresignedURL> datasetUrl = datasetService.getDownloadUrl(

--- a/packages/server/src/main/resources/db/migration/V20__dataset_column_index.sql
+++ b/packages/server/src/main/resources/db/migration/V20__dataset_column_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS dataset_column_1 ON dataset_column(dataset_id);


### PR DESCRIPTION
### Summary
Add DB index to dataset_column, fix contradictory condition where a dataset with partially filled column stats gets into an infinite loop.