### PR TITLE
Fix: Model Config warnings for stratified parameters

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-entry.vue
@@ -86,8 +86,8 @@ import { Model, ModelConfiguration } from '@/types/Types';
 import {
 	getParameterSource,
 	getParameterDistribution,
-	isNumberInputEmpty,
-	getOtherValues
+	getOtherValues,
+	isParameterInputEmpty
 } from '@/services/model-configurations';
 import TeraDistributionInput from '@/components/model/petrinet/tera-distribution-input.vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
@@ -134,13 +134,6 @@ function getSourceLabel(initialId) {
 }
 
 const getOtherValuesLabel = computed(() => `Configuration values (${otherValueList.value?.length})`);
-
-function isParameterInputEmpty(parameter) {
-	if (parameter.type === DistributionType.Constant) {
-		return isNumberInputEmpty(parameter.parameters.value);
-	}
-	return isNumberInputEmpty(parameter.parameters.maximum) || isNumberInputEmpty(parameter.parameters.minimum);
-}
 
 onMounted(async () => {
 	const identifiers = getParameter(props.model, props.parameterId)?.grounding?.identifiers;

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-table.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-parameter-table.vue
@@ -170,7 +170,7 @@
 
 <script setup lang="ts">
 import { Model, ModelConfiguration, ModelDistribution, ParameterSemantic } from '@/types/Types';
-import { getParameterDistribution, getParameters } from '@/services/model-configurations';
+import { getParameterDistribution, getParameters, isParameterInputEmpty } from '@/services/model-configurations';
 import { StratifiedMatrix } from '@/types/Model';
 import { computed, ref } from 'vue';
 import { collapseParameters, isStratifiedModel } from '@/model-representation/mira/mira';
@@ -234,10 +234,7 @@ const hasEmptyParameters = computed(() => ({ baseParameter }) => {
 		s.referenceId.startsWith(`${baseParameter}_`)
 	);
 
-	return parametersForThisGroup.some((p) => {
-		const value = p.distribution?.parameters?.value;
-		return value === null || value === undefined || value === '' || Number.isNaN(value);
-	});
+	return parametersForThisGroup.some((p) => isParameterInputEmpty(p.distribution));
 });
 
 const matrixModalId = ref('');

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import Textarea from 'primevue/textarea';
 import MultiSelect from 'primevue/multiselect';
@@ -86,6 +86,18 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	useStructure: useStructure.value,
 	useFactoredParameter: useFactoredParameter.value
 }));
+
+watch(
+	() => props.config,
+	() => {
+		strataName.value = props.config.name;
+		selectedVariables.value = props.config.selectedVariables;
+		labels.value = props.config.groupLabels;
+		cartesianProduct.value = props.config.cartesianProduct;
+		structure.value = props.config.structure;
+		useStructure.value = props.config.useStructure;
+	}
+);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed } from 'vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import Textarea from 'primevue/textarea';
 import MultiSelect from 'primevue/multiselect';
@@ -86,18 +86,6 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	useStructure: useStructure.value,
 	useFactoredParameter: useFactoredParameter.value
 }));
-
-watch(
-	() => props.config,
-	() => {
-		strataName.value = props.config.name;
-		selectedVariables.value = props.config.selectedVariables;
-		labels.value = props.config.groupLabels;
-		cartesianProduct.value = props.config.cartesianProduct;
-		structure.value = props.config.structure;
-		useStructure.value = props.config.useStructure;
-	}
-);
 </script>
 
 <style scoped>

--- a/packages/client/hmi-client/src/services/model-configurations.ts
+++ b/packages/client/hmi-client/src/services/model-configurations.ts
@@ -255,6 +255,13 @@ export function isNumberInputEmpty(value: string) {
 	return isNaN(number) || !isNumber(number);
 }
 
+export function isParameterInputEmpty(parameter: ModelDistribution) {
+	if (parameter.type === DistributionType.Constant) {
+		return isNumberInputEmpty(parameter.parameters.value);
+	}
+	return isNumberInputEmpty(parameter.parameters.maximum) || isNumberInputEmpty(parameter.parameters.minimum);
+}
+
 export function getMissingInputAmount(modelConfiguration: ModelConfiguration) {
 	let missingInputs = 0;
 	modelConfiguration.initialSemanticList.forEach((initial) => {


### PR DESCRIPTION
# Description
Correct logic around the warning colour for parameters within a stratified model. 
Previously if any of the parameters within a group were set to constant it would warn user that values were missing.

# Solution:
- Move helper function `isParameterInputEmpty` and utilize it for both stratified and non stratified parameters.

# Screenshots:

Before:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c081197c-33c4-460a-b273-f2316b2a9530" />

After
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/f9be61a8-aa30-4366-855d-adf4fedfd5f2" />
