### PR TITLE
Compare Dataset Criteria fixes

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-operation.ts
@@ -7,7 +7,8 @@ const DOCUMENTATION_URL = 'https://documentation.terarium.ai/datasets/compare-da
 export enum TimepointOption {
 	LAST = 'at the last timepoint',
 	FIRST = 'at the first timepoint',
-	PEAK = 'at its peak'
+	PEAK = 'at its peak',
+	AVERAGE = 'over all timepoints'
 }
 
 export enum RankOption {

--- a/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/compare-datasets/compare-datasets-operation.ts
@@ -7,7 +7,7 @@ const DOCUMENTATION_URL = 'https://documentation.terarium.ai/datasets/compare-da
 export enum TimepointOption {
 	LAST = 'at the last timepoint',
 	FIRST = 'at the first timepoint',
-	OVERALL = 'at its peak'
+	PEAK = 'at its peak'
 }
 
 export enum RankOption {
@@ -32,7 +32,7 @@ export const blankCriteriaOfInterest = {
 	selectedConfigurationId: null,
 	selectedVariable: null,
 	rank: RankOption.MINIMUM,
-	timepoint: TimepointOption.OVERALL
+	timepoint: TimepointOption.PEAK
 };
 
 // Map groundTruth dataset variable to the other dataset variables

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -1438,7 +1438,7 @@ export function useCharts(
 				if (!chartData.value || !card.selectedVariable) return;
 
 				const variableKey = `${chartData.value.pyciemssMap[card.selectedVariable]}_mean`;
-				let pointOfComparison: Record<string, number> = {};
+				const pointOfComparison: Record<string, number> = {};
 				const resultSummary = cloneDeep(chartData.value.resultSummary); // Must clone to avoid modifying the original data
 				const relevantKeys = Object.keys(resultSummary[0]).filter((key) => key.includes(variableKey));
 
@@ -1455,9 +1455,15 @@ export function useCharts(
 						currentMax = 0;
 					});
 				} else if (card.timepoint === TimepointOption.FIRST) {
-					pointOfComparison = resultSummary[0];
+					relevantKeys.forEach((key) => {
+						pointOfComparison[key] = resultSummary[0][key];
+					});
 				} else if (card.timepoint === TimepointOption.LAST) {
-					pointOfComparison = resultSummary[resultSummary.length - 1];
+					// Note that the datasets lengths do not have to match so we will find the last value for each key individually.
+					relevantKeys.forEach((key) => {
+						const lastTimepoint = resultSummary.filter((record) => record[key]).length - 1;
+						pointOfComparison[key] = resultSummary[lastTimepoint][key];
+					});
 				} else if (card.timepoint === TimepointOption.AVERAGE) {
 					// Get the average value for each relevant key.
 					// Note that as the dataset's length do not have to match we will

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -1443,18 +1443,17 @@ export function useCharts(
 				const relevantKeys = Object.keys(resultSummary[0]).filter((key) => key.includes(variableKey));
 
 				if (card.timepoint === TimepointOption.PEAK) {
-					// Note that the reduce function here only compares the variable of interest
-					// so only those key/value pairs will be relevant in the pointOfComparison object.
-					// Other keys like timepoint_id (that we aren't using) will be in pointOfComparison
-					// but they won't coincide with the value of the variable of interest.
-					pointOfComparison = resultSummary.reduce((acc, val) =>
-						Object.keys(val).reduce((acc2, key) => {
-							if (key.includes(variableKey)) {
-								acc2[key] = Math.max(acc[key], val[key]);
+					// For each relevant key find the maximum value independently.
+					let currentMax = 0;
+					relevantKeys.forEach((key) => {
+						resultSummary.forEach((record) => {
+							if (record[key] && record[key] > currentMax) {
+								currentMax = record[key];
 							}
-							return acc2;
-						}, acc)
-					);
+						});
+						pointOfComparison[key] = currentMax;
+						currentMax = 0;
+					});
 				} else if (card.timepoint === TimepointOption.FIRST) {
 					pointOfComparison = resultSummary[0];
 				} else if (card.timepoint === TimepointOption.LAST) {

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -1466,13 +1466,11 @@ export function useCharts(
 					});
 				} else if (card.timepoint === TimepointOption.AVERAGE) {
 					// Get the average value for each relevant key.
-					// Note that as the dataset's length do not have to match we will
-					// Check each key's length individually.
+					// Note that as the dataset's length do not have to match we will check each key's length individually.
 					let runningSum = 0;
 					relevantKeys.forEach((key) => {
 						resultSummary.forEach((record) => {
 							if (record[key]) {
-								// This key may not exist for every timestep if dataset's end time does not match.
 								runningSum += record[key];
 							}
 						});

--- a/packages/client/hmi-client/src/composables/useCharts.ts
+++ b/packages/client/hmi-client/src/composables/useCharts.ts
@@ -1440,7 +1440,7 @@ export function useCharts(
 				const variableKey = `${chartData.value.pyciemssMap[card.selectedVariable]}_mean`;
 				let pointOfComparison: Record<string, number> = {};
 
-				if (card.timepoint === TimepointOption.OVERALL) {
+				if (card.timepoint === TimepointOption.PEAK) {
 					const resultSummary = cloneDeep(chartData.value.resultSummary); // Must clone to avoid modifying the original data
 
 					// Note that the reduce function here only compares the variable of interest


### PR DESCRIPTION
# Description
- Rename TimepointOption  `OVERALL` to `PEAK` as to not be confused with the new `AVERAGE` option. 

Correct logic for the follow:
- PEAK -> Should find each dataset variable's peak independently. 
- LAST -> should not assume each dataset has the same length.
- FIRST -> Just reduce the size of the payload to be only the relevant data.

Add logic for:
- AVERAGE -> this will find the average value for a variable within the each dataset independently. 

# NOTE:
I am not sure if cleaning this up any further is worth it. If you have suggestions or believe it is please let me know.
If you find this hard to follow or read please let me know

# Video:
Here I have set up two SIR simulation runs. The only difference here is that one runs for 20 timesteps and the other for 90.

**Before:**


https://github.com/user-attachments/assets/64f2199c-37cc-4d30-b469-15ce43001658


**After:**


https://github.com/user-attachments/assets/34a1eb5b-85e2-4cce-8204-41733a4074d5

