### PR TITLE
FIX: Model Transition descriptions should now be visible

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -205,7 +205,8 @@ const createTransitionParts = () => {
 		subject: t.subject ? t.subject.name : '',
 		outcome: t.outcome ? t.outcome.name : '',
 		controllers: getControllerNames(t).join(', '),
-		expression: t.rate_law
+		expression: t.rate_law,
+		description: t.subject.description ? t.subject.description : ''
 	});
 
 	const templatesMap = collapseTemplates(props.mmt).matrixMap;

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-petrinet-parts.vue
@@ -148,7 +148,8 @@ import {
 	PartType,
 	ModelError,
 	ModelErrorSeverity,
-	ModelErrorType
+	ModelErrorType,
+	getTransitions
 } from '@/model-representation/service';
 import TeraStratifiedMatrixModal from '@/components/model/petrinet/model-configurations/tera-stratified-matrix-modal.vue';
 import { ModelPartItem, ModelPartItemTree, StratifiedMatrix } from '@/types/Model';
@@ -206,10 +207,14 @@ const createTransitionParts = () => {
 		outcome: t.outcome ? t.outcome.name : '',
 		controllers: getControllerNames(t).join(', '),
 		expression: t.rate_law,
-		description: t.subject.description ? t.subject.description : ''
+		description: transitionsMap.get(t.name)?.description ?? ''
 	});
 
-	const templatesMap = collapseTemplates(props.mmt).matrixMap;
+	const allTransitions = getTransitions(props.model); // Note this is from model
+	const transitionsMap = new Map<string, Transition>();
+	allTransitions.forEach((ele) => transitionsMap.set(ele.id, ele));
+	const templatesMap = collapseTemplates(props.mmt).matrixMap; // Note this is from mmt.
+
 	return Array.from(templatesMap.keys()).map((templateId) => {
 		const children = templatesMap.get(templateId) as MiraTemplate[];
 		if (children.length === 1) {
@@ -228,7 +233,7 @@ const createTransitionParts = () => {
 	});
 };
 
-const transitionsList = createTransitionParts();
+const transitionsList = computed(() => createTransitionParts());
 
 const parameterMatrixModalId = ref('');
 const transitionMatrixModalId = ref('');

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -213,12 +213,10 @@ export function getStates(model: Model): (State & RegNetVertex)[] {
 
 export function getTransitions(model: Model): Transition[] {
 	const modelType = getModelType(model);
-	switch (modelType) {
-		case AMRSchemaNames.PETRINET:
-			return model.model?.transitions ?? [];
-		default:
-			return [];
+	if (modelType === AMRSchemaNames.PETRINET) {
+		return model.model?.transitions ?? [];
 	}
+	return [];
 }
 
 /**

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -211,6 +211,16 @@ export function getStates(model: Model): (State & RegNetVertex)[] {
 	}
 }
 
+export function getTransitions(model: Model): Transition[] {
+	const modelType = getModelType(model);
+	switch (modelType) {
+		case AMRSchemaNames.PETRINET:
+			return model.model?.transitions ?? [];
+		default:
+			return [];
+	}
+}
+
 /**
  * Retrieves the metadata for a specific initial in the model.
  * @param {Model} model - The model object.
@@ -538,6 +548,9 @@ export function createPartsList(parts, model, partType) {
 				break;
 			case PartType.PARAMETER:
 				types = getParameters(model);
+				break;
+			case PartType.TRANSITION:
+				types = getTransitions(model);
 				break;
 			default:
 				types = model;

--- a/packages/client/hmi-client/src/model-representation/service.ts
+++ b/packages/client/hmi-client/src/model-representation/service.ts
@@ -549,9 +549,6 @@ export function createPartsList(parts, model, partType) {
 			case PartType.PARAMETER:
 				types = getParameters(model);
 				break;
-			case PartType.TRANSITION:
-				types = getTransitions(model);
-				break;
 			default:
 				types = model;
 		}


### PR DESCRIPTION
# Description

Previously we were using the `mmt` when reading for the transitions. However we were using the `model` when writing to the transitions.
Here I am merging the two when reading in order to get the `model`'s description.


# Testing

Previously if you write into a transition description it will not be shown.
If you extract into one it will also not be shown.

Now if you write into it you should see it saved:
![image](https://github.com/user-attachments/assets/3a1819e8-9480-4004-8189-cb08f2790f5d)
