### PR TITLE
Fix: Stratify Group Form

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratification-group-form.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed } from 'vue';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import Textarea from 'primevue/textarea';
 import MultiSelect from 'primevue/multiselect';
@@ -86,18 +86,6 @@ const updatedConfig = computed<StratifyGroup>(() => ({
 	useStructure: useStructure.value,
 	useFactoredParameter: useFactoredParameter.value
 }));
-
-watch(
-	() => props.config,
-	() => {
-		strataName.value = props.config.name;
-		selectedVariables.value = props.config.selectedVariables;
-		labels.value = props.config.groupLabels;
-		cartesianProduct.value = props.config.cartesianProduct;
-		structure.value = props.config.structure;
-		useStructure.value = props.config.useStructure;
-	}
-);
 </script>
 
 <style scoped>


### PR DESCRIPTION
# Description
There is an issue with updating the stratify group form too quickly.
This issue is because we had some weird logic such that we would update the local variable twice per user interaction.
This was causing issues where if a user were to update the multi select more quickly than the update-state then we could end up over writting the user's changes via the watcher.

# Explanation:
Using the selectedVariables as an example 
We would update via a `MultiSelect` v-model. 
This will then trigger an update state to update the state's version of `selectedVariables`
This update state will then trigger a watcher within this group form. 
This watcher will then set this `selectedVariables` to be the value provided by the node's state

As we have already updated this local `selectedVariables` with the multiselect we should not and do not need to update it again with the watcher. 

```
Stratify-Drilldown:
<group-form 
  …
  :config="node.state.strataGroup"
  …
  @update-self="update state here"
/>

Group Form:
<MultiSelect
  v-model="selectedVariables"
/>

selectedVariables = ref(props.config.selectedVariables);

watch props.config
  selectedVariables = props.config.selectedVariables
```

