### PR TITLE
fix backend units tests for knowledge controller

### DIFF
--- a/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeControllerTests.java
+++ b/packages/server/src/test/java/software/uncharted/terarium/hmiserver/controller/knowledge/KnowledgeControllerTests.java
@@ -190,28 +190,6 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 	@WithUserDetails(MockUser.URSULA)
 	public void profileModel() throws Exception {
 		DocumentAsset documentAsset = (DocumentAsset) new DocumentAsset()
-			.setText(
-				"""
-				In this paper, we study the effectiveness of the modelling approach on the pandemic due to the spreading
-				of the novel COVID-19 disease and develop a susceptible-infected-removed (SIR) model that provides a
-				theoretical framework to investigate its spread within a community. Here, the model is based upon the
-				well-known susceptible-infected-removed (SIR) model with the difference that a total population is not
-				deﬁned or kept constant per se and the number of susceptible individuals does not decline monotonically.
-				To the contrary, as we show herein, it can be increased in surge periods! In particular, we investigate
-				the time evolution of different populations and monitor diverse signiﬁcant parameters for the spread
-				of the disease in various communities, represented by China, South Korea, India, Australia, USA, Italy
-				and the state of Texas in the USA. The SIR model can provide us with insights and predictions of the
-				spread of the virus in communities that the recorded data alone cannot. Our work shows the importance
-				of modelling the spread of COVID-19 by the SIR model that we propose here, as it can help to assess
-				the impact of the disease by offering valuable predictions. Our analysis takes into account data from
-				January to June, 2020, the period that contains the data before and during the implementation of strict
-				and control measures. We propose predictions on various parameters related to the spread of COVID-19
-				and on the number of susceptible, infected and removed populations until September 2020. By comparing
-				the recorded data with the data from our modelling approaches, we deduce that the spread of COVID-
-				19 can be under control in all communities considered, if proper restrictions and strong policies are
-				implemented to control the infection rates early from the spread of the disease.
-				"""
-			)
 			.setName("test-pdf-name")
 			.setDescription("my description");
 
@@ -272,28 +250,6 @@ public class KnowledgeControllerTests extends TerariumApplicationTests {
 			.andExpect(status().isOk());
 
 		DocumentAsset documentAsset = (DocumentAsset) new DocumentAsset()
-			.setText(
-				"""
-				In this paper, we study the effectiveness of the modelling approach on the pandemic due to the spreading
-				of the novel COVID-19 disease and develop a susceptible-infected-removed (SIR) model that provides a
-				theoretical framework to investigate its spread within a community. Here, the model is based upon the
-				well-known susceptible-infected-removed (SIR) model with the difference that a total population is not
-				deﬁned or kept constant per se and the number of susceptible individuals does not decline monotonically.
-				To the contrary, as we show herein, it can be increased in surge periods! In particular, we investigate
-				the time evolution of different populations and monitor diverse signiﬁcant parameters for the spread
-				of the disease in various communities, represented by China, South Korea, India, Australia, USA, Italy
-				and the state of Texas in the USA. The SIR model can provide us with insights and predictions of the
-				spread of the virus in communities that the recorded data alone cannot. Our work shows the importance
-				of modelling the spread of COVID-19 by the SIR model that we propose here, as it can help to assess
-				the impact of the disease by offering valuable predictions. Our analysis takes into account data from
-				January to June, 2020, the period that contains the data before and during the implementation of strict
-				and control measures. We propose predictions on various parameters related to the spread of COVID-19
-				and on the number of susceptible, infected and removed populations until September 2020. By comparing
-				the recorded data with the data from our modelling approaches, we deduce that the spread of COVID-
-				19 can be under control in all communities considered, if proper restrictions and strong policies are
-				implemented to control the infection rates early from the spread of the disease.
-				"""
-			)
 			.setName("test-pdf-name")
 			.setDescription("my description");
 


### PR DESCRIPTION
# Description

* There is an issue with the knowledge controller tests after recent changes removing the text attribute for the DocumentAsset.  This should allow the tests to pass again

