### PR TITLE
bug: Client warnings - dependies imported but not resolved #6964

### DIFF
--- a/packages/client/hmi-client/src/components/code/tera-code.vue
+++ b/packages/client/hmi-client/src/components/code/tera-code.vue
@@ -167,7 +167,7 @@ import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
 import { computed, ref, watch, onMounted } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import TeraCodeDynamic from './tera-code-dynamic.vue';
 import TeraDirectory from './tera-directory.vue';

--- a/packages/client/hmi-client/src/components/code/tera-directory.vue
+++ b/packages/client/hmi-client/src/components/code/tera-directory.vue
@@ -16,7 +16,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue';
 import Tree, { TreeExpandedKeys, TreeSelectionKeys } from 'primevue/tree';
-import { TreeNode } from 'primevue/treenode';
+import type { TreeNode } from 'primevue/treenode';
 
 const directoryTree = ref<TreeNode[]>([]);
 

--- a/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
+++ b/packages/client/hmi-client/src/components/drilldown/tera-drilldown.vue
@@ -124,7 +124,7 @@ import { ref, computed, onMounted, onUnmounted, useSlots, ComponentPublicInstanc
 import Button from 'primevue/button';
 import Chip from 'primevue/chip';
 import Menu from 'primevue/menu';
-import { MenuItem, MenuItemCommandEvent } from 'primevue/menuitem';
+import type { MenuItem, MenuItemCommandEvent } from 'primevue/menuitem';
 import type { TabViewChangeEvent } from 'primevue/tabview';
 import { type WorkflowNode } from '@/types/workflow';
 import { isAssetOperator } from '@/services/workflow';

--- a/packages/client/hmi-client/src/components/home/tera-project-menu.vue
+++ b/packages/client/hmi-client/src/components/home/tera-project-menu.vue
@@ -21,7 +21,7 @@ import Menu from 'primevue/menu';
 import { computed, ref } from 'vue';
 import { exportProjectAsFile } from '@/services/project';
 import { AcceptedExtensions } from '@/types/common';
-import { MenuItem } from 'primevue/menuitem';
+import type { MenuItem } from 'primevue/menuitem';
 import useAuthStore from '@/stores/auth';
 
 const props = defineProps<{ project: Project | null }>();

--- a/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-beaker-code-cell.vue
@@ -23,7 +23,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import { SessionContext } from '@jupyterlab/apputils';
 import { INotebookItem, JupyterMessage, renderMime } from '@/services/jupyter';
 import Button from 'primevue/button';

--- a/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
+++ b/packages/client/hmi-client/src/components/llm/tera-jupyter-response.vue
@@ -108,7 +108,7 @@ import Button from 'primevue/button';
 import Textarea from 'primevue/textarea';
 import Menu from 'primevue/menu';
 import { defineEmits, ref, computed, onMounted } from 'vue';
-import { MenuItem } from 'primevue/menuitem';
+import type { MenuItem } from 'primevue/menuitem';
 import Checkbox from 'primevue/checkbox';
 
 const emit = defineEmits([

--- a/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
+++ b/packages/client/hmi-client/src/components/navbar/tera-navbar.vue
@@ -172,7 +172,7 @@ import Avatar from 'primevue/avatar';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import Menu from 'primevue/menu';
-import { MenuItem } from 'primevue/menuitem';
+import type { MenuItem } from 'primevue/menuitem';
 import { RoutePath } from '@/router/index';
 import { RouteName } from '@/router/routes';
 import useAuthStore from '@/stores/auth';

--- a/packages/client/hmi-client/src/components/widgets/tera-import-github-file.vue
+++ b/packages/client/hmi-client/src/components/widgets/tera-import-github-file.vue
@@ -164,7 +164,7 @@ import { getGithubCode, getGithubRepositoryContent } from '@/services/github-imp
 import type { DocumentAsset, GithubFile, GithubRepo } from '@/types/Types';
 import { AssetType, FileCategory } from '@/types/Types';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import { getModeForPath } from 'ace-builds/src-noconflict/ext-modelist';
 import '@/ace-config';
 import Checkbox from 'primevue/checkbox';

--- a/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-comparison/tera-model-comparison-drilldown.vue
@@ -199,7 +199,7 @@ import { logger } from '@/utils/logger';
 import Button from 'primevue/button';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import TeraNotebookJupyterInput from '@/components/llm/tera-notebook-jupyter-input.vue';
 import teraNotebookOutput from '@/components/drilldown/tera-notebook-output.vue';
 import Image from 'primevue/image';

--- a/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-config/tera-model-config-drilldown.vue
@@ -224,7 +224,7 @@ import Button from 'primevue/button';
 import TeraInputText from '@/components/widgets/tera-input-text.vue';
 import Textarea from 'primevue/textarea';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import TeraDrilldownPreview from '@/components/drilldown/tera-drilldown-preview.vue';
 import TeraDrilldownSection from '@/components/drilldown/tera-drilldown-section.vue';
 import TeraDrilldown from '@/components/drilldown/tera-drilldown.vue';

--- a/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/model-edit/tera-model-edit-drilldown.vue
@@ -73,7 +73,7 @@ import { cloneDeep, isEmpty, isEqual, debounce } from 'lodash';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import '@/ace-config';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import Button from 'primevue/button';
 import { DrilldownTabs } from '@/types/common';
 import type { Model } from '@/types/Types';

--- a/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
+++ b/packages/client/hmi-client/src/components/workflow/ops/stratify-mira/tera-stratify-drilldown.vue
@@ -114,7 +114,7 @@ import Button from 'primevue/button';
 import { v4 as uuidv4 } from 'uuid';
 import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { VAceEditor } from 'vue3-ace-editor';
-import { VAceEditorInstance } from 'vue3-ace-editor/types';
+import type { VAceEditorInstance } from 'vue3-ace-editor/types';
 import { blankStratifyGroup, StratifyGroup, StratifyOperationStateMira } from './stratify-mira-operation';
 
 const props = defineProps<{

--- a/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
+++ b/packages/client/hmi-client/src/components/workflow/tera-workflow.vue
@@ -212,7 +212,7 @@ import { v4 as uuidv4 } from 'uuid';
 import TeraProgressSpinner from '@/components/widgets/tera-progress-spinner.vue';
 
 import { useRouter, useRoute } from 'vue-router';
-import { MenuItem } from 'primevue/menuitem';
+import type { MenuItem } from 'primevue/menuitem';
 import * as EventService from '@/services/event';
 import { useProjects } from '@/composables/project';
 // import useAuthStore from '@/stores/auth';


### PR DESCRIPTION
Use type import to fix warnings

To test:

1.  Delete existing client `node_modules`
2. `yarn install`
3. Start vite / dev server
4. Fail to observe the aforementioned  warnings


