### PR TITLE
TA3 operators to have correct cancel ids

### DIFF
--- a/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
+++ b/packages/client/hmi-client/src/components/pyciemss/tera-pyciemss-cancel-button.vue
@@ -10,17 +10,16 @@ import { cancelCiemssJob } from '@/services/models/simulation-service';
 import { logger } from '@/utils/logger';
 
 const props = defineProps<{
-	simulationRunId?: string | string[];
+	simulationRunIds?: string[];
 }>();
 
 const isCancelling = ref(false);
-const disabled = computed(() => _.isEmpty(props.simulationRunId) || isCancelling.value);
+const disabled = computed(() => _.isEmpty(props.simulationRunIds) || isCancelling.value);
 
 const cancelSimulation = async () => {
-	if (!props.simulationRunId) return;
+	if (!props.simulationRunIds) return;
 	isCancelling.value = true;
-	const cancelIds = Array.isArray(props.simulationRunId) ? props.simulationRunId : [props.simulationRunId];
-	cancelIds.forEach(async (id) => {
+	props.simulationRunIds.forEach(async (id) => {
 		if (!id) return;
 		await cancelCiemssJob(id);
 		logger.success(`Simulation ${id} has been cancelled.`);

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -24,7 +24,7 @@
 							:disabled="isEmpty(node.outputs[0].value)"
 						/>
 						<span class="flex gap-2">
-							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunIds" />
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-ids="cancelRunIds" />
 							<span v-tooltip="runButtonMessage">
 								<Button label="Run" icon="pi pi-play" @click="runCalibrate" :disabled="isRunDisabled" />
 							</span>

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-drilldown.vue
@@ -24,7 +24,7 @@
 							:disabled="isEmpty(node.outputs[0].value)"
 						/>
 						<span class="flex gap-2">
-							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunIds" />
 							<span v-tooltip="runButtonMessage">
 								<Button label="Run" icon="pi pi-play" @click="runCalibrate" :disabled="isRunDisabled" />
 							</span>
@@ -683,11 +683,12 @@ const datasetId = computed<string | undefined>(() => props.node.inputs[1]?.value
 const policyInterventionId = computed(() => props.node.inputs[2].value?.[0]);
 const interventionPolicy = ref<InterventionPolicy | null>(null);
 
-const cancelRunId = computed(
-	() =>
-		props.node.state.inProgressForecastId ||
-		props.node.state.inProgressCalibrationId ||
-		props.node.state.inProgressPreForecastId
+const cancelRunIds = computed(() =>
+	[
+		props.node.state.inProgressForecastId,
+		props.node.state.inProgressPreForecastId,
+		props.node.state.inProgressCalibrationId
+	].filter((id) => Boolean(id))
 );
 const currentDatasetFileName = ref<string>();
 

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
@@ -207,6 +207,7 @@ const pollResult = async (runId: string) => {
 	state.errorMessage = { name: '', value: '', traceback: '' };
 
 	if (pollerResults.state === PollerState.Cancelled) {
+		state.inProgressPreForecastId = '';
 		state.inProgressForecastId = '';
 		state.inProgressCalibrationId = '';
 		poller.stop();

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -15,7 +15,7 @@
 			>
 				<template #header>
 					<div class="flex gap-2 ml-auto">
-						<tera-pyciemss-cancel-button :simulation-run-id="cancelRunId" />
+						<tera-pyciemss-cancel-button :simulation-run-id="cancelRunIds" />
 						<div v-tooltip="runButtonMessage">
 							<Button
 								:disabled="isRunDisabled"
@@ -477,12 +477,14 @@ const runButtonMessage = computed(() =>
 	isRunDisabled.value ? `${mappingFilledTooltip.value} ${nodeInputsFilledTooltip.value}` : ''
 );
 
-const cancelRunId = computed(
-	() =>
-		props.node.state.inProgressForecastId ||
-		props.node.state.inProgressCalibrationId ||
-		props.node.state.inProgressPreForecastId
+const cancelRunIds = computed(() =>
+	[
+		props.node.state.inProgressPreForecastId,
+		props.node.state.inProgressForecastId,
+		props.node.state.inProgressCalibrationId
+	].filter((id) => Boolean(id))
 );
+
 const inProgressCalibrationId = computed(() => props.node.state.inProgressCalibrationId);
 const inProgressForecastId = computed(() => props.node.state.inProgressForecastId);
 const isRunInProgress = computed(() => Boolean(inProgressCalibrationId.value || inProgressForecastId.value));

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-ciemss-drilldown.vue
@@ -15,7 +15,7 @@
 			>
 				<template #header>
 					<div class="flex gap-2 ml-auto">
-						<tera-pyciemss-cancel-button :simulation-run-id="cancelRunIds" />
+						<tera-pyciemss-cancel-button :simulation-run-ids="cancelRunIds" />
 						<div v-tooltip="runButtonMessage">
 							<Button
 								:disabled="isRunDisabled"

--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ensemble-ciemss/tera-calibrate-ensemble-node-ciemss.vue
@@ -152,6 +152,7 @@ const pollResult = async (runId: string) => {
 
 	if (pollerResults.state === PollerState.Cancelled) {
 		state.currentProgress = 0;
+		state.inProgressPreForecastId = '';
 		state.inProgressForecastId = '';
 		state.inProgressCalibrationId = '';
 		poller.stop();

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -25,7 +25,7 @@
 								severity="secondary"
 								:disabled="_.isEmpty(node.outputs[0].value)"
 							/>
-							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunIds" />
 							<div v-tooltip="runButtonMessage">
 								<Button :disabled="isRunDisabled" label="Run" icon="pi pi-play" @click="runOptimize" />
 							</div>
@@ -586,8 +586,13 @@ const showSaveDialog = ref<boolean>(false);
 
 const chartWidthDiv = ref(null);
 const chartSize = useDrilldownChartSize(chartWidthDiv);
-const cancelRunId = computed(() => props.node.state.inProgressPostForecastId || props.node.state.inProgressOptimizeId);
-
+const cancelRunIds = computed(() =>
+	[
+		props.node.state.inProgressPreForecastId,
+		props.node.state.inProgressPostForecastId,
+		props.node.state.inProgressOptimizeId
+	].filter((id) => Boolean(id))
+);
 const activePolicyGroups = computed(() =>
 	knobs.value.interventionPolicyGroups.filter((ele) => !!ele.relativeImportance)
 );

--- a/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/optimize-ciemss/tera-optimize-ciemss-drilldown.vue
@@ -25,7 +25,7 @@
 								severity="secondary"
 								:disabled="_.isEmpty(node.outputs[0].value)"
 							/>
-							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunIds" />
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-ids="cancelRunIds" />
 							<div v-tooltip="runButtonMessage">
 								<Button :disabled="isRunDisabled" label="Run" icon="pi pi-play" @click="runOptimize" />
 							</div>

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ciemss/tera-simulate-ciemss-drilldown.vue
@@ -19,7 +19,7 @@
 					<div class="flex align-items-center justify-content-between px-3">
 						<p>{{ blankMessage }}.</p>
 						<span class="flex gap-2">
-							<tera-pyciemss-cancel-button :simulation-run-id="cancelRunIds" />
+							<tera-pyciemss-cancel-button :simulation-run-ids="cancelRunIds" />
 							<Button
 								label="Run"
 								icon="pi pi-play"

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-ciemss-drilldown.vue
@@ -18,7 +18,7 @@
 					<div class="toolbar">
 						<p>Click Run to start the simulation.</p>
 						<span class="flex gap-2">
-							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-id="cancelRunId" />
+							<tera-pyciemss-cancel-button class="mr-auto" :simulation-run-ids="cancelRunIds" />
 							<Button label="Run" icon="pi pi-play" @click="runEnsemble" :disabled="false" />
 						</span>
 					</div>
@@ -396,7 +396,9 @@ const allModelConfigurations = ref<ModelConfiguration[]>([]);
 const newSolutionMappingKey = ref<string>('');
 const runResults = ref<{ [runId: string]: DataArray }>({});
 const runResultsSummary = ref<{ [runId: string]: DataArray }>({});
-const cancelRunId = computed(() => props.node.state.inProgressForecastId);
+const cancelRunIds = computed(() =>
+	!_.isEmpty(props.node.state.inProgressForecastId) ? [props.node.state.inProgressForecastId] : []
+);
 // -------------- Charts && chart settings ----------------
 const chartWidthDiv = ref(null);
 const pyciemssMap = ref<Record<string, string>>({});

--- a/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/simulate-ensemble-ciemss/tera-simulate-ensemble-node-ciemss.vue
@@ -101,25 +101,25 @@ const poller = new Poller();
 const pollResult = async (runId: string) => {
 	poller.setPollAction(async () => pollAction(runId));
 	const pollerResults = await poller.start();
-
+	const state = _.cloneDeep(props.node.state);
 	if (pollerResults.state === PollerState.Cancelled) {
+		state.inProgressForecastId = '';
 		poller.stop();
 	} else if (pollerResults.state !== PollerState.Done || !pollerResults.data) {
 		const simulation = await getSimulation(runId);
 		if (simulation?.status && simulation?.statusMessage) {
-			const state = _.cloneDeep(props.node.state);
 			state.errorMessage = {
 				name: `Simulate: ${runId} has failed`,
 				value: simulation.status,
 				traceback: simulation.statusMessage
 			};
-			emit('update-state', state);
 		}
 		// throw if there are any failed runs for now
 		logger.error(`Simulate: ${runId} has failed`, {
 			toastTitle: 'Error - Pyciemss'
 		});
 	}
+	emit('update-state', state);
 	return pollerResults;
 };
 


### PR DESCRIPTION
# Description
Update the ta3 operators to have their cancel id logic slightly cleaner.
We can provide a list of ids, so where relevant we will send a list of any ids that pass `Boolean(id)` aka not `""`
