### PR TITLE
Keep date context in calibrated model

### DIFF
--- a/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/calibrate-ciemss/tera-calibrate-ciemss-node.vue
@@ -395,6 +395,7 @@ watch(
 				parameterSemanticList: _.cloneDeep(baseConfig.parameterSemanticList),
 				initialSemanticList: _.cloneDeep(baseConfig.initialSemanticList),
 				inferredParameterList: inferredParameters,
+				temporalContext: baseConfig.temporalContext,
 				temporary: true
 			};
 


### PR DESCRIPTION
# Description
When running a calibrate we should keep the temporal context.

