### PR TITLE
Hookup OCR equations to model from equations

### DIFF
--- a/packages/client/hmi-client/src/components/model/petrinet/tera-equation-container.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-equation-container.vue
@@ -76,6 +76,6 @@ main.is-editing {
 	border: 4px solid transparent;
 	border-radius: var(--border-radius);
 	position: relative;
-	top: 0rem;
+	top: 0;
 }
 </style>

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-equation-container.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-equation-container.vue
@@ -1,22 +1,5 @@
 <template>
 	<main :class="isEditingStyle">
-		<section v-if="isEditable" class="controls">
-			<Button v-if="isEditing" class="p-button-sm p-button-outlined" @click="emit('cancel-edit')" label="Cancel" />
-			<Button
-				v-if="isEditing"
-				class="p-button-sm"
-				:disabled="disableSave"
-				@click="emit('update-model-from-equation')"
-				label="Save"
-			/>
-			<Button
-				v-else
-				class="p-button-sm p-button-outlined"
-				@click="emit('start-editing')"
-				:loading="!!isUpdating"
-				label="Edit"
-			/>
-		</section>
 		<section class="math-editor-container">
 			<slot name="math-editor" />
 			<Button
@@ -37,17 +20,15 @@ import Button from 'primevue/button';
 
 const props = defineProps<{
 	isEditing: boolean;
-	isEditable: boolean;
 	disableSave?: boolean;
 	equationType?: string;
 	isUpdating?: boolean;
 }>();
 
-const emit = defineEmits(['cancel-edit', 'add-equation', 'start-editing', 'update-model-from-equation']);
+const emit = defineEmits(['cancel-edit', 'add-equation', 'start-editing']);
 
 const equationType = computed(() => props.equationType ?? 'equation');
 const isEditingStyle = computed(() => (props.isEditing ? 'is-editing' : ''));
-const mathContainerStyle = computed(() => (props.isEditable ? '-1rem' : '0rem'));
 </script>
 
 <style scoped>
@@ -95,6 +76,6 @@ main.is-editing {
 	border: 4px solid transparent;
 	border-radius: var(--border-radius);
 	position: relative;
-	top: v-bind('mathContainerStyle');
+	top: 0rem;
 }
 </style>

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-description.vue
@@ -8,7 +8,7 @@
 			<tera-model-diagram :model="model" :mmt-data="mmtData" />
 		</AccordionTab>
 		<AccordionTab header="Model equations">
-			<tera-model-equation :model="model" :is-editable="false" @model-updated="emit('update-model')" />
+			<tera-model-equation :model="model" @model-updated="emit('update-model')" />
 		</AccordionTab>
 		<AccordionTab v-if="!isEmpty(relatedTerariumArtifacts)" header="Associated resources">
 			<DataTable :value="relatedTerariumModels">

--- a/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
+++ b/packages/client/hmi-client/src/components/model/petrinet/tera-model-equation.vue
@@ -1,12 +1,10 @@
 <template>
 	<tera-equation-container
 		:is-editing="isEditing"
-		:is-editable="isEditable"
 		:isUpdating="isUpdating"
 		@cancel-edit="cancelEdit"
 		@add-equation="addEquation"
 		@start-editing="isEditing = true"
-		@update-model-from-equation="updateModelFromEquations"
 	>
 		<template #math-editor>
 			<div v-if="exceedEquationsThreshold == false">
@@ -14,7 +12,7 @@
 					v-for="(eq, index) in equations"
 					:key="index"
 					:index="index"
-					:is-editable="isEditable"
+					:is-editable="false"
 					:is-editing-eq="isEditing"
 					:latex-equation="eq"
 					@equation-updated="setNewEquation"
@@ -34,15 +32,12 @@ import { ref, watch } from 'vue';
 import TeraMathEditor from '@/components/mathml/tera-math-editor.vue';
 import TeraEquationContainer from '@/components/model/petrinet/tera-equation-container.vue';
 import type { Model } from '@/types/Types';
-import { equationsToAMR, EquationsToAMRRequest } from '@/services/knowledge';
 import { cleanLatexEquations } from '@/utils/math';
 import { isEmpty, isEqual } from 'lodash';
-import { useToastService } from '@/services/toast';
 import { getModelEquation } from '@/services/model';
 
 const props = defineProps<{
 	model: Model;
-	isEditable: boolean;
 }>();
 
 const emit = defineEmits(['model-updated']);
@@ -79,18 +74,6 @@ const cancelEdit = () => {
 const updateLatexFormula = (equationsList: string[]) => {
 	equations.value = equationsList;
 	if (isEmpty(originalEquations.value)) originalEquations.value = Array.from(equationsList);
-};
-
-const updateModelFromEquations = async () => {
-	isUpdating.value = true;
-	isEditing.value = false;
-	const request: EquationsToAMRRequest = { equations: equations.value, modelId: props.model.id };
-	const modelId = await equationsToAMR(request);
-	if (modelId) {
-		emit('model-updated');
-		useToastService().success('Success', `Model Updated from equation`);
-	}
-	isUpdating.value = false;
 };
 
 watch(

--- a/packages/client/hmi-client/src/components/operator/tera-operator-model-preview.vue
+++ b/packages/client/hmi-client/src/components/operator/tera-operator-model-preview.vue
@@ -2,7 +2,7 @@
 	<SelectButton class="p-button-xsm" :model-value="view" :options="viewOptions" @change="handleChange" />
 	<div class="container">
 		<tera-model-diagram v-if="view === View.Diagram" :model="model" :feature-config="{ isPreview: true }" />
-		<tera-model-equation v-else-if="view === View.Equation" :model="model" :is-editable="false" />
+		<tera-model-equation v-else-if="view === View.Equation" :model="model" />
 	</div>
 </template>
 <script setup lang="ts">

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/model-from-equations-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/model-from-equations-operation.ts
@@ -5,9 +5,10 @@ const DOCUMENTATION_URL = 'https://documentation.terarium.ai/modeling/create-mod
 
 export interface EquationBlock {
 	text: string;
-	isEditedByAI?: boolean;
-	pageNumber?: number;
-	extractionError?: boolean;
+	provenance?: {
+		documentId: string;
+		extractionAssetId: string;
+	};
 }
 
 export interface ModelFromEquationsState {

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/model-from-equations-operation.ts
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/model-from-equations-operation.ts
@@ -7,7 +7,7 @@ export interface EquationBlock {
 	text: string;
 	provenance?: {
 		documentId: string;
-		extractionAssetId: string;
+		extractionItemId: string;
 	};
 }
 

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -186,7 +186,7 @@
 													class="w-full overflow-y-scroll"
 												/>
 												<span class="mt-3" v-if="equation.asset.provenance"
-													>Page {{ documentExtractionMap.get(equation.asset.provenance.extractionAssetId)?.page }}</span
+													>Page {{ documentExtractionMap.get(equation.asset.provenance.extractionItemId)?.page }}</span
 												>
 											</template>
 											<template #footer v-if="selectedItem === equation.id">
@@ -252,7 +252,7 @@
 													class="w-full overflow-y-scroll"
 												/>
 												<span class="mt-3" v-if="equation.asset.provenance"
-													>Page {{ documentExtractionMap.get(equation.asset.provenance.extractionAssetId)?.page }}</span
+													>Page {{ documentExtractionMap.get(equation.asset.provenance.extractionItemId)?.page }}</span
 												>
 											</template>
 											<template #footer v-if="selectedItem === equation.id">
@@ -516,7 +516,7 @@ const selectEnrichment = (enrichment: Enrichment) => {
 const selectItem = (equation: AssetBlock<EquationBlock>, event?) => {
 	selectedItem.value = equation.id;
 	if (pdfViewer.value && !!equation.asset.provenance) {
-		const pageNumber = documentExtractionMap.value.get(equation.asset.provenance.extractionAssetId)?.page;
+		const pageNumber = documentExtractionMap.value.get(equation.asset.provenance.extractionItemId)?.page;
 		pdfViewer.value.goToPage(pageNumber);
 	}
 
@@ -625,7 +625,7 @@ onMounted(async () => {
 							text: eq.text,
 							provenance: {
 								documentId: document.value!.id!,
-								extractionAssetId: eq.id
+								extractionItemId: eq.id
 							}
 						}
 					};
@@ -737,14 +737,14 @@ async function onRun() {
 			if (!equationsWithSourceMap.has(equation.asset.provenance!.documentId)) {
 				equationsWithSourceMap.set(equation.asset.provenance!.documentId, [
 					{
-						id: equation.asset.provenance!.extractionAssetId,
+						id: equation.asset.provenance!.extractionItemId,
 						equationStr: equation.asset.text
 					}
 				]);
 			} else {
 				const existingEquations = equationsWithSourceMap.get(equation.asset.provenance!.documentId);
 				existingEquations?.push({
-					id: equation.asset.provenance!.extractionAssetId,
+					id: equation.asset.provenance!.extractionItemId,
 					equationStr: equation.asset.text
 				});
 			}

--- a/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-from-equations/tera-model-from-equations-drilldown.vue
@@ -182,7 +182,7 @@
 													v-model="equation.asset.text"
 													autoResize
 													rows="1"
-													placeholder="Add an expression with LaTeX"
+													placeholder="Add LaTeX expression"
 													class="w-full overflow-y-scroll"
 												/>
 												<span class="mt-3" v-if="equation.asset.provenance"
@@ -248,7 +248,7 @@
 													v-model="equation.asset.text"
 													autoResize
 													rows="1"
-													placeholder="Add an expression with LaTeX"
+													placeholder="Add LaTeX expression"
 													class="w-full overflow-y-scroll"
 												/>
 												<span class="mt-3" v-if="equation.asset.provenance"

--- a/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-node.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model/tera-model-node.vue
@@ -15,7 +15,7 @@
 					:key="model.id"
 					:feature-config="{ isPreview: true }"
 				/>
-				<tera-model-equation v-else-if="view === ModelNodeView.Equation" :model="model" :is-editable="false" />
+				<tera-model-equation v-else-if="view === ModelNodeView.Equation" :model="model" />
 			</div>
 			<Button label="Open" @click="emit('open-drilldown')" severity="secondary" outlined />
 		</template>

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -1,7 +1,7 @@
 import API from '@/api/api';
 import { AxiosResponse } from 'axios';
 import { extractionStatusUpdateHandler, subscribe } from '@/services/ClientEventService';
-import { type DocumentAsset, type Model, ClientEventType } from '@/types/Types';
+import { type DocumentAsset, type Model, ClientEventType, ExtractionItem } from '@/types/Types';
 import { logger } from '@/utils/logger';
 import { Workflow, WorkflowNode } from '@/types/workflow';
 
@@ -33,6 +33,7 @@ export const getCleanedEquations = async (
  */
 export interface EquationsToAMRRequest {
 	equations: string[];
+	equationsWithSource?: Map<NonNullable<DocumentAsset['id']>, { id: ExtractionItem['id']; equationStr: string }[]>;
 	modelId?: Model['id'];
 	documentId?: DocumentAsset['id'];
 	workflowId?: Workflow['id'];
@@ -45,8 +46,12 @@ export interface EquationsToAMRRequest {
  * @return {Promise<any>}
  */
 export const equationsToAMR = async (request: EquationsToAMRRequest): Promise<string | null> => {
+	const payload = {
+		...request,
+		equationsWithSource: request.equationsWithSource ? Object.fromEntries(request.equationsWithSource) : {}
+	};
 	try {
-		const response: AxiosResponse<string> = await API.post(`/knowledge/equations-to-model`, request);
+		const response: AxiosResponse<string> = await API.post(`/knowledge/equations-to-model-new`, payload);
 		return response.data;
 	} catch (error: unknown) {
 		logger.error(error, { showToast: false });

--- a/packages/client/hmi-client/src/services/knowledge.ts
+++ b/packages/client/hmi-client/src/services/knowledge.ts
@@ -51,7 +51,7 @@ export const equationsToAMR = async (request: EquationsToAMRRequest): Promise<st
 		equationsWithSource: request.equationsWithSource ? Object.fromEntries(request.equationsWithSource) : {}
 	};
 	try {
-		const response: AxiosResponse<string> = await API.post(`/knowledge/equations-to-model-new`, payload);
+		const response: AxiosResponse<string> = await API.post(`/knowledge/equations-to-model`, payload);
 		return response.data;
 	} catch (error: unknown) {
 		logger.error(error, { showToast: false });

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -913,13 +913,13 @@ export interface ProjectGroupPermission {
 }
 
 export interface IProjectUserPermissionDisplayModel {
-    user: User;
-    username: string;
+		user: User;
     email: string;
-    permissionLevel: Permission;
     givenName: string;
+    username: string;
     id: string;
     familyName: string;
+    permissionLevel: Permission;
 }
 
 export interface ProvenanceNode {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -913,13 +913,13 @@ export interface ProjectGroupPermission {
 }
 
 export interface IProjectUserPermissionDisplayModel {
-	user: User;
-	email: string;
-	givenName: string;
-	username: string;
-	id: string;
-	familyName: string;
-	permissionLevel: Permission;
+    user: User;
+    username: string;
+    email: string;
+    permissionLevel: Permission;
+    givenName: string;
+    id: string;
+    familyName: string;
 }
 
 export interface ProvenanceNode {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -913,13 +913,13 @@ export interface ProjectGroupPermission {
 }
 
 export interface IProjectUserPermissionDisplayModel {
-    permissionLevel: Permission;
-    user: User;
-    givenName: string;
-    username: string;
-    email: string;
-    id: string;
-    familyName: string;
+	user: User;
+	email: string;
+	givenName: string;
+	username: string;
+	id: string;
+	familyName: string;
+	permissionLevel: Permission;
 }
 
 export interface ProvenanceNode {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -913,11 +913,11 @@ export interface ProjectGroupPermission {
 }
 
 export interface IProjectUserPermissionDisplayModel {
+    permissionLevel: Permission;
     user: User;
+    givenName: string;
     username: string;
     email: string;
-    permissionLevel: Permission;
-    givenName: string;
     id: string;
     familyName: string;
 }

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -914,12 +914,12 @@ export interface ProjectGroupPermission {
 
 export interface IProjectUserPermissionDisplayModel {
     user: User;
-    email: string;
+    permissionLevel: Permission;
     username: string;
+    email: string;
     givenName: string;
     id: string;
     familyName: string;
-    permissionLevel: Permission;
 }
 
 export interface ProvenanceNode {

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -914,8 +914,8 @@ export interface ProjectGroupPermission {
 
 export interface IProjectUserPermissionDisplayModel {
     user: User;
-    email: string;
     username: string;
+    email: string;
     permissionLevel: Permission;
     givenName: string;
     id: string;

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -913,10 +913,10 @@ export interface ProjectGroupPermission {
 }
 
 export interface IProjectUserPermissionDisplayModel {
-		user: User;
+    user: User;
     email: string;
-    givenName: string;
     username: string;
+    givenName: string;
     id: string;
     familyName: string;
     permissionLevel: Permission;

--- a/packages/client/hmi-client/src/types/Types.ts
+++ b/packages/client/hmi-client/src/types/Types.ts
@@ -914,9 +914,9 @@ export interface ProjectGroupPermission {
 
 export interface IProjectUserPermissionDisplayModel {
     user: User;
-    permissionLevel: Permission;
-    username: string;
     email: string;
+    username: string;
+    permissionLevel: Permission;
     givenName: string;
     id: string;
     familyName: string;

--- a/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
+++ b/packages/server/src/main/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeController.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import software.uncharted.terarium.hmiserver.annotations.HasProjectAccess;
 import software.uncharted.terarium.hmiserver.configuration.Config;
-import software.uncharted.terarium.hmiserver.models.ClientEventType;
 import software.uncharted.terarium.hmiserver.models.dataservice.document.DocumentAsset;
 import software.uncharted.terarium.hmiserver.models.dataservice.model.Model;
 import software.uncharted.terarium.hmiserver.models.task.TaskRequest;
@@ -44,14 +43,12 @@ import software.uncharted.terarium.hmiserver.service.ClientEventService;
 import software.uncharted.terarium.hmiserver.service.CurrentUserService;
 import software.uncharted.terarium.hmiserver.service.ExtractionService;
 import software.uncharted.terarium.hmiserver.service.data.ModelService;
-import software.uncharted.terarium.hmiserver.service.notification.NotificationGroupInstance;
 import software.uncharted.terarium.hmiserver.service.notification.NotificationService;
 import software.uncharted.terarium.hmiserver.service.tasks.EquationsCleanupResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.LatexToSympyResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.SympyToAMRResponseHandler;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService;
 import software.uncharted.terarium.hmiserver.service.tasks.TaskService.TaskMode;
-import software.uncharted.terarium.hmiserver.utils.JsonUtil;
 import software.uncharted.terarium.hmiserver.utils.Messages;
 import software.uncharted.terarium.hmiserver.utils.rebac.Schema;
 
@@ -70,8 +67,6 @@ public class KnowledgeController {
 	private final TaskService taskService;
 
 	private final CurrentUserService currentUserService;
-	private final ClientEventService clientEventService;
-	private final NotificationService notificationService;
 
 	private final EquationsCleanupResponseHandler equationsCleanupResponseHandler;
 
@@ -158,7 +153,7 @@ public class KnowledgeController {
 		private List<String> equations;
 	}
 
-	@PostMapping("/equations-to-model-new")
+	@PostMapping("/equations-to-model")
 	@Secured(Roles.USER)
 	@HasProjectAccess(level = Schema.Permission.WRITE)
 	public ResponseEntity<UUID> equationsToModelNew(
@@ -234,157 +229,6 @@ public class KnowledgeController {
 			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, messages.get("postgres.service-unavailable"));
 		}
 
-		return ResponseEntity.ok(model.getId());
-	}
-
-	/**
-	 * Equations LaTeX to AMR
-	 *
-	 * @return UUID Model ID, or null if the model was not created or updated
-	 */
-	@PostMapping("/equations-to-model")
-	@Secured(Roles.USER)
-	@HasProjectAccess(level = Schema.Permission.WRITE)
-	public ResponseEntity<UUID> equationsToModel(
-		@RequestBody final JsonNode req,
-		@RequestParam(name = "project-id", required = false) final UUID projectId
-	) {
-		// Parse the request
-		UUID documentId = JsonUtil.parseUuidFromRequest(req, "documentId");
-		UUID modelId = JsonUtil.parseUuidFromRequest(req, "modelId");
-
-		// Create the notification properties
-		final NotificationProperties notificationProperties = new NotificationProperties();
-		notificationProperties.setProjectId(projectId);
-		notificationProperties.setDocumentId(documentId);
-		notificationProperties.setModelId(modelId);
-		notificationProperties.setWorkflowId(JsonUtil.parseUuidFromRequest(req, "workflowId"));
-		notificationProperties.setNodeId(JsonUtil.parseUuidFromRequest(req, "nodeId"));
-
-		// Create the notification group
-		final NotificationGroupInstance<NotificationProperties> notificationInterface = new NotificationGroupInstance<>(
-			clientEventService,
-			notificationService,
-			ClientEventType.KNOWLEDGE_ENRICHMENT_MODEL,
-			projectId,
-			notificationProperties,
-			currentUserService.get().getId()
-		);
-
-		notificationInterface.sendMessage("Beginning model enrichment using document extraction...");
-		log.info("Beginning model {} enrichment using document {} extraction...", modelId, documentId);
-
-		// Cleanup equations from the request
-		List<String> equations = new ArrayList<>();
-		if (req.get("equations") != null) {
-			for (final JsonNode equation : req.get("equations")) {
-				equations.add(equation.asText());
-			}
-		}
-		TaskRequest cleanupReq = cleanupEquationsTaskRequest(projectId, equations);
-		TaskResponse cleanupResp = null;
-		try {
-			cleanupResp = taskService.runTask(TaskMode.SYNC, cleanupReq);
-			if (cleanupResp.getStatus() != TaskStatus.SUCCESS) {
-				log.error("Task failed", cleanupResp.getStderr());
-				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, cleanupResp.getStderr());
-			}
-		} catch (final JsonProcessingException e) {
-			log.warn("Unable to clean-up equations due to a JsonProcessingException. Reverting to original equations.", e);
-		} catch (final TimeoutException e) {
-			log.warn("Unable to clean-up equations due to a TimeoutException. Reverting to original equations.", e);
-		} catch (final InterruptedException e) {
-			log.warn("Unable to clean-up equations due to a InterruptedException. Reverting to original equations.", e);
-		} catch (final ExecutionException e) {
-			log.warn("Unable to clean-up equations due to a ExecutionException. Reverting to original equations.", e);
-		}
-
-		notificationInterface.sendMessage("Equations cleaned up.");
-
-		// get the equations from the cleanup response, or use the original equations
-		JsonNode equationsReq = req.get("equations");
-		if (cleanupResp != null && cleanupResp.getOutput() != null) {
-			try {
-				JsonNode output = mapper.readValue(cleanupResp.getOutput(), JsonNode.class);
-				if (output.get("response") != null && output.get("response").get("equations") != null) {
-					equationsReq = output.get("response").get("equations");
-				}
-			} catch (IOException e) {
-				log.warn("Unable to retrieve cleaned-up equations from GoLLM response. Reverting to original equations.", e);
-			}
-		}
-
-		final Model responseAMR;
-		final TaskRequest latexToSympyRequest;
-		final TaskResponse latexToSympyResponse;
-		final TaskRequest sympyToAMRRequest;
-		final TaskResponse sympyToAMRResponse;
-
-		try {
-			// 1. LaTeX to sympy code
-			latexToSympyRequest = createLatexToSympyTask(equationsReq);
-			latexToSympyResponse = taskService.runTaskSync(latexToSympyRequest);
-
-			if (latexToSympyResponse.getStatus() != TaskStatus.SUCCESS) {
-				log.error("Task Failed", latexToSympyResponse.getStderr());
-				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, latexToSympyResponse.getStderr());
-			}
-
-			// 2. hand off
-			final String code = extractCodeFromLatexToSympy(latexToSympyResponse);
-
-			// 3. sympy code string to amr json
-			sympyToAMRRequest = createSympyToAMRTask(code);
-			sympyToAMRResponse = taskService.runTaskSync(sympyToAMRRequest);
-			if (sympyToAMRResponse.getStatus() != TaskStatus.SUCCESS) {
-				log.error("Task Failed", sympyToAMRResponse.getStderr());
-				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, sympyToAMRResponse.getStderr());
-			}
-
-			final JsonNode taskResponseJSON = mapper.readValue(sympyToAMRResponse.getOutput(), JsonNode.class);
-			final ObjectNode amrNode = taskResponseJSON.get("response").get("amr").deepCopy();
-			responseAMR = mapper.convertValue(amrNode, Model.class);
-		} catch (final Exception e) {
-			log.error(messages.get("task.mira.internal-error"), e);
-			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, messages.get("task.mira.internal-error"));
-		}
-
-		// We only handle Petri Net models
-		if (!responseAMR.isPetrinet()) {
-			throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, messages.get("bad-equations.petrinet"));
-		}
-
-		notificationInterface.sendMessage("AMR extracted via MIRA.");
-
-		modelService.fixGreekLetters(responseAMR);
-		notificationInterface.sendMessage("Greek letters fixed.");
-
-		// If no model id is provided, create a new model asset
-		Model model;
-		if (modelId == null) {
-			try {
-				model = modelService.createAsset(responseAMR, projectId);
-			} catch (final IOException e) {
-				log.error("An error occurred while trying to create a model.", e);
-				throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, messages.get("postgres.service-unavailable"));
-			}
-
-			notificationInterface.sendMessage("Model created.");
-			// If a model id is provided, update the existing model
-		} else {
-			try {
-				model = modelService.updateAsset(responseAMR, projectId).orElseThrow(() -> new IOException("Model not found"));
-			} catch (final IOException | IllegalArgumentException e) {
-				log.error("An error occurred while trying to update a model.", e);
-				throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, messages.get("postgres.service-unavailable"));
-			}
-
-			notificationInterface.sendMessage("Model updated.");
-		}
-
-		notificationInterface.sendFinalMessage("Model from equations done.");
-
-		// Return the model id
 		return ResponseEntity.ok(model.getId());
 	}
 


### PR DESCRIPTION
# Description

* Hookup _new_ OCR formulas to model from equations drilldown
* modified `EquationBlock` data structure accordingly to hold a provenance reference, addtional info can be lookedup in a map (i.e bounding boxes, page number, etc...)
* OCR formulas are already edited by AI, so will no longer be cleaning equations on the front end
* removed some unused function related to the `old` equations-to-model endpoint
* removed the old equations-to-model endpoint entirely

