### PR TITLE
denormalize extraction data structure

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -418,6 +418,14 @@ export interface EvaluationScenarioSummary {
     timestampMillis: number;
 }
 
+export interface Extraction {
+    extractedBy: string;
+    pages: any;
+    body: any;
+    groups: any;
+    extractions: ExtractionItem[];
+}
+
 export interface ExtractionResponse {
     id: string;
     status: string;
@@ -873,6 +881,21 @@ export interface ProvenanceEdge {
     right: ProvenanceNode;
 }
 
+export interface ExtractionItem {
+    id: string;
+    type: string;
+    subType: string;
+    extractedBy: string;
+    page: number;
+    pageWidth: number;
+    pageHeight: number;
+    bbox: BBox;
+    charspan: number[];
+    rawText: string;
+    text: string;
+    data: any;
+}
+
 export interface PermissionRole {
     id: string;
     name: string;
@@ -947,6 +970,13 @@ export interface VariableStatement {
     value?: StatementValue;
     metadata?: VariableStatementMetadata[];
     provenance?: ProvenanceInfo;
+}
+
+export interface BBox {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
 }
 
 export interface Authority {

--- a/packages/gollm/tasks/enrich_dataset.py
+++ b/packages/gollm/tasks/enrich_dataset.py
@@ -11,6 +11,7 @@ from taskrunner import TaskRunnerInterface
 def cleanup():
     pass
 
+
 def main():
     global taskrunner
     exit_code = 0
@@ -22,7 +23,7 @@ def main():
         input_dict = taskrunner.read_input_dict_with_timeout()
 
         taskrunner.log("Creating DatasetCardModel from input")
-        inputs = DatasetCardModel(**input_dict)
+        input_model = DatasetCardModel(**input_dict)
 
         try:
             llm = determine_llm(input_model.llm)
@@ -31,7 +32,7 @@ def main():
             llm = AzureTools()
             taskrunner.log(f"WARNING: {e}, defaulting to {llm.name}")
 
-        response = enrich_dataset_chain(llm, dataset=inputs.dataset, document=inputs.document)
+        response = enrich_dataset_chain(llm, dataset=input_model.dataset, document=input_model.document)
         taskrunner.log("Received response from LLM")
 
         taskrunner.write_output_dict_with_timeout({"response": response})
@@ -44,6 +45,7 @@ def main():
     taskrunner.log("Shutting down")
     taskrunner.shutdown()
     sys.exit(exit_code)
+
 
 if __name__ == "__main__":
     main()

--- a/packages/ocr_extraction/src/server.py
+++ b/packages/ocr_extraction/src/server.py
@@ -15,6 +15,8 @@ from table_extraction import extract_tables
 
 logging.basicConfig(level=logging.INFO)
 
+extractor = "docling"
+
 app = FastAPI()
 IMAGE_RESOLUTION_SCALE = 2.0
 pipeline_options = PdfPipelineOptions()
@@ -48,7 +50,7 @@ async def health_check():
 async def process_and_predict(file: UploadFile = File(...)):
     logging.info("In predict")
     file_bytes = await file.read()
-    logging.info(f"Len = {len(file_bytes)}")
+    logging.info(f"File length = {len(file_bytes)}")
     docstream = DocumentStream(name="test", stream=BytesIO(file_bytes))
     result = converter.convert(docstream)
 
@@ -68,10 +70,10 @@ async def process_and_predict(file: UploadFile = File(...)):
 
             latex_str = equation_model.predict(text_img_byte_arr.getvalue())
 
-            logging.info(f"{text_ref}")
-            logging.info(f"Docling model: {element.text}")
-            logging.info(f"Textteller model: {latex_str}")
-            logging.info("")
+            # logging.info(f"{text_ref}")
+            # logging.info(f"Docling model: {element.text}")
+            # logging.info(f"Textteller model: {latex_str}")
+            # logging.info("")
             latex_extraction_dict[text_ref] = latex_str
 
     # - Extract tables using GPT model
@@ -82,6 +84,7 @@ async def process_and_predict(file: UploadFile = File(...)):
     # Collect and format result
     ################################################################################
     final_result = {}
+    final_result["extractedBy"] = extractor
     result_dict = result.document.export_to_dict()
 
 
@@ -131,7 +134,7 @@ async def process_and_predict(file: UploadFile = File(...)):
         item["id"] = text["self_ref"]
         item["type"] = "text"
         item["subType"] = text["label"]
-        item["extractedBy"] = "docling"
+        item["extractedBy"] = extractor
 
 
         item["page"] = prov["page_no"]
@@ -161,7 +164,7 @@ async def process_and_predict(file: UploadFile = File(...)):
         item["id"] = picture["self_ref"]
         item["type"] = "picture"
         item["subType"] = picture["label"]
-        item["extractedBy"] = "docling"
+        item["extractedBy"] = extractor
 
         item["page"] = prov["page_no"]
         item["pageWidth"] = pages[str(item["page"])]["size"]["width"]
@@ -183,7 +186,7 @@ async def process_and_predict(file: UploadFile = File(...)):
         item["id"] = id
         item["type"] = "table"
         item["subType"] = table["label"]
-        item["extractedBy"] = "docling"
+        item["extractedBy"] = extractor
 
         item["page"] = prov["page_no"]
         item["pageWidth"] = pages[str(item["page"])]["size"]["width"]

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/BBox.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/BBox.java
@@ -1,0 +1,16 @@
+package software.uncharted.terarium.hmiserver.models.extraction;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+import software.uncharted.terarium.hmiserver.models.TerariumAsset;
+
+@Data
+public class BBox {
+
+	public Float left;
+	public Float top;
+	public Float right;
+	public Float bottom;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/Extraction.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/Extraction.java
@@ -8,11 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 
 @Slf4j
-@TSModel
 @Data
+@TSModel
 public class Extraction {
 
-	private String id;
 	private String extractedBy;
 
 	// Layout infomration, not used, type these out later - Mar 20

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/Extraction.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/Extraction.java
@@ -8,25 +8,17 @@ import lombok.extern.slf4j.Slf4j;
 import software.uncharted.terarium.hmiserver.annotations.TSModel;
 
 @Slf4j
-@Data
 @TSModel
-public class ExtractionItem {
+@Data
+public class Extraction {
 
-	// Identifying fields:
 	private String id;
-	private String type;
-	private String subType;
 	private String extractedBy;
 
-	// Provenance fields
-	private Long page;
-	private Double pageWidth;
-	private Double pageHeight;
-	private BBox bbox;
-	private List<Long> charspan;
+	// Layout infomration, not used, type these out later - Mar 20
+	private JsonNode pages;
+	private JsonNode body;
+	private JsonNode groups;
 
-	// Data fiels
-	private String rawText;
-	private String text;
-	private JsonNode data;
+	private List<ExtractionItem> extractions;
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/ExtractionItem.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/ExtractionItem.java
@@ -1,0 +1,32 @@
+package software.uncharted.terarium.hmiserver.models.extraction;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import java.util.List;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import software.uncharted.terarium.hmiserver.annotations.TSModel;
+
+@Slf4j
+@Entity
+@TSModel
+public class ExtractionItem {
+
+	// Identifying fields:
+	private String id;
+	private String type;
+	private String subType;
+	private String extractedBy;
+
+	// Provenance fields
+	private Long page;
+	private Double pageWidth;
+	private Double pageHeight;
+	private BBox bbox;
+	private List<Long> charspan;
+
+	// Data fiels
+	private String rawText;
+	private String text;
+}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/ExtractionItem.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/extraction/ExtractionItem.java
@@ -9,7 +9,6 @@ import software.uncharted.terarium.hmiserver.annotations.TSModel;
 
 @Slf4j
 @Data
-@TSModel
 public class ExtractionItem {
 
 	// Identifying fields:


### PR DESCRIPTION
### Summary
The first two points here were geared for tabular lookups in DBs so we wouldn't need to resort to json-queries, I don't think we will go these route, but whether these attrs are nested or flattened shouldn't do too much harm.
- Denormalize data structure to make page and source attributes more readily accessible in ExtractionItem
- For similar reason above, flatten provenance
- Introduce type and subType rather than explicit text/picture/table sections
- Java data models
- Added the idea of "rawText" and "text", this is to support secondary processes. For example we have latex-string and cleaned-latex-string