### PR TITLE
remove deprecated document_asset.assets

### DIFF
--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -216,10 +216,6 @@ export interface DocumentAsset extends TerariumAsset {
      * @deprecated
      */
     documentAbstract?: string;
-    /**
-     * @deprecated
-     */
-    assets?: DocumentExtraction[];
     extractions?: ExtractedDocumentPage[];
     thumbnail?: any;
     extraction?: Extraction;
@@ -808,12 +804,6 @@ export interface NonNumericColumnStats {
     missing_values: number;
 }
 
-export interface DocumentExtraction {
-    fileName: string;
-    assetType: ExtractionAssetType;
-    metadata: { [index: string]: any };
-}
-
 export interface ExtractedDocumentPage {
     pageNumber: number;
     text: string;
@@ -1307,10 +1297,4 @@ export enum InterventionSemanticType {
 export enum InterventionValueType {
     Value = "value",
     Percentage = "percentage",
-}
-
-export enum ExtractionAssetType {
-    Figure = "FIGURE",
-    Table = "TABLE",
-    Equation = "EQUATION",
 }

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/dataservice/DocumentController.java
@@ -166,28 +166,6 @@ public class DocumentController {
 			return ResponseEntity.notFound().build();
 		}
 
-		// Test if the document as any assets
-		if (document.get().getAssets() == null) {
-			return ResponseEntity.ok(document.get());
-		}
-
-		document
-			.get()
-			.getAssets()
-			.forEach(asset -> {
-				try {
-					// Add the S3 bucket url to each asset metadata
-					final Optional<PresignedURL> url = documentAssetService.getDownloadUrl(id, asset.getFileName());
-					if (url.isEmpty()) {
-						return;
-					}
-					final PresignedURL presignedURL = url.get();
-					asset.getMetadata().put("url", presignedURL.getUrl());
-				} catch (final Exception e) {
-					log.error("Unable to extract S3 url for assets or extract equations", e);
-				}
-			});
-
 		// Return the updated document
 		return ResponseEntity.ok(document.get());
 	}

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/document/DocumentAsset.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/models/dataservice/document/DocumentAsset.java
@@ -79,12 +79,6 @@ public class DocumentAsset extends TerariumAsset {
 	@Type(JsonType.class)
 	@Column(columnDefinition = "json")
 	@Deprecated
-	private List<DocumentExtraction> assets;
-
-	@TSOptional
-	@Type(JsonType.class)
-	@Column(columnDefinition = "json")
-	@Deprecated
 	private List<ExtractedDocumentPage> extractions = new ArrayList<>();
 
 	@TSOptional
@@ -114,15 +108,6 @@ public class DocumentAsset extends TerariumAsset {
 		if (this.fileNames == null) {
 			this.fileNames = new ArrayList<>();
 		}
-
-		// ensure these are included in filenames
-		if (this.assets != null) {
-			for (final DocumentExtraction asset : assets) {
-				if (!this.fileNames.contains(asset.getFileName())) {
-					this.fileNames.add(asset.getFileName());
-				}
-			}
-		}
 		return this.fileNames;
 	}
 
@@ -151,14 +136,6 @@ public class DocumentAsset extends TerariumAsset {
 		if (this.grounding != null) {
 			clone.grounding = this.grounding.clone();
 		}
-
-		if (this.assets != null) {
-			clone.assets = new ArrayList<>();
-			for (final DocumentExtraction asset : this.assets) {
-				clone.assets.add(asset.clone());
-			}
-		}
-
 		return clone;
 	}
 

--- a/packages/server/src/main/resources/db/migration/V21__drop_document_assset_assets_column.sql
+++ b/packages/server/src/main/resources/db/migration/V21__drop_document_assset_assets_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE document_asset DROP COLUMN IF EXISTS assets;

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/DocumentServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/DocumentServiceTests.java
@@ -62,10 +62,6 @@ public class DocumentServiceTests extends TerariumApplicationTests {
 		return grounding;
 	}
 
-	static DocumentExtraction createDocExtraction() {
-		return new DocumentExtraction().setFileName("Hello World.pdf").setAssetType(ExtractionAssetType.FIGURE);
-	}
-
 	static DocumentAsset createDocument() throws Exception {
 		return createDocument("A");
 	}
@@ -81,8 +77,6 @@ public class DocumentServiceTests extends TerariumApplicationTests {
 		documentAsset.setMetadata(new HashMap<>());
 		documentAsset.getMetadata().put("hello", JsonNodeFactory.instance.textNode("world-" + key));
 		documentAsset.setPublicAsset(true);
-		documentAsset.setAssets(new ArrayList<>());
-		documentAsset.getAssets().add(createDocExtraction());
 		return documentAsset;
 	}
 

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/DocumentServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/DocumentServiceTests.java
@@ -89,7 +89,6 @@ public class DocumentServiceTests extends TerariumApplicationTests {
 		Assertions.assertEquals(before.getId(), after.getId());
 		Assertions.assertNotNull(after.getId());
 		Assertions.assertNotNull(after.getCreatedOn());
-		Assertions.assertEquals(3, after.getFileNames().size());
 
 		Assertions.assertNotNull(after.getGrounding());
 		Assertions.assertNotNull(after.getGrounding().getId());

--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/service/data/TerariumAssetCloneServiceTests.java
@@ -79,10 +79,6 @@ public class TerariumAssetCloneServiceTests extends TerariumApplicationTests {
 		return grounding;
 	}
 
-	static DocumentExtraction createDocExtraction() {
-		return new DocumentExtraction().setFileName("Hello World.pdf").setAssetType(ExtractionAssetType.FIGURE);
-	}
-
 	static DocumentAsset createDocument(final String key) throws Exception {
 		final DocumentAsset documentAsset = new DocumentAsset();
 		documentAsset.setName("test-document-name-" + key);
@@ -94,8 +90,6 @@ public class TerariumAssetCloneServiceTests extends TerariumApplicationTests {
 		documentAsset.setMetadata(new HashMap<>());
 		documentAsset.getMetadata().put("hello", objectMapper.readTree("{\"hello\": \"world-" + key + "\"}"));
 		documentAsset.setPublicAsset(true);
-		documentAsset.setAssets(new ArrayList<>());
-		documentAsset.getAssets().add(createDocExtraction());
 		return documentAsset;
 	}
 


### PR DESCRIPTION
### Summary
Remove deprecated column "assets" and associated clean ups, as well as migration script to drop the column from the DB.

Makes the code a little leaner and easier to understand.


### Testing
- Start as normal `./hmiServerDev.sh start staging run` and check in DB column is dropped. 
- App should work normally (eg, view pdf document)

